### PR TITLE
fix: use correct iroh pkarr URL

### DIFF
--- a/fedimint-core/src/iroh_prod.rs
+++ b/fedimint-core/src/iroh_prod.rs
@@ -1,7 +1,7 @@
 /// The Iroh/Pkarr DNS server hosted by Fedimint project
 pub const FM_DNS_PKARR_RELAY_PROD: [&str; 2] = [
-    "https://dns.irohdns-eu-01.dev.fedimint.org",
-    "https://dns.irohdns-us-01.dev.fedimint.org",
+    "https://dns.irohdns-eu-01.dev.fedimint.org/pkarr",
+    "https://dns.irohdns-us-01.dev.fedimint.org/pkarr",
 ];
 
 /// The Iroh relays hosted by Fedimint project


### PR DESCRIPTION
Fairly confident this should solve our connection issues. 

For pkarr relays I had to do the same in my iroh test tool. Also the default n0 pkarr relay URL is `https://dns.iroh.link/pkarr` while the DNS discovery domain is `dns.iroh.link`. We don't use the DNS discovery method so far, so I'll keep the full URL as config for now. 

Eventually I'd just keep the domains and then do string interpolation using that so we can add DNS discovery, but when I tried that meant a lot of changes we don't need to backport that.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
