### PR TITLE
chore: Set `FM_IN_DEVIMINT` for `fedimintd` as well

### DIFF
--- a/devimint/src/vars.rs
+++ b/devimint/src/vars.rs
@@ -243,6 +243,7 @@ impl Global {
 
 declare_vars! {
     Fedimintd = (globals: &Global, federation_name: String, peer_id: PeerId, overrides: &FedimintdPeerOverrides) => {
+        FM_IN_DEVIMINT: String = "1".to_string(); env: FM_IN_DEVIMINT_ENV;
         FM_BIND_P2P: String = format!("127.0.0.1:{}", overrides.p2p.port()); env: "FM_BIND_P2P";
         FM_BIND_API_WS: String = format!("127.0.0.1:{}", overrides.api.port()); env: "FM_BIND_API_WS";
         FM_BIND_API_IROH: String = format!("127.0.0.1:{}", overrides.api.port()); env: "FM_BIND_API_IROH";


### PR DESCRIPTION
This flag is one of the things triggering debug-only behavior inside Fedimint.

Seems like it might not be set currently for `fedimintd` which in certain situation might lead to prod-like settings in tests.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
