### PR TITLE
docs: add lnaddress_api to meta fields

### DIFF
--- a/docs/meta_fields/README.md
+++ b/docs/meta_fields/README.md
@@ -12,6 +12,7 @@ The following meta fields have been defined as part of the core Fedimint protoco
 * [`welcome_message`](welcome_message.md): A welcome message for new users joining the federation
 * [`vetted_gateways`](vetted_gateways.md): A list of gateway identifiers vetted by the federation
 * [`recurringd_api`](recurringd_api.md): The API URL of a recurringd instance that can be used by the clients to create LNURLs
+* [`lnaddress_api`](lnaddress_api.md): The API URL of a Lightning Address Server instance that is used to serve LNURLs
 
 ## Defining new meta fields
 

--- a/docs/meta_fields/lnaddress_api.md
+++ b/docs/meta_fields/lnaddress_api.md
@@ -1,0 +1,8 @@
+# `lnaddress_api`
+
+The API URL of a `Lightning Address Server` instance that can be used to serve LNURLs to Lightning wallets.
+See [lnaddrd](https://github.com/elsirion/lnaddrd/) as an example of an implementation.
+
+## Structure
+
+A valid URL string pointing to a `Lightning Address Server` API.


### PR DESCRIPTION
Similar to https://github.com/fedimint/fedimint/pull/7539, but adding a meta field for a Lightning Address server API.