### PR TITLE
chore: disable flaky gw_liquidity_test

### DIFF
--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -316,7 +316,8 @@ tests_to_run_in_parallel+=(
   "gw_reboot_test"
   "gw_config_test_lnd"
   "gw_restore_test"
-  "gw_liquidity_test"
+  # flaky https://github.com/fedimint/fedimint/issues/7546
+  # "gw_liquidity_test"
   "lnv2_module"
   "devimint_cli_test"
   "devimint_cli_test_single"


### PR DESCRIPTION
This test became very flaky and it's been like that for a while.

Re #7546
<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
