### PR TITLE
chore: change ldk-node-0 log name

### DIFF
--- a/scripts/dev/run-test/fm-run-test
+++ b/scripts/dev/run-test/fm-run-test
@@ -46,7 +46,7 @@ on_error() {
   echo
   echo
   echo "## LOG LDK-0 NODE:"
-  { cat  "$FM_RUN_TEST_TMPDIR"/devimint-*/gatewayd-ldk-0/ldk_node/logs/ldk_node_latest.log || true; } | grep -v "Failed to retrieve fee rate estimates" || true
+  { cat  "$FM_RUN_TEST_TMPDIR"/devimint-*/gatewayd-ldk-0/ldk_node/ldk_node.log || true; } | grep -v "Failed to retrieve fee rate estimates" || true
   echo
   echo "## FAIL END $test_name$version_str."
 }


### PR DESCRIPTION
The LDK node log name changed when we merged https://github.com/fedimint/fedimint/pull/7389

```
cat: '/build/fm-gw_liquidity-FDUV/devimint-*/gatewayd-ldk-0/ldk_node/logs/ldk_node_latest.log': No such file or directory
```

This PR fixes LDK node's log name when it prints to CI. It will help us debug https://github.com/fedimint/fedimint/issues/7476