### PR TITLE
feat: Implemented list_clients method in fedimint client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2670,6 +2670,7 @@ dependencies = [
  "fedimint-derive-secret",
  "fedimint-eventlog",
  "fedimint-logging",
+ "fedimint-rocksdb",
  "futures",
  "reqwest 0.12.9",
  "serde",

--- a/fedimint-client/Cargo.toml
+++ b/fedimint-client/Cargo.toml
@@ -35,6 +35,7 @@ fedimint-core = { workspace = true }
 fedimint-derive-secret = { workspace = true }
 fedimint-eventlog = { workspace = true }
 fedimint-logging = { workspace = true }
+fedimint-rocksdb = { workspace = true }
 futures = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }


### PR DESCRIPTION
ref: [fedimint/fedimint-web-sdk#135](https://github.com/fedimint/fedimint-web-sdk/issues/135)

Implemented list_clients method in fedimint_client to get connected federation ids 

**Context:** Needed while implementing handling multiple federation in web wallet and can check weather the user have already joined any federation or not and respectively redirect to specific page!