### PR TITLE
chore: don't build aarch64-linux container in the PRs

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -293,8 +293,10 @@ jobs:
         platform:
           - arch: x86_64-linux
             runs-on: [self-hosted, linux, x64]
+            run_in_pr: true
           - arch: aarch64-linux
             runs-on: [self-hosted, linux, arm64]
+            run_in_pr: false
         container:
           - name: fedimintd
             image: fedimint/fedimintd
@@ -312,18 +314,24 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout Code
+        if: github.event_name != 'pull_request' || matrix.platform.run_in_pr
         uses: actions/checkout@v4
       - name: Prepare
+        if: github.event_name != 'pull_request' || matrix.platform.run_in_pr
         uses: ./.github/actions/prepare
       - uses: actions/checkout@v4
+        if: github.event_name != 'pull_request' || matrix.platform.run_in_pr
       - uses: dpc/nix-installer-action@dpc/jj-vqymqvyntouw
+        if: github.event_name != 'pull_request' || matrix.platform.run_in_pr
       - uses: cachix/cachix-action@v16
+        if: github.event_name != 'pull_request' || matrix.platform.run_in_pr
         with:
           name: fedimint
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
         continue-on-error: true
 
       - name: Build ${{ matrix.container.name }} container for ${{ matrix.platform.arch }}
+        if: github.event_name != 'pull_request' || matrix.platform.run_in_pr
         run: |
           if [ "$GITHUB_EVENT_NAME" == "pull_request" ] || [ "$GITHUB_EVENT_NAME" == "merge_group" ]; then
             nix build -L .#ci.container.${{ matrix.container.name }} --system ${{ matrix.platform.arch }}
@@ -333,24 +341,24 @@ jobs:
           echo "container_tag=$(docker load < result | awk '{ print $3 }')" >> $GITHUB_ENV
 
       - name: Login to Docker Hub
-        if: github.ref == 'refs/heads/master' || github.ref_type == 'tag'
+        if: (github.ref == 'refs/heads/master' || github.ref_type == 'tag') && (github.event_name != 'pull_request' || matrix.platform.run_in_pr)
         uses: docker/login-action@v3
         with:
           username: fedimint
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Publish
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master' && (github.event_name != 'pull_request' || matrix.platform.run_in_pr)
         run: |
           nix_tag=${{ env.container_tag }} && hub_tag="${{ matrix.container.image }}:${LAST_COMMIT_SHA}-${{ matrix.platform.arch }}" && docker tag "$nix_tag" "$hub_tag" && docker push "$hub_tag"
 
       - name: Publish master tag
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master' && (github.event_name != 'pull_request' || matrix.platform.run_in_pr)
         run: |
           nix_tag=${{ env.container_tag }} && hub_tag="${{ matrix.container.image }}:master-${{ matrix.platform.arch }}" && docker tag "$nix_tag" "$hub_tag" && docker push "$hub_tag"
 
       - name: Publish tagged release
-        if: github.ref_type == 'tag'
+        if: github.ref_type == 'tag' && (github.event_name != 'pull_request' || matrix.platform.run_in_pr)
         run: |
           nix_tag=${{ env.container_tag }} && hub_tag="${{ matrix.container.image }}:${GITHUB_REF_NAME}-${{ matrix.platform.arch }}" && docker tag "$nix_tag" "$hub_tag" && docker push "$hub_tag"
 


### PR DESCRIPTION
Do it in MQ only. It's just waaay too slow.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
