### PR TITLE
refactor(ln): delay costly crypto in IncomingContract decoding

### DIFF
--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -2086,7 +2086,7 @@ pub async fn create_incoming_contract_output(
     let our_pub_key = secp256k1::PublicKey::from_keypair(redeem_key);
     let contract = IncomingContract {
         hash: offer.hash,
-        encrypted_preimage: offer.encrypted_preimage.clone(),
+        encrypted_preimage: offer.encrypted_preimage.into(),
         decrypted_preimage: DecryptedPreimage::Pending,
         gateway_key: our_pub_key,
     };

--- a/modules/fedimint-ln-common/src/contracts/incoming.rs
+++ b/modules/fedimint-ln-common/src/contracts/incoming.rs
@@ -8,7 +8,10 @@ use fedimint_core::{Amount, OutPoint, secp256k1};
 use serde::{Deserialize, Serialize};
 
 use crate::LightningInput;
-use crate::contracts::{ContractId, DecryptedPreimage, EncryptedPreimage, IdentifiableContract};
+use crate::contracts::{
+    ContractId, DecryptedPreimage, EncryptedPreimage, EncryptedPreimageUndecoded,
+    IdentifiableContract,
+};
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, Encodable, Decodable)]
 pub struct IncomingContractOffer {
@@ -59,7 +62,7 @@ pub struct IncomingContract {
     /// Payment hash which's corresponding preimage is being sold
     pub hash: bitcoin::hashes::sha256::Hash,
     /// Encrypted preimage as specified in offer
-    pub encrypted_preimage: EncryptedPreimage,
+    pub encrypted_preimage: EncryptedPreimageUndecoded,
     /// Status of preimage decryption, will either end in failure or contain the
     /// preimage eventually. In case decryption was successful the preimage
     /// is also the public key locking the contract, allowing the offer

--- a/modules/fedimint-ln-tests/tests/tests.rs
+++ b/modules/fedimint-ln-tests/tests/tests.rs
@@ -706,7 +706,8 @@ mod fedimint_migration_tests {
         let (_, pk) = fedimint_core::secp256k1::generate_keypair(&mut OsRng);
         let incoming_contract = IncomingContract {
             hash: secp256k1::hashes::sha256::Hash::hash(&BYTE_8),
-            encrypted_preimage: EncryptedPreimage::new(&PreimageKey(BYTE_33), &threshold_key),
+            encrypted_preimage: EncryptedPreimage::new(&PreimageKey(BYTE_33), &threshold_key)
+                .into(),
             decrypted_preimage: DecryptedPreimage::Some(PreimageKey(BYTE_33)),
             gateway_key: pk,
         };


### PR DESCRIPTION
Fix #3184

This avoids the cost of the cryptography during decoding when the contract is not actually accessed.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
