### PR TITLE
chore: revert wild in the dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -320,9 +320,6 @@
                   ]
                   ++ lib.optionals (!stdenv.isAarch64 && !stdenv.isDarwin) [ pkgs.semgrep ]
                   ++ lib.optionals (!stdenv.isDarwin) [
-                    # does not support macos
-                    (pkgs-unstable.callPackage ./nix/pkgs/wild.nix { })
-
                     # broken on MacOS?
                     pkgs.cargo-workspaces
 
@@ -361,8 +358,6 @@
                   if [ -z "$(git config --global merge.ours.driver)" ]; then
                       >&2 echo "⚠️  Recommended to run 'git config --global merge.ours.driver true' to enable better lock file handling. See https://blog.aspect.dev/easier-merges-on-lockfiles for more info"
                   fi
-
-                  export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS="-C link-arg=--ld-path=wild"
                 '';
               };
           in


### PR DESCRIPTION
Commands like `cargo nextest run` fail with:

```
  error: creating test list failed

Caused by:
  for `fedimint-dummy-tests::fedimint_dummy_tests`, command `/home/dpc/lab/fedimint/fedimint/target-nix/debug/deps/fedimint_dummy_tests-e1ac9f7caff
f2a1b --list --format terse` exited with code 127
--- stdout:

--- stderr:
/home/dpc/lab/fedimint/fedimint/target-nix/debug/deps/fedimint_dummy_tests-e1ac9f7cafff2a1b: error while loading shared libraries: libstdc++.so.6:
cannot open shared object file: No such file or directory

---
```

and there can be lots of reasons for it, possibly related to Nix wrapping described in: https://github.com/davidlattimore/wild?tab=readme-ov-file#nix

which compounds with flakebox complexity, etc. which I don't have time to tackle now.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
