### PR TITLE
fix(wallet-client): don't claim on-chain deposits smaller than the fee

### DIFF
--- a/devimint/src/version_constants.rs
+++ b/devimint/src/version_constants.rs
@@ -6,3 +6,5 @@ pub static VERSION_0_6_0_ALPHA: LazyLock<Version> =
     LazyLock::new(|| Version::parse("0.6.0-alpha").expect("version is parsable"));
 pub static VERSION_0_7_0_ALPHA: LazyLock<Version> =
     LazyLock::new(|| Version::parse("0.7.0-alpha").expect("version is parsable"));
+pub static VERSION_0_8_0_ALPHA: LazyLock<Version> =
+    LazyLock::new(|| Version::parse("0.8.0-alpha").expect("version is parsable"));

--- a/modules/fedimint-wallet-client/src/client_db.rs
+++ b/modules/fedimint-wallet-client/src/client_db.rs
@@ -154,6 +154,10 @@ pub struct ClaimedPegInPrefix;
 
 #[derive(Clone, Debug, Encodable, Decodable, Serialize)]
 pub struct ClaimedPegInData {
+    /// The Fedimint transaction id of the claim transaction. If there was no
+    /// claim transaction due to the deposit being smaller than the deposit fee
+    /// there will be no claim transaction and the transaction id will be all
+    /// zeros.
     pub claim_txid: TransactionId,
     pub change: Vec<fedimint_core::OutPoint>,
 }

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -58,8 +58,8 @@ use fedimint_core::task::{MaybeSend, MaybeSync, TaskGroup, sleep};
 use fedimint_core::util::backoff_util::background_backoff;
 use fedimint_core::util::{BoxStream, backoff_util, retry};
 use fedimint_core::{
-    Amount, OutPoint, TransactionId, apply, async_trait_maybe_send, push_db_pair_items, runtime,
-    secp256k1,
+    Amount, BitcoinHash, OutPoint, TransactionId, apply, async_trait_maybe_send,
+    push_db_pair_items, runtime, secp256k1,
 };
 use fedimint_derive_secret::{ChildId, DerivableSecret};
 use fedimint_logging::LOG_CLIENT_MODULE_WALLET;
@@ -1204,6 +1204,11 @@ impl WalletClientModule {
             debug!(target: LOG_CLIENT_MODULE_WALLET, has=pegins.len(), "Enough deposits detected");
 
             for (_outpoint, transaction_id, change) in pegins {
+                if transaction_id == TransactionId::from_byte_array([0; 32]) && change.is_empty() {
+                    debug!(target: LOG_CLIENT_MODULE_WALLET, "Deposited amount was too low, skipping");
+                    continue;
+                }
+
                 debug!(target: LOG_CLIENT_MODULE_WALLET, out_points=?change, "Ensuring deposists claimed");
                 let tx_subscriber = self.client_ctx.transaction_updates(operation_id).await;
 

--- a/modules/fedimint-wallet-client/src/pegin_monitor.rs
+++ b/modules/fedimint-wallet-client/src/pegin_monitor.rs
@@ -14,7 +14,7 @@ use fedimint_core::envs::is_running_in_test_env;
 use fedimint_core::task::sleep;
 use fedimint_core::txoproof::TxOutProof;
 use fedimint_core::util::FmtCompactAnyhow as _;
-use fedimint_core::{secp256k1, time};
+use fedimint_core::{BitcoinHash, TransactionId, secp256k1, time};
 use fedimint_logging::LOG_CLIENT_MODULE_WALLET;
 use fedimint_wallet_common::WalletInput;
 use fedimint_wallet_common::txoproof::PegInProof;
@@ -396,7 +396,7 @@ async fn check_idx_pegins(
     Ok(outcomes)
 }
 
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 async fn claim_peg_in(
     client_ctx: &ClientContext<WalletClientModule>,
     tweak_idx: TweakIdx,
@@ -407,6 +407,8 @@ async fn claim_peg_in(
     tx_out_proof: TxOutProof,
     federation_knows_utxo: bool,
 ) -> anyhow::Result<()> {
+    /// Returns the claim transactions output range if a claim happened or
+    /// `None` otherwise if the deposit was smaller than the deposit fee.
     async fn claim_peg_in_inner(
         client_ctx: &ClientContext<WalletClientModule>,
         dbtx: &mut DatabaseTransaction<'_>,
@@ -416,7 +418,7 @@ async fn claim_peg_in(
         txout_proof: TxOutProof,
         operation_id: OperationId,
         federation_knows_utxo: bool,
-    ) -> OutPointRange {
+    ) -> Option<OutPointRange> {
         let pegin_proof = PegInProof::new(
             txout_proof,
             btc_transaction.clone(),
@@ -438,6 +440,11 @@ async fn claim_peg_in(
             amount,
         };
 
+        if amount <= client_ctx.self_ref().cfg().fee_consensus.peg_in_abs {
+            warn!(target: LOG_CLIENT_MODULE_WALLET, "We won't claim a deposit lower than the deposit fee");
+            return None;
+        }
+
         client_ctx
             .log_event(
                 dbtx,
@@ -449,14 +456,16 @@ async fn claim_peg_in(
             )
             .await;
 
-        client_ctx
-            .claim_inputs(
-                dbtx,
-                ClientInputBundle::new_no_sm(vec![client_input]),
-                operation_id,
-            )
-            .await
-            .expect("Cannot claim input, additional funding needed")
+        Some(
+            client_ctx
+                .claim_inputs(
+                    dbtx,
+                    ClientInputBundle::new_no_sm(vec![client_input]),
+                    operation_id,
+                )
+                .await
+                .expect("Cannot claim input, additional funding needed"),
+        )
     }
 
     let tx_out_proof = &tx_out_proof;
@@ -468,7 +477,7 @@ async fn claim_peg_in(
         .autocommit(
             |dbtx, _| {
                 Box::pin(async {
-                    let change_range = claim_peg_in_inner(
+                    let maybe_change_range = claim_peg_in_inner(
                         client_ctx,
                         dbtx,
                         transaction,
@@ -480,15 +489,24 @@ async fn claim_peg_in(
                     )
                     .await;
 
+                    let claimed_pegin_data = if let Some(change_range) = maybe_change_range {
+                        ClaimedPegInData {
+                            claim_txid: change_range.txid(),
+                            change: change_range.into_iter().collect(),
+                        }
+                    } else {
+                        ClaimedPegInData {
+                            claim_txid: TransactionId::from_byte_array([0; 32]),
+                            change: vec![],
+                        }
+                    };
+
                     dbtx.insert_entry(
                         &ClaimedPegInKey {
                             peg_in_index: tweak_idx,
                             btc_out_point: out_point,
                         },
-                        &ClaimedPegInData {
-                            claim_txid: change_range.txid(),
-                            change: change_range.into_iter().collect(),
-                        },
+                        &claimed_pegin_data,
                     )
                     .await;
 

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -810,6 +810,82 @@ async fn peg_ins_that_are_unconfirmed_are_rejected() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn dust_deposits_are_ignored() -> anyhow::Result<()> {
+    let fixtures = fixtures();
+    let fed = fixtures.new_fed_degraded().await;
+    let client = fed.new_client().await;
+    let wallet_module = client.get_first_module::<WalletClientModule>()?;
+    let bitcoin = fixtures.bitcoin();
+    let bitcoin = bitcoin.lock_exclusive().await;
+    info!("Starting test dust_deposits_are_ignored");
+
+    let finality_delay = 10;
+    bitcoin.mine_blocks(finality_delay).await;
+    await_consensus_to_catch_up(&client, 1).await?;
+    await_consensus_upgrade(&client, &fed).await?;
+
+    assert_eq!(client.get_balance().await, sats(0));
+    let (op, address, _) = wallet_module
+        .allocate_deposit_address_expert_only(())
+        .await?;
+
+    info!(?address, "Peg-in address generated");
+    let (_proof, tx) = bitcoin
+        .send_and_mine_block(
+            &address,
+            bsats(wallet_module.get_fee_consensus().peg_in_abs.msats / 1000 - 1),
+        )
+        .await;
+
+    let mut deposit_updates = wallet_module.subscribe_deposit(op).await?.into_stream();
+    info!("Waiting for transaction");
+    assert!(matches!(
+        deposit_updates.next().await.unwrap(),
+        DepositStateV2::WaitingForTransaction
+    ));
+    info!("Waiting for confirmation");
+    assert!(matches!(
+        deposit_updates.next().await.unwrap(),
+        DepositStateV2::WaitingForConfirmation { btc_out_point, .. } if btc_out_point.txid == tx.compute_txid()
+    ));
+
+    bitcoin.mine_blocks(finality_delay).await;
+
+    // Afaik technically not necessary, but useful to speed up test (should probably
+    // just poll more often in tests?)
+    let await_update_while_rechecking = async {
+        loop {
+            wallet_module
+                .recheck_pegin_address_by_op_id(op)
+                .await
+                .expect("Operation exists");
+            select! {
+                update = deposit_updates.next() => {
+                    break update;
+                },
+                _ = sleep_in_test("Waiting for address recheck", Duration::from_millis(100)) => { }
+            }
+        }
+    };
+
+    info!("Waiting for claim tx");
+    assert!(matches!(
+        await_update_while_rechecking.await.unwrap(),
+        DepositStateV2::Confirmed { btc_out_point, .. } if btc_out_point.txid == tx.compute_txid()
+    ));
+
+    info!("Waiting for e-cash");
+    assert!(matches!(
+        deposit_updates.next().await.unwrap(),
+        DepositStateV2::Claimed { btc_out_point, .. } if btc_out_point.txid == tx.compute_txid()
+    ));
+
+    info!("Checking balance after deposit");
+    assert_eq!(client.get_balance().await, Amount::ZERO);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn construct_wallet_summary() -> anyhow::Result<()> {
     let fixtures = fixtures();
     let fed = fixtures.new_fed_degraded().await;


### PR DESCRIPTION
Claiming on-chain deposits worth less than the fee that needs to be paid to the federation for them doesn't make economic sense and can lead to panics if the wallet doesn't have enough funds and losing money otherwise. Let's not do that.

Great find @cvaz21 and @maan2003!

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
