### PR TITLE
fix: exclude `target*` dirs from taplo

### DIFF
--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,4 +1,5 @@
 include = ["**/Cargo.toml"]
+exclude = ["target*/**"]
 
 [formatting]
 reorder_keys = true


### PR DESCRIPTION
When working on release branches and compiling locally we'll have build artifacts related to that release in `target-nix`. If you switch to a different version (e.g. `master`), the git pre-commit hook will fail since older versions might not have the correct formatting.

```
❯ git commit
 INFO taplo:format_files:load_config: found configuration file path="/home/stachurski/code/fedimint/.taplo.toml"
 INFO taplo:format_files:collect_files: found files total=143 excluded=0 cwd="/home/stachurski/code/fedimint"
ERROR taplo:format_files: the file is not properly formatted path="/home/stachurski/code/fedimint/target-nix/package/devimint-0.8.0/Cargo.toml"
```

This PR updates `.taplo.toml` to ignore the formatting in any `Cargo.toml` files in `target*`.