### PR TITLE
chore(ci): bump nix closure size limit

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -498,7 +498,7 @@ jobs:
               closure_size=$(nix path-info -rS --json .#$bin | nix run nixpkgs#jq '. | to_entries[] | select(.value.ultimate == true) | .value.narSize')
               >&2 echo "$bin's Nix closure size: $closure_size"
 
-              if [ 200000000 -lt $closure_size ]; then
+              if [ 220000000 -lt $closure_size ]; then
                 >&2 echo "$bin's Nix closure size seems too big: $closure_size"
                 exit 1
               fi


### PR DESCRIPTION
After cutting the `v0.8.0-beta.0` tag the release job fails due to the `gatewayd` closure size.

```
gatewayd's Nix closure size seems too big: 212189616
```

https://github.com/fedimint/fedimint/actions/runs/16078077766/job/45377647469#step:6:143

This approach kicks the can by bumping the closure size limit (we set the can kicking precedence in https://github.com/fedimint/fedimint/pull/7196). Another approach is to modify debug symbols, but I don't think it's worth degrading debug symbols if we only need to slightly increase the closure limit. Please let me know if you see any better approaches.