### PR TITLE
chore: add taplo to our dev workflow

### DIFF
--- a/crypto/aead/Cargo.toml
+++ b/crypto/aead/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "fedimint-aead"
-version = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
 description = "aead utilities on top of ring"
+edition = { workspace = true }
 license = { workspace = true }
+name = "fedimint-aead"
 readme = { workspace = true }
 repository = { workspace = true }
+version = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/crypto/derive-secret/Cargo.toml
+++ b/crypto/derive-secret/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "fedimint-derive-secret"
-version = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
 description = "Fedimint derivable secret implementation"
+edition = { workspace = true }
 license = { workspace = true }
+name = "fedimint-derive-secret"
 readme = { workspace = true }
 repository = { workspace = true }
+version = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/crypto/hkdf/Cargo.toml
+++ b/crypto/hkdf/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "fedimint-hkdf"
-version = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
 description = "RFC5869 HKDF implementation on top of bitcoin_hashes"
+edition = { workspace = true }
 license = { workspace = true }
+name = "fedimint-hkdf"
 readme = { workspace = true }
 repository = { workspace = true }
+version = { workspace = true }
 
 [lib]
 name = "hkdf"

--- a/crypto/tbs/Cargo.toml
+++ b/crypto/tbs/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "fedimint-tbs"
-version = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
 description = "tbs is a helper cryptography library for threshold blind signatures"
+edition = { workspace = true }
 license = { workspace = true }
+name = "fedimint-tbs"
 readme = { workspace = true }
 repository = { workspace = true }
+version = { workspace = true }
 
 [features]
 default = []
@@ -17,9 +17,9 @@ name = "tbs"
 path = "src/lib.rs"
 
 [[bench]]
+harness = false
 name = "tbs"
 path = "benches/tbs.rs"
-harness = false
 
 [dependencies]
 bls12_381 = { workspace = true }

--- a/crypto/tpe/Cargo.toml
+++ b/crypto/tpe/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
+authors = { workspace = true }
+description = "tpe is a helper cryptography library for threshold point encryption"
+edition = { workspace = true }
+license = { workspace = true }
 name = "fedimint-tpe"
 version = { workspace = true }
-authors = { workspace = true }
-edition = { workspace = true }
-description = "tpe is a helper cryptography library for threshold point encryption"
-license = { workspace = true }
 
 [features]
 default = []

--- a/docs/Cargo.toml
+++ b/docs/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "fedimint-docs"
-edition = { workspace = true }
 authors = { workspace = true }
-version = { workspace = true }
-publish = false
+edition = { workspace = true }
 license = { workspace = true }
+name = "fedimint-docs"
+publish = false
 readme = { workspace = true }
 repository = { workspace = true }
+version = { workspace = true }
 
 [lib]
 name = "fedimint_docs"

--- a/fedimint-api-client/Cargo.toml
+++ b/fedimint-api-client/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "fedimint-api-client"
-version = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
 description = "fedimint-api-client provides common code used by client."
+edition = { workspace = true }
 license = { workspace = true }
+name = "fedimint-api-client"
 readme = { workspace = true }
 repository = { workspace = true }
+version = { workspace = true }
 
 [package.metadata.cargo-udeps.ignore]
 development = ["tokio-test"]
@@ -53,20 +53,20 @@ z32 = { workspace = true }
 workspace = true
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
+arti-client = { workspace = true, optional = true }
+curve25519-dalek = { workspace = true, optional = true }
+iroh = { workspace = true, default-features = false, features = [
+  "discovery-pkarr-dht",
+] }
 jsonrpsee-ws-client = { workspace = true, features = ["tls"] }
+rustls-pki-types = { workspace = true }
+strum = { workspace = true, optional = true }
 tokio-rustls = { version = "0.26.0", default-features = false, features = [
   "logging",
   "tls12",
   "ring",
 ] }
 webpki-roots = { workspace = true }
-rustls-pki-types = { workspace = true }
-arti-client = { workspace = true, optional = true }
-strum = { workspace = true, optional = true }
-curve25519-dalek = { workspace = true, optional = true }
-iroh = { workspace = true, default-features = false, features = [
-  "discovery-pkarr-dht",
-] }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 jsonrpsee-wasm-client = { workspace = true }

--- a/fedimint-bip39/Cargo.toml
+++ b/fedimint-bip39/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "fedimint-bip39"
-version = { workspace = true }
+description = "Allows using bip39 mnemonic phrases to generate fedimint client keys"
 edition = { workspace = true }
 license = { workspace = true }
+name = "fedimint-bip39"
 readme = { workspace = true }
-description = "Allows using bip39 mnemonic phrases to generate fedimint client keys"
 repository = { workspace = true }
+version = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/fedimint-bitcoind/Cargo.toml
+++ b/fedimint-bitcoind/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "fedimint-bitcoind"
-version = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
 description = "Bitcoin Core connectivity used by Fedimint"
+edition = { workspace = true }
 license = { workspace = true }
+name = "fedimint-bitcoind"
 readme = { workspace = true }
 repository = { workspace = true }
+version = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/fedimint-build/Cargo.toml
+++ b/fedimint-build/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "fedimint-build"
-version = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
 description = "Fedimint build script utilities for including git version information in builds"
+edition = { workspace = true }
 license = { workspace = true }
+name = "fedimint-build"
 readme = { workspace = true }
 repository = { workspace = true }
+version = { workspace = true }
 
 [lib]
 name = "fedimint_build"

--- a/fedimint-cli/Cargo.toml
+++ b/fedimint-cli/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
-name = "fedimint-cli"
+description = "Fedimint client CLI interface"
 edition = { workspace = true }
 homepage = { workspace = true }
 keywords = { workspace = true }
 license = { workspace = true }
+name = "fedimint-cli"
+readme = { workspace = true }
 repository = { workspace = true }
 version = { workspace = true }
-readme = { workspace = true }
-description = "Fedimint client CLI interface"
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/fedimint-client-module/Cargo.toml
+++ b/fedimint-client-module/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
-name = "fedimint-client-module"
+description = "Library for sending transactions to the Fedimint federation."
 edition = { workspace = true }
 homepage = { workspace = true }
 keywords = { workspace = true }
 license = { workspace = true }
+name = "fedimint-client-module"
+readme = { workspace = true }
 repository = { workspace = true }
 version = { workspace = true }
-readme = { workspace = true }
-description = "Library for sending transactions to the Fedimint federation."
 
 [package.metadata.cargo-udeps.ignore]
 # cargo udeps can't detect that one

--- a/fedimint-client-wasm/Cargo.toml
+++ b/fedimint-client-wasm/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-edition = { workspace = true }
-name = "fedimint-client-wasm"
-version = { workspace = true }
 authors = { workspace = true }
 description = "fedimint client for wasm"
+edition = { workspace = true }
 license = { workspace = true }
+name = "fedimint-client-wasm"
 readme = { workspace = true }
 repository = { workspace = true }
+version = { workspace = true }
 
 # https://rustwasm.github.io/wasm-pack/book/cargo-toml-configuration.html
 [package.metadata.wasm-pack.profile.release]
@@ -34,9 +34,9 @@ fedimint-wallet-client = { workspace = true }
 futures = { workspace = true }
 imbl = { workspace = true }
 js-sys = { workspace = true }
+lightning-invoice = { workspace = true }
 rexie = { workspace = true }
 serde_json = { workspace = true }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
 wasm-bindgen-test = { workspace = true }
-lightning-invoice = { workspace = true }

--- a/fedimint-client/Cargo.toml
+++ b/fedimint-client/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
-name = "fedimint-client"
+description = "Library for sending transactions to the Fedimint federation."
 edition = { workspace = true }
 homepage = { workspace = true }
 keywords = { workspace = true }
 license = { workspace = true }
+name = "fedimint-client"
+readme = { workspace = true }
 repository = { workspace = true }
 version = { workspace = true }
-readme = { workspace = true }
-description = "Library for sending transactions to the Fedimint federation."
 
 [package.metadata.cargo-udeps.ignore]
 # cargo udeps can't detect that one

--- a/fedimint-dbtool/Cargo.toml
+++ b/fedimint-dbtool/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
-name = "fedimint-dbtool"
-version = { workspace = true }
+description = "Tool to inspect Fedimint client and server databases"
 edition = { workspace = true }
 license = { workspace = true }
+name = "fedimint-dbtool"
 readme = { workspace = true }
-description = "Tool to inspect Fedimint client and server databases"
 repository = { workspace = true }
+version = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]
 
 [[bin]]
-path = "src/main.rs"
 name = "fedimint-dbtool"
+path = "src/main.rs"
 
 [lib]
 name = "fedimint_dbtool"

--- a/fedimint-derive/Cargo.toml
+++ b/fedimint-derive/Cargo.toml
@@ -1,20 +1,20 @@
 [package]
-name = "fedimint-derive"
-version = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
 description = "fedimint-derive provides helper macros for serialization."
+edition = { workspace = true }
 license = { workspace = true }
+name = "fedimint-derive"
 readme = { workspace = true }
 repository = { workspace = true }
+version = { workspace = true }
 
 [features]
 diagnostics = []
 
 [lib]
-proc-macro = true
 name = "fedimint_derive"
 path = "src/lib.rs"
+proc-macro = true
 
 [dependencies]
 itertools = { workspace = true }

--- a/fedimint-eventlog/Cargo.toml
+++ b/fedimint-eventlog/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "fedimint-eventlog"
-version = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
 description = "fedimint-eventlog provides a eventlog handling primitives for Fedimint."
+edition = { workspace = true }
 license = { workspace = true }
+name = "fedimint-eventlog"
 readme = { workspace = true }
 repository = { workspace = true }
+version = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/fedimint-load-test-tool/Cargo.toml
+++ b/fedimint-load-test-tool/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "fedimint-load-test-tool"
-version = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
 description = "fedimint-load-test-tool is a tool to load test the fedimint server and gateway."
+edition = { workspace = true }
 license = { workspace = true }
+name = "fedimint-load-test-tool"
 publish = false
+version = { workspace = true }
 
 [[bin]]
 name = "fedimint-load-test-tool"

--- a/fedimint-logging/Cargo.toml
+++ b/fedimint-logging/Cargo.toml
@@ -1,19 +1,19 @@
 [package]
-name = "fedimint-logging"
-version = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
 description = "contains some utilities for logging and tracing"
+edition = { workspace = true }
 license = { workspace = true }
+name = "fedimint-logging"
 readme = { workspace = true }
 repository = { workspace = true }
+version = { workspace = true }
 
 [features]
 telemetry = [
-    "tracing-opentelemetry",
-    "opentelemetry-jaeger",
-    "console-subscriber",
-    "opentelemetry"
+  "tracing-opentelemetry",
+  "opentelemetry-jaeger",
+  "console-subscriber",
+  "opentelemetry",
 ]
 
 [lib]

--- a/fedimint-metrics/Cargo.toml
+++ b/fedimint-metrics/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "fedimint-metrics"
-version = { workspace = true }
+description = "fedimint-metrics allows exporting prometheus metrics from Fedimint."
 edition = { workspace = true }
 license = { workspace = true }
+name = "fedimint-metrics"
 readme = { workspace = true }
-description = "fedimint-metrics allows exporting prometheus metrics from Fedimint."
 repository = { workspace = true }
+version = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/fedimint-recoverytool/Cargo.toml
+++ b/fedimint-recoverytool/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "fedimint-recoverytool"
-version = { workspace = true }
-edition = { workspace = true }
 authors = { workspace = true }
 description = "Tool for retrieving on-chain funds from a decommissioned Fedimint federation"
+edition = { workspace = true }
 license = { workspace = true }
+name = "fedimint-recoverytool"
 readme = { workspace = true }
 repository = { workspace = true }
+version = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/fedimint-recurringd-tests/Cargo.toml
+++ b/fedimint-recurringd-tests/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "fedimint-recurringd-tests"
-version = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
 description = "fedimint-recurringd-tests contains integration tests for fedimint-recurringd"
+edition = { workspace = true }
 license = { workspace = true }
+name = "fedimint-recurringd-tests"
 publish = false
+version = { workspace = true }
 
 [[bin]]
 name = "fedimint-recurringd-tests"

--- a/fedimint-recurringd/Cargo.toml
+++ b/fedimint-recurringd/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
-name = "fedimint-recurringd"
+description = "recurringd is a service that allows Fedimint users to receive recurring payments"
 edition = { workspace = true }
 homepage = { workspace = true }
 keywords = { workspace = true }
 license = { workspace = true }
+name = "fedimint-recurringd"
+readme = { workspace = true }
 repository = { workspace = true }
 version = { workspace = true }
-readme = { workspace = true }
-description = "recurringd is a service that allows Fedimint users to receive recurring payments"
 
 [[bin]]
 name = "fedimint-recurringd"

--- a/fedimint-rocksdb/Cargo.toml
+++ b/fedimint-rocksdb/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "fedimint-rocksdb"
-version = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
 description = "fedimint-rocksdb provides a rocksdb-backed database implementation for Fedimint."
+edition = { workspace = true }
 license = { workspace = true }
+name = "fedimint-rocksdb"
 readme = { workspace = true }
 repository = { workspace = true }
+version = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/fedimint-server-bitcoin-rpc/Cargo.toml
+++ b/fedimint-server-bitcoin-rpc/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "fedimint-server-bitcoin-rpc"
-version = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
 description = "Bitcoin RPC implementations for Fedimint server"
+edition = { workspace = true }
 license = { workspace = true }
+name = "fedimint-server-bitcoin-rpc"
 readme = { workspace = true }
 repository = { workspace = true }
+version = { workspace = true }
 
 [lib]
 name = "fedimint_server_bitcoin_rpc"
@@ -21,7 +21,7 @@ esplora-client = { workspace = true }
 fedimint-core = { workspace = true }
 fedimint-logging = { workspace = true }
 fedimint-server-core = { workspace = true }
-tracing = { workspace = true } 
+tracing = { workspace = true }
 
 [lints]
 workspace = true

--- a/fedimint-server-tests/Cargo.toml
+++ b/fedimint-server-tests/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
-name = "fedimint-server-tests"
-version = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
 description = { workspace = true }
 documentation = { workspace = true }
-readme = { workspace = true }
+edition = { workspace = true }
 homepage = { workspace = true }
-repository = { workspace = true }
-license = { workspace = true }
 keywords = { workspace = true }
+license = { workspace = true }
+name = "fedimint-server-tests"
+readme = { workspace = true }
+repository = { workspace = true }
+version = { workspace = true }
 
 [[test]]
 name = "fedimint_server_migration"

--- a/fedimint-server-ui/Cargo.toml
+++ b/fedimint-server-ui/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "fedimint-server-ui"
-version = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
 description = "fedimint-server-ui is a server-side rendered admin web UI for fedimintd."
+edition = { workspace = true }
 license = { workspace = true }
+name = "fedimint-server-ui"
 readme = { workspace = true }
 repository = { workspace = true }
+version = { workspace = true }
 
 [lib]
 name = "fedimint_server_ui"

--- a/fedimint-testing-core/Cargo.toml
+++ b/fedimint-testing-core/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "fedimint-testing-core"
-version = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
 description = "fedimint-testing provides a basic utils for testing fedimint components"
+edition = { workspace = true }
 license = { workspace = true }
+name = "fedimint-testing-core"
 readme = { workspace = true }
 repository = { workspace = true }
+version = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/fedimint-testing/Cargo.toml
+++ b/fedimint-testing/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "fedimint-testing"
-version = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
 description = "fedimint-testing provides a library of shared objects and utilities for testing fedimint components"
+edition = { workspace = true }
 license = { workspace = true }
+name = "fedimint-testing"
 readme = { workspace = true }
 repository = { workspace = true }
+version = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/fedimint-wasm-tests/Cargo.toml
+++ b/fedimint-wasm-tests/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "fedimint-wasm-tests"
-version = { workspace = true }
+description = "Wasm tests for the fedimint."
 edition = { workspace = true }
 license = { workspace = true }
-description = "Wasm tests for the fedimint."
+name = "fedimint-wasm-tests"
 publish = false
+version = { workspace = true }
 
 [lib]
 crate-type = ["rlib", "cdylib"]

--- a/fedimintd/Cargo.toml
+++ b/fedimintd/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
-name = "fedimintd"
+description = "fedimintd daemon for Fedimint"
 edition = { workspace = true }
 homepage = { workspace = true }
 keywords = { workspace = true }
 license = { workspace = true }
+name = "fedimintd"
+readme = { workspace = true }
 repository = { workspace = true }
 version = { workspace = true }
-readme = { workspace = true }
-description = "fedimintd daemon for Fedimint"
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/flake.nix
+++ b/flake.nix
@@ -296,6 +296,7 @@
                     pkgs.just
                     pkgs.time
                     pkgs.gawk
+                    pkgs.taplo
 
                     (pkgs.writeShellScriptBin "git-recommit" "exec git commit --edit -F <(cat \"$(git rev-parse --git-path COMMIT_EDITMSG)\" | grep -v -E '^#.*') \"$@\"")
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "fedimint-fuzz"
-edition = { workspace = true }
 authors = { workspace = true }
-version = { workspace = true }
-publish = false
+edition = { workspace = true }
 license = { workspace = true }
+name = "fedimint-fuzz"
+publish = false
 readme = { workspace = true }
 repository = { workspace = true }
+version = { workspace = true }
 
 [package.metadata]
 cargo-fuzz = true

--- a/gateway/fedimint-gateway-client/Cargo.toml
+++ b/gateway/fedimint-gateway-client/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
-name = "fedimint-gateway-client"
+description = "Client for interacting with the gateway"
 edition = { workspace = true }
 homepage = { workspace = true }
 keywords = { workspace = true }
 license = { workspace = true }
+name = "fedimint-gateway-client"
+readme = { workspace = true }
 repository = { workspace = true }
 version = { workspace = true }
-readme = { workspace = true }
-description = "Client for interacting with the gateway"
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/gateway/fedimint-gateway-common/Cargo.toml
+++ b/gateway/fedimint-gateway-common/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "fedimint-gateway-common"
-version = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
 description = "Contains common structs and logic between the gateway client and server"
+edition = { workspace = true }
 license = { workspace = true }
+name = "fedimint-gateway-common"
 readme = { workspace = true }
 repository = { workspace = true }
+version = { workspace = true }
 
 [features]
 tor = ["fedimint-api-client/tor"]

--- a/gateway/fedimint-gateway-server-db/Cargo.toml
+++ b/gateway/fedimint-gateway-server-db/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "fedimint-gateway-server-db"
-version = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
 description = "fedimint-gateway-server sends/receives Lightning Network payments on behalf of Fedimint clients (db defintions)"
+edition = { workspace = true }
 license = { workspace = true }
+name = "fedimint-gateway-server-db"
 readme = { workspace = true }
 repository = { workspace = true }
+version = { workspace = true }
 
 [lib]
 name = "fedimint_gateway_server_db"

--- a/gateway/fedimint-gateway-server/Cargo.toml
+++ b/gateway/fedimint-gateway-server/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "fedimint-gateway-server"
-version = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
 description = "fedimint-gateway-server sends/receives Lightning Network payments on behalf of Fedimint clients"
+edition = { workspace = true }
 license = { workspace = true }
+name = "fedimint-gateway-server"
 readme = { workspace = true }
 repository = { workspace = true }
+version = { workspace = true }
 
 [features]
 tor = [

--- a/gateway/fedimint-lightning/Cargo.toml
+++ b/gateway/fedimint-lightning/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "fedimint-lightning"
-version = { workspace = true }
 authors = ["The Fedimint Developers"]
-edition = { workspace = true }
 description = "fedimint-lightning handle the gateway's interaction with the lightning node"
+edition = { workspace = true }
 license = { workspace = true }
+name = "fedimint-lightning"
 readme = "../../README.md"
 repository = "https://github.com/fedimint/fedimint"
+version = { workspace = true }
 
 [lib]
 name = "fedimint_lightning"

--- a/justfile.fedimint.just
+++ b/justfile.fedimint.just
@@ -284,10 +284,12 @@ cargo_sort_defaults := "-w -g --order package,features,bin,lib,test,bench,depend
 # Fix sort order in `Cargo.toml` files
 cargo-sort-fix *ARGS="":
   cargo sort {{cargo_sort_defaults}} {{ARGS}}
+  shopt -s globstar && taplo fmt -- **/Cargo.toml
 
 # Check sort order in `Cargo.toml` files
 cargo-sort-check *ARGS="":
   cargo sort {{cargo_sort_defaults}} --check {{ARGS}}
+  shopt -s globstar && taplo fmt -- --check **/Cargo.toml
 
 # deploy our docker-compose deployment to HOST
 deploy-docker-demo HOST:

--- a/lnurlp/Cargo.toml
+++ b/lnurlp/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
-name = "lnurlp"
-description = "A tiny command line tool to fetch BOLT11 invoices from LNURLs"
-version = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
+description = "A tiny command line tool to fetch BOLT11 invoices from LNURLs"
 documentation = { workspace = true }
-readme = "README.md"
+edition = { workspace = true }
 homepage = { workspace = true }
-repository = { workspace = true }
-license = { workspace = true }
 keywords = ["bitcoin", "lightning", "lnurl"]
+license = { workspace = true }
+name = "lnurlp"
+readme = "README.md"
+repository = { workspace = true }
+version = { workspace = true }
 
 [[bin]]
 name = "lnurlp"

--- a/modules/fedimint-dummy-client/Cargo.toml
+++ b/modules/fedimint-dummy-client/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "fedimint-dummy-client"
-version = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
 description = "fedimint-dummy is a dummy example fedimint module."
+edition = { workspace = true }
 license = { workspace = true }
+name = "fedimint-dummy-client"
 readme = { workspace = true }
 repository = { workspace = true }
+version = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/modules/fedimint-dummy-common/Cargo.toml
+++ b/modules/fedimint-dummy-common/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "fedimint-dummy-common"
-version = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
 description = "fedimint-dummy-common is a dummy example fedimint module. (common types)"
+edition = { workspace = true }
 license = { workspace = true }
+name = "fedimint-dummy-common"
 readme = { workspace = true }
 repository = { workspace = true }
+version = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/modules/fedimint-dummy-server/Cargo.toml
+++ b/modules/fedimint-dummy-server/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "fedimint-dummy-server"
-version = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
 description = "fedimint-dummy is a dummy example fedimint module."
+edition = { workspace = true }
 license = { workspace = true }
+name = "fedimint-dummy-server"
 readme = { workspace = true }
 repository = { workspace = true }
+version = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/modules/fedimint-dummy-tests/Cargo.toml
+++ b/modules/fedimint-dummy-tests/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "fedimint-dummy-tests"
-version = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
 description = "fedimint-dummy is a dummy example fedimint module."
+edition = { workspace = true }
 license = { workspace = true }
+name = "fedimint-dummy-tests"
 publish = false
+version = { workspace = true }
 
 [[test]]
 name = "fedimint_dummy_tests"

--- a/modules/fedimint-empty-client/Cargo.toml
+++ b/modules/fedimint-empty-client/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "fedimint-empty-client"
-version = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
 description = "fedimint-empty is an empty fedimint module, good template for a new module."
+edition = { workspace = true }
 license = { workspace = true }
+name = "fedimint-empty-client"
 readme = { workspace = true }
 repository = { workspace = true }
+version = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/modules/fedimint-empty-common/Cargo.toml
+++ b/modules/fedimint-empty-common/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "fedimint-empty-common"
-version = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
 description = "fedimint-empty-common is a empty fedimint module (common types)"
+edition = { workspace = true }
 license = { workspace = true }
+name = "fedimint-empty-common"
 readme = { workspace = true }
 repository = { workspace = true }
+version = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/modules/fedimint-empty-server/Cargo.toml
+++ b/modules/fedimint-empty-server/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "fedimint-empty-server"
-version = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
 description = "fedimint-empty is a empty fedimint module, good template for a new module."
+edition = { workspace = true }
 license = { workspace = true }
+name = "fedimint-empty-server"
 readme = { workspace = true }
 repository = { workspace = true }
+version = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/modules/fedimint-gw-client/Cargo.toml
+++ b/modules/fedimint-gw-client/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "fedimint-gw-client"
-version = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
 description = "fedimint-gw-client is a crate for servicing lightning payments on behalf of fedimint clients"
+edition = { workspace = true }
 license = { workspace = true }
+name = "fedimint-gw-client"
 readme = { workspace = true }
 repository = { workspace = true }
+version = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/modules/fedimint-gwv2-client/Cargo.toml
+++ b/modules/fedimint-gwv2-client/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "fedimint-gwv2-client"
-version = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
 description = "fedimint-gwv2-client is a crate for servicing lightning payments on behalf of fedimint clients"
+edition = { workspace = true }
 license = { workspace = true }
+name = "fedimint-gwv2-client"
 readme = { workspace = true }
 repository = { workspace = true }
+version = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/modules/fedimint-ln-client/Cargo.toml
+++ b/modules/fedimint-ln-client/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "fedimint-ln-client"
-version = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
 description = "fedimint-ln is a lightning payment service module."
+edition = { workspace = true }
 license = { workspace = true }
+name = "fedimint-ln-client"
 readme = { workspace = true }
 repository = { workspace = true }
+version = { workspace = true }
 
 [package.metadata.cargo-udeps.ignore]
 # cargo udeps can't detect that one
@@ -16,8 +16,8 @@ normal = ["aquamarine"]
 rustc-args = ["--cfg", "tokio_unstable"]
 
 [features]
-default = []
 cli = ["dep:clap"]
+default = []
 
 [lib]
 name = "fedimint_ln_client"

--- a/modules/fedimint-ln-common/Cargo.toml
+++ b/modules/fedimint-ln-common/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "fedimint-ln-common"
-version = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
 description = "fedimint-ln-common is a lightning payment service module (common types)."
+edition = { workspace = true }
 license = { workspace = true }
+name = "fedimint-ln-common"
 readme = { workspace = true }
 repository = { workspace = true }
+version = { workspace = true }
 
 [package.metadata.cargo-udeps.ignore]
 # cargo udeps can't detect that one

--- a/modules/fedimint-ln-tests/Cargo.toml
+++ b/modules/fedimint-ln-tests/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "fedimint-ln-tests"
-version = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
 description = "fedimint-ln-tests contains integration tests for the lightning module"
+edition = { workspace = true }
 license = { workspace = true }
+name = "fedimint-ln-tests"
 publish = false
+version = { workspace = true }
 
 [[test]]
 name = "fedimint_ln_tests"

--- a/modules/fedimint-lnv2-client/Cargo.toml
+++ b/modules/fedimint-lnv2-client/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
+authors = { workspace = true }
+description = "fedimint-ln is a lightning payment service module."
+edition = { workspace = true }
+license = { workspace = true }
 name = "fedimint-lnv2-client"
 version = { workspace = true }
-authors = { workspace = true }
-edition = { workspace = true }
-description = "fedimint-ln is a lightning payment service module."
-license = { workspace = true }
 
 [package.metadata.cargo-udeps.ignore]
 # cargo udeps can't detect that one
 normal = ["aquamarine"]
 
 [features]
-default = []
 cli = ["dep:clap"]
+default = []
 
 [lib]
 name = "fedimint_lnv2_client"

--- a/modules/fedimint-lnv2-common/Cargo.toml
+++ b/modules/fedimint-lnv2-common/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
+authors = { workspace = true }
+description = "fedimint-ln-common is a lightning payment service module (common types)."
+edition = { workspace = true }
+license = { workspace = true }
 name = "fedimint-lnv2-common"
 version = { workspace = true }
-authors = { workspace = true }
-edition = { workspace = true }
-description = "fedimint-ln-common is a lightning payment service module (common types)."
-license = { workspace = true }
 
 [package.metadata.cargo-udeps.ignore]
 # cargo udeps can't detect that one

--- a/modules/fedimint-lnv2-server/Cargo.toml
+++ b/modules/fedimint-lnv2-server/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
+authors = { workspace = true }
+description = "fedimint-ln is a lightning payment service module."
+edition = { workspace = true }
+license = { workspace = true }
 name = "fedimint-lnv2-server"
 version = { workspace = true }
-authors = { workspace = true }
-edition = { workspace = true }
-description = "fedimint-ln is a lightning payment service module."
-license = { workspace = true }
 
 [lib]
 name = "fedimint_lnv2_server"

--- a/modules/fedimint-lnv2-tests/Cargo.toml
+++ b/modules/fedimint-lnv2-tests/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "fedimint-lnv2-tests"
-version = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
 description = "fedimint-lnv2-tests contains integration tests for the lnv2 module"
+edition = { workspace = true }
 license = { workspace = true }
+name = "fedimint-lnv2-tests"
 publish = false
+version = { workspace = true }
 
 [[bin]]
 name = "lnv2-module-tests"

--- a/modules/fedimint-meta-client/Cargo.toml
+++ b/modules/fedimint-meta-client/Cargo.toml
@@ -1,19 +1,19 @@
 [package]
-name = "fedimint-meta-client"
-version = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
 description = "fedimint-meta is a meta consensus fedimint module."
+edition = { workspace = true }
 license = { workspace = true }
+name = "fedimint-meta-client"
 readme = { workspace = true }
 repository = { workspace = true }
+version = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]
 
 [features]
-default = []
 cli = ["dep:clap"]
+default = []
 
 [lib]
 name = "fedimint_meta_client"

--- a/modules/fedimint-meta-common/Cargo.toml
+++ b/modules/fedimint-meta-common/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "fedimint-meta-common"
-version = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
 description = "fedimint-meta-common is a meta-consensus fedimint module. (common types)"
+edition = { workspace = true }
 license = { workspace = true }
+name = "fedimint-meta-common"
 readme = { workspace = true }
 repository = { workspace = true }
+version = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/modules/fedimint-meta-server/Cargo.toml
+++ b/modules/fedimint-meta-server/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "fedimint-meta-server"
-version = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
 description = "fedimint-meta is a meta consensus fedimint module."
+edition = { workspace = true }
 license = { workspace = true }
+name = "fedimint-meta-server"
 readme = { workspace = true }
 repository = { workspace = true }
+version = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/modules/fedimint-meta-tests/Cargo.toml
+++ b/modules/fedimint-meta-tests/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "fedimint-meta-tests"
-version = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
 description = "fedimint-mint-tests contains integration tests for the meta module"
+edition = { workspace = true }
 license = { workspace = true }
+name = "fedimint-meta-tests"
 publish = false
+version = { workspace = true }
 
 # workaround: cargo-deny in Nix needs to see at least one
 # artifact here

--- a/modules/fedimint-mint-common/Cargo.toml
+++ b/modules/fedimint-mint-common/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "fedimint-mint-common"
-version = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
 description = "fedimint-mint-common is a chaumian ecash mint module. (common types)"
+edition = { workspace = true }
 license = { workspace = true }
+name = "fedimint-mint-common"
 readme = { workspace = true }
 repository = { workspace = true }
+version = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/modules/fedimint-mint-server/Cargo.toml
+++ b/modules/fedimint-mint-server/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "fedimint-mint-server"
-version = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
 description = "fedimint-mint is a chaumian ecash mint module."
+edition = { workspace = true }
 license = { workspace = true }
+name = "fedimint-mint-server"
 readme = { workspace = true }
 repository = { workspace = true }
+version = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/modules/fedimint-mint-tests/Cargo.toml
+++ b/modules/fedimint-mint-tests/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "fedimint-mint-tests"
-version = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
 description = "fedimint-mint-tests contains integration tests for the mint module"
+edition = { workspace = true }
 license = { workspace = true }
+name = "fedimint-mint-tests"
 publish = false
+version = { workspace = true }
 
 [[test]]
 name = "fedimint_mint_tests"

--- a/modules/fedimint-unknown-common/Cargo.toml
+++ b/modules/fedimint-unknown-common/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "fedimint-unknown-common"
-version = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
 description = "fedimint-unknown-common is a fedimint module that doesn't have any client side implementation. (common types)"
+edition = { workspace = true }
 license = { workspace = true }
+name = "fedimint-unknown-common"
 readme = { workspace = true }
 repository = { workspace = true }
+version = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/modules/fedimint-unknown-server/Cargo.toml
+++ b/modules/fedimint-unknown-server/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "fedimint-unknown-server"
-version = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
 description = "fedimint-unknown-server is a test fedimint module that doesn't have any client side implementation."
+edition = { workspace = true }
 license = { workspace = true }
+name = "fedimint-unknown-server"
 readme = { workspace = true }
 repository = { workspace = true }
+version = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/modules/fedimint-wallet-client/Cargo.toml
+++ b/modules/fedimint-wallet-client/Cargo.toml
@@ -1,19 +1,19 @@
 [package]
-name = "fedimint-wallet-client"
-version = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
 description = "fedimint-wallet is a n on-chain bitcoin wallet module. It uses a key-value store and is not a standard HD wallet."
+edition = { workspace = true }
 license = { workspace = true }
+name = "fedimint-wallet-client"
 readme = { workspace = true }
 repository = { workspace = true }
+version = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]
 
 [features]
-default = []
 cli = ["dep:clap"]
+default = []
 
 [lib]
 name = "fedimint_wallet_client"

--- a/modules/fedimint-wallet-common/Cargo.toml
+++ b/modules/fedimint-wallet-common/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "fedimint-wallet-common"
-version = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
 description = "fedimint-wallet-common is a n on-chain bitcoin wallet module. It uses a key-value store and is not a standard HD wallet. (common types)"
+edition = { workspace = true }
 license = { workspace = true }
+name = "fedimint-wallet-common"
 readme = { workspace = true }
 repository = { workspace = true }
+version = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/modules/fedimint-wallet-tests/Cargo.toml
+++ b/modules/fedimint-wallet-tests/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "fedimint-wallet-tests"
-version = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
 description = "fedimint-wallet-tests contains integration tests for the lightning module"
+edition = { workspace = true }
 license = { workspace = true }
+name = "fedimint-wallet-tests"
 publish = false
+version = { workspace = true }
 
 [[bin]]
 name = "wallet-module-tests"

--- a/nix/check-cargo-sort.sh
+++ b/nix/check-cargo-sort.sh
@@ -3,3 +3,6 @@
 set -eo pipefail
 
 cargo sort -w -g --order package,features,bin,lib,test,bench,dependencies,dev-dependencies,build-dependencies --check >/dev/null
+
+shopt -s globstar
+taplo fmt --check -- **/Cargo.toml

--- a/utils/portalloc/Cargo.toml
+++ b/utils/portalloc/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "fedimint-portalloc"
-version = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
 description = "Port allocation utility for Fedimint"
+edition = { workspace = true }
 license = { workspace = true }
+name = "fedimint-portalloc"
 readme = { workspace = true }
 repository = { workspace = true }
+version = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]


### PR DESCRIPTION
https://github.com/tamasfe/taplo is a Toml LSP.

It does not entirely replace `cargo-sort`, but can do stuff that `cargo-sort` can't:

* more strict ordering of *all* keys in Cargo.toml
* interactive autocompletion etc. in text editor (it's a full thing LSP)

This integrates it with our existing dev workflow.
<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
