### PR TITLE
fix(rocksdb): unlocking order

### DIFF
--- a/fedimint-rocksdb/src/db_locked.rs
+++ b/fedimint-rocksdb/src/db_locked.rs
@@ -14,9 +14,11 @@ use tracing::{debug, info};
 /// Use [`LockedBuilder`] to create.
 #[derive(Debug)]
 pub struct Locked<DB> {
-    inner: DB,
-    #[allow(dead_code)] // only for `Drop`
+    // only for `Drop`, MUST be first, as struct fields are dropped in
+    // a field reverse order
+    #[allow(dead_code)]
     lock: fs_lock::FileLock,
+    inner: DB,
 }
 
 /// Builder for [`Locked`]


### PR DESCRIPTION
Still seeing db locking failures, and I think this might be the last reason. Details matter.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
