### PR TITLE
chore: try wild linker (only in dev shell)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,9 @@
     nixpkgs = {
       url = "github:nixos/nixpkgs/nixos-24.11";
     };
-    nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
+    nixpkgs-unstable = {
+      url = "github:nixos/nixpkgs/nixos-unstable";
+    };
     flake-utils.url = "github:numtide/flake-utils";
     fenix = {
       url = "github:nix-community/fenix";
@@ -68,6 +70,7 @@
     // flake-utils.lib.eachDefaultSystem (
       system:
       let
+        pkgs-unstable = nixpkgs-unstable.legacyPackages.${system};
         pkgs = import nixpkgs {
           inherit system;
           overlays = [
@@ -317,6 +320,9 @@
                   ]
                   ++ lib.optionals (!stdenv.isAarch64 && !stdenv.isDarwin) [ pkgs.semgrep ]
                   ++ lib.optionals (!stdenv.isDarwin) [
+                    # does not support macos
+                    (pkgs-unstable.callPackage ./nix/pkgs/wild.nix { })
+
                     # broken on MacOS?
                     pkgs.cargo-workspaces
 
@@ -355,6 +361,8 @@
                   if [ -z "$(git config --global merge.ours.driver)" ]; then
                       >&2 echo "⚠️  Recommended to run 'git config --global merge.ours.driver true' to enable better lock file handling. See https://blog.aspect.dev/easier-merges-on-lockfiles for more info"
                   fi
+
+                  export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS="-C link-arg=--ld-path=wild"
                 '';
               };
           in

--- a/nix/pkgs/wild.nix
+++ b/nix/pkgs/wild.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  pkg-config,
+}:
+
+rustPlatform.buildRustPackage rec {
+  name = "wild-${version}";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner = "davidlattimore";
+    repo = "wild";
+    rev = "81d9c116f42c232769807e0e003eac7e70f95b6e";
+    sha256 = "sha256-tVGvSd4aege3xz/CrEl98AwuEJlsM3nVVG0urTSajFQ=";
+  };
+
+  doCheck = false;
+
+  buildInputs = [
+    pkg-config
+  ];
+
+  cargoHash = "sha256-dXIYJfjz6okiLJuX4ZHu0Ft2/9XDjCrvvl/eqeuvBkU=";
+
+  meta = with lib; {
+    description = "A very fast linker for Linux";
+    homepage = "https://github.com/davidlattimore/wild";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dpc ];
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
I've tried #6850 with a newest version of wild, and it is 20% faster on incremental builds, which is a nice improvement, so why not?

```
> echo $CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS
-C link-arg=-fuse-ld=mold -C link-arg=-Wl,--compress-debug-sections=zlib
> env BENCH_COMP_SKIP_PROFILE=release just bench-compilation
...
                       total    user     sys
Full  check   debug:   52.78  854.30  125.46
Incr  check   debug:    4.21    8.25    7.88
Full  build   debug:   91.71 1712.73  180.90
Incr  build   debug:   10.27   28.92   23.64



> echo $CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS
-C link-arg=--ld-path=wild
> just bench-compilation-quick-incr
                       total    user     sys
Incr  check   debug:    5.78   12.22   21.79

> env BENCH_COMP_SKIP_PROFILE=release just bench-compilation

                       total    user     sys
Full  check   debug:   53.78  841.27  121.82
Incr  check   debug:    4.22    8.31    7.98
Full  build   debug:   91.17 1688.65  179.37
Incr  build   debug:    7.93   24.45   21.45
```

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
