### PR TITLE
[Backport releases/v0.7] chore: don't panic in `ClientConnection::connection`

### DIFF
--- a/fedimint-api-client/src/api/mod.rs
+++ b/fedimint-api-client/src/api/mod.rs
@@ -1060,6 +1060,15 @@ impl IRawFederationApi for ReconnectFederationApi {
         .into()
     }
 
+    #[instrument(
+        target = LOG_NET_API,
+        skip_all,
+        fields(
+            peer_id = %peer_id,
+            method = %method,
+            params = %params.params,
+        )
+    )]
     async fn request_raw(
         &self,
         peer_id: PeerId,

--- a/fedimint-api-client/src/api/mod.rs
+++ b/fedimint-api-client/src/api/mod.rs
@@ -1189,7 +1189,14 @@ impl ClientConnection {
         self.sender
             .send(sender)
             .await
-            .expect("Api connection request channel closed unexpectedly");
+            .inspect_err(|err| {
+                warn!(
+                    target: LOG_CLIENT_NET_API,
+                    err = %err.fmt_compact(),
+                    "Api connection request channel closed unexpectedly"
+                );
+            })
+            .ok()?;
 
         receiver.await.ok()
     }

--- a/fedimint-server/src/consensus/engine.rs
+++ b/fedimint-server/src/consensus/engine.rs
@@ -832,6 +832,7 @@ impl ConsensusEngine {
             }
         };
 
+        let mut backoff = fedimint_core::util::backoff_util::api_networking_backoff();
         loop {
             let result = federation_api
                 .request_with_strategy(
@@ -847,6 +848,8 @@ impl ConsensusEngine {
                     error.report_if_unusual("Requesting Session Outcome");
                 }
             }
+
+            sleep(backoff.next().expect("infinite retries")).await;
         }
     }
 


### PR DESCRIPTION
# Description
Backport of #7419 to `releases/v0.7`.