### PR TITLE
chore: add `.taplo.toml`

### DIFF
--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,0 +1,4 @@
+include = ["**/Cargo.toml"]
+
+[formatting]
+reorder_keys = true


### PR DESCRIPTION
If you're using taplo (LSP for Toml files), this will make it automatically sort the keys, which is what we want.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
