### PR TITLE
chore(ci): add annotations for multi arch images in docker manifest

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -371,6 +371,8 @@ jobs:
           # Get all unique container names from the matrix
           containers=$(echo '${{ needs.containers.outputs.matrix }}' | jq -r '.[].container.name' | sort -u)
 
+          # Reference the following blog post for multi arch images with nix and docker manifest
+          # https://tech.aufomm.com/how-to-build-multi-arch-docker-image-on-nixos/?utm_source=chatgpt.com#Tag-multi-arch
           for container in $containers; do
             image="fedimint/$container"
             if [ "$GITHUB_REF" = "refs/heads/master" ]; then
@@ -378,18 +380,24 @@ jobs:
               docker manifest create "$image:master" \
                 "$image:master-x86_64-linux" \
                 "$image:master-aarch64-linux"
+              docker manifest annotate "$image:master" "$image:master-x86_64-linux" --arch amd64
+              docker manifest annotate "$image:master" "$image:master-aarch64-linux" --arch arm64
               docker manifest push "$image:master"
 
               echo "Creating manifest for $image:${GITHUB_SHA}"
               docker manifest create "$image:${GITHUB_SHA}" \
                 "$image:${GITHUB_SHA}-x86_64-linux" \
                 "$image:${GITHUB_SHA}-aarch64-linux"
+              docker manifest annotate "$image:${GITHUB_SHA}" "$image:${GITHUB_SHA}-x86_64-linux" --arch amd64
+              docker manifest annotate "$image:${GITHUB_SHA}" "$image:${GITHUB_SHA}-aarch64-linux" --arch arm64
               docker manifest push "$image:${GITHUB_SHA}"
             elif [ "$GITHUB_REF_TYPE" = "tag" ]; then
               echo "Creating manifest for $image:${GITHUB_REF_NAME}"
               docker manifest create "$image:${GITHUB_REF_NAME}" \
                 "$image:${GITHUB_REF_NAME}-x86_64-linux" \
                 "$image:${GITHUB_REF_NAME}-aarch64-linux"
+              docker manifest annotate "$image:${GITHUB_REF_NAME}" "$image:${GITHUB_REF_NAME}-x86_64-linux" --arch amd64
+              docker manifest annotate "$image:${GITHUB_REF_NAME}" "$image:${GITHUB_REF_NAME}-aarch64-linux" --arch arm64
               docker manifest push "$image:${GITHUB_REF_NAME}"
             fi
           done


### PR DESCRIPTION
Debugging related to https://github.com/fedimint/fedimint/issues/7371

Referencing this [blog post](https://tech.aufomm.com/how-to-build-multi-arch-docker-image-on-nixos/?utm_source=chatgpt.com#Tag-multi-arch), it looks like we need to add `docker manifest annotate` to unify multi arch images under a single tag.

This is untested since it's tricky to push containers from a PR branch. I think it will be easiest to iterate by merging to `master` and checking that the multi arch images are correctly annotated in Docker Hub.