### PR TITLE
[Backport releases/v0.8] fix: ApiCallDone should not be persisted

### DIFF
--- a/fedimint-client-module/src/api.rs
+++ b/fedimint-client-module/src/api.rs
@@ -51,6 +51,7 @@ impl Event for ApiCallDone {
     const MODULE: Option<fedimint_core::core::ModuleKind> = None;
 
     const KIND: EventKind = EventKind::from_static("api-call-done");
+    const PERSIST: bool = false;
 }
 
 use fedimint_eventlog::{DBTransactionEventLogExt as _, Event, EventKind};


### PR DESCRIPTION
# Description
Backport of #7641 to `releases/v0.8`.