### PR TITLE
chore(devimint): just kill, don't interrupt

### DIFF
--- a/devimint/src/lib.rs
+++ b/devimint/src/lib.rs
@@ -36,6 +36,7 @@ pub mod external;
 pub mod faucet;
 pub mod federation;
 pub mod gatewayd;
+mod process_reaper;
 pub mod recurringd;
 pub mod recurringdv2;
 pub mod tests;

--- a/devimint/src/process_reaper.rs
+++ b/devimint/src/process_reaper.rs
@@ -1,0 +1,139 @@
+use std::sync::{Condvar, LazyLock, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use nix::sys::signal::{self, Signal};
+use nix::sys::wait::waitpid;
+use nix::unistd::Pid;
+use tokio::process::Child;
+
+/// How long to wait after SIGTERM before escalating to SIGKILL.
+///
+/// Long enough for iroh-quinn to flush its close frames (avoids the
+/// `untracked_bytes <= segment_size` debug assertion in
+/// iroh-quinn-proto 0.13), short enough that test teardown stays snappy.
+const GRACE_PERIOD: Duration = Duration::from_millis(250);
+
+/// Deferred process reaper.
+///
+/// [`kill_process`] sends SIGTERM and enqueues the pid. A dedicated
+/// background thread owns the escalation to SIGKILL after [`GRACE_PERIOD`]
+/// and the subsequent `waitpid`. [`reap_killed_processes`] blocks until
+/// every enqueued pid has been reaped, so ports and file locks are
+/// guaranteed released before we spawn a replacement.
+///
+/// Doing the graceful SIGTERM→wait→SIGKILL dance off the tokio runtime
+/// lets `Drop` stay fully synchronous while still giving peers a chance
+/// to close QUIC connections cleanly.
+struct Reaper {
+    state: Mutex<Vec<PendingKill>>,
+    cv: Condvar,
+}
+
+struct PendingKill {
+    pid: Pid,
+    enqueued_at: Instant,
+}
+
+static REAPER: LazyLock<&'static Reaper> = LazyLock::new(|| {
+    let reaper: &'static Reaper = Box::leak(Box::new(Reaper {
+        state: Mutex::new(Vec::new()),
+        cv: Condvar::new(),
+    }));
+    thread::Builder::new()
+        .name("devimint-reaper".into())
+        .spawn(move || reaper_loop(reaper))
+        .expect("failed to spawn devimint reaper thread");
+    reaper
+});
+
+fn reaper_loop(reaper: &'static Reaper) -> ! {
+    let mut state = reaper.state.lock().expect("reaper lock");
+    loop {
+        if state.is_empty() {
+            state = reaper.cv.wait(state).expect("reaper cv");
+            continue;
+        }
+
+        let now = Instant::now();
+        let next_deadline = state
+            .iter()
+            .map(|e| e.enqueued_at + GRACE_PERIOD)
+            .min()
+            .expect("non-empty checked above");
+
+        if now < next_deadline {
+            let (s, _) = reaper
+                .cv
+                .wait_timeout(state, next_deadline - now)
+                .expect("reaper cv");
+            state = s;
+            continue;
+        }
+
+        // SIGKILL + reap any entries past their grace deadline.
+        // waitpid after SIGKILL returns in microseconds, so holding
+        // the lock across it is fine.
+        //
+        // Errors are ignored on purpose: SIGTERM may have already killed
+        // the process (ESRCH), or tokio's internal pidfd/SIGCHLD machinery
+        // may have raced us to reap (ECHILD). Both outcomes are fine — we
+        // only care that the process is gone and its zombie is cleared.
+        state.retain(|entry| {
+            if entry.enqueued_at + GRACE_PERIOD <= now {
+                let _ = signal::kill(entry.pid, Signal::SIGKILL);
+                let _ = waitpid(entry.pid, None);
+                false
+            } else {
+                true
+            }
+        });
+
+        if state.is_empty() {
+            reaper.cv.notify_all();
+        }
+    }
+}
+
+pub fn kill_process(child: &Child) {
+    let Some(id) = child.id() else {
+        return;
+    };
+    let pid = Pid::from_raw(id as _);
+    // Send SIGTERM now so the grace period starts immediately, without
+    // waiting for the reaper thread to wake up. `kill()` is non-blocking
+    // (the kernel just queues the signal), so this is safe in Drop.
+    let _ = signal::kill(pid, Signal::SIGTERM);
+
+    let reaper = *REAPER;
+    reaper.state.lock().expect("reaper lock").push(PendingKill {
+        pid,
+        enqueued_at: Instant::now(),
+    });
+    reaper.cv.notify_all();
+}
+
+/// Block until the reaper queue is fully drained.
+///
+/// Note: this waits for *all* currently-enqueued kills, not just the
+/// caller's. That's fine in devimint, where process lifecycle is
+/// single-threaded per test — callers don't enqueue concurrently.
+pub fn reap_killed_processes() {
+    let reaper = *REAPER;
+    let wait = || {
+        let mut state = reaper.state.lock().expect("reaper lock");
+        while !state.is_empty() {
+            state = reaper.cv.wait(state).expect("reaper cv");
+        }
+    };
+
+    // Use `block_in_place` only when we're inside a multi-thread tokio
+    // runtime — it panics on `current_thread` runtimes and is pointless
+    // outside any runtime (Drop at program exit, sync tests).
+    match tokio::runtime::Handle::try_current().map(|h| h.runtime_flavor()) {
+        Ok(tokio::runtime::RuntimeFlavor::MultiThread) => {
+            fedimint_core::runtime::block_in_place(wait);
+        }
+        _ => wait(),
+    }
+}

--- a/devimint/src/util.rs
+++ b/devimint/src/util.rs
@@ -16,7 +16,7 @@ use fedimint_core::envs::{
     is_env_var_set,
 };
 use fedimint_core::module::ApiAuth;
-use fedimint_core::task::{self, block_in_place, block_on};
+use fedimint_core::task::{self};
 use fedimint_core::time::now;
 use fedimint_core::util::FmtCompactAnyhow as _;
 use fedimint_core::util::backoff_util::custom_backoff;
@@ -26,7 +26,7 @@ use serde::de::DeserializeOwned;
 use tokio::fs::OpenOptions;
 use tokio::process::Child;
 use tokio::sync::Mutex;
-use tracing::{debug, warn};
+use tracing::debug;
 
 use crate::envs::{
     FM_BACKWARDS_COMPATIBILITY_TEST_ENV, FM_BITCOIN_CLI_BASE_EXECUTABLE_ENV,
@@ -62,20 +62,7 @@ pub fn parse_map(s: &str) -> Result<BTreeMap<String, String>> {
     Ok(map)
 }
 
-fn send_sigterm(child: &Child) {
-    send_signal(child, nix::sys::signal::Signal::SIGTERM);
-}
-
-fn send_sigkill(child: &Child) {
-    send_signal(child, nix::sys::signal::Signal::SIGKILL);
-}
-
-fn send_signal(child: &Child, signal: nix::sys::signal::Signal) {
-    let _ = nix::sys::signal::kill(
-        nix::unistd::Pid::from_raw(child.id().expect("pid should be present") as _),
-        signal,
-    );
-}
+use crate::process_reaper;
 
 /// Kills process when all references to ProcessHandle are dropped.
 ///
@@ -87,7 +74,7 @@ pub struct ProcessHandle(Arc<Mutex<ProcessHandleInner>>);
 impl ProcessHandle {
     pub async fn terminate(&self) -> Result<()> {
         let mut inner = self.0.lock().await;
-        inner.terminate().await?;
+        inner.terminate();
         Ok(())
     }
 
@@ -109,43 +96,28 @@ pub struct ProcessHandleInner {
 }
 
 impl ProcessHandleInner {
-    async fn terminate(&mut self) -> anyhow::Result<()> {
-        if let Some(child) = self.child.as_mut() {
+    /// Signal and wait for the child to be reaped.
+    ///
+    /// Blocks synchronously. This matters for:
+    /// - explicit `terminate().await` callers that `rm -rf` the data dir right
+    ///   after;
+    /// - `Drop` at program exit, so children don't outlive `devimint` and race
+    ///   post-test cleanup in `fm-run-test`.
+    ///
+    /// The wait is a plain `CondVar::wait` in the reaper — we never
+    /// `block_on` an async fn, so we don't reintroduce the panic-unsafe
+    /// executor-stall hazard that motivated this PR.
+    fn terminate(&mut self) {
+        if let Some(child) = self.child.take() {
             debug!(
                 target: LOG_DEVIMINT,
-                name=%self.name,
-                signal="SIGTERM",
-                "sending signal to terminate child process"
+                name = %self.name,
+                "killing child process"
             );
 
-            send_sigterm(child);
-
-            if (fedimint_core::runtime::timeout(Duration::from_secs(2), child.wait()).await)
-                .is_err()
-            {
-                debug!(
-                    target: LOG_DEVIMINT,
-                    name=%self.name,
-                    signal="SIGKILL",
-                    "sending signal to terminate child process"
-                );
-
-                send_sigkill(child);
-
-                match fedimint_core::runtime::timeout(Duration::from_secs(5), child.wait()).await {
-                    Ok(Ok(_)) => {}
-                    Ok(Err(err)) => {
-                        bail!("Failed to terminate child process {}: {}", self.name, err);
-                    }
-                    Err(_) => {
-                        bail!("Failed to terminate child process {}: timeout", self.name);
-                    }
-                }
-            }
+            process_reaper::kill_process(&child);
+            process_reaper::reap_killed_processes();
         }
-        // only drop the child handle if succeeded to terminate
-        self.child.take();
-        Ok(())
     }
 
     async fn await_terminated(&mut self) -> anyhow::Result<()> {
@@ -180,27 +152,7 @@ impl Drop for ProcessHandleInner {
             return;
         }
 
-        if std::thread::panicking() {
-            // Doing block_in_place + block on trickery
-            // breaks down during panics, so let's just
-            // try to kill it and move on
-            if let Some(mut child) = self.child.take() {
-                send_sigterm(&child);
-                let _ = child.try_wait();
-            }
-            return;
-        }
-
-        block_in_place(|| {
-            if let Err(err) = block_on(self.terminate()) {
-                warn!(
-                    target: LOG_DEVIMINT,
-                    name=%self.name,
-                    err = %err.fmt_compact_anyhow(),
-                    "Error terminating process on drop"
-                );
-            }
-        });
+        self.terminate();
     }
 }
 
@@ -216,6 +168,9 @@ impl ProcessManager {
 
     /// Logs to $FM_LOGS_DIR/{name}.{out,err}
     pub async fn spawn_daemon(&self, name: &str, mut cmd: Command) -> Result<ProcessHandle> {
+        // Reap any recently killed processes so their resources
+        // (ports, file locks) are fully released before we bind new ones.
+        process_reaper::reap_killed_processes();
         debug!(target: LOG_DEVIMINT, %name, "Spawning daemon");
         let logs_dir = env::var(FM_LOGS_DIR_ENV)?;
         let path = format!("{logs_dir}/{name}.log");


### PR DESCRIPTION
I've seen this async drop hack going wrong when debugging due to bugs and panics, etc. and after thinking a bit about it - I don't see a reason
to just not send SIGKILL, and be done with it, without waiting for anything. Makes things terminate faster too. However there was a problem
with that - the test suite would actually be flaky. After some debugging, it turned out that this method is too fast, and we might (in some tests) start the process again before it was actually killed. So the solution for that is to wait before starting, not during drop.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
