### PR TITLE
chore: pin stable iroh dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,7 +142,7 @@ clap = { version = "4.5.40", features = ["derive", "env"] }
 clap_complete = "4.5.54"
 console-subscriber = "0.4.1"
 criterion = "0.5.1"
-iroh-relay = { version = "0.34.1", default-features = false }
+iroh-relay = { version = "=0.34.1", default-features = false }
 # We need to pin this arti's `curve25519-dalek` dependency, due to `https://rustsec.org/advisories/RUSTSEC-2024-0344` vulnerability
 # It's been updated by https://gitlab.torproject.org/tpo/core/arti/-/merge_requests/2211, should be removed in next release.
 curve25519-dalek = ">=4.1.3"
@@ -217,8 +217,8 @@ honggfuzz = { version = "=0.5.55", default-features = false } # needs to be pinn
 hyper = "1.6"
 imbl = "5.0.0"
 impl-tools = "0.10.3"
-iroh = { version = "0.34.1", default-features = false }
-iroh-base = { version = "0.34.1", default-features = false }
+iroh = { version = "=0.34.1", default-features = false }
+iroh-base = { version = "=0.34.1", default-features = false }
 iroh-next = { version = "0.35.0", default-features = false, package = "iroh" }
 iroh-next-base = { version = "0.35.0", default-features = false, package = "iroh-base" }
 itertools = "0.13.0"


### PR DESCRIPTION
This should prevent dependabot etc. from trying to upgrade them and make it explicit that they must not change.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
