### PR TITLE
fix(ci): don't pass gh token to lychee, just cache

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -17,13 +17,13 @@ jobs:
           key: cache-lychee-${{ github.sha }}
           restore-keys: cache-lychee-
 
-      # accept 429 only for PR runs where secret isn't available
+      # Accept 429 status codes so we don't fail when GitHub rate-limits us. The --github-token option didn't work and
+      # this way we'll successfully check *some* links each run, cache them and check others the next run.
       - name: Check links
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
         run: |
-          nix run nixpkgs#lychee -- \
+          nix develop .#linkcheck -c lychee \
             --verbose \
             --cache \
-            --accept '${{ github.event_name == 'pull_request' && '200, 429' || '200' }}' \
+            --cache-exclude-status "429" \
+            --accept "200, 429" \
             docs README.md

--- a/flake.nix
+++ b/flake.nix
@@ -404,6 +404,10 @@
               };
             };
 
+            linkcheck = flakeboxLib.mkDevShell {
+              nativeBuildInputs = [ nixpkgs-unstable.legacyPackages.${system}.lychee ];
+            };
+
             # Like `cross` but only with wasm
             crossWasm = flakeboxLib.mkDevShell (
               commonShellArgs


### PR DESCRIPTION
Master link check CI is still failing, I tried:
* Updating `lychee` and pinning it to a more predictable version
* Passing the GH token as an argument instead of a env var
* Not caching the 429 error codes but allow them even on master

The last approach made it kinda work: we cache all successful fetches, so each run covers some more github URLs before hitting the rate limit. 

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
