### PR TITLE
fix: correct how the ui displays sync percentage

### DIFF
--- a/fedimint-server-ui/src/dashboard/bitcoin.rs
+++ b/fedimint-server-ui/src/dashboard/bitcoin.rs
@@ -29,7 +29,7 @@ pub fn render(url: SafeUrl, status: &Option<ServerBitcoinRpcStatus>) -> Markup {
                             @if let Some(sync) = status.sync_percentage {
                                 tr {
                                     th { "Sync Progress" }
-                                    td { (format!("{:.1}%", sync)) }
+                                    td { (format!("{:.1}%", sync * 100.0)) }
                                 }
                             }
                         }


### PR DESCRIPTION
The guardian UI shows the sync percentage is 1.0% when it's 100%. This change correctly displays the sync percentage. The bitcoin rpc returns the node's estimated chain sync percentage as a float between 0.0 and 1.0, so IMO the appropriate fix is to change at the UI instead of modifying the rpc.

https://github.com/fedimint/fedimint/blob/deace979529d33f1ee9872f6c8d09330e652c2bb/fedimint-server-core/src/bitcoin_rpc.rs#L168-L170

**Guardian dashboard for fully synced node**

<img width="1280" height="833" alt="Screenshot_20250727_185905" src="https://github.com/user-attachments/assets/4a0170c8-64c8-4052-a386-487d58f16cd6" />
