### PR TITLE
[Backport v0.8] chore(ci): bump nix closure size limit

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -498,7 +498,7 @@ jobs:
               closure_size=$(nix path-info -rS --json .#$bin | nix run nixpkgs#jq '. | to_entries[] | select(.value.ultimate == true) | .value.narSize')
               >&2 echo "$bin's Nix closure size: $closure_size"
 
-              if [ 200000000 -lt $closure_size ]; then
+              if [ 220000000 -lt $closure_size ]; then
                 >&2 echo "$bin's Nix closure size seems too big: $closure_size"
                 exit 1
               fi


### PR DESCRIPTION
Closes https://github.com/fedimint/fedimint/issues/7570