### PR TITLE
chore: bench decoding of G2Affine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3647,6 +3647,7 @@ dependencies = [
  "futures",
  "hex",
  "itertools 0.13.0",
+ "rand 0.8.5",
  "rayon",
  "serde",
  "serde-big-array",

--- a/modules/fedimint-mint-client/Cargo.toml
+++ b/modules/fedimint-mint-client/Cargo.toml
@@ -63,6 +63,7 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }
+rand = { workspace = true }
 test-log = { workspace = true }
 
 [lints]

--- a/modules/fedimint-mint-client/benches/notes.rs
+++ b/modules/fedimint-mint-client/benches/notes.rs
@@ -1,8 +1,10 @@
 use std::hint::black_box;
 
+use bls12_381::{G2Affine, G2Projective};
 use criterion::{Criterion, criterion_group, criterion_main};
 use fedimint_core::encoding::Decodable;
 use fedimint_mint_client::{SpendableNote, SpendableNoteUndecoded};
+use threshold_crypto::group::Group as _;
 
 fn bench_note_decoding(c: &mut Criterion) {
     const NOTE_HEX: &str = "a5dd3ebacad1bc48bd8718eed5a8da1d68f91323bef2848ac4fa2e6f8eed710f3178fd4aef047cc234e6b1127086f33cc408b39818781d9521475360de6b205f3328e490a6d99d5e2553a4553207c8bd";
@@ -22,5 +24,21 @@ fn bench_note_decoding(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, bench_note_decoding);
+fn bench_g2_decoding(c: &mut Criterion) {
+    let g2 = G2Projective::random(rand::thread_rng());
+    let g2 = G2Affine::from(g2);
+
+    let compressed = g2.to_compressed();
+    let uncompressed = g2.to_uncompressed();
+
+    let mut group = c.benchmark_group("G2Affine decoding");
+
+    group.bench_function("G2Affine from uncompressed", |b| {
+        b.iter(|| G2Affine::from_uncompressed(&black_box(uncompressed)).unwrap())
+    });
+    group.bench_function("G2Affine from compressed", |b| {
+        b.iter(|| G2Affine::from_compressed(&black_box(compressed)).unwrap())
+    });
+}
+criterion_group!(benches, bench_note_decoding, bench_g2_decoding);
 criterion_main!(benches);


### PR DESCRIPTION
```
G2Affine decoding/G2Affine from uncompressed
                        time:   [76.191 µs 76.299 µs 76.470 µs]
                        change: [-0.9999% -0.7658% -0.5508%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
  3 (3.00%) high severe
Benchmarking G2Affine decoding/G2Affine from compressed: Collecting 100 samples in estimated 5.9313 s (30k iteratio
G2Affine decoding/G2Affine from compressed
                        time:   [194.90 µs 195.03 µs 195.20 µs]
                        change: [-0.4594% -0.2456% -0.0644%] (p = 0.01 < 0.05)
                        Change within noise threshold.
```

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
