### PR TITLE
chore: further optimize wasm & add additional target

### DIFF
--- a/fedimint-client-wasm/Cargo.toml
+++ b/fedimint-client-wasm/Cargo.toml
@@ -10,7 +10,7 @@ version = { workspace = true }
 
 # https://rustwasm.github.io/wasm-pack/book/cargo-toml-configuration.html
 [package.metadata.wasm-pack.profile.release]
-wasm-opt = ['-Os']
+wasm-opt = ['-Oz']
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/nix/flakebox.nix
+++ b/nix/flakebox.nix
@@ -705,30 +705,33 @@ in
 
     wasmBundleClientPkgDeps = craneLib.buildWorkspaceDepsOnly {
       pname = "${commonArgs.pname}-client-wasm";
-      "CARGO_PROFILE_RELEASE_OPT_LEVEL" = "s";
+      "CARGO_PROFILE_RELEASE_OPT_LEVEL" = "z";
       buildPhaseCargoCommand = "runLowPrio cargo build --profile $CARGO_PROFILE --locked -p fedimint-client-wasm";
     };
 
     wasmBundleClientPkg = craneLib.buildWorkspace {
       cargoArtifacts = wasmBundleClientPkgDeps;
       pname = "${commonArgs.pname}-client-wasm";
-      "CARGO_PROFILE_RELEASE_OPT_LEVEL" = "s";
+      "CARGO_PROFILE_RELEASE_OPT_LEVEL" = "z";
       buildPhaseCargoCommand = "runLowPrio cargo build --profile $CARGO_PROFILE --locked -p fedimint-client-wasm";
     };
 
     wasmBundle = craneLibTests.mkCargoDerivation {
       pname = "wasm-bundle";
       cargoArtifacts = wasmBundleClientPkg;
-      "CARGO_PROFILE_RELEASE_OPT_LEVEL" = "s";
+      "CARGO_PROFILE_RELEASE_OPT_LEVEL" = "z";
       nativeBuildInputs = commonCliTestArgs.nativeBuildInputs ++ [
         pkgs.wasm-bindgen-cli
         pkgs.wasm-pack
         pkgs.binaryen
       ];
       buildPhaseCargoCommand = ''
-        runLowPrio wasm-pack build fedimint-client-wasm
+        runLowPrio wasm-pack build --release fedimint-client-wasm
+        runLowPrio wasm-pack build --release --target web --out-dir web fedimint-client-wasm
         mkdir -p $out/share/fedimint-client-wasm
+        mkdir -p $out/share/fedimint-client-wasm-web
         cp fedimint-client-wasm/pkg/* $out/share/fedimint-client-wasm
+        cp fedimint-client-wasm/web/* $out/share/fedimint-client-wasm-web
       '';
     };
 


### PR DESCRIPTION
<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->

ref: https://github.com/fedimint/fedimint/pull/6586
cc: @maan2003 

* sets even more aggressive flag to optimize for size (`z` saves about 7% in bundle size compared to `s`)
* Adds additional wasm-pack target for web sdk (web)


```sh
❯ ls -la result/share/fedimint-client-wasm
total 8080
dr-xr-xr-x 8 alex nixbld     256 Dec 31  1969 .
dr-xr-xr-x 4 alex nixbld     128 Dec 31  1969 ..
-r--r--r-- 1 alex nixbld    2153 Dec 31  1969 fedimint_client_wasm.d.ts
-r--r--r-- 1 alex nixbld     212 Dec 31  1969 fedimint_client_wasm.js
-r--r--r-- 1 alex nixbld   49803 Dec 31  1969 fedimint_client_wasm_bg.js
-r--r--r-- 1 alex nixbld 8197192 Dec 31  1969 fedimint_client_wasm_bg.wasm
-r--r--r-- 1 alex nixbld    4106 Dec 31  1969 fedimint_client_wasm_bg.wasm.d.ts
-r--r--r-- 1 alex nixbld     601 Dec 31  1969 package.json

❯ ls result/share/fedimint-client-wasm-web -la
total 8080
dr-xr-xr-x 7 alex nixbld     224 Dec 31  1969 .
dr-xr-xr-x 4 alex nixbld     128 Dec 31  1969 ..
-r--r--r-- 1 alex nixbld    7091 Dec 31  1969 fedimint_client_wasm.d.ts
-r--r--r-- 1 alex nixbld   57761 Dec 31  1969 fedimint_client_wasm.js
-r--r--r-- 1 alex nixbld 8191992 Dec 31  1969 fedimint_client_wasm_bg.wasm
-r--r--r-- 1 alex nixbld    4106 Dec 31  1969 fedimint_client_wasm_bg.wasm.d.ts
-r--r--r-- 1 alex nixbld     534 Dec 31  1969 package.json
```


