### PR TITLE
chore: add yq to fedimintd container

### DIFF
--- a/nix/flakebox.nix
+++ b/nix/flakebox.nix
@@ -841,7 +841,14 @@ in
       {
         fedimintd = pkgs.dockerTools.buildLayeredImage {
           name = "fedimintd";
-          contents = [ fedimint-pkgs ] ++ defaultPackages;
+          contents = [
+            fedimint-pkgs
+          ]
+          ++ defaultPackages
+          ++ [
+            # yq is needed to enable easier config management for start9
+            pkgs.yq-go
+          ];
           config = {
             Cmd = [ ]; # entrypoint will handle empty vs non-empty cmd
             Env = [ "FM_DATA_DIR=/data" ];


### PR DESCRIPTION
Integrating start9 and connecting to the bitcoin node requires parsing yaml files. Without `yq` it makes parsing the files brittle and complex, so adding `yq` to just the `fedimintd` container will simplify the integration.

Also worth noting we build docker images with nix using `pkgs.dockerTools.buildLayeredImage`, which produces a minimal image without a package manager so we can't do something like `apt install yq`.

Example parsing logic without `yq`

```bash
# Config file structure:
# fedimintd-bitcoin-backend:
#   backend-type: <bitcoind|esplora>
#   user: <username>           # only for bitcoind
#   password: <password>       # only for bitcoind
#   url: 'https://...'         # only for esplora

# Function to parse values from fedimintd-bitcoin-backend section only
parse_fedimintd_bitcoin_backend_config() {
    local key="$1"
    # Matches only keys in the `fedimintd-bitcoin-backend` section
    sed -n '/^fedimintd-bitcoin-backend:/,/^[^ ]/{/^[[:space:]]\+'"$key"':/p}' /start-os/start9/config.yaml | awk '{print $2}' | tr -d "'"
}

BACKEND_TYPE=$(parse_fedimintd_bitcoin_backend_config "backend-type")
```