### PR TITLE
feat: announce on nostr link

### DIFF
--- a/fedimint-server-ui/src/dashboard/invite.rs
+++ b/fedimint-server-ui/src/dashboard/invite.rs
@@ -2,6 +2,8 @@ use maud::{Markup, html};
 
 // Card with invite code text and copy button
 pub fn render(invite_code: &str) -> Markup {
+    let observer_link = format!("https://observer.fedimint.org/nostr?check={}", invite_code);
+
     html! {
         div class="card h-100" {
             div class="card-header dashboard-header" { "Invite Code" }
@@ -10,10 +12,15 @@ pub fn render(invite_code: &str) -> Markup {
                     (invite_code)
                 }
 
-                div class="text-center mt-3" {
+                // Flex container for both buttons side by side
+                div class="d-flex justify-content-center gap-2 mt-3" {
                     button type="button" class="btn btn-outline-primary" id="copyInviteCodeBtn"
                         onclick=(format!("navigator.clipboard.writeText('{}');", invite_code)) {
                         "Copy to Clipboard"
+                    }
+
+                    a href=(observer_link) target="_blank" class="btn btn-outline-success" {
+                        "Announce on Nostr"
                     }
                 }
 


### PR DESCRIPTION
Adds a link to the dashboard to Fedimint Observer for mint operators to announce their federation on Nostr.

<img width="1328" height="365" alt="image" src="https://github.com/user-attachments/assets/38e0f0ce-9457-42d9-804f-88a201dd02c3" />

