### PR TITLE
[Backport releases/v0.6] fix: unnecessary `Result` in `list_peg_in_tweak_idxes`

### DIFF
--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -902,11 +902,8 @@ impl WalletClientModule {
         }))
     }
 
-    pub async fn list_peg_in_tweak_idxes(
-        &self,
-    ) -> anyhow::Result<BTreeMap<TweakIdx, PegInTweakIndexData>> {
-        Ok(self
-            .client_ctx
+    pub async fn list_peg_in_tweak_idxes(&self) -> BTreeMap<TweakIdx, PegInTweakIndexData> {
+        self.client_ctx
             .module_db()
             .clone()
             .begin_transaction_nc()
@@ -915,7 +912,7 @@ impl WalletClientModule {
             .await
             .map(|(key, data)| (key.0, data))
             .collect()
-            .await)
+            .await
     }
 
     pub async fn find_tweak_idx_by_address(


### PR DESCRIPTION
# Description
Backport of #7449 to `releases/v0.6`.