### PR TITLE
chore: don't panic in `ClientConnection::connection`

### DIFF
--- a/fedimint-api-client/src/api/mod.rs
+++ b/fedimint-api-client/src/api/mod.rs
@@ -1189,7 +1189,14 @@ impl ClientConnection {
         self.sender
             .send(sender)
             .await
-            .expect("Api connection request channel closed unexpectedly");
+            .inspect_err(|err| {
+                warn!(
+                    target: LOG_CLIENT_NET_API,
+                    err = %err.fmt_compact(),
+                    "Api connection request channel closed unexpectedly"
+                );
+            })
+            .ok()?;
 
         receiver.await.ok()
     }


### PR DESCRIPTION
If the other side panicked or is shutting down, it does us no good to pile up more panic messages on top.

Instead, `warn!` and return `None` upwards, denoting not being able to connect.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
