### PR TITLE
chore: LNv2 make select_gateway public

### DIFF
--- a/modules/fedimint-lnv2-client/src/lib.rs
+++ b/modules/fedimint-lnv2-client/src/lib.rs
@@ -418,7 +418,7 @@ impl LightningClientModule {
         }
     }
 
-    async fn select_gateway(
+    pub async fn select_gateway(
         &self,
         invoice: Option<Bolt11Invoice>,
     ) -> Result<(SafeUrl, RoutingInfo), SelectGatewayError> {


### PR DESCRIPTION
I want to be able to show users the fees they will be charged up front in LNv2. This is currently very difficult. Making `select_gateway` public will make this much easier.