### PR TITLE
[releases/v0.7] chore: bump version to v0.7.3-alpha

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2089,7 +2089,7 @@ dependencies = [
 
 [[package]]
 name = "devimint"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "axum 0.8.1",
@@ -2525,7 +2525,7 @@ checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
 name = "fedimint-aead"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "argon2",
@@ -2557,7 +2557,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-api-client"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "async-channel 2.3.1",
@@ -2636,7 +2636,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-bip39"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "bip39",
  "fedimint-client",
@@ -2647,7 +2647,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-bitcoind"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2669,14 +2669,14 @@ dependencies = [
 
 [[package]]
 name = "fedimint-build"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "fedimint-cli"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2714,7 +2714,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2742,7 +2742,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client-module"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -2771,7 +2771,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client-wasm"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2795,7 +2795,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-core"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "async-channel 2.3.1",
@@ -2856,7 +2856,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dbtool"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2891,7 +2891,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-derive"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -2901,7 +2901,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-derive-secret"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "bitcoin_hashes 0.14.0",
@@ -2913,11 +2913,11 @@ dependencies = [
 
 [[package]]
 name = "fedimint-docs"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 
 [[package]]
 name = "fedimint-dummy-client"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2937,7 +2937,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dummy-common"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -2947,7 +2947,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dummy-server"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2963,7 +2963,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dummy-tests"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "fedimint-client",
@@ -2984,7 +2984,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-empty-client"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3001,7 +3001,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-empty-common"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -3011,7 +3011,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-empty-server"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3027,7 +3027,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-eventlog"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3044,7 +3044,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-fuzz"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "fedimint-core",
  "fedimint-ln-common",
@@ -3057,7 +3057,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-client"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "bcrypt",
@@ -3081,7 +3081,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-common"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "bitcoin",
  "clap",
@@ -3098,7 +3098,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-server"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3167,7 +3167,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-server-db"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -3194,7 +3194,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gw-client"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3221,7 +3221,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gwv2-client"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3248,14 +3248,14 @@ dependencies = [
 
 [[package]]
 name = "fedimint-hkdf"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "bitcoin_hashes 0.14.0",
 ]
 
 [[package]]
 name = "fedimint-lightning"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3282,7 +3282,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-client"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3314,7 +3314,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-common"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -3331,7 +3331,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-server"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3357,7 +3357,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-tests"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-client"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3415,7 +3415,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-common"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3434,7 +3434,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-server"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3459,7 +3459,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-tests"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3486,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-load-test-tool"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "clap",
@@ -3513,7 +3513,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-logging"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "console-subscriber",
@@ -3525,7 +3525,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-client"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3546,7 +3546,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-common"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -3560,7 +3560,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-server"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3579,7 +3579,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-tests"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "clap",
@@ -3593,7 +3593,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-metrics"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "axum 0.8.1",
@@ -3605,7 +3605,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-client"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3645,7 +3645,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-common"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "bitcoin_hashes 0.14.0",
@@ -3658,7 +3658,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-server"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3684,7 +3684,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-tests"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "bitcoin_hashes 0.14.0",
@@ -3717,7 +3717,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-portalloc"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "dirs 6.0.0",
@@ -3731,7 +3731,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-recoverytool"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -3754,7 +3754,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-recurringd"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "axum 0.8.1",
@@ -3780,7 +3780,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-rocksdb"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3796,7 +3796,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "async-channel 2.3.1",
@@ -3848,7 +3848,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server-core"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3862,7 +3862,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server-tests"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "bitcoin",
  "fedimint-api-client",
@@ -3882,7 +3882,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server-ui"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3904,7 +3904,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-tbs"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "bls12_381",
  "criterion",
@@ -3919,7 +3919,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-testing"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3952,7 +3952,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-testing-core"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "fedimint-client",
@@ -4064,7 +4064,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-tpe"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "bitcoin_hashes 0.14.0",
  "bls12_381",
@@ -4078,7 +4078,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-unknown-common"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -4088,7 +4088,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-unknown-server"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4102,7 +4102,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-client"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -4131,7 +4131,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-common"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -4147,7 +4147,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-server"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4177,7 +4177,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-tests"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4209,7 +4209,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wasm-tests"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "fedimint-api-client",
@@ -4229,7 +4229,7 @@ dependencies = [
 
 [[package]]
 name = "fedimintd"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -4554,7 +4554,7 @@ dependencies = [
 
 [[package]]
 name = "gateway-tests"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "clap",
@@ -6371,7 +6371,7 @@ dependencies = [
 
 [[package]]
 name = "lnurlp"
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.7.2-rc.0"
+version = "0.7.3-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2024"
 description = "Fedimint is a Federated Chaumian E-Cash Mint, natively compatible with Bitcoin & the Lightning Network"
@@ -125,66 +125,66 @@ bytes = "1.10.1"
 chrono = "0.4.40"
 clap = { version = "4.5.34", features = ["derive", "env"] }
 criterion = "0.5.1"
-devimint = { path = "./devimint", version = "=0.7.2-rc.0" }
+devimint = { path = "./devimint", version = "=0.7.3-alpha" }
 erased-serde = "0.4"
 esplora-client = { version = "0.10.0", default-features = false, features = [
   "async-https-rustls",
 ] }
-fedimintd = { path = "./fedimintd", version = "=0.7.2-rc.0" }
-fedimint-aead = { path = "./crypto/aead", version = "=0.7.2-rc.0" }
-fedimint-api-client = { path = "./fedimint-api-client", version = "=0.7.2-rc.0" }
-fedimint-bip39 = { path = "./fedimint-bip39", version = "=0.7.2-rc.0" }
-fedimint-bitcoind = { path = "./fedimint-bitcoind", version = "=0.7.2-rc.0" }
-fedimint-build = { path = "./fedimint-build", version = "=0.7.2-rc.0" }
-fedimint-client = { path = "./fedimint-client", version = "=0.7.2-rc.0" }
-fedimint-client-module = { path = "./fedimint-client-module", version = "=0.7.2-rc.0" }
-fedimint-core = { path = "./fedimint-core", version = "=0.7.2-rc.0" }
-fedimint-derive = { path = "./fedimint-derive", version = "=0.7.2-rc.0" }
-fedimint-derive-secret = { path = "./crypto/derive-secret", version = "=0.7.2-rc.0" }
-fedimint-dummy-client = { path = "./modules/fedimint-dummy-client", version = "=0.7.2-rc.0" }
-fedimint-dummy-common = { path = "./modules/fedimint-dummy-common", version = "=0.7.2-rc.0" }
-fedimint-dummy-server = { path = "./modules/fedimint-dummy-server", version = "=0.7.2-rc.0" }
-fedimint-empty-common = { path = "./modules/fedimint-empty-common", version = "=0.7.2-rc.0" }
-fedimint-eventlog = { path = "./fedimint-eventlog", version = "=0.7.2-rc.0" }
-fedimint-gateway-common = { package = "fedimint-gateway-common", path = "./gateway/fedimint-gateway-common", version = "=0.7.2-rc.0" }
-fedimint-gateway-server = { package = "fedimint-gateway-server", path = "./gateway/fedimint-gateway-server", version = "=0.7.2-rc.0" }
-fedimint-gateway-server-db = { package = "fedimint-gateway-server-db", path = "./gateway/fedimint-gateway-server-db", version = "=0.7.2-rc.0" }
-fedimint-gw-client = { path = "./modules/fedimint-gw-client", version = "=0.7.2-rc.0" }
-fedimint-gwv2-client = { path = "./modules/fedimint-gwv2-client", version = "=0.7.2-rc.0" }
-fedimint-lightning = { package = "fedimint-lightning", path = "./gateway/fedimint-lightning", version = "=0.7.2-rc.0" }
-fedimint-lnv2-client = { path = "./modules/fedimint-lnv2-client", version = "=0.7.2-rc.0" }
-fedimint-lnv2-common = { path = "./modules/fedimint-lnv2-common", version = "=0.7.2-rc.0" }
-fedimint-lnv2-server = { path = "./modules/fedimint-lnv2-server", version = "=0.7.2-rc.0" }
-fedimint-ln-client = { path = "./modules/fedimint-ln-client", version = "=0.7.2-rc.0" }
-fedimint-ln-common = { path = "./modules/fedimint-ln-common", version = "=0.7.2-rc.0" }
-fedimint-ln-server = { path = "./modules/fedimint-ln-server", version = "=0.7.2-rc.0" }
-fedimint-logging = { path = "./fedimint-logging", version = "=0.7.2-rc.0" }
-fedimint-meta-client = { path = "./modules/fedimint-meta-client", version = "=0.7.2-rc.0" }
-fedimint-meta-common = { path = "./modules/fedimint-meta-common", version = "=0.7.2-rc.0" }
-fedimint-meta-server = { path = "./modules/fedimint-meta-server", version = "=0.7.2-rc.0" }
-fedimint-metrics = { path = "./fedimint-metrics", version = "=0.7.2-rc.0" }
-fedimint-mint-client = { path = "./modules/fedimint-mint-client", version = "=0.7.2-rc.0" }
-fedimint-mint-common = { path = "./modules/fedimint-mint-common", version = "=0.7.2-rc.0" }
-fedimint-mint-server = { path = "./modules/fedimint-mint-server", version = "=0.7.2-rc.0" }
-fedimint-portalloc = { path = "utils/portalloc", version = "=0.7.2-rc.0" }
-fedimint-rocksdb = { path = "./fedimint-rocksdb", version = "=0.7.2-rc.0" }
-fedimint-server = { path = "./fedimint-server", version = "=0.7.2-rc.0" }
-fedimint-server-core = { path = "./fedimint-server-core", version = "=0.7.2-rc.0" }
-fedimint-server-ui = { path = "./fedimint-server-ui", version = "=0.7.2-rc.0" }
-fedimint-testing = { path = "./fedimint-testing", version = "=0.7.2-rc.0" }
-fedimint-testing-core = { path = "./fedimint-testing-core", version = "=0.7.2-rc.0" }
-fedimint-unknown-common = { path = "./modules/fedimint-unknown-common", version = "=0.7.2-rc.0" }
-fedimint-unknown-server = { path = "./modules/fedimint-unknown-server", version = "=0.7.2-rc.0" }
-fedimint-wallet-client = { path = "./modules/fedimint-wallet-client", version = "=0.7.2-rc.0" }
-fedimint-wallet-common = { path = "./modules/fedimint-wallet-common", version = "=0.7.2-rc.0" }
-fedimint-wallet-server = { path = "./modules/fedimint-wallet-server", version = "=0.7.2-rc.0" }
+fedimintd = { path = "./fedimintd", version = "=0.7.3-alpha" }
+fedimint-aead = { path = "./crypto/aead", version = "=0.7.3-alpha" }
+fedimint-api-client = { path = "./fedimint-api-client", version = "=0.7.3-alpha" }
+fedimint-bip39 = { path = "./fedimint-bip39", version = "=0.7.3-alpha" }
+fedimint-bitcoind = { path = "./fedimint-bitcoind", version = "=0.7.3-alpha" }
+fedimint-build = { path = "./fedimint-build", version = "=0.7.3-alpha" }
+fedimint-client = { path = "./fedimint-client", version = "=0.7.3-alpha" }
+fedimint-client-module = { path = "./fedimint-client-module", version = "=0.7.3-alpha" }
+fedimint-core = { path = "./fedimint-core", version = "=0.7.3-alpha" }
+fedimint-derive = { path = "./fedimint-derive", version = "=0.7.3-alpha" }
+fedimint-derive-secret = { path = "./crypto/derive-secret", version = "=0.7.3-alpha" }
+fedimint-dummy-client = { path = "./modules/fedimint-dummy-client", version = "=0.7.3-alpha" }
+fedimint-dummy-common = { path = "./modules/fedimint-dummy-common", version = "=0.7.3-alpha" }
+fedimint-dummy-server = { path = "./modules/fedimint-dummy-server", version = "=0.7.3-alpha" }
+fedimint-empty-common = { path = "./modules/fedimint-empty-common", version = "=0.7.3-alpha" }
+fedimint-eventlog = { path = "./fedimint-eventlog", version = "=0.7.3-alpha" }
+fedimint-gateway-common = { package = "fedimint-gateway-common", path = "./gateway/fedimint-gateway-common", version = "=0.7.3-alpha" }
+fedimint-gateway-server = { package = "fedimint-gateway-server", path = "./gateway/fedimint-gateway-server", version = "=0.7.3-alpha" }
+fedimint-gateway-server-db = { package = "fedimint-gateway-server-db", path = "./gateway/fedimint-gateway-server-db", version = "=0.7.3-alpha" }
+fedimint-gw-client = { path = "./modules/fedimint-gw-client", version = "=0.7.3-alpha" }
+fedimint-gwv2-client = { path = "./modules/fedimint-gwv2-client", version = "=0.7.3-alpha" }
+fedimint-lightning = { package = "fedimint-lightning", path = "./gateway/fedimint-lightning", version = "=0.7.3-alpha" }
+fedimint-lnv2-client = { path = "./modules/fedimint-lnv2-client", version = "=0.7.3-alpha" }
+fedimint-lnv2-common = { path = "./modules/fedimint-lnv2-common", version = "=0.7.3-alpha" }
+fedimint-lnv2-server = { path = "./modules/fedimint-lnv2-server", version = "=0.7.3-alpha" }
+fedimint-ln-client = { path = "./modules/fedimint-ln-client", version = "=0.7.3-alpha" }
+fedimint-ln-common = { path = "./modules/fedimint-ln-common", version = "=0.7.3-alpha" }
+fedimint-ln-server = { path = "./modules/fedimint-ln-server", version = "=0.7.3-alpha" }
+fedimint-logging = { path = "./fedimint-logging", version = "=0.7.3-alpha" }
+fedimint-meta-client = { path = "./modules/fedimint-meta-client", version = "=0.7.3-alpha" }
+fedimint-meta-common = { path = "./modules/fedimint-meta-common", version = "=0.7.3-alpha" }
+fedimint-meta-server = { path = "./modules/fedimint-meta-server", version = "=0.7.3-alpha" }
+fedimint-metrics = { path = "./fedimint-metrics", version = "=0.7.3-alpha" }
+fedimint-mint-client = { path = "./modules/fedimint-mint-client", version = "=0.7.3-alpha" }
+fedimint-mint-common = { path = "./modules/fedimint-mint-common", version = "=0.7.3-alpha" }
+fedimint-mint-server = { path = "./modules/fedimint-mint-server", version = "=0.7.3-alpha" }
+fedimint-portalloc = { path = "utils/portalloc", version = "=0.7.3-alpha" }
+fedimint-rocksdb = { path = "./fedimint-rocksdb", version = "=0.7.3-alpha" }
+fedimint-server = { path = "./fedimint-server", version = "=0.7.3-alpha" }
+fedimint-server-core = { path = "./fedimint-server-core", version = "=0.7.3-alpha" }
+fedimint-server-ui = { path = "./fedimint-server-ui", version = "=0.7.3-alpha" }
+fedimint-testing = { path = "./fedimint-testing", version = "=0.7.3-alpha" }
+fedimint-testing-core = { path = "./fedimint-testing-core", version = "=0.7.3-alpha" }
+fedimint-unknown-common = { path = "./modules/fedimint-unknown-common", version = "=0.7.3-alpha" }
+fedimint-unknown-server = { path = "./modules/fedimint-unknown-server", version = "=0.7.3-alpha" }
+fedimint-wallet-client = { path = "./modules/fedimint-wallet-client", version = "=0.7.3-alpha" }
+fedimint-wallet-common = { path = "./modules/fedimint-wallet-common", version = "=0.7.3-alpha" }
+fedimint-wallet-server = { path = "./modules/fedimint-wallet-server", version = "=0.7.3-alpha" }
 fs-lock = "=0.1.8" # https://github.com/cargo-bins/cargo-binstall/issues/2090
 futures = "0.3.31"
 futures-util = "0.3.30"
 group = "0.13.0"
 hex = "0.4.3"
 hex-conservative = "0.3.0"
-hkdf = { package = "fedimint-hkdf", path = "./crypto/hkdf", version = "=0.7.2-rc.0" }
+hkdf = { package = "fedimint-hkdf", path = "./crypto/hkdf", version = "=0.7.3-alpha" }
 hyper = "1.6"
 iroh = { version = "0.34.0", default-features = false }
 iroh-base = { version = "0.34.0", default-features = false }
@@ -220,7 +220,7 @@ strum = { version = "0.26", features = ["derive"] }
 strum_macros = "0.26"
 subtle = "2.6.1"
 test-log = { version = "0.2", features = ["trace"], default-features = false }
-tbs = { package = "fedimint-tbs", path = "./crypto/tbs", version = "=0.7.2-rc.0" }
+tbs = { package = "fedimint-tbs", path = "./crypto/tbs", version = "=0.7.3-alpha" }
 thiserror = "2.0.12"
 threshold_crypto = { version = "0.2.1", package = "fedimint-threshold-crypto" }
 tokio = "1.44.1"
@@ -231,7 +231,7 @@ tonic_lnd = { version = "0.2.0", package = "fedimint-tonic-lnd", features = [
   "lightningrpc",
   "routerrpc",
 ] }
-tpe = { package = "fedimint-tpe", path = "./crypto/tpe", version = "=0.7.2-rc.0" }
+tpe = { package = "fedimint-tpe", path = "./crypto/tpe", version = "=0.7.3-alpha" }
 tracing = "0.1.41"
 tracing-subscriber = "0.3.19"
 tracing-test = "0.2.5"

--- a/fedimint-cli/Cargo.toml
+++ b/fedimint-cli/Cargo.toml
@@ -31,9 +31,9 @@ bitcoin = { workspace = true }
 clap = { workspace = true }
 clap_complete = "4.5.47"
 fedimint-aead = { workspace = true }
-fedimint-api-client = { path = "../fedimint-api-client", version = "=0.7.2-rc.0" }
+fedimint-api-client = { path = "../fedimint-api-client", version = "=0.7.3-alpha" }
 fedimint-bip39 = { workspace = true }
-fedimint-client = { path = "../fedimint-client", version = "=0.7.2-rc.0" }
+fedimint-client = { path = "../fedimint-client", version = "=0.7.3-alpha" }
 fedimint-core = { workspace = true }
 fedimint-eventlog = { workspace = true }
 fedimint-ln-client = { workspace = true, features = ["cli"] }

--- a/fedimint-client-module/Cargo.toml
+++ b/fedimint-client-module/Cargo.toml
@@ -29,7 +29,7 @@ aquamarine = { workspace = true }
 async-stream = { workspace = true }
 async-trait = { workspace = true }
 bitcoin = { workspace = true }
-fedimint-api-client = { path = "../fedimint-api-client", version = "=0.7.2-rc.0" }
+fedimint-api-client = { path = "../fedimint-api-client", version = "=0.7.3-alpha" }
 fedimint-core = { workspace = true }
 fedimint-derive-secret = { workspace = true }
 fedimint-eventlog = { workspace = true }

--- a/fedimint-testing/Cargo.toml
+++ b/fedimint-testing/Cargo.toml
@@ -31,8 +31,8 @@ fedimint-client = { workspace = true }
 fedimint-client-module = { workspace = true }
 fedimint-core = { workspace = true }
 fedimint-gateway-common = { workspace = true }
-fedimint-gateway-server = { package = "fedimint-gateway-server", path = "../gateway/fedimint-gateway-server", version = "=0.7.2-rc.0" }
-fedimint-lightning = { package = "fedimint-lightning", path = "../gateway/fedimint-lightning", version = "=0.7.2-rc.0" }
+fedimint-gateway-server = { package = "fedimint-gateway-server", path = "../gateway/fedimint-gateway-server", version = "=0.7.3-alpha" }
+fedimint-lightning = { package = "fedimint-lightning", path = "../gateway/fedimint-lightning", version = "=0.7.3-alpha" }
 fedimint-ln-common = { workspace = true }
 fedimint-logging = { workspace = true }
 fedimint-portalloc = { workspace = true }

--- a/gateway/fedimint-gateway-common/Cargo.toml
+++ b/gateway/fedimint-gateway-common/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 [dependencies]
 bitcoin = { workspace = true }
 clap = { workspace = true }
-fedimint-api-client = { path = "../../fedimint-api-client", version = "=0.7.2-rc.0" }
+fedimint-api-client = { path = "../../fedimint-api-client", version = "=0.7.3-alpha" }
 fedimint-core = { workspace = true }
 fedimint-eventlog = { workspace = true }
 fedimint-lnv2-common = { workspace = true }

--- a/gateway/fedimint-gateway-server/Cargo.toml
+++ b/gateway/fedimint-gateway-server/Cargo.toml
@@ -49,7 +49,7 @@ fedimint-gateway-common = { workspace = true }
 fedimint-gateway-server-db = { workspace = true }
 fedimint-gw-client = { workspace = true }
 fedimint-gwv2-client = { workspace = true }
-fedimint-lightning = { path = "../fedimint-lightning", version = "=0.7.2-rc.0" }
+fedimint-lightning = { path = "../fedimint-lightning", version = "=0.7.3-alpha" }
 fedimint-ln-client = { workspace = true }
 fedimint-ln-common = { workspace = true }
 fedimint-lnv2-client = { workspace = true }

--- a/gateway/fedimint-lightning/Cargo.toml
+++ b/gateway/fedimint-lightning/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/lib.rs"
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 bitcoin = { workspace = true }
-fedimint-bip39 = { version = "=0.7.2-rc.0", path = "../../fedimint-bip39" }
+fedimint-bip39 = { version = "=0.7.3-alpha", path = "../../fedimint-bip39" }
 fedimint-bitcoind = { workspace = true }
 fedimint-core = { workspace = true }
 fedimint-gateway-common = { workspace = true }

--- a/modules/fedimint-gw-client/Cargo.toml
+++ b/modules/fedimint-gw-client/Cargo.toml
@@ -26,13 +26,13 @@ async-stream = { workspace = true }
 async-trait = { workspace = true }
 bitcoin = { workspace = true }
 erased-serde = { workspace = true }
-fedimint-api-client = { path = "../../fedimint-api-client", version = "=0.7.2-rc.0" }
+fedimint-api-client = { path = "../../fedimint-api-client", version = "=0.7.3-alpha" }
 fedimint-client = { workspace = true }
 fedimint-client-module = { workspace = true }
 fedimint-core = { workspace = true }
 fedimint-derive-secret = { workspace = true }
 fedimint-eventlog = { workspace = true }
-fedimint-lightning = { path = "../../gateway/fedimint-lightning", version = "=0.7.2-rc.0" }
+fedimint-lightning = { path = "../../gateway/fedimint-lightning", version = "=0.7.3-alpha" }
 fedimint-ln-client = { workspace = true }
 fedimint-ln-common = { workspace = true }
 futures = { workspace = true }

--- a/modules/fedimint-wallet-client/Cargo.toml
+++ b/modules/fedimint-wallet-client/Cargo.toml
@@ -47,6 +47,6 @@ tracing = { workspace = true }
 fedimint-bitcoind = { workspace = true }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
-fedimint-bitcoind = { version = "=0.7.2-rc.0", path = "../../fedimint-bitcoind", default-features = false, features = [
+fedimint-bitcoind = { version = "=0.7.3-alpha", path = "../../fedimint-bitcoind", default-features = false, features = [
   "esplora-client",
 ] }


### PR DESCRIPTION
Followup now that we released `v0.7.2` (see: https://github.com/fedimint/fedimint/issues/7441)