### PR TITLE
fix: order of locking not immediately clear

### DIFF
--- a/fedimint-rocksdb/src/db_locked.rs
+++ b/fedimint-rocksdb/src/db_locked.rs
@@ -51,11 +51,14 @@ impl LockedBuilder {
     }
 
     /// Create [`Locked`] by giving it the database to wrap
-    pub fn with_db<DB>(self, db: DB) -> Locked<DB> {
-        Locked {
-            inner: db,
+    pub fn with_db<DB>(
+        self,
+        db_fn: impl FnOnce() -> anyhow::Result<DB>,
+    ) -> anyhow::Result<Locked<DB>> {
+        Ok(Locked {
+            inner: db_fn()?,
             lock: self.lock,
-        }
+        })
     }
 }
 

--- a/fedimint-rocksdb/src/lib.rs
+++ b/fedimint-rocksdb/src/lib.rs
@@ -55,6 +55,7 @@ impl RocksDb {
 
         block_in_place(|| Self::open_blocking(db_path))
     }
+
     pub fn open_blocking(db_path: &Path) -> anyhow::Result<Locked<RocksDb>> {
         block_in_place(|| {
             std::fs::create_dir_all(
@@ -62,9 +63,10 @@ impl RocksDb {
                     .parent()
                     .ok_or_else(|| anyhow::anyhow!("db path must have a base dir"))?,
             )?;
-            Ok(LockedBuilder::new(db_path)?.with_db(Self::open_blocking_unlocked(db_path)?))
+            LockedBuilder::new(db_path)?.with_db(|| Self::open_blocking_unlocked(db_path))
         })
     }
+
     pub fn open_blocking_unlocked(db_path: &Path) -> anyhow::Result<RocksDb> {
         let mut opts = get_default_options()?;
         // Since we turned synchronous writes one we should never encounter a corrupted


### PR DESCRIPTION
In an expression:

```
xyz().bar(baz());
```

it is not clear that `baz` has to run after `xyz`, which I suspect might be the reason for locking failures, like:

https://github.com/fedimint/fedimint/actions/runs/15007989771/job/42386156342

Best not to depend on it, but use a lambda.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
