### PR TITLE
feat: define recurringd_api meta field

### DIFF
--- a/docs/meta_fields/recurringd_api.md
+++ b/docs/meta_fields/recurringd_api.md
@@ -1,0 +1,9 @@
+# `recurringd_api`
+
+The API URL of a `recurringd` instance that can be used by the clients to create LNURLs.
+Longer term the intention is to merge the functionality into the gateways,
+but for now an independent discovery mechanism is useful.
+
+## Structure
+
+A valid URL string pointing to a `recurringd` API.


### PR DESCRIPTION
Recurring payment support in Fedimint requires yet another service: `recurringd`. Since instances only support specific federations for now, having a discovery mechanism is useful. Meta fields seem a good place for it.

Thx @maan2003 for the suggestion :)

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
