### PR TITLE
fix: ApiCallDone should not be persisted

### DIFF
--- a/fedimint-client-module/src/api.rs
+++ b/fedimint-client-module/src/api.rs
@@ -51,6 +51,7 @@ impl Event for ApiCallDone {
     const MODULE: Option<fedimint_core::core::ModuleKind> = None;
 
     const KIND: EventKind = EventKind::from_static("api-call-done");
+    const PERSIST: bool = false;
 }
 
 use fedimint_eventlog::{DBTransactionEventLogExt as _, Event, EventKind};


### PR DESCRIPTION
This is a potentially high-volume event and was
not supposed to be persisted at all.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
