### PR TITLE
[Backport releases/v0.8] fix: correct how the ui displays sync percentage

### DIFF
--- a/fedimint-server-ui/src/dashboard/bitcoin.rs
+++ b/fedimint-server-ui/src/dashboard/bitcoin.rs
@@ -29,7 +29,7 @@ pub fn render(url: SafeUrl, status: &Option<ServerBitcoinRpcStatus>) -> Markup {
                             @if let Some(sync) = status.sync_percentage {
                                 tr {
                                     th { "Sync Progress" }
-                                    td { (format!("{:.1}%", sync)) }
+                                    td { (format!("{:.1}%", sync * 100.0)) }
                                 }
                             }
                         }


### PR DESCRIPTION
# Description
Backport of #7614 to `releases/v0.8`.