### PR TITLE
chore: bump version to v0.7.2-alpha

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2078,7 +2078,7 @@ dependencies = [
 
 [[package]]
 name = "devimint"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "axum 0.8.1",
@@ -2514,7 +2514,7 @@ checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
 name = "fedimint-aead"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "argon2",
@@ -2546,7 +2546,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-api-client"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "async-channel 2.3.1",
@@ -2625,7 +2625,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-bip39"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "bip39",
  "fedimint-client",
@@ -2636,7 +2636,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-bitcoind"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2658,14 +2658,14 @@ dependencies = [
 
 [[package]]
 name = "fedimint-build"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "fedimint-cli"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2703,7 +2703,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2731,7 +2731,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client-module"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -2760,7 +2760,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client-wasm"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2784,7 +2784,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-core"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "async-channel 2.3.1",
@@ -2845,7 +2845,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dbtool"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2880,7 +2880,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-derive"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -2890,7 +2890,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-derive-secret"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "bitcoin_hashes 0.14.0",
@@ -2902,11 +2902,11 @@ dependencies = [
 
 [[package]]
 name = "fedimint-docs"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 
 [[package]]
 name = "fedimint-dummy-client"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2926,7 +2926,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dummy-common"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -2936,7 +2936,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dummy-server"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2952,7 +2952,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dummy-tests"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "fedimint-client",
@@ -2973,7 +2973,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-empty-client"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2990,7 +2990,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-empty-common"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -3000,7 +3000,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-empty-server"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3016,7 +3016,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-eventlog"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3033,7 +3033,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-fuzz"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "fedimint-core",
  "fedimint-ln-common",
@@ -3046,7 +3046,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-client"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "bcrypt",
@@ -3070,7 +3070,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-common"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "bitcoin",
  "clap",
@@ -3087,7 +3087,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-server"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3156,7 +3156,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-server-db"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -3183,7 +3183,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gw-client"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3210,7 +3210,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gwv2-client"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3237,14 +3237,14 @@ dependencies = [
 
 [[package]]
 name = "fedimint-hkdf"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "bitcoin_hashes 0.14.0",
 ]
 
 [[package]]
 name = "fedimint-lightning"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3271,7 +3271,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-client"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3303,7 +3303,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-common"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -3320,7 +3320,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-server"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3346,7 +3346,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-tests"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3375,7 +3375,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-client"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-common"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3423,7 +3423,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-server"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3448,7 +3448,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-tests"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3475,7 +3475,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-load-test-tool"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "clap",
@@ -3502,7 +3502,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-logging"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "console-subscriber",
@@ -3514,7 +3514,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-client"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3535,7 +3535,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-common"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -3549,7 +3549,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-server"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3568,7 +3568,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-tests"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "clap",
@@ -3582,7 +3582,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-metrics"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "axum 0.8.1",
@@ -3594,7 +3594,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-client"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3634,7 +3634,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-common"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "bitcoin_hashes 0.14.0",
@@ -3647,7 +3647,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-server"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3673,7 +3673,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-tests"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "bitcoin_hashes 0.14.0",
@@ -3706,7 +3706,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-portalloc"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "dirs 6.0.0",
@@ -3720,7 +3720,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-recoverytool"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -3743,7 +3743,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-recurringd"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "axum 0.8.1",
@@ -3768,7 +3768,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-rocksdb"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3784,7 +3784,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "async-channel 2.3.1",
@@ -3836,7 +3836,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server-core"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3850,7 +3850,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server-tests"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "bitcoin",
  "fedimint-api-client",
@@ -3870,7 +3870,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server-ui"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3892,7 +3892,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-tbs"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "bls12_381",
  "criterion",
@@ -3907,7 +3907,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-testing"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3940,7 +3940,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-testing-core"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "fedimint-client",
@@ -4052,7 +4052,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-tpe"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "bitcoin_hashes 0.14.0",
  "bls12_381",
@@ -4066,7 +4066,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-unknown-common"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -4076,7 +4076,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-unknown-server"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4090,7 +4090,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-client"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -4119,7 +4119,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-common"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -4135,7 +4135,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-server"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4165,7 +4165,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-tests"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4197,7 +4197,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wasm-tests"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "fedimint-api-client",
@@ -4217,7 +4217,7 @@ dependencies = [
 
 [[package]]
 name = "fedimintd"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -4542,7 +4542,7 @@ dependencies = [
 
 [[package]]
 name = "gateway-tests"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "clap",
@@ -6359,7 +6359,7 @@ dependencies = [
 
 [[package]]
 name = "lnurlp"
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.7.1-beta.0"
+version = "0.7.2-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2024"
 description = "Fedimint is a Federated Chaumian E-Cash Mint, natively compatible with Bitcoin & the Lightning Network"
@@ -124,66 +124,66 @@ bytes = "1.10.1"
 chrono = "0.4.40"
 clap = { version = "4.5.34", features = ["derive", "env"] }
 criterion = "0.5.1"
-devimint = { path = "./devimint", version = "=0.7.1-beta.0" }
+devimint = { path = "./devimint", version = "=0.7.2-alpha" }
 erased-serde = "0.4"
 esplora-client = { version = "0.10.0", default-features = false, features = [
   "async-https-rustls",
 ] }
-fedimintd = { path = "./fedimintd", version = "=0.7.1-beta.0" }
-fedimint-aead = { path = "./crypto/aead", version = "=0.7.1-beta.0" }
-fedimint-api-client = { path = "./fedimint-api-client", version = "=0.7.1-beta.0" }
-fedimint-bip39 = { path = "./fedimint-bip39", version = "=0.7.1-beta.0" }
-fedimint-bitcoind = { path = "./fedimint-bitcoind", version = "=0.7.1-beta.0" }
-fedimint-build = { path = "./fedimint-build", version = "=0.7.1-beta.0" }
-fedimint-client = { path = "./fedimint-client", version = "=0.7.1-beta.0" }
-fedimint-client-module = { path = "./fedimint-client-module", version = "=0.7.1-beta.0" }
-fedimint-core = { path = "./fedimint-core", version = "=0.7.1-beta.0" }
-fedimint-derive = { path = "./fedimint-derive", version = "=0.7.1-beta.0" }
-fedimint-derive-secret = { path = "./crypto/derive-secret", version = "=0.7.1-beta.0" }
-fedimint-dummy-client = { path = "./modules/fedimint-dummy-client", version = "=0.7.1-beta.0" }
-fedimint-dummy-common = { path = "./modules/fedimint-dummy-common", version = "=0.7.1-beta.0" }
-fedimint-dummy-server = { path = "./modules/fedimint-dummy-server", version = "=0.7.1-beta.0" }
-fedimint-empty-common = { path = "./modules/fedimint-empty-common", version = "=0.7.1-beta.0" }
-fedimint-eventlog = { path = "./fedimint-eventlog", version = "=0.7.1-beta.0" }
-fedimint-gateway-common = { package = "fedimint-gateway-common", path = "./gateway/fedimint-gateway-common", version = "=0.7.1-beta.0" }
-fedimint-gateway-server = { package = "fedimint-gateway-server", path = "./gateway/fedimint-gateway-server", version = "=0.7.1-beta.0" }
-fedimint-gateway-server-db = { package = "fedimint-gateway-server-db", path = "./gateway/fedimint-gateway-server-db", version = "=0.7.1-beta.0" }
-fedimint-gw-client = { path = "./modules/fedimint-gw-client", version = "=0.7.1-beta.0" }
-fedimint-gwv2-client = { path = "./modules/fedimint-gwv2-client", version = "=0.7.1-beta.0" }
-fedimint-lightning = { package = "fedimint-lightning", path = "./gateway/fedimint-lightning", version = "=0.7.1-beta.0" }
-fedimint-lnv2-client = { path = "./modules/fedimint-lnv2-client", version = "=0.7.1-beta.0" }
-fedimint-lnv2-common = { path = "./modules/fedimint-lnv2-common", version = "=0.7.1-beta.0" }
-fedimint-lnv2-server = { path = "./modules/fedimint-lnv2-server", version = "=0.7.1-beta.0" }
-fedimint-ln-client = { path = "./modules/fedimint-ln-client", version = "=0.7.1-beta.0" }
-fedimint-ln-common = { path = "./modules/fedimint-ln-common", version = "=0.7.1-beta.0" }
-fedimint-ln-server = { path = "./modules/fedimint-ln-server", version = "=0.7.1-beta.0" }
-fedimint-logging = { path = "./fedimint-logging", version = "=0.7.1-beta.0" }
-fedimint-meta-client = { path = "./modules/fedimint-meta-client", version = "=0.7.1-beta.0" }
-fedimint-meta-common = { path = "./modules/fedimint-meta-common", version = "=0.7.1-beta.0" }
-fedimint-meta-server = { path = "./modules/fedimint-meta-server", version = "=0.7.1-beta.0" }
-fedimint-metrics = { path = "./fedimint-metrics", version = "=0.7.1-beta.0" }
-fedimint-mint-client = { path = "./modules/fedimint-mint-client", version = "=0.7.1-beta.0" }
-fedimint-mint-common = { path = "./modules/fedimint-mint-common", version = "=0.7.1-beta.0" }
-fedimint-mint-server = { path = "./modules/fedimint-mint-server", version = "=0.7.1-beta.0" }
-fedimint-portalloc = { path = "utils/portalloc", version = "=0.7.1-beta.0" }
-fedimint-rocksdb = { path = "./fedimint-rocksdb", version = "=0.7.1-beta.0" }
-fedimint-server = { path = "./fedimint-server", version = "=0.7.1-beta.0" }
-fedimint-server-core = { path = "./fedimint-server-core", version = "=0.7.1-beta.0" }
-fedimint-server-ui = { path = "./fedimint-server-ui", version = "=0.7.1-beta.0" }
-fedimint-testing = { path = "./fedimint-testing", version = "=0.7.1-beta.0" }
-fedimint-testing-core = { path = "./fedimint-testing-core", version = "=0.7.1-beta.0" }
-fedimint-unknown-common = { path = "./modules/fedimint-unknown-common", version = "=0.7.1-beta.0" }
-fedimint-unknown-server = { path = "./modules/fedimint-unknown-server", version = "=0.7.1-beta.0" }
-fedimint-wallet-client = { path = "./modules/fedimint-wallet-client", version = "=0.7.1-beta.0" }
-fedimint-wallet-common = { path = "./modules/fedimint-wallet-common", version = "=0.7.1-beta.0" }
-fedimint-wallet-server = { path = "./modules/fedimint-wallet-server", version = "=0.7.1-beta.0" }
+fedimintd = { path = "./fedimintd", version = "=0.7.2-alpha" }
+fedimint-aead = { path = "./crypto/aead", version = "=0.7.2-alpha" }
+fedimint-api-client = { path = "./fedimint-api-client", version = "=0.7.2-alpha" }
+fedimint-bip39 = { path = "./fedimint-bip39", version = "=0.7.2-alpha" }
+fedimint-bitcoind = { path = "./fedimint-bitcoind", version = "=0.7.2-alpha" }
+fedimint-build = { path = "./fedimint-build", version = "=0.7.2-alpha" }
+fedimint-client = { path = "./fedimint-client", version = "=0.7.2-alpha" }
+fedimint-client-module = { path = "./fedimint-client-module", version = "=0.7.2-alpha" }
+fedimint-core = { path = "./fedimint-core", version = "=0.7.2-alpha" }
+fedimint-derive = { path = "./fedimint-derive", version = "=0.7.2-alpha" }
+fedimint-derive-secret = { path = "./crypto/derive-secret", version = "=0.7.2-alpha" }
+fedimint-dummy-client = { path = "./modules/fedimint-dummy-client", version = "=0.7.2-alpha" }
+fedimint-dummy-common = { path = "./modules/fedimint-dummy-common", version = "=0.7.2-alpha" }
+fedimint-dummy-server = { path = "./modules/fedimint-dummy-server", version = "=0.7.2-alpha" }
+fedimint-empty-common = { path = "./modules/fedimint-empty-common", version = "=0.7.2-alpha" }
+fedimint-eventlog = { path = "./fedimint-eventlog", version = "=0.7.2-alpha" }
+fedimint-gateway-common = { package = "fedimint-gateway-common", path = "./gateway/fedimint-gateway-common", version = "=0.7.2-alpha" }
+fedimint-gateway-server = { package = "fedimint-gateway-server", path = "./gateway/fedimint-gateway-server", version = "=0.7.2-alpha" }
+fedimint-gateway-server-db = { package = "fedimint-gateway-server-db", path = "./gateway/fedimint-gateway-server-db", version = "=0.7.2-alpha" }
+fedimint-gw-client = { path = "./modules/fedimint-gw-client", version = "=0.7.2-alpha" }
+fedimint-gwv2-client = { path = "./modules/fedimint-gwv2-client", version = "=0.7.2-alpha" }
+fedimint-lightning = { package = "fedimint-lightning", path = "./gateway/fedimint-lightning", version = "=0.7.2-alpha" }
+fedimint-lnv2-client = { path = "./modules/fedimint-lnv2-client", version = "=0.7.2-alpha" }
+fedimint-lnv2-common = { path = "./modules/fedimint-lnv2-common", version = "=0.7.2-alpha" }
+fedimint-lnv2-server = { path = "./modules/fedimint-lnv2-server", version = "=0.7.2-alpha" }
+fedimint-ln-client = { path = "./modules/fedimint-ln-client", version = "=0.7.2-alpha" }
+fedimint-ln-common = { path = "./modules/fedimint-ln-common", version = "=0.7.2-alpha" }
+fedimint-ln-server = { path = "./modules/fedimint-ln-server", version = "=0.7.2-alpha" }
+fedimint-logging = { path = "./fedimint-logging", version = "=0.7.2-alpha" }
+fedimint-meta-client = { path = "./modules/fedimint-meta-client", version = "=0.7.2-alpha" }
+fedimint-meta-common = { path = "./modules/fedimint-meta-common", version = "=0.7.2-alpha" }
+fedimint-meta-server = { path = "./modules/fedimint-meta-server", version = "=0.7.2-alpha" }
+fedimint-metrics = { path = "./fedimint-metrics", version = "=0.7.2-alpha" }
+fedimint-mint-client = { path = "./modules/fedimint-mint-client", version = "=0.7.2-alpha" }
+fedimint-mint-common = { path = "./modules/fedimint-mint-common", version = "=0.7.2-alpha" }
+fedimint-mint-server = { path = "./modules/fedimint-mint-server", version = "=0.7.2-alpha" }
+fedimint-portalloc = { path = "utils/portalloc", version = "=0.7.2-alpha" }
+fedimint-rocksdb = { path = "./fedimint-rocksdb", version = "=0.7.2-alpha" }
+fedimint-server = { path = "./fedimint-server", version = "=0.7.2-alpha" }
+fedimint-server-core = { path = "./fedimint-server-core", version = "=0.7.2-alpha" }
+fedimint-server-ui = { path = "./fedimint-server-ui", version = "=0.7.2-alpha" }
+fedimint-testing = { path = "./fedimint-testing", version = "=0.7.2-alpha" }
+fedimint-testing-core = { path = "./fedimint-testing-core", version = "=0.7.2-alpha" }
+fedimint-unknown-common = { path = "./modules/fedimint-unknown-common", version = "=0.7.2-alpha" }
+fedimint-unknown-server = { path = "./modules/fedimint-unknown-server", version = "=0.7.2-alpha" }
+fedimint-wallet-client = { path = "./modules/fedimint-wallet-client", version = "=0.7.2-alpha" }
+fedimint-wallet-common = { path = "./modules/fedimint-wallet-common", version = "=0.7.2-alpha" }
+fedimint-wallet-server = { path = "./modules/fedimint-wallet-server", version = "=0.7.2-alpha" }
 fs-lock = "=0.1.8" # https://github.com/cargo-bins/cargo-binstall/issues/2090
 futures = "0.3.31"
 futures-util = "0.3.30"
 group = "0.13.0"
 hex = "0.4.3"
 hex-conservative = "0.3.0"
-hkdf = { package = "fedimint-hkdf", path = "./crypto/hkdf", version = "=0.7.1-beta.0" }
+hkdf = { package = "fedimint-hkdf", path = "./crypto/hkdf", version = "=0.7.2-alpha" }
 hyper = "1.6"
 iroh = { version = "0.34.0", default-features = false }
 iroh-base = { version = "0.34.0", default-features = false }
@@ -219,7 +219,7 @@ strum = { version = "0.26", features = ["derive"] }
 strum_macros = "0.26"
 subtle = "2.6.1"
 test-log = { version = "0.2", features = ["trace"], default-features = false }
-tbs = { package = "fedimint-tbs", path = "./crypto/tbs", version = "=0.7.1-beta.0" }
+tbs = { package = "fedimint-tbs", path = "./crypto/tbs", version = "=0.7.2-alpha" }
 thiserror = "2.0.12"
 threshold_crypto = { version = "0.2.1", package = "fedimint-threshold-crypto" }
 tokio = "1.44.1"
@@ -230,7 +230,7 @@ tonic_lnd = { version = "0.2.0", package = "fedimint-tonic-lnd", features = [
   "lightningrpc",
   "routerrpc",
 ] }
-tpe = { package = "fedimint-tpe", path = "./crypto/tpe", version = "=0.7.1-beta.0" }
+tpe = { package = "fedimint-tpe", path = "./crypto/tpe", version = "=0.7.2-alpha" }
 tracing = "0.1.41"
 tracing-subscriber = "0.3.19"
 tracing-test = "0.2.5"

--- a/fedimint-cli/Cargo.toml
+++ b/fedimint-cli/Cargo.toml
@@ -31,9 +31,9 @@ bitcoin = { workspace = true }
 clap = { workspace = true }
 clap_complete = "4.5.47"
 fedimint-aead = { workspace = true }
-fedimint-api-client = { path = "../fedimint-api-client", version = "=0.7.1-beta.0" }
+fedimint-api-client = { path = "../fedimint-api-client", version = "=0.7.2-alpha" }
 fedimint-bip39 = { workspace = true }
-fedimint-client = { path = "../fedimint-client", version = "=0.7.1-beta.0" }
+fedimint-client = { path = "../fedimint-client", version = "=0.7.2-alpha" }
 fedimint-core = { workspace = true }
 fedimint-eventlog = { workspace = true }
 fedimint-ln-client = { workspace = true, features = ["cli"] }

--- a/fedimint-client-module/Cargo.toml
+++ b/fedimint-client-module/Cargo.toml
@@ -29,7 +29,7 @@ aquamarine = { workspace = true }
 async-stream = { workspace = true }
 async-trait = { workspace = true }
 bitcoin = { workspace = true }
-fedimint-api-client = { path = "../fedimint-api-client", version = "=0.7.1-beta.0" }
+fedimint-api-client = { path = "../fedimint-api-client", version = "=0.7.2-alpha" }
 fedimint-core = { workspace = true }
 fedimint-derive-secret = { workspace = true }
 fedimint-eventlog = { workspace = true }

--- a/fedimint-testing/Cargo.toml
+++ b/fedimint-testing/Cargo.toml
@@ -31,8 +31,8 @@ fedimint-client = { workspace = true }
 fedimint-client-module = { workspace = true }
 fedimint-core = { workspace = true }
 fedimint-gateway-common = { workspace = true }
-fedimint-gateway-server = { package = "fedimint-gateway-server", path = "../gateway/fedimint-gateway-server", version = "=0.7.1-beta.0" }
-fedimint-lightning = { package = "fedimint-lightning", path = "../gateway/fedimint-lightning", version = "=0.7.1-beta.0" }
+fedimint-gateway-server = { package = "fedimint-gateway-server", path = "../gateway/fedimint-gateway-server", version = "=0.7.2-alpha" }
+fedimint-lightning = { package = "fedimint-lightning", path = "../gateway/fedimint-lightning", version = "=0.7.2-alpha" }
 fedimint-ln-common = { workspace = true }
 fedimint-logging = { workspace = true }
 fedimint-portalloc = { workspace = true }

--- a/gateway/fedimint-gateway-common/Cargo.toml
+++ b/gateway/fedimint-gateway-common/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 [dependencies]
 bitcoin = { workspace = true }
 clap = { workspace = true }
-fedimint-api-client = { path = "../../fedimint-api-client", version = "=0.7.1-beta.0" }
+fedimint-api-client = { path = "../../fedimint-api-client", version = "=0.7.2-alpha" }
 fedimint-core = { workspace = true }
 fedimint-eventlog = { workspace = true }
 fedimint-lnv2-common = { workspace = true }

--- a/gateway/fedimint-gateway-server/Cargo.toml
+++ b/gateway/fedimint-gateway-server/Cargo.toml
@@ -49,7 +49,7 @@ fedimint-gateway-common = { workspace = true }
 fedimint-gateway-server-db = { workspace = true }
 fedimint-gw-client = { workspace = true }
 fedimint-gwv2-client = { workspace = true }
-fedimint-lightning = { path = "../fedimint-lightning", version = "=0.7.1-beta.0" }
+fedimint-lightning = { path = "../fedimint-lightning", version = "=0.7.2-alpha" }
 fedimint-ln-client = { workspace = true }
 fedimint-ln-common = { workspace = true }
 fedimint-lnv2-client = { workspace = true }

--- a/gateway/fedimint-lightning/Cargo.toml
+++ b/gateway/fedimint-lightning/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/lib.rs"
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 bitcoin = { workspace = true }
-fedimint-bip39 = { version = "=0.7.1-beta.0", path = "../../fedimint-bip39" }
+fedimint-bip39 = { version = "=0.7.2-alpha", path = "../../fedimint-bip39" }
 fedimint-bitcoind = { workspace = true }
 fedimint-core = { workspace = true }
 fedimint-gateway-common = { workspace = true }

--- a/modules/fedimint-gw-client/Cargo.toml
+++ b/modules/fedimint-gw-client/Cargo.toml
@@ -26,13 +26,13 @@ async-stream = { workspace = true }
 async-trait = { workspace = true }
 bitcoin = { workspace = true }
 erased-serde = { workspace = true }
-fedimint-api-client = { path = "../../fedimint-api-client", version = "=0.7.1-beta.0" }
+fedimint-api-client = { path = "../../fedimint-api-client", version = "=0.7.2-alpha" }
 fedimint-client = { workspace = true }
 fedimint-client-module = { workspace = true }
 fedimint-core = { workspace = true }
 fedimint-derive-secret = { workspace = true }
 fedimint-eventlog = { workspace = true }
-fedimint-lightning = { path = "../../gateway/fedimint-lightning", version = "=0.7.1-beta.0" }
+fedimint-lightning = { path = "../../gateway/fedimint-lightning", version = "=0.7.2-alpha" }
 fedimint-ln-client = { workspace = true }
 fedimint-ln-common = { workspace = true }
 futures = { workspace = true }

--- a/modules/fedimint-wallet-client/Cargo.toml
+++ b/modules/fedimint-wallet-client/Cargo.toml
@@ -47,6 +47,6 @@ tracing = { workspace = true }
 fedimint-bitcoind = { workspace = true }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
-fedimint-bitcoind = { version = "=0.7.1-beta.0", path = "../../fedimint-bitcoind", default-features = false, features = [
+fedimint-bitcoind = { version = "=0.7.2-alpha", path = "../../fedimint-bitcoind", default-features = false, features = [
   "esplora-client",
 ] }


### PR DESCRIPTION
We released `v0.7.1` (see: https://github.com/fedimint/fedimint/issues/7369), so we can now bump to `v0.7.2-alpha`.