### PR TITLE
chore: iroh dns and relay env variables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3769,6 +3769,7 @@ dependencies = [
  "hyper 1.6.0",
  "iroh",
  "iroh-base",
+ "iroh-relay",
  "itertools 0.13.0",
  "jsonrpsee",
  "parity-scale-codec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,28 +79,28 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.0-alpha"
 authors = ["The Fedimint Developers"]
-edition = "2024"
 description = "Fedimint is a Federated Chaumian E-Cash Mint, natively compatible with Bitcoin & the Lightning Network"
 documentation = "https://github.com/fedimint/fedimint/tree/master/docs"
-readme = "README.md"
+edition = "2024"
 homepage = "https://fedimint.org"
-repository = "https://github.com/fedimint/fedimint"
-license = "MIT"
 keywords = ["bitcoin", "lightning", "chaumian", "e-cash", "federated"]
+license = "MIT"
+readme = "README.md"
+repository = "https://github.com/fedimint/fedimint"
+version = "0.8.0-alpha"
 
 [workspace.metadata]
-name = "fedimint"
 authors = ["The Fedimint Developers"]
-edition = "2024"
 description = "Fedimint is a Federated Chaumian E-Cash Mint, natively compatible with Bitcoin & the Lightning Network"
 documentation = "https://github.com/fedimint/fedimint/tree/master/docs"
-readme = "README.md"
+edition = "2024"
 homepage = "https://fedimint.org"
-repository = "https://github.com/fedimint/fedimint"
-license-file = "LICENSE"
 keywords = ["bitcoin", "lightning", "chaumian", "e-cash", "federated"]
+license-file = "LICENSE"
+name = "fedimint"
+readme = "README.md"
+repository = "https://github.com/fedimint/fedimint"
 
 [workspace.metadata.crane]
 name = "fedimint"
@@ -127,18 +127,18 @@ bcrypt = "0.16.0"
 bech32 = "0.11.0"
 bincode = "1.3.3"
 bip39 = "2.1.0"
-bitcoincore-rpc = "0.19.0"
-bitcoin_hashes = "0.14.0"
+bitcoin = { version = "0.32.5", features = ["serde"] }
 bitcoin-io = "0.1.2"
 bitcoin-units = "0.1.2"
-bitcoin = { version = "0.32.5", features = ["serde"] }
+bitcoin_hashes = "0.14.0"
+bitcoincore-rpc = "0.19.0"
 bitvec = "1.0.1"
 bls12_381 = "0.8.0"
 bon = "3.6.3"
 bytes = "1.10.1"
 chrono = "0.4.41"
-clap_complete = "4.5.48"
 clap = { version = "4.5.37", features = ["derive", "env"] }
+clap_complete = "4.5.48"
 console-subscriber = "0.4.1"
 criterion = "0.5.1"
 # We need to pin this arti's `curve25519-dalek` dependency, due to `https://rustsec.org/advisories/RUSTSEC-2024-0344` vulnerability
@@ -147,26 +147,27 @@ curve25519-dalek = ">=4.1.3"
 devimint = { path = "./devimint", version = "=0.8.0-alpha" }
 dirs = "6.0.0"
 erased-serde = "0.4"
-esplora-client = { version = "0.10.0", default-features = false, features = ["async-https-rustls"] }
+esplora-client = { version = "0.10.0", default-features = false, features = [
+  "async-https-rustls",
+] }
 fedimint-aead = { path = "./crypto/aead", version = "=0.8.0-alpha" }
 fedimint-api-client = { path = "./fedimint-api-client", version = "=0.8.0-alpha" }
 fedimint-bip39 = { path = "./fedimint-bip39", version = "=0.8.0-alpha" }
 fedimint-bitcoind = { path = "./fedimint-bitcoind", version = "=0.8.0-alpha" }
 fedimint-build = { path = "./fedimint-build", version = "=0.8.0-alpha" }
-fedimint-client-module = { path = "./fedimint-client-module", version = "=0.8.0-alpha" }
 fedimint-client = { path = "./fedimint-client", version = "=0.8.0-alpha" }
+fedimint-client-module = { path = "./fedimint-client-module", version = "=0.8.0-alpha" }
 fedimint-core = { path = "./fedimint-core", version = "=0.8.0-alpha" }
 fedimint-derive = { path = "./fedimint-derive", version = "=0.8.0-alpha" }
 fedimint-derive-secret = { path = "./crypto/derive-secret", version = "=0.8.0-alpha" }
-fedimintd = { path = "./fedimintd", version = "=0.8.0-alpha" }
 fedimint-dummy-client = { path = "./modules/fedimint-dummy-client", version = "=0.8.0-alpha" }
 fedimint-dummy-common = { path = "./modules/fedimint-dummy-common", version = "=0.8.0-alpha" }
 fedimint-dummy-server = { path = "./modules/fedimint-dummy-server", version = "=0.8.0-alpha" }
 fedimint-empty-common = { path = "./modules/fedimint-empty-common", version = "=0.8.0-alpha" }
 fedimint-eventlog = { path = "./fedimint-eventlog", version = "=0.8.0-alpha" }
 fedimint-gateway-common = { package = "fedimint-gateway-common", path = "./gateway/fedimint-gateway-common", version = "=0.8.0-alpha" }
-fedimint-gateway-server-db = { package = "fedimint-gateway-server-db", path = "./gateway/fedimint-gateway-server-db", version = "=0.8.0-alpha" }
 fedimint-gateway-server = { package = "fedimint-gateway-server", path = "./gateway/fedimint-gateway-server", version = "=0.8.0-alpha" }
+fedimint-gateway-server-db = { package = "fedimint-gateway-server-db", path = "./gateway/fedimint-gateway-server-db", version = "=0.8.0-alpha" }
 fedimint-gw-client = { path = "./modules/fedimint-gw-client", version = "=0.8.0-alpha" }
 fedimint-gwv2-client = { path = "./modules/fedimint-gwv2-client", version = "=0.8.0-alpha" }
 fedimint-lightning = { package = "fedimint-lightning", path = "./gateway/fedimint-lightning", version = "=0.8.0-alpha" }
@@ -186,20 +187,21 @@ fedimint-mint-common = { path = "./modules/fedimint-mint-common", version = "=0.
 fedimint-mint-server = { path = "./modules/fedimint-mint-server", version = "=0.8.0-alpha" }
 fedimint-portalloc = { path = "utils/portalloc", version = "=0.8.0-alpha" }
 fedimint-rocksdb = { path = "./fedimint-rocksdb", version = "=0.8.0-alpha" }
+fedimint-server = { path = "./fedimint-server", version = "=0.8.0-alpha" }
 fedimint-server-bitcoin-rpc = { path = "./fedimint-server-bitcoin-rpc", version = "=0.8.0-alpha" }
 fedimint-server-core = { path = "./fedimint-server-core", version = "=0.8.0-alpha" }
-fedimint-server = { path = "./fedimint-server", version = "=0.8.0-alpha" }
 fedimint-server-ui = { path = "./fedimint-server-ui", version = "=0.8.0-alpha" }
-fedimint-testing-core = { path = "./fedimint-testing-core", version = "=0.8.0-alpha" }
 fedimint-testing = { path = "./fedimint-testing", version = "=0.8.0-alpha" }
+fedimint-testing-core = { path = "./fedimint-testing-core", version = "=0.8.0-alpha" }
 fedimint-unknown-common = { path = "./modules/fedimint-unknown-common", version = "=0.8.0-alpha" }
 fedimint-unknown-server = { path = "./modules/fedimint-unknown-server", version = "=0.8.0-alpha" }
 fedimint-wallet-client = { path = "./modules/fedimint-wallet-client", version = "=0.8.0-alpha" }
 fedimint-wallet-common = { path = "./modules/fedimint-wallet-common", version = "=0.8.0-alpha" }
 fedimint-wallet-server = { path = "./modules/fedimint-wallet-server", version = "=0.8.0-alpha" }
+fedimintd = { path = "./fedimintd", version = "=0.8.0-alpha" }
 ff = "0.13.1"
-fs2 = "0.4.3"
 fs-lock = "=0.1.8" # https://github.com/cargo-bins/cargo-binstall/issues/2090
+fs2 = "0.4.3"
 futures = "0.3.31"
 futures-util = "0.3.30"
 getrandom = "0.2.15"
@@ -213,17 +215,18 @@ honggfuzz = { version = "=0.5.55", default-features = false } # needs to be pinn
 hyper = "1.6"
 imbl = "5.0.0"
 impl-tools = "0.10.3"
-iroh-base = { version = "0.34.1", default-features = false }
 iroh = { version = "0.34.1", default-features = false }
+iroh-base = { version = "0.34.1", default-features = false }
+iroh-relay = { version = "0.34.1", default-features = false }
 itertools = "0.13.0"
 jaq-core = "2.1.1"
 jaq-json = { version = "1.1.1", features = ["serde_json"] }
+js-sys = "0.3.69"
 jsonrpsee = "0.24.9"
 jsonrpsee-core = "0.24.9"
 jsonrpsee-types = "0.24.8"
 jsonrpsee-wasm-client = "0.24.9"
 jsonrpsee-ws-client = { version = "0.24.9", default-features = false }
-js-sys = "0.3.69"
 ldk-node = "0.4.3"
 lightning = "0.0.125"
 lightning-invoice = { version = "0.32.0", features = ["std"] }
@@ -261,15 +264,15 @@ rustls-pki-types = { version = "1.12.0" }
 scopeguard = "1.2.0"
 secp256k1 = { version = "0.29.0", default-features = false }
 semver = "1.0.26"
+serde = { version = "1.0.219", features = ["derive"] }
 serde-big-array = "0.5.1"
-serdect = "0.2.0"
 serde_json = "1.0.140"
 serde_millis = "0.1.1"
-serde = { version = "1.0.219", features = ["derive"] }
+serdect = "0.2.0"
 sha3 = "0.10.8"
 slotmap = "1.0.7"
-strum_macros = "0.26"
 strum = { version = "0.26", features = ["derive"] }
+strum_macros = "0.26"
 substring = "1.4.5"
 subtle = "2.6.1"
 syn = "2.0"
@@ -291,8 +294,8 @@ tonic_lnd = { version = "0.2.0", package = "fedimint-tonic-lnd", features = [
   "lightningrpc",
   "routerrpc",
 ] }
-tower-http = "0.6.2"
 tower = { version = "0.4.13", default-features = false }
+tower-http = "0.6.2"
 tpe = { package = "fedimint-tpe", path = "./crypto/tpe", version = "=0.8.0-alpha" }
 tracing = "0.1.41"
 tracing-opentelemetry = "0.24.0"
@@ -302,8 +305,8 @@ url = "2.5.4"
 wasm-bindgen = "=0.2.100" # must match the nix provided wasm-bindgen-cli version
 wasm-bindgen-futures = "0.4.42"
 wasm-bindgen-test = "0.3.43"
-webpki-roots = "1.0.0"
 web-sys = "0.3.77"
+webpki-roots = "1.0.0"
 z32 = "1"
 
 [workspace.lints.clippy]
@@ -331,16 +334,16 @@ fedimint-threshold-crypto = { opt-level = 3 }
 ff = { opt-level = 3 }
 group = { opt-level = 3 }
 hashbrown = { opt-level = 3 }
-tikv-jemalloc-sys = { opt-level = 3 }
 libc = { opt-level = 3 }
 memchr = { opt-level = 3 }
 pairing = { opt-level = 3 }
-ppv-lite86 = { opt-level = 3 }
 parity-scale-codec = { opt-level = 3 }
+ppv-lite86 = { opt-level = 3 }
+rand = { opt-level = 3 }
 rand_chacha = { opt-level = 3 }
 rand_core = { opt-level = 3 }
-rand = { opt-level = 3 }
 ring = { opt-level = 3 }
+tikv-jemalloc-sys = { opt-level = 3 }
 # due to some miscompilation(?) this seems actually neccessary,
 # otherwise we see segfaults in Nix sandbox
 librocksdb-sys = { opt-level = 3 }
@@ -355,15 +358,15 @@ zeroize = { opt-level = 3 }
 opt-level = 1
 
 [profile.ci]
-inherits = "dev"
 debug = "line-tables-only"
 incremental = false
+inherits = "dev"
 
 [profile.ci.build-override]
 debug = false
 opt-level = 1
 
 [profile.release]
+codegen-units = 4
 debug = "line-tables-only"
 lto = "fat"
-codegen-units = 4

--- a/fedimint-server/Cargo.toml
+++ b/fedimint-server/Cargo.toml
@@ -45,6 +45,7 @@ iroh = { workspace = true, features = [
 iroh-base = { workspace = true, default-features = false, features = [
   "ticket",
 ] }
+iroh-relay = { workspace = true, default-features = false }
 itertools = { workspace = true }
 jsonrpsee = { workspace = true, features = ["server"] }
 parity-scale-codec = { workspace = true }

--- a/fedimint-server/src/config/mod.rs
+++ b/fedimint-server/src/config/mod.rs
@@ -208,6 +208,10 @@ pub struct ConfigGenSettings {
     pub api_url: Option<SafeUrl>,
     /// Enable iroh for networking
     pub enable_iroh: bool,
+    /// Optional URL of the Iroh DNS server
+    pub iroh_dns: Option<SafeUrl>,
+    /// Optional URLs of the Iroh relays to register on
+    pub iroh_relays: Vec<SafeUrl>,
     /// Set the params (if leader) or just the local params (if follower)
     pub modules: ServerModuleConfigGenParamsRegistry,
     /// Registry for config gen

--- a/fedimint-server/src/lib.rs
+++ b/fedimint-server/src/lib.rs
@@ -105,6 +105,8 @@ pub async fn run(
                 IrohConnector::new(
                     cfg.private.iroh_p2p_sk.clone().unwrap(),
                     settings.p2p_bind,
+                    settings.iroh_dns.clone(),
+                    settings.iroh_relays.clone(),
                     cfg.consensus
                         .iroh_endpoints
                         .iter()
@@ -160,6 +162,8 @@ pub async fn run(
         connections,
         p2p_status_receivers,
         settings.api_bind,
+        settings.iroh_dns,
+        settings.iroh_relays,
         cfg,
         db,
         module_init_registry.clone(),
@@ -297,6 +301,8 @@ pub async fn run_config_gen(
         IrohConnector::new(
             cg_params.iroh_p2p_sk.clone().unwrap(),
             settings.p2p_bind,
+            settings.iroh_dns,
+            settings.iroh_relays,
             cg_params
                 .iroh_endpoints()
                 .iter()

--- a/fedimint-testing/src/federation.rs
+++ b/fedimint-testing/src/federation.rs
@@ -295,6 +295,8 @@ impl FederationTestBuilder {
                     connections,
                     p2p_status_receivers,
                     api_bind,
+                    None,
+                    vec![],
                     cfg.clone(),
                     db.clone(),
                     module_init_registry,

--- a/fedimintd/src/lib.rs
+++ b/fedimintd/src/lib.rs
@@ -130,6 +130,18 @@ struct ServerOpts {
     #[arg(long, env = FM_ENABLE_IROH_ENV)]
     enable_iroh: bool,
 
+    /// Optional URL of the Iroh DNS server
+    #[arg(long, env = "FM_IROH_DNS", requires = "enable_iroh")]
+    iroh_dns: Option<SafeUrl>,
+
+    /// Optional URLs of the Iroh relays to use for registering
+    #[arg(long, env = "FM_IROH_RELAY", requires = "enable_iroh")]
+    iroh_relays: Vec<SafeUrl>,
+
+    /// Number of checkpoints from the current session to retain on disk
+    #[arg(long, env = FM_DB_CHECKPOINT_RETENTION_ENV, default_value = "1")]
+    db_checkpoint_retention: u64,
+
     /// Enable tokio console logging
     #[arg(long, env = FM_BIND_TOKIO_CONSOLE_ENV)]
     bind_tokio_console: Option<SocketAddr>,
@@ -141,10 +153,6 @@ struct ServerOpts {
     /// Enable prometheus metrics
     #[arg(long, env = FM_BIND_METRCIS_ENV)]
     bind_metrics: Option<SocketAddr>,
-
-    /// Number of checkpoints from the current session to retain on disk
-    #[arg(long, env = FM_DB_CHECKPOINT_RETENTION_ENV, default_value = "1")]
-    db_checkpoint_retention: u64,
 
     /// Comma separated list of API secrets.
     ///
@@ -241,6 +249,8 @@ pub async fn run(
         p2p_url: server_opts.p2p_url,
         api_url: server_opts.api_url,
         enable_iroh: server_opts.enable_iroh,
+        iroh_dns: server_opts.iroh_dns,
+        iroh_relays: server_opts.iroh_relays,
         modules: server_gen_params.clone(),
         registry: server_gens.clone(),
     };


### PR DESCRIPTION
Allows using custom relay settings in `fedimintd` via command line arguments.

Taken and fixed second commit from #7309 , skipped removing connectivity overrides, as we're going to need them for the tests to work offline.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
