### PR TITLE
[Backport releases/v0.7] chore: LNv2 make select_gateway public

### DIFF
--- a/modules/fedimint-lnv2-client/src/lib.rs
+++ b/modules/fedimint-lnv2-client/src/lib.rs
@@ -419,7 +419,7 @@ impl LightningClientModule {
         }
     }
 
-    async fn select_gateway(
+    pub async fn select_gateway(
         &self,
         invoice: Option<Bolt11Invoice>,
     ) -> Result<(SafeUrl, RoutingInfo), SelectGatewayError> {


### PR DESCRIPTION
# Description
Backport of #7454 to `releases/v0.7`.