### PR TITLE
chore: remove self-hosted iroh DNS infrastructure

### DIFF
--- a/fedimint-api-client/src/api/iroh.rs
+++ b/fedimint-api-client/src/api/iroh.rs
@@ -91,8 +91,9 @@ impl IrohConnector {
             }
 
             #[cfg(not(target_family = "wasm"))]
-            let builder = builder.discovery_dht();
-            let endpoint = builder.bind().await?;
+            let builder = builder.discovery_dht().discovery_n0();
+
+            let endpoint = builder.discovery_n0().bind().await?;
             debug!(
                 target: LOG_NET_IROH,
                 node_id = %endpoint.node_id(),

--- a/fedimint-core/src/iroh_prod.rs
+++ b/fedimint-core/src/iroh_prod.rs
@@ -1,7 +1,11 @@
+//! We want to provide our own infrastructure to be independent of n0, but for
+//! now we don't use the discovery part of it pending figuring out some
+//! performance regressions.
+
 /// The Iroh/Pkarr DNS server hosted by Fedimint project
-pub const FM_DNS_PKARR_RELAY_PROD: [&str; 2] = [
-    "https://dns.irohdns-eu-01.dev.fedimint.org/pkarr",
-    "https://dns.irohdns-us-01.dev.fedimint.org/pkarr",
+pub const FM_DNS_PKARR_RELAY_PROD: [&str; 0] = [
+    // "https://dns.irohdns-eu-01.dev.fedimint.org/pkarr",
+    // "https://dns.irohdns-us-01.dev.fedimint.org/pkarr",
 ];
 
 /// The Iroh relays hosted by Fedimint project

--- a/fedimint-server/src/net/p2p_connector.rs
+++ b/fedimint-server/src/net/p2p_connector.rs
@@ -370,6 +370,7 @@ pub(crate) async fn build_iroh_endpoint(
 
     builder = builder
         .discovery_dht()
+        .discovery_n0()
         .relay_mode(relay_mode)
         .secret_key(secret_key)
         .alpns(vec![alpn.to_vec()]);


### PR DESCRIPTION
@bradleystachurski [noticed major performance degradation](https://github.com/fedimint/fedimint/issues/7580#issuecomment-3070140276) when using our self-hosted discovery infrastructure (even after fixing initial mis-configuration). There might be a bug in iroh or further problems in our infra, either way we'd rather not block the release given [iroh isn't rug-pulling us anytime soon](https://www.iroh.computer/blog/iroh-0-90-the-canary-series).

This should be fixed asap after the release though.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
