### PR TITLE
feat: Added block count and session count in client rpc

### DIFF
--- a/fedimint-client/src/client.rs
+++ b/fedimint-client/src/client.rs
@@ -14,7 +14,7 @@ use bitcoin::secp256k1::{self, PublicKey};
 use fedimint_api_client::api::global_api::with_request_hook::ApiRequestHook;
 use fedimint_api_client::api::net::Connector;
 use fedimint_api_client::api::{
-    ApiVersionSet, DynGlobalApi, FederationApiExt as _, IGlobalFederationApi,
+    ApiVersionSet, DynGlobalApi, FederationApiExt as _, FederationResult, IGlobalFederationApi,
 };
 use fedimint_client_module::module::recovery::RecoveryProgress;
 use fedimint_client_module::module::{
@@ -1350,6 +1350,10 @@ impl Client {
         }
     }
 
+    async fn fetch_session_count(&self) -> FederationResult<u64> {
+        self.api.session_count().await
+    }
+
     async fn fetch_and_update_config(
         &self,
         config: ClientConfig,
@@ -1435,6 +1439,10 @@ impl Client {
                         .paginate_operations_rev(limit, req.last_seen)
                         .await;
                     yield serde_json::to_value(operations)?;
+                }
+                "session_count" => {
+                    let count = self.fetch_session_count().await?;
+                    yield serde_json::to_value(count)?;
                 }
                 "has_pending_recoveries" => {
                     let has_pending = self.has_pending_recoveries();

--- a/modules/fedimint-wallet-client/src/api.rs
+++ b/modules/fedimint-wallet-client/src/api.rs
@@ -6,8 +6,8 @@ use fedimint_core::task::{MaybeSend, MaybeSync};
 use fedimint_core::{PeerId, apply, async_trait_maybe_send};
 use fedimint_wallet_common::endpoint_constants::{
     ACTIVATE_CONSENSUS_VERSION_VOTING_ENDPOINT, BITCOIN_KIND_ENDPOINT, BITCOIN_RPC_CONFIG_ENDPOINT,
-    BLOCK_COUNT_ENDPOINT, MODULE_CONSENSUS_VERSION_ENDPOINT, PEG_OUT_FEES_ENDPOINT,
-    UTXO_CONFIRMED_ENDPOINT, WALLET_SUMMARY_ENDPOINT,
+    BLOCK_COUNT_ENDPOINT, BLOCK_COUNT_LOCAL_ENDPOINT, MODULE_CONSENSUS_VERSION_ENDPOINT,
+    PEG_OUT_FEES_ENDPOINT, UTXO_CONFIRMED_ENDPOINT, WALLET_SUMMARY_ENDPOINT,
 };
 use fedimint_wallet_common::{PegOutFees, WalletSummary};
 
@@ -28,6 +28,8 @@ pub trait WalletFederationApi {
     async fn fetch_bitcoin_rpc_config(&self, auth: ApiAuth) -> FederationResult<BitcoinRpcConfig>;
 
     async fn fetch_wallet_summary(&self) -> FederationResult<WalletSummary>;
+
+    async fn fetch_block_count_local(&self) -> FederationResult<u32>;
 
     async fn is_utxo_confirmed(&self, outpoint: bitcoin::OutPoint) -> FederationResult<bool>;
 
@@ -76,6 +78,14 @@ where
     async fn fetch_consensus_block_count(&self) -> FederationResult<u64> {
         self.request_current_consensus(
             BLOCK_COUNT_ENDPOINT.to_string(),
+            ApiRequestErased::default(),
+        )
+        .await
+    }
+
+    async fn fetch_block_count_local(&self) -> FederationResult<u32> {
+        self.request_current_consensus(
+            BLOCK_COUNT_LOCAL_ENDPOINT.to_string(),
             ApiRequestErased::default(),
         )
         .await

--- a/modules/fedimint-wallet-client/src/api.rs
+++ b/modules/fedimint-wallet-client/src/api.rs
@@ -1,9 +1,13 @@
+use anyhow::anyhow;
 use bitcoin::{Address, Amount};
-use fedimint_api_client::api::{FederationApiExt, FederationResult, IModuleFederationApi};
+use fedimint_api_client::api::{
+    FederationApiExt, FederationError, FederationResult, IModuleFederationApi, PeerResult,
+};
+use fedimint_api_client::query::FilterMapThreshold;
 use fedimint_core::envs::BitcoinRpcConfig;
 use fedimint_core::module::{ApiAuth, ApiRequestErased, ModuleConsensusVersion};
 use fedimint_core::task::{MaybeSend, MaybeSync};
-use fedimint_core::{PeerId, apply, async_trait_maybe_send};
+use fedimint_core::{NumPeersExt, PeerId, apply, async_trait_maybe_send};
 use fedimint_wallet_common::endpoint_constants::{
     ACTIVATE_CONSENSUS_VERSION_VOTING_ENDPOINT, BITCOIN_KIND_ENDPOINT, BITCOIN_RPC_CONFIG_ENDPOINT,
     BLOCK_COUNT_ENDPOINT, BLOCK_COUNT_LOCAL_ENDPOINT, MODULE_CONSENSUS_VERSION_ENDPOINT,
@@ -84,11 +88,35 @@ where
     }
 
     async fn fetch_block_count_local(&self) -> FederationResult<u32> {
-        self.request_current_consensus(
-            BLOCK_COUNT_LOCAL_ENDPOINT.to_string(),
-            ApiRequestErased::default(),
-        )
-        .await
+        let filter_map = |_peer: PeerId, block_count: Option<u32>| -> PeerResult<Option<u32>> {
+            Ok(block_count)
+        };
+
+        let block_count_responses = self
+            .request_with_strategy(
+                FilterMapThreshold::<Option<u32>, Option<u32>>::new(
+                    filter_map,
+                    self.all_peers().to_num_peers().threshold().into(),
+                ),
+                BLOCK_COUNT_LOCAL_ENDPOINT.to_string(),
+                ApiRequestErased::default(),
+            )
+            .await?;
+
+        let mut response: Vec<u32> = block_count_responses.into_values().flatten().collect();
+
+        if response.is_empty() {
+            return Err(FederationError::general(
+                BLOCK_COUNT_LOCAL_ENDPOINT.to_string(),
+                ApiRequestErased::default(),
+                anyhow!("No valid block counts received"),
+            ));
+        }
+
+        response.sort_unstable();
+        let final_block_count = response[response.len() / 2];
+
+        Ok(final_block_count)
     }
 
     async fn fetch_peg_out_fees(

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -570,6 +570,7 @@ pub struct WalletClientContext {
 pub struct PegInRequest {
     pub extra_meta: serde_json::Value,
 }
+
 #[derive(Deserialize)]
 struct SubscribeDepositRequest {
     operation_id: OperationId,

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -511,6 +511,11 @@ impl ClientModule for WalletClientModule {
                         .expect("Serialization error");
                     yield result;
                 }
+                "get_block_count_local" => {
+                    let block_count = self.get_block_count_local().await
+                        .expect("Failed to fetch block count");
+                    yield serde_json::to_value(block_count)?;
+                }
                 "peg_in" => {
                     let req: PegInRequest = serde_json::from_value(request)?;
                     let response = self.peg_in(req)
@@ -667,6 +672,10 @@ impl WalletClientModule {
     /// Returns a summary of the wallet's coins
     pub async fn get_wallet_summary(&self) -> anyhow::Result<WalletSummary> {
         Ok(self.module_api.fetch_wallet_summary().await?)
+    }
+
+    pub async fn get_block_count_local(&self) -> anyhow::Result<u32> {
+        Ok(self.module_api.fetch_block_count_local().await?)
     }
 
     pub fn create_withdraw_output(


### PR DESCRIPTION
Implemented `block_count` and `session_count` in client rpc for showing it in wallet guardians details