### PR TITLE
chore: replace our custom runtime abstract with n0-future

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2776,6 +2776,7 @@ dependencies = [
  "lightning-types",
  "macro_rules_attribute",
  "miniscript",
+ "n0-future",
  "parity-scale-codec",
  "rand 0.8.5",
  "scopeguard",
@@ -6562,9 +6563,9 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "n0-future"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "399e11dc3b0e8d9d65b27170d22f5d779d52d9bed888db70d7e0c2c7ce3dfc52"
+checksum = "7bb0e5d99e681ab3c938842b96fcb41bf8a7bb4bfdb11ccbd653a7e83e06c794"
 dependencies = [
  "cfg_aliases",
  "derive_more 1.0.0",

--- a/fedimint-core/Cargo.toml
+++ b/fedimint-core/Cargo.toml
@@ -48,6 +48,7 @@ lightning-invoice = { workspace = true, features = ["serde"] }
 lightning-types = { workspace = true }
 macro_rules_attribute = { workspace = true }
 miniscript = { workspace = true, features = ["serde"] }
+n0-future = "0.1.3"
 parity-scale-codec = { workspace = true, features = ["derive"] }
 rand = { workspace = true }
 scopeguard = { workspace = true }

--- a/fedimint-core/src/runtime.rs
+++ b/fedimint-core/src/runtime.rs
@@ -1,158 +1,30 @@
-//! Copyright 2021 The Matrix.org Foundation C.I.C.
-//! Abstraction over an executor so we can spawn tasks under WASM the same way
-//! we do usually.
-
-// Adapted from https://github.com/matrix-org/matrix-rust-sdk
-
 use std::future::Future;
-use std::time::Duration;
 
 use fedimint_logging::LOG_RUNTIME;
-use thiserror::Error;
-use tokio::time::Instant;
+pub use n0_future::task::{JoinError, JoinHandle};
+pub use n0_future::time::{Elapsed, Instant, SystemTime, sleep, sleep_until, timeout};
 use tracing::Instrument;
 
-#[derive(Debug, Error)]
-#[error("deadline has elapsed")]
-pub struct Elapsed;
-
-pub use self::r#impl::*;
-
-#[cfg(not(target_family = "wasm"))]
-mod r#impl {
-    pub use tokio::task::{JoinError, JoinHandle};
-
-    use super::{Duration, Elapsed, Future, Instant, Instrument, LOG_RUNTIME};
-
-    pub fn spawn<F, T>(name: &str, future: F) -> tokio::task::JoinHandle<T>
-    where
-        F: Future<Output = T> + 'static + Send,
-        T: Send + 'static,
-    {
-        let span = tracing::debug_span!(target: LOG_RUNTIME, parent: None, "spawn", task = name);
-        // nosemgrep: ban-tokio-spawn
-        tokio::spawn(future.instrument(span))
-    }
-
-    // note: this call does not exist on wasm and you need to handle it
-    // conditionally at the call site of packages that compile on wasm
-    pub fn block_in_place<F, R>(f: F) -> R
-    where
-        F: FnOnce() -> R,
-    {
-        // nosemgrep: ban-raw-block-in-place
-        tokio::task::block_in_place(f)
-    }
-
-    // note: this call does not exist on wasm and you need to handle it
-    // conditionally at the call site of packages that compile on wasm
-    pub fn block_on<F: Future>(future: F) -> F::Output {
-        // nosemgrep: ban-raw-block-on
-        tokio::runtime::Handle::current().block_on(future)
-    }
-
-    pub async fn sleep(duration: Duration) {
-        // nosemgrep: ban-tokio-sleep
-        tokio::time::sleep(duration).await;
-    }
-
-    pub async fn sleep_until(deadline: Instant) {
-        tokio::time::sleep_until(deadline).await;
-    }
-
-    pub async fn timeout<T>(duration: Duration, future: T) -> Result<T::Output, Elapsed>
-    where
-        T: Future,
-    {
-        tokio::time::timeout(duration, future)
-            .await
-            .map_err(|_| Elapsed)
-    }
+pub fn spawn<F, T>(name: &str, future: F) -> JoinHandle<T>
+where
+    F: Future<Output = T> + 'static + Send,
+    T: Send + 'static,
+{
+    let span = tracing::debug_span!(target: LOG_RUNTIME, parent: None, "spawn", task = name);
+    n0_future::task::spawn(future.instrument(span))
 }
 
-#[cfg(target_family = "wasm")]
-mod r#impl {
+#[cfg(not(target_family = "wasm"))]
+pub fn block_in_place<F, R>(f: F) -> R
+where
+    F: FnOnce() -> R,
+{
+    // nosemgrep: ban-raw-block-in-place
+    tokio::task::block_in_place(f)
+}
 
-    pub use std::convert::Infallible as JoinError;
-    use std::pin::Pin;
-    use std::task::{Context, Poll};
-
-    use async_lock::{RwLock, RwLockReadGuard, RwLockWriteGuard};
-    use futures_util::FutureExt;
-    use futures_util::future::RemoteHandle;
-
-    use super::*;
-
-    #[derive(Debug)]
-    pub struct JoinHandle<T> {
-        handle: Option<RemoteHandle<T>>,
-    }
-
-    impl<T> JoinHandle<T> {
-        pub fn abort(&mut self) {
-            drop(self.handle.take());
-        }
-    }
-
-    impl<T> Drop for JoinHandle<T> {
-        fn drop(&mut self) {
-            // don't abort the spawned future
-            if let Some(h) = self.handle.take() {
-                h.forget();
-            }
-        }
-    }
-    impl<T: 'static> Future for JoinHandle<T> {
-        type Output = Result<T, JoinError>;
-
-        fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-            if let Some(handle) = self.handle.as_mut() {
-                Pin::new(handle).poll(cx).map(Ok)
-            } else {
-                Poll::Pending
-            }
-        }
-    }
-
-    pub fn spawn<F, T>(name: &str, future: F) -> JoinHandle<T>
-    where
-        F: Future<Output = T> + 'static,
-    {
-        let span = tracing::debug_span!(target: LOG_RUNTIME, "spawn", task = name);
-        let (fut, handle) = future.remote_handle();
-        wasm_bindgen_futures::spawn_local(fut);
-
-        JoinHandle {
-            handle: Some(handle),
-        }
-    }
-
-    pub(crate) fn spawn_local<F>(name: &str, future: F) -> JoinHandle<()>
-    where
-        // No Send needed on wasm
-        F: Future<Output = ()> + 'static,
-    {
-        spawn(name, future)
-    }
-
-    pub async fn sleep(duration: Duration) {
-        gloo_timers::future::sleep(duration.min(Duration::from_millis(i32::MAX as _))).await
-    }
-
-    pub async fn sleep_until(deadline: Instant) {
-        // nosemgrep: ban-system-time-now
-        // nosemgrep: ban-instant-now
-        sleep(deadline.saturating_duration_since(Instant::now())).await
-    }
-
-    pub async fn timeout<T>(duration: Duration, future: T) -> Result<T::Output, Elapsed>
-    where
-        T: Future,
-    {
-        futures::pin_mut!(future);
-        futures::select_biased! {
-            value = future.fuse() => Ok(value),
-            _ = sleep(duration).fuse() => Err(Elapsed),
-        }
-    }
+#[cfg(not(target_family = "wasm"))]
+pub fn block_on<F: Future>(future: F) -> F::Output {
+    // nosemgrep: ban-raw-block-on
+    tokio::runtime::Handle::current().block_on(future)
 }

--- a/fedimint-core/src/time.rs
+++ b/fedimint-core/src/time.rs
@@ -1,16 +1,7 @@
-// nosemgrep: ban-system-time-now
-use std::time::SystemTime;
+use n0_future::time::SystemTime;
 
-#[cfg(not(target_family = "wasm"))]
 pub fn now() -> SystemTime {
-    // nosemgrep: ban-system-time-now
     SystemTime::now()
-}
-
-#[cfg(target_family = "wasm")]
-pub fn now() -> SystemTime {
-    SystemTime::UNIX_EPOCH
-        + std::time::Duration::from_secs_f64(js_sys::Date::new_0().get_time() / 1000.)
 }
 
 /// Returns the duration since the Unix epoch


### PR DESCRIPTION
we already use n0-future through iroh, we shouldn't maintain our own compat layer

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
