### PR TITLE
fix: recurringd in mprocs and log printing api endpoint

### DIFF
--- a/fedimint-recurringd/src/main.rs
+++ b/fedimint-recurringd/src/main.rs
@@ -27,7 +27,7 @@ use serde_json::json;
 use tokio::net::TcpListener;
 use tower_http::cors;
 use tower_http::cors::CorsLayer;
-use tracing::debug;
+use tracing::{debug, info};
 
 #[derive(Debug, Parser)]
 struct CliOpts {
@@ -90,6 +90,7 @@ async fn main() -> anyhow::Result<()> {
             recurring_invoice_server,
         });
 
+    info!(api_address = %cli_opts.bind_address, "recurringd started");
     let listener = TcpListener::bind(&cli_opts.bind_address).await?;
     axum::serve(listener, app).await?;
 

--- a/misc/mprocs.yaml
+++ b/misc/mprocs.yaml
@@ -26,3 +26,5 @@ procs:
     shell: tail -n +0 -F $FM_LOGS_DIR/bitcoind.log
   devimint:
     shell: tail -n +0 -F $FM_LOGS_DIR/devimint-outer.log
+  recurringd:
+    shell: tail -n +0 -F $FM_LOGS_DIR/recurringd.log


### PR DESCRIPTION
Adds recurringd to the mprocs logs and a log statement printing the API endpoint for recurringd
