### PR TITLE
[Backport releases/v0.8] fix: use separate environment variables for bitcoind username and password

### DIFF
--- a/devimint/src/vars.rs
+++ b/devimint/src/vars.rs
@@ -205,6 +205,8 @@ declare_vars! {
         FM_BITCOIN_RPC_URL: String = f!("http://bitcoin:bitcoin@127.0.0.1:{FM_PORT_BTC_RPC}"); env: "FM_BITCOIN_RPC_URL";
         FM_BITCOIN_RPC_KIND: String = "bitcoind"; env: "FM_BITCOIN_RPC_KIND";
         FM_BITCOIND_URL: String = f!("http://bitcoin:bitcoin@127.0.0.1:{FM_PORT_BTC_RPC}"); env: "FM_BITCOIND_URL";
+        FM_BITCOIND_USERNAME: String = "bitcoin"; env: "FM_BITCOIND_USERNAME";
+        FM_BITCOIND_PASSWORD: String = "bitcoin"; env: "FM_BITCOIND_PASSWORD";
         FM_DEFAULT_BITCOIN_RPC_URL: String = f!("http://bitcoin:bitcoin@127.0.0.1:{FM_PORT_BTC_RPC}"); env: FM_DEFAULT_BITCOIN_RPC_URL_ENV;
         FM_DEFAULT_BITCOIN_RPC_KIND: String = "bitcoind"; env: FM_DEFAULT_BITCOIN_RPC_KIND_ENV;
 

--- a/fedimint-server-bitcoin-rpc/src/bitcoind.rs
+++ b/fedimint-server-bitcoin-rpc/src/bitcoind.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, anyhow};
+use anyhow::anyhow;
 use bitcoin::{BlockHash, Network, Transaction};
 use bitcoincore_rpc::Error::JsonRpc;
 use bitcoincore_rpc::bitcoincore_rpc_json::EstimateMode;
@@ -19,13 +19,8 @@ pub struct BitcoindClient {
 }
 
 impl BitcoindClient {
-    pub fn new(url: &SafeUrl) -> anyhow::Result<Self> {
-        let auth = Auth::UserPass(
-            url.username().to_owned(),
-            url.password()
-                .context("Bitcoin RPC URL is missing password")?
-                .to_owned(),
-        );
+    pub fn new(username: String, password: String, url: &SafeUrl) -> anyhow::Result<Self> {
+        let auth = Auth::UserPass(username, password);
 
         let url = url
             .without_auth()

--- a/fedimint-server-bitcoin-rpc/src/lib.rs
+++ b/fedimint-server-bitcoin-rpc/src/lib.rs
@@ -20,14 +20,19 @@ pub struct BitcoindClientWithFallback {
 }
 
 impl BitcoindClientWithFallback {
-    pub fn new(bitcoind_url: &SafeUrl, esplora_url: &SafeUrl) -> Result<Self> {
+    pub fn new(
+        username: String,
+        password: String,
+        bitcoind_url: &SafeUrl,
+        esplora_url: &SafeUrl,
+    ) -> Result<Self> {
         warn!(
             target: LOG_SERVER,
             %bitcoind_url,
             %esplora_url,
             "Initiallizing bitcoin bitcoind backend with esplora fallback"
         );
-        let bitcoind_client = BitcoindClient::new(bitcoind_url)?;
+        let bitcoind_client = BitcoindClient::new(username, password, bitcoind_url)?;
         let esplora_client = EsploraClient::new(esplora_url)?;
 
         Ok(Self {

--- a/fedimint-testing/src/fixtures.rs
+++ b/fedimint-testing/src/fixtures.rs
@@ -86,7 +86,23 @@ impl Fixtures {
             };
 
             let server_bitcoin_rpc = match rpc_config.kind.as_ref() {
-                "bitcoind" => BitcoindClient::new(&rpc_config.url).unwrap().into_dyn(),
+                "bitcoind" => {
+                    // Directly extract the authentication details from the url.
+                    // Since this is just testing we can be careful to not use characters that need
+                    // to be URL-encoded
+                    let bitcoind_username = rpc_config.url.username();
+                    let bitcoind_password = rpc_config
+                        .url
+                        .password()
+                        .expect("bitcoind password was not set");
+                    BitcoindClient::new(
+                        bitcoind_username.to_string(),
+                        bitcoind_password.to_string(),
+                        &rpc_config.url,
+                    )
+                    .unwrap()
+                    .into_dyn()
+                }
                 "esplora" => EsploraClient::new(&rpc_config.url).unwrap().into_dyn(),
                 kind => panic!("Unknown bitcoin rpc kind {kind}"),
             };

--- a/fedimintd/src/envs.rs
+++ b/fedimintd/src/envs.rs
@@ -34,6 +34,10 @@ pub const FM_DB_CHECKPOINT_RETENTION_ENV: &str = "FM_DB_CHECKPOINT_RETENTION";
 
 pub const FM_IROH_API_MAX_CONNECTIONS_ENV: &str = "FM_IROH_API_MAX_CONNECTIONS";
 
+pub const FM_BITCOIND_USERNAME_ENV: &str = "FM_BITCOIND_USERNAME";
+
+pub const FM_BITCOIND_PASSWORD_ENV: &str = "FM_BITCOIND_PASSWORD";
+
 // TODO: Eventually Iroh should provide something better than this.
 // <https://github.com/n0-computer/iroh/discussions/3212>
 pub const FM_IROH_API_MAX_REQUESTS_PER_CONNECTION_ENV: &str =

--- a/fedimintd/src/lib.rs
+++ b/fedimintd/src/lib.rs
@@ -71,6 +71,11 @@ const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(10);
 #[command(version)]
 #[command(
     group(
+        ArgGroup::new("bitcoind_auth")
+            .args(["bitcoind_url"])
+            .requires_all(["bitcoind_username", "bitcoind_password", "bitcoind_url"])
+    ),
+    group(
         ArgGroup::new("bitcoin_rpc")
             .required(true)
             .multiple(true)

--- a/fedimintd/src/lib.rs
+++ b/fedimintd/src/lib.rs
@@ -71,9 +71,15 @@ const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(10);
 #[command(version)]
 #[command(
     group(
+        ArgGroup::new("bitcoind_password_auth")
+           .args(["bitcoind_password", "bitcoind_url_password_file"])
+           .multiple(false)
+    ),
+    group(
         ArgGroup::new("bitcoind_auth")
             .args(["bitcoind_url"])
-            .requires_all(["bitcoind_username", "bitcoind_password", "bitcoind_url"])
+            .requires("bitcoind_password_auth")
+            .requires_all(["bitcoind_username", "bitcoind_url"])
     ),
     group(
         ArgGroup::new("bitcoin_rpc")


### PR DESCRIPTION
# Description
Backport of #7602 to `releases/v0.8`.