### PR TITLE
Fix multi arch docker hub

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -368,6 +368,10 @@ jobs:
     needs: containers
     runs-on: [self-hosted, linux, x64]
     steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      - name: Prepare
+        uses: ./.github/actions/prepare
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -380,7 +384,7 @@ jobs:
           containers="fedimintd fedimint-cli gatewayd gateway-cli fedimint-recurringd devtools"
 
           # Reference the following blog post for multi arch images with nix and docker manifest
-          # https://tech.aufomm.com/how-to-build-multi-arch-docker-image-on-nixos/?utm_source=chatgpt.com#Tag-multi-arch
+          # https://tech.aufomm.com/how-to-build-multi-arch-docker-image-on-nixos
           for container in $containers; do
             image="fedimint/$container"
             if [ "$GITHUB_REF" = "refs/heads/master" ]; then
@@ -392,13 +396,13 @@ jobs:
               docker manifest annotate "$image:master" "$image:master-aarch64-linux" --arch arm64
               docker manifest push "$image:master"
 
-              echo "Creating manifest for $image:${GITHUB_SHA}"
-              docker manifest create "$image:${GITHUB_SHA}" \
-                "$image:${GITHUB_SHA}-x86_64-linux" \
-                "$image:${GITHUB_SHA}-aarch64-linux"
-              docker manifest annotate "$image:${GITHUB_SHA}" "$image:${GITHUB_SHA}-x86_64-linux" --arch amd64
-              docker manifest annotate "$image:${GITHUB_SHA}" "$image:${GITHUB_SHA}-aarch64-linux" --arch arm64
-              docker manifest push "$image:${GITHUB_SHA}"
+              echo "Creating manifest for $image:${LAST_COMMIT_SHA}"
+              docker manifest create "$image:${LAST_COMMIT_SHA}" \
+                "$image:${LAST_COMMIT_SHA}-x86_64-linux" \
+                "$image:${LAST_COMMIT_SHA}-aarch64-linux"
+              docker manifest annotate "$image:${LAST_COMMIT_SHA}" "$image:${LAST_COMMIT_SHA}-x86_64-linux" --arch amd64
+              docker manifest annotate "$image:${LAST_COMMIT_SHA}" "$image:${LAST_COMMIT_SHA}-aarch64-linux" --arch arm64
+              docker manifest push "$image:${LAST_COMMIT_SHA}"
             elif [ "$GITHUB_REF_TYPE" = "tag" ]; then
               echo "Creating manifest for $image:${GITHUB_REF_NAME}"
               docker manifest create "$image:${GITHUB_REF_NAME}" \

--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -376,8 +376,8 @@ jobs:
 
       - name: Create and push multi-arch manifests
         run: |
-          # Get all unique container names from the matrix
-          containers=$(echo '${{ needs.containers.outputs.matrix }}' | jq -r '.[].container.name' | sort -u)
+          # hardcode container names since they're not available as outputs from the container job
+          containers="fedimintd fedimint-cli gatewayd gateway-cli fedimint-recurringd devtools"
 
           # Reference the following blog post for multi arch images with nix and docker manifest
           # https://tech.aufomm.com/how-to-build-multi-arch-docker-image-on-nixos/?utm_source=chatgpt.com#Tag-multi-arch


### PR DESCRIPTION
Closes https://github.com/fedimint/fedimint/issues/7371

Please reference the debugging branch to see the successful runs https://github.com/fedimint/fedimint/pull/7556

We had two issues that prevented this in CI
- We tried to reference the container names as outputs from the containers job, but there are no outputs so containers was empty and this was a no-op
  -  Unfortunately parallel matrix runs make outputs a bit messy to work with without a third party GH action, so I hardcoded the container names in the manifest job
  - I also tried parsing the yaml with `yq`, but it's not available on our runners
- `GITHUB_SHA` wasn't matching up with `LAST_COMMIT_SHA` that we tag the images with, since we didn't checkout the codebase in the manifest job

These change publish a manifest to docker hub that unifies multiple architectures under a single tag.
![Screenshot_20250703_082830](https://github.com/user-attachments/assets/5f571b41-96e1-4e7a-b26d-daf36ba97448)