### PR TITLE
[releases/v0.7] chore: bump docker tag to v0.7.2

### DIFF
--- a/docker/deploy-fedimintd/.env
+++ b/docker/deploy-fedimintd/.env
@@ -15,4 +15,4 @@ FM_BITCOIN_RPC_URL=http://bitcoin:bitcoin@bitcoin:8332
 # FM_BITCOIN_RPC_URL=https://blockstream.info/api/
 
 # fedimintd image
-FEDIMINTD_IMAGE=fedimint/fedimintd:v0.7.1
+FEDIMINTD_IMAGE=fedimint/fedimintd:v0.7.2


### PR DESCRIPTION
We released `v0.7.2` so we can bump the referenced tag for docker deployments (see: https://github.com/fedimint/fedimint/issues/7441)