### PR TITLE
[Backport releases/v0.8] fix: use correct iroh pkarr URL

### DIFF
--- a/fedimint-core/src/iroh_prod.rs
+++ b/fedimint-core/src/iroh_prod.rs
@@ -1,7 +1,7 @@
 /// The Iroh/Pkarr DNS server hosted by Fedimint project
 pub const FM_DNS_PKARR_RELAY_PROD: [&str; 2] = [
-    "https://dns.irohdns-eu-01.dev.fedimint.org",
-    "https://dns.irohdns-us-01.dev.fedimint.org",
+    "https://dns.irohdns-eu-01.dev.fedimint.org/pkarr",
+    "https://dns.irohdns-us-01.dev.fedimint.org/pkarr",
 ];
 
 /// The Iroh relays hosted by Fedimint project


### PR DESCRIPTION
# Description
Backport of #7578 to `releases/v0.8`.