### PR TITLE
chore: make jemalloc a feature flag

### DIFF
--- a/fedimint-cli/Cargo.toml
+++ b/fedimint-cli/Cargo.toml
@@ -13,7 +13,8 @@ description = "Fedimint client CLI interface"
 rustc-args = ["--cfg", "tokio_unstable"]
 
 [features]
-default = ["tor"]
+default = ["tor", "jemalloc"]
+jemalloc = ["fedimint-rocksdb/jemalloc", "dep:tikv-jemallocator"]
 tor = ["fedimint-client/tor", "fedimint-api-client/tor"]
 
 [[bin]]
@@ -52,6 +53,7 @@ rand = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+tikv-jemallocator = { workspace = true, optional = true }
 time = { workspace = true, features = ["formatting"] }
 tokio = { workspace = true, features = ["full", "tracing"] }
 tracing = { workspace = true }
@@ -61,6 +63,3 @@ fedimint-build = { workspace = true }
 
 [lints]
 workspace = true
-
-[target.'cfg(not(any(target_env = "msvc", target_os = "ios", target_os = "android")))'.dependencies]
-tikv-jemallocator = { workspace = true }

--- a/fedimint-cli/src/main.rs
+++ b/fedimint-cli/src/main.rs
@@ -1,12 +1,10 @@
 use fedimint_cli::FedimintCli;
 use fedimint_core::fedimint_build_code_version_env;
-#[cfg(not(any(target_env = "msvc", target_os = "ios", target_os = "android")))]
-use tikv_jemallocator::Jemalloc;
 
-#[cfg(not(any(target_env = "msvc", target_os = "ios", target_os = "android")))]
+#[cfg(feature = "jemalloc")]
 #[global_allocator]
 // rocksdb suffers from memory fragmentation when using standard allocator
-static GLOBAL: Jemalloc = Jemalloc;
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/fedimint-rocksdb/Cargo.toml
+++ b/fedimint-rocksdb/Cargo.toml
@@ -15,6 +15,10 @@ rustc-args = ["--cfg", "tokio_unstable"]
 name = "fedimint_rocksdb"
 path = "src/lib.rs"
 
+[features]
+default = []
+jemalloc = ["rocksdb/jemalloc"]
+
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/fedimintd/Cargo.toml
+++ b/fedimintd/Cargo.toml
@@ -20,6 +20,10 @@ path = "src/bin/main.rs"
 name = "fedimintd"
 path = "src/lib.rs"
 
+[features]
+default = ["jemalloc"]
+jemalloc = ["fedimint-rocksdb/jemalloc", "dep:tikv-jemallocator"]
+
 [dependencies]
 anyhow = { workspace = true }
 bitcoin = { workspace = true }
@@ -46,12 +50,10 @@ futures = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+tikv-jemallocator = { workspace = true, optional = true }
 
 [build-dependencies]
 fedimint-build = { workspace = true }
 
 [lints]
 workspace = true
-
-[target.'cfg(not(any(target_env = "msvc", target_os = "ios", target_os = "android")))'.dependencies]
-tikv-jemallocator = { workspace = true }

--- a/fedimintd/src/bin/main.rs
+++ b/fedimintd/src/bin/main.rs
@@ -1,11 +1,9 @@
 use fedimint_core::fedimint_build_code_version_env;
-#[cfg(not(any(target_env = "msvc", target_os = "ios", target_os = "android")))]
-use tikv_jemallocator::Jemalloc;
 
-#[cfg(not(any(target_env = "msvc", target_os = "ios", target_os = "android")))]
+#[cfg(feature = "jemalloc")]
 #[global_allocator]
 // rocksdb suffers from memory fragmentation when using standard allocator
-static GLOBAL: Jemalloc = Jemalloc;
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/gateway/fedimint-gateway-server/Cargo.toml
+++ b/gateway/fedimint-gateway-server/Cargo.toml
@@ -9,6 +9,8 @@ readme = { workspace = true }
 repository = { workspace = true }
 
 [features]
+default = ["jemalloc"]
+jemalloc = ["fedimint-rocksdb/jemalloc", "dep:tikv-jemallocator"]
 tor = [
   "fedimint-client/tor",
   "fedimint-api-client/tor",
@@ -71,6 +73,7 @@ serde_json = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
 thiserror = { workspace = true }
+tikv-jemallocator = { workspace = true, optional = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
 tonic = { workspace = true, features = ["transport", "tls"] }
@@ -97,6 +100,3 @@ fedimint-build = { workspace = true }
 
 [lints]
 workspace = true
-
-[target.'cfg(not(any(target_env = "msvc", target_os = "ios", target_os = "android")))'.dependencies]
-tikv-jemallocator = { workspace = true }

--- a/gateway/fedimint-gateway-server/src/bin/gatewayd.rs
+++ b/gateway/fedimint-gateway-server/src/bin/gatewayd.rs
@@ -14,14 +14,12 @@ use fedimint_core::fedimint_build_code_version_env;
 use fedimint_core::util::handle_version_hash_command;
 use fedimint_gateway_server::Gateway;
 use fedimint_logging::{LOG_GATEWAY, TracingSetup};
-#[cfg(not(any(target_env = "msvc", target_os = "ios", target_os = "android")))]
-use tikv_jemallocator::Jemalloc;
 use tracing::info;
 
-#[cfg(not(any(target_env = "msvc", target_os = "ios", target_os = "android")))]
+#[cfg(feature = "jemalloc")]
 #[global_allocator]
 // rocksdb suffers from memory fragmentation when using standard allocator
-static GLOBAL: Jemalloc = Jemalloc;
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 fn main() -> Result<(), anyhow::Error> {
     let runtime = Arc::new(tokio::runtime::Runtime::new()?);


### PR DESCRIPTION
all the cfgs are gone, just using features even for binaries now.
nobody should be using the raw fedimintd binary on android/ios anyways.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
