### PR TITLE
fix(logging): ANSI escape sequences don't belong in files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3456,6 +3456,7 @@ version = "0.8.0-alpha"
 dependencies = [
  "anyhow",
  "console-subscriber",
+ "is-terminal",
  "opentelemetry 0.27.1",
  "opentelemetry-jaeger",
  "tracing-opentelemetry",
@@ -4814,6 +4815,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5720,13 +5727,13 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.12"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi 0.5.1",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,28 +79,28 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.0-alpha"
 authors = ["The Fedimint Developers"]
-edition = "2024"
 description = "Fedimint is a Federated Chaumian E-Cash Mint, natively compatible with Bitcoin & the Lightning Network"
 documentation = "https://github.com/fedimint/fedimint/tree/master/docs"
-readme = "README.md"
+edition = "2024"
 homepage = "https://fedimint.org"
-repository = "https://github.com/fedimint/fedimint"
-license = "MIT"
 keywords = ["bitcoin", "lightning", "chaumian", "e-cash", "federated"]
+license = "MIT"
+readme = "README.md"
+repository = "https://github.com/fedimint/fedimint"
+version = "0.8.0-alpha"
 
 [workspace.metadata]
-name = "fedimint"
 authors = ["The Fedimint Developers"]
-edition = "2024"
 description = "Fedimint is a Federated Chaumian E-Cash Mint, natively compatible with Bitcoin & the Lightning Network"
 documentation = "https://github.com/fedimint/fedimint/tree/master/docs"
-readme = "README.md"
+edition = "2024"
 homepage = "https://fedimint.org"
-repository = "https://github.com/fedimint/fedimint"
-license-file = "LICENSE"
 keywords = ["bitcoin", "lightning", "chaumian", "e-cash", "federated"]
+license-file = "LICENSE"
+name = "fedimint"
+readme = "README.md"
+repository = "https://github.com/fedimint/fedimint"
 
 [workspace.metadata.crane]
 name = "fedimint"
@@ -127,46 +127,48 @@ bcrypt = "0.16.0"
 bech32 = "0.11.0"
 bincode = "1.3.3"
 bip39 = "2.1.0"
-bitcoincore-rpc = "0.19.0"
-bitcoin_hashes = "0.14.0"
+bitcoin = { version = "0.32.5", features = ["serde"] }
 bitcoin-io = "0.1.2"
 bitcoin-units = "0.1.2"
-bitcoin = { version = "0.32.5", features = ["serde"] }
+bitcoin_hashes = "0.14.0"
+bitcoincore-rpc = "0.19.0"
 bitvec = "1.0.1"
 bls12_381 = "0.8.0"
 bon = "3.6.3"
 bytes = "1.10.1"
 chrono = "0.4.41"
-clap_complete = "4.5.48"
 clap = { version = "4.5.37", features = ["derive", "env"] }
+clap_complete = "4.5.48"
 console-subscriber = "0.4.1"
 criterion = "0.5.1"
+is-terminal = "0.4.16"
 # We need to pin this arti's `curve25519-dalek` dependency, due to `https://rustsec.org/advisories/RUSTSEC-2024-0344` vulnerability
 # It's been updated by https://gitlab.torproject.org/tpo/core/arti/-/merge_requests/2211, should be removed in next release.
 curve25519-dalek = ">=4.1.3"
 devimint = { path = "./devimint", version = "=0.8.0-alpha" }
 dirs = "6.0.0"
 erased-serde = "0.4"
-esplora-client = { version = "0.10.0", default-features = false, features = ["async-https-rustls"] }
+esplora-client = { version = "0.10.0", default-features = false, features = [
+  "async-https-rustls",
+] }
 fedimint-aead = { path = "./crypto/aead", version = "=0.8.0-alpha" }
 fedimint-api-client = { path = "./fedimint-api-client", version = "=0.8.0-alpha" }
 fedimint-bip39 = { path = "./fedimint-bip39", version = "=0.8.0-alpha" }
 fedimint-bitcoind = { path = "./fedimint-bitcoind", version = "=0.8.0-alpha" }
 fedimint-build = { path = "./fedimint-build", version = "=0.8.0-alpha" }
-fedimint-client-module = { path = "./fedimint-client-module", version = "=0.8.0-alpha" }
 fedimint-client = { path = "./fedimint-client", version = "=0.8.0-alpha" }
+fedimint-client-module = { path = "./fedimint-client-module", version = "=0.8.0-alpha" }
 fedimint-core = { path = "./fedimint-core", version = "=0.8.0-alpha" }
 fedimint-derive = { path = "./fedimint-derive", version = "=0.8.0-alpha" }
 fedimint-derive-secret = { path = "./crypto/derive-secret", version = "=0.8.0-alpha" }
-fedimintd = { path = "./fedimintd", version = "=0.8.0-alpha" }
 fedimint-dummy-client = { path = "./modules/fedimint-dummy-client", version = "=0.8.0-alpha" }
 fedimint-dummy-common = { path = "./modules/fedimint-dummy-common", version = "=0.8.0-alpha" }
 fedimint-dummy-server = { path = "./modules/fedimint-dummy-server", version = "=0.8.0-alpha" }
 fedimint-empty-common = { path = "./modules/fedimint-empty-common", version = "=0.8.0-alpha" }
 fedimint-eventlog = { path = "./fedimint-eventlog", version = "=0.8.0-alpha" }
 fedimint-gateway-common = { package = "fedimint-gateway-common", path = "./gateway/fedimint-gateway-common", version = "=0.8.0-alpha" }
-fedimint-gateway-server-db = { package = "fedimint-gateway-server-db", path = "./gateway/fedimint-gateway-server-db", version = "=0.8.0-alpha" }
 fedimint-gateway-server = { package = "fedimint-gateway-server", path = "./gateway/fedimint-gateway-server", version = "=0.8.0-alpha" }
+fedimint-gateway-server-db = { package = "fedimint-gateway-server-db", path = "./gateway/fedimint-gateway-server-db", version = "=0.8.0-alpha" }
 fedimint-gw-client = { path = "./modules/fedimint-gw-client", version = "=0.8.0-alpha" }
 fedimint-gwv2-client = { path = "./modules/fedimint-gwv2-client", version = "=0.8.0-alpha" }
 fedimint-lightning = { package = "fedimint-lightning", path = "./gateway/fedimint-lightning", version = "=0.8.0-alpha" }
@@ -186,20 +188,21 @@ fedimint-mint-common = { path = "./modules/fedimint-mint-common", version = "=0.
 fedimint-mint-server = { path = "./modules/fedimint-mint-server", version = "=0.8.0-alpha" }
 fedimint-portalloc = { path = "utils/portalloc", version = "=0.8.0-alpha" }
 fedimint-rocksdb = { path = "./fedimint-rocksdb", version = "=0.8.0-alpha" }
+fedimint-server = { path = "./fedimint-server", version = "=0.8.0-alpha" }
 fedimint-server-bitcoin-rpc = { path = "./fedimint-server-bitcoin-rpc", version = "=0.8.0-alpha" }
 fedimint-server-core = { path = "./fedimint-server-core", version = "=0.8.0-alpha" }
-fedimint-server = { path = "./fedimint-server", version = "=0.8.0-alpha" }
 fedimint-server-ui = { path = "./fedimint-server-ui", version = "=0.8.0-alpha" }
-fedimint-testing-core = { path = "./fedimint-testing-core", version = "=0.8.0-alpha" }
 fedimint-testing = { path = "./fedimint-testing", version = "=0.8.0-alpha" }
+fedimint-testing-core = { path = "./fedimint-testing-core", version = "=0.8.0-alpha" }
 fedimint-unknown-common = { path = "./modules/fedimint-unknown-common", version = "=0.8.0-alpha" }
 fedimint-unknown-server = { path = "./modules/fedimint-unknown-server", version = "=0.8.0-alpha" }
 fedimint-wallet-client = { path = "./modules/fedimint-wallet-client", version = "=0.8.0-alpha" }
 fedimint-wallet-common = { path = "./modules/fedimint-wallet-common", version = "=0.8.0-alpha" }
 fedimint-wallet-server = { path = "./modules/fedimint-wallet-server", version = "=0.8.0-alpha" }
+fedimintd = { path = "./fedimintd", version = "=0.8.0-alpha" }
 ff = "0.13.1"
-fs2 = "0.4.3"
 fs-lock = "=0.1.8" # https://github.com/cargo-bins/cargo-binstall/issues/2090
+fs2 = "0.4.3"
 futures = "0.3.31"
 futures-util = "0.3.30"
 getrandom = "0.2.15"
@@ -213,17 +216,17 @@ honggfuzz = { version = "=0.5.55", default-features = false } # needs to be pinn
 hyper = "1.6"
 imbl = "5.0.0"
 impl-tools = "0.10.3"
-iroh-base = { version = "0.34.1", default-features = false }
 iroh = { version = "0.34.1", default-features = false }
+iroh-base = { version = "0.34.1", default-features = false }
 itertools = "0.13.0"
 jaq-core = "2.1.1"
 jaq-json = { version = "1.1.1", features = ["serde_json"] }
+js-sys = "0.3.69"
 jsonrpsee = "0.24.9"
 jsonrpsee-core = "0.24.9"
 jsonrpsee-types = "0.24.8"
 jsonrpsee-wasm-client = "0.24.9"
 jsonrpsee-ws-client = { version = "0.24.9", default-features = false }
-js-sys = "0.3.69"
 ldk-node = "0.4.3"
 lightning = "0.0.125"
 lightning-invoice = { version = "0.32.0", features = ["std"] }
@@ -261,15 +264,15 @@ rustls-pki-types = { version = "1.11.0" }
 scopeguard = "1.2.0"
 secp256k1 = { version = "0.29.0", default-features = false }
 semver = "1.0.26"
+serde = { version = "1.0.219", features = ["derive"] }
 serde-big-array = "0.5.1"
-serdect = "0.2.0"
 serde_json = "1.0.140"
 serde_millis = "0.1.1"
-serde = { version = "1.0.219", features = ["derive"] }
+serdect = "0.2.0"
 sha3 = "0.10.8"
 slotmap = "1.0.7"
-strum_macros = "0.26"
 strum = { version = "0.26", features = ["derive"] }
+strum_macros = "0.26"
 substring = "1.4.5"
 subtle = "2.6.1"
 syn = "2.0"
@@ -291,8 +294,8 @@ tonic_lnd = { version = "0.2.0", package = "fedimint-tonic-lnd", features = [
   "lightningrpc",
   "routerrpc",
 ] }
-tower-http = "0.6.2"
 tower = { version = "0.4.13", default-features = false }
+tower-http = "0.6.2"
 tpe = { package = "fedimint-tpe", path = "./crypto/tpe", version = "=0.8.0-alpha" }
 tracing = "0.1.41"
 tracing-opentelemetry = "0.24.0"
@@ -302,8 +305,8 @@ url = "2.5.4"
 wasm-bindgen = "=0.2.100" # must match the nix provided wasm-bindgen-cli version
 wasm-bindgen-futures = "0.4.42"
 wasm-bindgen-test = "0.3.43"
-webpki-roots = "0.26.10"
 web-sys = "0.3.77"
+webpki-roots = "0.26.10"
 z32 = "1"
 
 [workspace.lints.clippy]
@@ -331,16 +334,16 @@ fedimint-threshold-crypto = { opt-level = 3 }
 ff = { opt-level = 3 }
 group = { opt-level = 3 }
 hashbrown = { opt-level = 3 }
-tikv-jemalloc-sys = { opt-level = 3 }
 libc = { opt-level = 3 }
 memchr = { opt-level = 3 }
 pairing = { opt-level = 3 }
-ppv-lite86 = { opt-level = 3 }
 parity-scale-codec = { opt-level = 3 }
+ppv-lite86 = { opt-level = 3 }
+rand = { opt-level = 3 }
 rand_chacha = { opt-level = 3 }
 rand_core = { opt-level = 3 }
-rand = { opt-level = 3 }
 ring = { opt-level = 3 }
+tikv-jemalloc-sys = { opt-level = 3 }
 # due to some miscompilation(?) this seems actually neccessary,
 # otherwise we see segfaults in Nix sandbox
 librocksdb-sys = { opt-level = 3 }
@@ -355,15 +358,15 @@ zeroize = { opt-level = 3 }
 opt-level = 1
 
 [profile.ci]
-inherits = "dev"
 debug = "line-tables-only"
 incremental = false
+inherits = "dev"
 
 [profile.ci.build-override]
 debug = false
 opt-level = 1
 
 [profile.release]
+codegen-units = 4
 debug = "line-tables-only"
 lto = "fat"
-codegen-units = 4

--- a/fedimint-logging/Cargo.toml
+++ b/fedimint-logging/Cargo.toml
@@ -1,19 +1,19 @@
 [package]
-name = "fedimint-logging"
-version = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
 description = "contains some utilities for logging and tracing"
+edition = { workspace = true }
 license = { workspace = true }
+name = "fedimint-logging"
 readme = { workspace = true }
 repository = { workspace = true }
+version = { workspace = true }
 
 [features]
 telemetry = [
-    "tracing-opentelemetry",
-    "opentelemetry-jaeger",
-    "console-subscriber",
-    "opentelemetry"
+  "tracing-opentelemetry",
+  "opentelemetry-jaeger",
+  "console-subscriber",
+  "opentelemetry",
 ]
 
 [lib]
@@ -23,6 +23,7 @@ path = "src/lib.rs"
 [dependencies]
 anyhow = { workspace = true }
 console-subscriber = { workspace = true, optional = true }
+is-terminal = { workspace = true }
 opentelemetry = { workspace = true, optional = true }
 opentelemetry-jaeger = { workspace = true, optional = true }
 tracing-opentelemetry = { workspace = true, optional = true }

--- a/fedimint-logging/src/lib.rs
+++ b/fedimint-logging/src/lib.rs
@@ -140,6 +140,7 @@ impl TracingSetup {
         };
 
         let fmt_layer = tracing_subscriber::fmt::layer()
+            .with_ansi(is_terminal::is_terminal(std::io::stderr()))
             .with_thread_names(false) // can be enabled for debugging
             .with_writer(fmt_writer)
             .with_filter(filter_layer);


### PR DESCRIPTION
Colors should only be enabled only if a given program is logging to a terminal.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
