### PR TITLE
chore: bump containers timeout from 60 to 120m

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -311,7 +311,9 @@ jobs:
           - name: devtools
             image: fedimint/devtools
     runs-on: ${{ matrix.platform.runs-on }}
-    timeout-minutes: 60
+    # TODO: reduce back to 60
+    # https://github.com/fedimint/fedimint/issues/7561
+    timeout-minutes: 120
     steps:
       - name: Checkout Code
         if: github.event_name != 'pull_request' || matrix.platform.run_in_pr


### PR DESCRIPTION
The containers job isn't completing within 60 minutes vs master for `aarch64-linux`. We're able to complete in a short period of time with the CI profile (see: https://github.com/fedimint/fedimint/pull/7556), but it takes much longer vs master. As a temporary workaround, let's try bumping from 60 to 120 minutes.

Using https://github.com/fedimint/fedimint/issues/7561 to followup with a better long-term fix.

![Screenshot_20250704_091011](https://github.com/user-attachments/assets/6a1a175c-cb4b-4587-a63c-6de4ed9ccc8f)

https://github.com/fedimint/fedimint/actions/runs/16064288213/job/45345062320