### PR TITLE
fix(ci): cast `IS_PRERELEASE` to bool using `fromJSON`

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -527,7 +527,7 @@ jobs:
         with:
           files: "bins/**"
           prerelease: ${{ env.IS_PRERELEASE }}
-          body: ${{ env.IS_PRERELEASE && env.PRERELEASE_MESSAGE || '' }}
+          body: ${{ fromJSON(env.IS_PRERELEASE) && env.PRERELEASE_MESSAGE || '' }}
 
       - name: Build DEB package
         if: matrix.platform.build-deb
@@ -564,7 +564,7 @@ jobs:
         with:
           files: "debs/**.deb"
           prerelease: ${{ env.IS_PRERELEASE }}
-          body: ${{ env.IS_PRERELEASE && env.PRERELEASE_MESSAGE || '' }}
+          body: ${{ fromJSON(env.IS_PRERELEASE) && env.PRERELEASE_MESSAGE || '' }}
 
       - name: Upload RPM packages
         if: matrix.platform.build-rpm
@@ -579,7 +579,7 @@ jobs:
         with:
           files: "rpms/**.rpm"
           prerelease: ${{ env.IS_PRERELEASE }}
-          body: ${{ env.IS_PRERELEASE && env.PRERELEASE_MESSAGE || '' }}
+          body: ${{ fromJSON(env.IS_PRERELEASE) && env.PRERELEASE_MESSAGE || '' }}
 
   status:
     name: Status


### PR DESCRIPTION
Fixes https://github.com/fedimint/fedimint/issues/7394

`env: IS_PRERELEASE` evaluates to a string, which is truthy for any non-empty string including `"false"`. This caused the body of a normal release to include the `PRERELEASE_MEASSGE`. We can cast the `"false"` string to a bool using `fromJSON`.

https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#fromjson