### PR TITLE
[releases/v0.7] Update docker deployment

### DIFF
--- a/docker/deploy-fedimintd/.env
+++ b/docker/deploy-fedimintd/.env
@@ -15,4 +15,4 @@ FM_BITCOIN_RPC_URL=http://bitcoin:bitcoin@bitcoin:8332
 # FM_BITCOIN_RPC_URL=https://blockstream.info/api/
 
 # fedimintd image
-FEDIMINTD_IMAGE=fedimint/fedimintd:v0.6.1
+FEDIMINTD_IMAGE=fedimint/fedimintd:v0.7.1

--- a/docker/deploy-fedimintd/docker-compose.yaml
+++ b/docker/deploy-fedimintd/docker-compose.yaml
@@ -65,15 +65,18 @@ services:
     restart: always
     labels:
       - "traefik.enable=true"
-      - "traefik.http.services.fedimintd.loadbalancer.server.port=8174"
-      - "traefik.http.routers.fedimintd.rule=Host(`${FM_DOMAIN}`) && Path(`/ws/`)"
-      - "traefik.http.routers.fedimintd.entrypoints=websecure"
-      - "traefik.http.routers.fedimintd.tls.certresolver=myresolver"
-      # Add UI routes for the built-in guardian dashboard UI
-      - "traefik.http.services.fedimintd-ui.loadbalancer.server.port=8175"
+      # API Service
+      - "traefik.http.routers.fedimintd-api.rule=Host(`${FM_DOMAIN}`) && Path(`/ws/`)"
+      - "traefik.http.routers.fedimintd-api.entrypoints=websecure"
+      - "traefik.http.routers.fedimintd-api.tls.certresolver=myresolver"
+      - "traefik.http.routers.fedimintd-api.service=fedimintd-api"
+      - "traefik.http.services.fedimintd-api.loadbalancer.server.port=8174"
+      # UI Service
       - "traefik.http.routers.fedimintd-ui.rule=Host(`${FM_DOMAIN}`)"
       - "traefik.http.routers.fedimintd-ui.entrypoints=websecure"
       - "traefik.http.routers.fedimintd-ui.tls.certresolver=myresolver"
+      - "traefik.http.routers.fedimintd-ui.service=fedimintd-ui"
+      - "traefik.http.services.fedimintd-ui.loadbalancer.server.port=8175"
     networks:
       fedimint_network:
         ipv4_address: 172.20.0.11


### PR DESCRIPTION
Working towards https://github.com/fedimint/fedimint/issues/7252

As part of the `v0.7.1` release (see: https://github.com/fedimint/fedimint/issues/7369), instead of deploying from `master` I deployed from the `releases/v0.7` branch, which required these changes. Now users will be able to reference the `docker` dir from the `releases/v0.7` branch to get the stable docker deployments.

Once this is merged, I'll open a PR to link to the `docker` dir from the `releases/v0.7` branch from the `master` `README.md`, which will close the issue.