### PR TITLE
fix(client): fetch api announcements on join

### DIFF
--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -877,6 +877,8 @@ pub async fn cli_tests(dev_fed: DevFed) -> Result<()> {
         fedimintd_version
     );
 
+    info!("Checking initial announcements...");
+
     retry(
         "Check initial announcements",
         aggressive_backoff(),
@@ -894,6 +896,9 @@ pub async fn cli_tests(dev_fed: DevFed) -> Result<()> {
                     initial_announcements.len()
                 )
             }
+
+            // Give the client some time to fetch updates
+            cmd!(client, "dev", "wait", "3").run().await?;
 
             if !initial_announcements
                 .values()

--- a/fedimint-api-client/src/lib.rs
+++ b/fedimint-api-client/src/lib.rs
@@ -29,7 +29,12 @@ impl Connector {
         &self,
         invite: &InviteCode,
     ) -> anyhow::Result<ClientConfig> {
-        debug!(target: LOG_CLIENT, %invite, "Downloading client config via invite code");
+        debug!(
+            target: LOG_CLIENT,
+            %invite,
+            peers = ?invite.peers(),
+            "Downloading client config via invite code"
+        );
 
         let federation_id = invite.federation_id();
         let api = DynGlobalApi::from_endpoints(invite.peers(), &invite.api_secret()).await?;

--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -677,12 +677,12 @@ impl FedimintCli {
         let mnemonic = load_or_generate_mnemonic(client_builder.db_no_decoders()).await?;
 
         let client = client_builder
-            .join_with_invite(
-                RootSecret::LegacyDoubleDerive(Bip39RootSecretStrategy::<12>::to_root_secret(
-                    &mnemonic,
-                )),
-                &invite_code,
-            )
+            .preview(&invite_code)
+            .await
+            .map_err_cli()?
+            .join(RootSecret::LegacyDoubleDerive(
+                Bip39RootSecretStrategy::<12>::to_root_secret(&mnemonic),
+            ))
             .await
             .map(Arc::new)
             .map_err_cli()?;
@@ -753,7 +753,10 @@ impl FedimintCli {
             Bip39RootSecretStrategy::<12>::to_root_secret(&mnemonic),
         );
         let client = builder
-            .recover(root_secret, &invite_code, None)
+            .preview(&invite_code)
+            .await
+            .map_err_cli()?
+            .recover(root_secret, None)
             .await
             .map(Arc::new)
             .map_err_cli()?;

--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -37,8 +37,8 @@ use fedimint_bip39::{Bip39RootSecretStrategy, Mnemonic};
 use fedimint_client::module::meta::{FetchKind, LegacyMetaSource, MetaSource};
 use fedimint_client::module::module::init::ClientModuleInit;
 use fedimint_client::module_init::ClientModuleInitRegistry;
-use fedimint_client::secret::{RootSecretStrategy, get_default_client_secret};
-use fedimint_client::{AdminCreds, Client, ClientBuilder, ClientHandleArc};
+use fedimint_client::secret::RootSecretStrategy;
+use fedimint_client::{AdminCreds, Client, ClientBuilder, ClientHandleArc, RootSecret};
 use fedimint_core::config::{FederationId, FederationIdPrefix};
 use fedimint_core::core::{ModuleInstanceId, OperationId};
 use fedimint_core::db::{Database, DatabaseValue};
@@ -662,10 +662,7 @@ impl FedimintCli {
         client_builder.with_module_inits(self.module_inits.clone());
         client_builder.with_primary_module_kind(fedimint_mint_client::KIND);
 
-        #[cfg(feature = "tor")]
-        if cli.use_tor {
-            client_builder.with_tor_connector();
-        }
+        client_builder.with_connector(cli.connector());
 
         Ok(client_builder)
     }
@@ -675,24 +672,16 @@ impl FedimintCli {
         cli: &Opts,
         invite_code: InviteCode,
     ) -> CliResult<ClientHandleArc> {
-        let client_config = cli
-            .connector()
-            .download_from_invite_code(&invite_code)
-            .await
-            .map_err_cli()?;
-
         let client_builder = self.make_client_builder(cli).await?;
 
         let mnemonic = load_or_generate_mnemonic(client_builder.db_no_decoders()).await?;
 
         let client = client_builder
-            .join(
-                get_default_client_secret(
-                    &Bip39RootSecretStrategy::<12>::to_root_secret(&mnemonic),
-                    &client_config.global.calculate_federation_id(),
-                ),
-                client_config.clone(),
-                invite_code.api_secret(),
+            .join_with_invite(
+                RootSecret::LegacyDoubleDerive(Bip39RootSecretStrategy::<12>::to_root_secret(
+                    &mnemonic,
+                )),
+                &invite_code,
             )
             .await
             .map(Arc::new)
@@ -721,14 +710,9 @@ impl FedimintCli {
         )
         .map_err_cli()?;
 
-        let config = client_builder.load_existing_config().await.map_err_cli()?;
-
-        let federation_id = config.calculate_federation_id();
-
         let client = client_builder
-            .open(get_default_client_secret(
-                &Bip39RootSecretStrategy::<12>::to_root_secret(&mnemonic),
-                &federation_id,
+            .open(RootSecret::LegacyDoubleDerive(
+                Bip39RootSecretStrategy::<12>::to_root_secret(&mnemonic),
             ))
             .await
             .map(Arc::new)
@@ -746,13 +730,6 @@ impl FedimintCli {
         invite_code: InviteCode,
     ) -> CliResult<ClientHandleArc> {
         let builder = self.make_client_builder(cli).await?;
-
-        let client_config = cli
-            .connector()
-            .download_from_invite_code(&invite_code)
-            .await
-            .map_err_cli()?;
-
         match Client::load_decodable_client_secret_opt::<Vec<u8>>(builder.db_no_decoders())
             .await
             .map_err_cli()?
@@ -772,21 +749,11 @@ impl FedimintCli {
             }
         }
 
-        let root_secret = get_default_client_secret(
-            &Bip39RootSecretStrategy::<12>::to_root_secret(&mnemonic),
-            &client_config.calculate_federation_id(),
+        let root_secret = RootSecret::LegacyDoubleDerive(
+            Bip39RootSecretStrategy::<12>::to_root_secret(&mnemonic),
         );
-        let backup = builder
-            .download_backup_from_federation(&root_secret, &client_config, invite_code.api_secret())
-            .await
-            .map_err_cli()?;
         let client = builder
-            .recover(
-                root_secret,
-                client_config.clone(),
-                invite_code.api_secret(),
-                backup,
-            )
+            .recover(root_secret, &invite_code, None)
             .await
             .map(Arc::new)
             .map_err_cli()?;

--- a/fedimint-client/src/api_announcements.rs
+++ b/fedimint-client/src/api_announcements.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Context, bail};
+use fedimint_api_client::api::DynGlobalApi;
 use fedimint_core::config::ClientConfig;
 use fedimint_core::db::{Database, IDatabaseTransactionOpsCoreTyped};
 use fedimint_core::encoding::{Decodable, Encodable};
@@ -37,79 +38,109 @@ impl_db_lookup!(
 
 /// Fetches API URL announcements from guardians, validates them and updates the
 /// DB if any new more upt to date ones are found.
-pub async fn run_api_announcement_sync(client_inner: Arc<Client>) {
+pub(crate) async fn run_api_announcement_sync(client_inner: Arc<Client>) {
     // Wait for the guardian keys to be available
     let guardian_pub_keys = client_inner.get_guardian_public_keys_blocking().await;
     loop {
-        let results = join_all(client_inner.api.all_peers().iter()
-            .map(|peer_id| async {
-                let peer_id = *peer_id;
-                let announcements =
-
-                retry(
-                    "Fetch api announcement (sync)",
-                    backoff_util::aggressive_backoff(),
-                    || async {
-                        client_inner
-                            .api
-                            .api_announcements(peer_id)
-                            .await
-                            .with_context(move || format!("Fetching API announcements from peer {peer_id} failed"))
-                    },
-                )
-                .await?;
-
-                // If any of the announcements is invalid something is fishy with that
-                // guardian and we ignore all its responses
-                for (peer_id, announcement) in &announcements {
-                    let Some(guardian_pub_key) = guardian_pub_keys.get(peer_id) else {
-                        bail!("Guardian public key not found for peer {}", peer_id);
-                    };
-
-                    if !announcement.verify(SECP256K1, guardian_pub_key) {
-                        bail!("Failed to verify announcement for peer {}", peer_id);
-                    }
-                }
-
-                client_inner
-                    .db()
-                    .autocommit(
-                        |dbtx, _|{
-                            let announcements_inner = announcements.clone();
-                        Box::pin(async move {
-                            for (peer, new_announcement) in announcements_inner {
-                                let replace_current_announcement = dbtx
-                                    .get_value(&ApiAnnouncementKey(peer))
-                                    .await.is_none_or(|current_announcement| {
-                                        current_announcement.api_announcement.nonce
-                                            < new_announcement.api_announcement.nonce
-                                    });
-                                if replace_current_announcement {
-                                    debug!(target: LOG_CLIENT, ?peer, %new_announcement.api_announcement.api_url, "Updating API announcement");
-                                    dbtx.insert_entry(&ApiAnnouncementKey(peer), &new_announcement)
-                                        .await;
-                                }
-                            }
-
-                            Result::<(), ()>::Ok(())
-                        })},
-                        None,
-                    )
-                    .await
-                    .expect("Will never return an error");
-
-                Ok(())
-            })).await;
-
-        for (peer_id, result) in guardian_pub_keys.keys().zip(results) {
-            if let Err(e) = result {
-                warn!(target: LOG_CLIENT, %peer_id, ?e, "Failed to process API announcements");
-            }
-        }
+        let _ =
+            refresh_api_announcement_sync(&client_inner.api, client_inner.db(), &guardian_pub_keys)
+                .await;
 
         // Check once an hour if there are new announcements
         sleep(Duration::from_secs(3600)).await;
     }
+}
+
+pub(crate) async fn refresh_api_announcement_sync(
+    api: &DynGlobalApi,
+    db: &Database,
+    guardian_pub_keys: &BTreeMap<PeerId, bitcoin::secp256k1::PublicKey>,
+) -> anyhow::Result<()> {
+    let results = fetch_api_announcements_from_all_peers(api, guardian_pub_keys).await;
+
+    let mut some_success = false;
+
+    for (peer_id, result) in guardian_pub_keys.keys().zip(results) {
+        match result {
+            Ok(announcements) => {
+                store_api_announcements(db, announcements).await;
+                some_success |= true
+            }
+            Err(e) => {
+                warn!(target: LOG_CLIENT, %peer_id, ?e, "Failed to process API announcements");
+            }
+        }
+    }
+
+    if some_success {
+        Ok(())
+    } else {
+        bail!("Unable to get any api announcements");
+    }
+}
+
+async fn fetch_api_announcements_from_all_peers(
+    api: &DynGlobalApi,
+    guardian_pub_keys: &BTreeMap<PeerId, bitcoin::secp256k1::PublicKey>,
+) -> Vec<Result<BTreeMap<PeerId, SignedApiAnnouncement>, anyhow::Error>> {
+    join_all(api.all_peers().iter().map(|peer_id| async {
+        let peer_id = *peer_id;
+        let announcements = retry(
+            "Fetch api announcement (sync)",
+            backoff_util::aggressive_backoff(),
+            || async {
+                api.api_announcements(peer_id).await.with_context(move || {
+                    format!("Fetching API announcements from peer {peer_id} failed")
+                })
+            },
+        )
+        .await?;
+
+        // If any of the announcements is invalid something is fishy with that
+        // guardian and we ignore all its responses
+        for (peer_id, announcement) in &announcements {
+            let Some(guardian_pub_key) = guardian_pub_keys.get(peer_id) else {
+                bail!("Guardian public key not found for peer {}", peer_id);
+            };
+
+            if !announcement.verify(SECP256K1, guardian_pub_key) {
+                bail!("Failed to verify announcement for peer {}", peer_id);
+            }
+        }
+        Ok(announcements)
+    }))
+    .await
+}
+
+pub(crate) async fn store_api_announcements(
+    db: &Database,
+    announcements: BTreeMap<PeerId, SignedApiAnnouncement>,
+) {
+    db
+        .autocommit(
+            |dbtx, _|{
+                let announcements_inner = announcements.clone();
+            Box::pin(async move {
+                for (peer, new_announcement) in announcements_inner {
+                    let replace_current_announcement = dbtx
+                        .get_value(&ApiAnnouncementKey(peer))
+                        .await.is_none_or(|current_announcement| {
+                            current_announcement.api_announcement.nonce
+                                < new_announcement.api_announcement.nonce
+                        });
+                    if replace_current_announcement {
+                        debug!(target: LOG_CLIENT, ?peer, %new_announcement.api_announcement.api_url, "Updating API announcement");
+                        dbtx.insert_entry(&ApiAnnouncementKey(peer), &new_announcement)
+                            .await;
+                    }
+                }
+
+                Result::<(), ()>::Ok(())
+            })},
+            None,
+        )
+        .await
+        .expect("Will never return an error");
 }
 
 /// Returns a list of all peers and their respective API URLs taking into

--- a/fedimint-client/src/client/builder.rs
+++ b/fedimint-client/src/client/builder.rs
@@ -16,17 +16,18 @@ use fedimint_client_module::meta::LegacyMetaSource;
 use fedimint_client_module::module::init::ClientModuleInit;
 use fedimint_client_module::module::recovery::RecoveryProgress;
 use fedimint_client_module::module::{ClientModuleRegistry, FinalClientIface};
-use fedimint_client_module::secret::DeriveableSecretClientExt as _;
+use fedimint_client_module::secret::{DeriveableSecretClientExt as _, get_default_client_secret};
 use fedimint_client_module::transaction::{
     TRANSACTION_SUBMISSION_MODULE_INSTANCE, TxSubmissionContext, tx_submission_sm_decoder,
 };
 use fedimint_client_module::{AdminCreds, ModuleRecoveryStarted};
-use fedimint_core::config::{ClientConfig, ModuleInitRegistry};
+use fedimint_core::config::{ClientConfig, FederationId, ModuleInitRegistry};
 use fedimint_core::core::{ModuleInstanceId, ModuleKind};
 use fedimint_core::db::{
     Database, IDatabaseTransactionOpsCoreTyped as _, verify_module_db_integrity_dbtx,
 };
 use fedimint_core::envs::is_running_in_test_env;
+use fedimint_core::invite_code::InviteCode;
 use fedimint_core::module::ApiVersion;
 use fedimint_core::module::registry::{ModuleDecoderRegistry, ModuleRegistry};
 use fedimint_core::task::TaskGroup;
@@ -42,7 +43,9 @@ use tracing::{debug, warn};
 
 use super::handle::ClientHandle;
 use super::{Client, client_decoders};
-use crate::api_announcements::{get_api_urls, run_api_announcement_sync};
+use crate::api_announcements::{
+    get_api_urls, refresh_api_announcement_sync, run_api_announcement_sync,
+};
 use crate::backup::{ClientBackup, Metadata};
 use crate::db::{
     self, ApiSecretKey, ClientInitStateKey, ClientMetadataKey, ClientModuleRecovery,
@@ -54,6 +57,51 @@ use crate::module_init::ClientModuleInitRegistry;
 use crate::oplog::OperationLog;
 use crate::sm::executor::Executor;
 use crate::sm::notifier::Notifier;
+
+/// The type of root secret hashing
+///
+/// Internally, client will always hash-in federation id
+/// to the root secret provided to the [`ClientBuilder`],
+/// to ensure a different secret is used for ever federation.
+/// This makes reusing a single root secret for different federations
+/// in a multi-federation client, perfectly fine, and frees the client
+/// from worrying about `FederationId`.
+///
+/// However, in the past some applications (including `fedimint-cli`)
+/// were doing the hashing-in of `FederationId` outside of `fedimint-client`,
+/// which lead to effectively doing it twice, and sub-optimal API, as the end
+/// application needed to know the federation id e.g. before joining federation,
+/// leaking downloading of configs and internals of joining federation outside.
+///
+/// This is now hard to cleanly fix, so to help phase out the old system,
+/// without affecting existing secrets, the following enum is used.
+#[derive(Clone)]
+pub enum RootSecret {
+    /// Derive an extra round of federation-id to the secret, like
+    /// Fedimint applications were doing manually in the past.
+    ///
+    /// **Note**: Applications MUST NOT do the derivation themselves anymore.
+    LegacyDoubleDerive(DerivableSecret),
+    /// Only use a single internal federation-id hashing.
+    ///
+    /// Use this method if you are building a new application, that
+    /// did not use old system in the past, and save yourself some trouble.
+    ///
+    /// The high level application is free to re-use the same secret for
+    /// multiple different federations. Or not. But client APIs will not
+    /// expose federation_id to the outside before join/recover operations.
+    Standard(DerivableSecret),
+}
+impl RootSecret {
+    fn to_inner(&self, federation_id: FederationId) -> DerivableSecret {
+        match self {
+            RootSecret::LegacyDoubleDerive(derivable_secret) => {
+                get_default_client_secret(derivable_secret, &federation_id)
+            }
+            RootSecret::Standard(derivable_secret) => derivable_secret.clone(),
+        }
+    }
+}
 
 /// Used to configure, assemble and build [`Client`]
 pub struct ClientBuilder {
@@ -344,7 +392,7 @@ impl ClientBuilder {
     /// # use fedimint_core::invite_code::InviteCode;
     /// # use fedimint_core::config::ClientConfig;
     /// # use fedimint_derive_secret::DerivableSecret;
-    /// # use fedimint_client::{Client, ClientBuilder};
+    /// # use fedimint_client::{Client, ClientBuilder, RootSecret};
     /// # use fedimint_core::db::Database;
     /// # use fedimint_core::config::META_FEDERATION_NAME_KEY;
     /// #
@@ -358,8 +406,6 @@ impl ClientBuilder {
     /// // Get invite code from user
     /// let invite_code = InviteCode::from_str("fed11qgqpw9thwvaz7te3xgmjuvpwxqhrzw3jxumrvvf0qqqjpetvlg8glnpvzcufhffgzhv8m75f7y34ryk7suamh8x7zetly8h0v9v0rm")
     ///     .expect("Invalid invite code");
-    /// let config = fedimint_api_client::api::net::Connector::default().download_from_invite_code(&invite_code).await
-    ///     .expect("Error downloading config");
     ///
     /// // Tell the user the federation name, bitcoin network
     /// // (e.g. from wallet module config), and other details
@@ -389,25 +435,63 @@ impl ClientBuilder {
     ///     // .with_module(LightningClientInit)
     ///     // .with_module(MintClientInit)
     ///     // .with_module(WalletClientInit::default())
-    ///     .join(root_secret, config, None)
+    ///     .join_with_invite(RootSecret::Standard(root_secret), &invite_code)
     ///     .await
     ///     .expect("Error joining federation");
     /// # }
     /// ```
-    pub async fn join(
+    pub async fn join_with_invite(
         self,
-        pre_root_secret: DerivableSecret,
+        pre_root_secret: RootSecret,
+        invite_code: &InviteCode,
+    ) -> anyhow::Result<ClientHandle> {
+        let config = self
+            .connector
+            .download_from_invite_code(invite_code)
+            .await?;
+
+        if let Some(guardian_pub_keys) = config.global.broadcast_public_keys.clone() {
+            // Fetching api announcements using invite urls before joining, then write them
+            // to database This ensures the client can communicated with the
+            // Federation even if all the peers moved.
+            let api = DynGlobalApi::from_endpoints(invite_code.peers(), &invite_code.api_secret())
+                .await?;
+            refresh_api_announcement_sync(&api, self.db_no_decoders(), &guardian_pub_keys).await?;
+        }
+
+        let pre_root_secret = pre_root_secret.to_inner(config.calculate_federation_id());
+
+        let client = self
+            .init(
+                pre_root_secret,
+                config.clone(),
+                invite_code.api_secret(),
+                InitMode::Fresh,
+            )
+            .await?;
+
+        Ok(client)
+    }
+
+    pub async fn join_with_existing_config(
+        self,
+        root_secret: DerivableSecret,
         config: ClientConfig,
         api_secret: Option<String>,
     ) -> anyhow::Result<ClientHandle> {
-        self.init(pre_root_secret, config, api_secret, InitMode::Fresh)
-            .await
+        let pre_root_secret =
+            get_default_client_secret(&root_secret, &config.global.calculate_federation_id());
+        let client = self
+            .init(pre_root_secret, config.clone(), api_secret, InitMode::Fresh)
+            .await?;
+
+        Ok(client)
     }
 
     /// Download most recent valid backup found from the Federation
-    pub async fn download_backup_from_federation(
+    async fn download_backup_from_federation(
         &self,
-        root_secret: &DerivableSecret,
+        pre_root_secret: DerivableSecret,
         config: &ClientConfig,
         api_secret: Option<String>,
     ) -> anyhow::Result<Option<ClientBackup>> {
@@ -424,7 +508,7 @@ impl ClientBuilder {
 
         Client::download_backup_from_federation_static(
             &api,
-            &Self::federation_root_secret(root_secret, config),
+            &Self::federation_root_secret(&pre_root_secret, config),
             &self.decoders(config),
         )
         .await
@@ -432,8 +516,9 @@ impl ClientBuilder {
 
     /// Join a (possibly) previous joined Federation
     ///
-    /// Unlike [`Self::join`], `recover` will run client module recovery for
-    /// each client module attempting to recover any previous module state.
+    /// Unlike [`Self::join_with_invite`], `recover` will run client module
+    /// recovery for each client module attempting to recover any previous
+    /// module state.
     ///
     /// Recovery process takes time during which each recovering client module
     /// will not be available for use.
@@ -442,16 +527,41 @@ impl ClientBuilder {
     /// used in a given Federation is safe.
     pub async fn recover(
         self,
-        root_secret: DerivableSecret,
-        config: ClientConfig,
-        api_secret: Option<String>,
-        backup: Option<ClientBackup>,
+        pre_root_secret: RootSecret,
+        invite_code: &InviteCode,
+        custom_backup: Option<ClientBackup>,
     ) -> anyhow::Result<ClientHandle> {
+        let config = self
+            .connector
+            .download_from_invite_code(invite_code)
+            .await?;
+
+        if let Some(guardian_pub_keys) = config.global.broadcast_public_keys.clone() {
+            // Fetching api announcements using invite urls before joining, then write them
+            // to database This ensures the client can communicated with the
+            // Federation even if all the peers moved.
+            let api = DynGlobalApi::from_endpoints(invite_code.peers(), &invite_code.api_secret())
+                .await?;
+            refresh_api_announcement_sync(&api, self.db_no_decoders(), &guardian_pub_keys).await?;
+        }
+
+        let pre_root_secret = pre_root_secret.to_inner(config.calculate_federation_id());
+        let backup = if let Some(backup) = custom_backup {
+            Some(backup)
+        } else {
+            self.download_backup_from_federation(
+                pre_root_secret.clone(),
+                &config,
+                invite_code.api_secret(),
+            )
+            .await?
+        };
+
         let client = self
             .init(
-                root_secret,
+                pre_root_secret,
                 config,
-                api_secret,
+                invite_code.api_secret(),
                 InitMode::Recover {
                     snapshot: backup.clone(),
                 },
@@ -461,10 +571,12 @@ impl ClientBuilder {
         Ok(client)
     }
 
-    pub async fn open(self, pre_root_secret: DerivableSecret) -> anyhow::Result<ClientHandle> {
+    pub async fn open(self, pre_root_secret: RootSecret) -> anyhow::Result<ClientHandle> {
         let Some(config) = Client::get_config_from_db(&self.db_no_decoders).await else {
             bail!("Client database not initialized")
         };
+
+        let pre_root_secret = pre_root_secret.to_inner(config.calculate_federation_id());
 
         match self
             .db_no_decoders()
@@ -542,7 +654,7 @@ impl ClientBuilder {
     /// Build a [`Client`] but do not start the executor
     async fn build_stopped(
         self,
-        root_secret: DerivableSecret,
+        pre_root_secret: DerivableSecret,
         config: &ClientConfig,
         api_secret: Option<String>,
         log_event_added_transient_tx: broadcast::Sender<EventLogEntry>,
@@ -628,7 +740,7 @@ impl ClientBuilder {
 
         let final_client = FinalClientIface::default();
 
-        let root_secret = Self::federation_root_secret(&root_secret, &config);
+        let root_secret = Self::federation_root_secret(&pre_root_secret, &config);
 
         let modules = {
             let mut modules = ClientModuleRegistry::default();
@@ -953,10 +1065,10 @@ impl ClientBuilder {
     /// eliminates the possibility of having the same client `root_secret`
     /// across multiple federations.
     fn federation_root_secret(
-        root_secret: &DerivableSecret,
+        pre_root_secret: &DerivableSecret,
         config: &ClientConfig,
     ) -> DerivableSecret {
-        root_secret.federation_key(&config.global.calculate_federation_id())
+        pre_root_secret.federation_key(&config.global.calculate_federation_id())
     }
 
     /// Register to receiver all new transient (unpersisted) events

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -96,7 +96,7 @@ pub mod module_init;
 
 pub mod sm;
 pub use client::Client;
-pub use client::builder::ClientBuilder;
+pub use client::builder::{ClientBuilder, RootSecret};
 pub use client::handle::{ClientHandle, ClientHandleArc};
 pub use fedimint_client_module as module;
 /// Re-exporting of everything from `fedimint_client_module`

--- a/fedimint-load-test-tool/src/common.rs
+++ b/fedimint-load-test-tool/src/common.rs
@@ -163,7 +163,9 @@ pub async fn build_client(
         client_builder.open(RootSecret::Standard(root_secret)).await
     } else if let Some(invite_code) = &invite_code {
         client_builder
-            .join_with_invite(RootSecret::Standard(root_secret), invite_code)
+            .preview(invite_code)
+            .await?
+            .join(RootSecret::Standard(root_secret))
             .await
     } else {
         bail!("Database not initialize and invite code not provided");

--- a/fedimint-load-test-tool/src/common.rs
+++ b/fedimint-load-test-tool/src/common.rs
@@ -9,7 +9,7 @@ use devimint::util::{FedimintCli, GatewayLdkCli, LnCli};
 use devimint::version_constants::VERSION_0_7_0_ALPHA;
 use fedimint_client::secret::{PlainRootSecretStrategy, RootSecretStrategy};
 use fedimint_client::transaction::TransactionBuilder;
-use fedimint_client::{Client, ClientHandleArc};
+use fedimint_client::{Client, ClientHandleArc, RootSecret};
 use fedimint_core::core::{IntoDynInstance, OperationId};
 use fedimint_core::db::Database;
 use fedimint_core::invite_code::InviteCode;
@@ -160,13 +160,10 @@ pub async fn build_client(
     let root_secret = PlainRootSecretStrategy::to_root_secret(&client_secret);
 
     let client = if Client::is_initialized(client_builder.db_no_decoders()).await {
-        client_builder.open(root_secret).await
+        client_builder.open(RootSecret::Standard(root_secret)).await
     } else if let Some(invite_code) = &invite_code {
-        let client_config = fedimint_api_client::api::net::Connector::default()
-            .download_from_invite_code(invite_code)
-            .await?;
         client_builder
-            .join(root_secret, client_config.clone(), invite_code.api_secret())
+            .join_with_invite(RootSecret::Standard(root_secret), invite_code)
             .await
     } else {
         bail!("Database not initialize and invite code not provided");

--- a/fedimint-recurringd/src/lib.rs
+++ b/fedimint-recurringd/src/lib.rs
@@ -128,10 +128,11 @@ impl RecurringInvoiceServer {
         client_builder.with_primary_module_kind(ModuleKind::from_static_str("mint"));
 
         let client = client_builder
-            .join_with_invite(
-                fedimint_client::RootSecret::LegacyDoubleDerive(Self::default_secret()),
-                invite_code,
-            )
+            .preview(invite_code)
+            .await?
+            .join(fedimint_client::RootSecret::LegacyDoubleDerive(
+                Self::default_secret(),
+            ))
             .await
             .map_err(RecurringPaymentError::JoiningFederationFailed)?;
         Ok(Arc::new(client))

--- a/fedimint-recurringd/src/lib.rs
+++ b/fedimint-recurringd/src/lib.rs
@@ -53,7 +53,11 @@ impl RecurringInvoiceServer {
             client_builder.with_module(LightningClientInit::default());
             client_builder.with_module(MintClientInit);
             client_builder.with_primary_module_kind(ModuleKind::from_static_str("mint"));
-            let client = client_builder.open(Self::default_secret()).await?;
+            let client = client_builder
+                .open(fedimint_client::RootSecret::LegacyDoubleDerive(
+                    Self::default_secret(),
+                ))
+                .await?;
             clients.insert(federation_id, Arc::new(client));
         }
 
@@ -114,11 +118,6 @@ impl RecurringInvoiceServer {
         client_db: Database,
         invite_code: &InviteCode,
     ) -> Result<ClientHandleArc, RecurringPaymentError> {
-        let config = Connector::default()
-            .download_from_invite_code(invite_code)
-            .await
-            .map_err(RecurringPaymentError::JoiningFederationFailed)?;
-
         let mut client_builder = Client::builder(client_db)
             .await
             .map_err(RecurringPaymentError::JoiningFederationFailed)?;
@@ -129,7 +128,10 @@ impl RecurringInvoiceServer {
         client_builder.with_primary_module_kind(ModuleKind::from_static_str("mint"));
 
         let client = client_builder
-            .join(Self::default_secret(), config, None)
+            .join_with_invite(
+                fedimint_client::RootSecret::LegacyDoubleDerive(Self::default_secret()),
+                invite_code,
+            )
             .await
             .map_err(RecurringPaymentError::JoiningFederationFailed)?;
         Ok(Arc::new(client))

--- a/fedimint-testing/src/federation.rs
+++ b/fedimint-testing/src/federation.rs
@@ -120,7 +120,7 @@ impl FederationTest {
             .await
             .unwrap();
         client_builder
-            .join(
+            .join_with_existing_config(
                 PlainRootSecretStrategy::to_root_secret(&client_secret),
                 client_config,
                 None,

--- a/fedimint-testing/src/federation.rs
+++ b/fedimint-testing/src/federation.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use fedimint_api_client::api::{DynGlobalApi, FederationApiExt};
 use fedimint_client::module_init::ClientModuleInitRegistry;
-use fedimint_client::{Client, ClientHandleArc};
+use fedimint_client::{Client, ClientHandleArc, RootSecret};
 use fedimint_client_module::AdminCreds;
 use fedimint_client_module::secret::{PlainRootSecretStrategy, RootSecretStrategy};
 use fedimint_core::PeerId;
@@ -120,11 +120,12 @@ impl FederationTest {
             .await
             .unwrap();
         client_builder
-            .join_with_existing_config(
+            .preview_with_existing_config(client_config, None)
+            .await
+            .expect("Preview failed")
+            .join(RootSecret::Standard(
                 PlainRootSecretStrategy::to_root_secret(&client_secret),
-                client_config,
-                None,
-            )
+            ))
             .await
             .map(Arc::new)
             .expect("Failed to build client")

--- a/fedimint-wasm-tests/src/lib.rs
+++ b/fedimint-wasm-tests/src/lib.rs
@@ -44,10 +44,11 @@ async fn client(invite_code: &InviteCode) -> Result<fedimint_client::ClientHandl
     let client_secret = load_or_generate_mnemonic(builder.db_no_decoders()).await?;
     builder.stopped();
     let client = builder
-        .join_with_invite(
-            RootSecret::Standard(PlainRootSecretStrategy::to_root_secret(&client_secret)),
-            invite_code,
-        )
+        .preview(invite_code)
+        .await?
+        .join(RootSecret::Standard(
+            PlainRootSecretStrategy::to_root_secret(&client_secret),
+        ))
         .await
         .map(Arc::new)?;
     if let Ok(ln_client) = client.get_first_module::<LightningClientModule>() {

--- a/gateway/fedimint-gateway-server/src/client.rs
+++ b/gateway/fedimint-gateway-server/src/client.rs
@@ -110,7 +110,9 @@ impl GatewayClientBuilder {
         let root_secret =
             RootSecret::Standard(Self::derive_federation_secret(mnemonic, &federation_id));
         let client = client_builder
-            .recover(root_secret, &config.invite_code, None)
+            .preview(&config.invite_code)
+            .await?
+            .recover(root_secret, None)
             .await
             .map(Arc::new)
             .map_err(AdminGatewayError::ClientCreationError)?;
@@ -155,7 +157,9 @@ impl GatewayClientBuilder {
             client_builder.open(root_secret).await
         } else {
             client_builder
-                .join_with_invite(root_secret, &invite_code)
+                .preview(&invite_code)
+                .await?
+                .join(root_secret)
                 .await
         }
         .map(Arc::new)

--- a/gateway/fedimint-gateway-server/src/client.rs
+++ b/gateway/fedimint-gateway-server/src/client.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use fedimint_bip39::{Bip39RootSecretStrategy, Mnemonic};
 use fedimint_client::db::ClientConfigKey;
 use fedimint_client::module_init::ClientModuleInitRegistry;
-use fedimint_client::{Client, ClientBuilder};
+use fedimint_client::{Client, ClientBuilder, RootSecret};
 use fedimint_client_module::secret::{PlainRootSecretStrategy, RootSecretStrategy};
 use fedimint_core::config::FederationId;
 use fedimint_core::core::ModuleKind;
@@ -102,32 +102,15 @@ impl GatewayClientBuilder {
         gateway: Arc<Gateway>,
         mnemonic: &Mnemonic,
     ) -> AdminResult<()> {
-        let client_config = config
-            .connector
-            .download_from_invite_code(&config.invite_code)
-            .await
-            .map_err(AdminGatewayError::ClientCreationError)?;
         let federation_id = config.invite_code.federation_id();
         let db = gateway.gateway_db.get_client_database(&federation_id);
         let client_builder = self
             .create_client_builder(db, &config, gateway.clone())
             .await?;
-        let secret = Self::derive_federation_secret(mnemonic, &federation_id);
-        let backup = client_builder
-            .download_backup_from_federation(
-                &secret,
-                &client_config,
-                config.invite_code.api_secret(),
-            )
-            .await
-            .map_err(AdminGatewayError::ClientCreationError)?;
+        let root_secret =
+            RootSecret::Standard(Self::derive_federation_secret(mnemonic, &federation_id));
         let client = client_builder
-            .recover(
-                secret.clone(),
-                client_config,
-                config.invite_code.api_secret(),
-                backup,
-            )
+            .recover(root_secret, &config.invite_code, None)
             .await
             .map(Arc::new)
             .map_err(AdminGatewayError::ClientCreationError)?;
@@ -167,16 +150,12 @@ impl GatewayClientBuilder {
 
         let client_builder = self.create_client_builder(db, &config, gateway).await?;
 
+        let root_secret = RootSecret::Standard(root_secret);
         if Client::is_initialized(client_builder.db_no_decoders()).await {
             client_builder.open(root_secret).await
         } else {
-            let client_config = config
-                .connector
-                .download_from_invite_code(&invite_code)
-                .await
-                .map_err(AdminGatewayError::ClientCreationError)?;
             client_builder
-                .join(root_secret, client_config.clone(), invite_code.api_secret())
+                .join_with_invite(root_secret, &invite_code)
                 .await
         }
         .map(Arc::new)


### PR DESCRIPTION
Fix #6976



**Edit**: Argh, the whole thing does not work, because we already exposed federation_id hashing into secret to the outside of join, and for that client needs federation_id, and for that they need to download the config.


**Edit**: OK, fixed that, but... Argh, as we need to do more stuff on join, we can't have it repeated over and over everywhere, so we need to fold it into client.  But that doesn't work with preview ...


**Edit**: Well, I had to refactor even more things. :shrug: . But I kind of like this explicit preview step now.
 
<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
