### PR TITLE
chore: remove dead code `serde_binary_human_readable`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2942,7 +2942,6 @@ dependencies = [
  "backtrace",
  "base64 0.22.1",
  "bech32",
- "bincode 1.3.3",
  "bitcoin",
  "bitcoin-io",
  "bitcoin-units",

--- a/fedimint-core/Cargo.toml
+++ b/fedimint-core/Cargo.toml
@@ -26,7 +26,6 @@ backon = { workspace = true }
 backtrace = { workspace = true }
 base64 = { workspace = true }
 bech32 = { workspace = true }
-bincode = { workspace = true }
 bitcoin = { workspace = true }
 bitcoin-io = { workspace = true }
 bitcoin-units = { workspace = true }

--- a/fedimint-core/src/config.rs
+++ b/fedimint-core/src/config.rs
@@ -893,33 +893,5 @@ pub fn load_from_file<T: DeserializeOwned>(path: &Path) -> Result<T, anyhow::Err
     Ok(serde_json::from_reader(file)?)
 }
 
-pub mod serde_binary_human_readable {
-    use std::borrow::Cow;
-
-    use hex::{FromHex, ToHex};
-    use serde::de::DeserializeOwned;
-    use serde::{Deserialize, Deserializer, Serialize, Serializer};
-
-    pub fn serialize<T: Serialize, S: Serializer>(x: &T, s: S) -> Result<S::Ok, S::Error> {
-        if s.is_human_readable() {
-            let bytes =
-                bincode::serialize(x).map_err(|e| serde::ser::Error::custom(format!("{e:?}")))?;
-            s.serialize_str(&bytes.encode_hex::<String>())
-        } else {
-            Serialize::serialize(x, s)
-        }
-    }
-
-    pub fn deserialize<'d, T: DeserializeOwned, D: Deserializer<'d>>(d: D) -> Result<T, D::Error> {
-        if d.is_human_readable() {
-            let hex_str: Cow<str> = Deserialize::deserialize(d)?;
-            let bytes = Vec::from_hex(hex_str.as_ref()).map_err(serde::de::Error::custom)?;
-            bincode::deserialize(&bytes).map_err(|e| serde::de::Error::custom(format!("{e:?}")))
-        } else {
-            Deserialize::deserialize(d)
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests;

--- a/fedimint-server/src/config/mod.rs
+++ b/fedimint-server/src/config/mod.rs
@@ -8,7 +8,6 @@ use fedimint_core::config::ServerModuleConfigGenParamsRegistry;
 pub use fedimint_core::config::{
     ClientConfig, FederationId, GlobalClientConfig, JsonWithKind, ModuleInitRegistry, P2PMessage,
     PeerUrl, ServerModuleConfig, ServerModuleConsensusConfig, TypedServerModuleConfig,
-    serde_binary_human_readable,
 };
 use fedimint_core::core::{ModuleInstanceId, ModuleKind};
 use fedimint_core::envs::is_running_in_test_env;


### PR DESCRIPTION
While the function is being exported, that looks more like an accident from a time when the function was in use in fedimint itself.

I was looking at https://github.com/fedimint/fedimint/pull/7584#event-18597347482 to determine if there was any consensus usage of `bincode` and noticed 1 of 2 occurrences isn't relevant anymore. 

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
