### PR TITLE
Drop 'v' prefix from docker tags

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -362,7 +362,8 @@ jobs:
       - name: Publish tagged release
         if: github.ref_type == 'tag' && (github.event_name != 'pull_request' || matrix.platform.run_in_pr)
         run: |
-          nix_tag=${{ env.container_tag }} && hub_tag="${{ matrix.container.image }}:${GITHUB_REF_NAME}-${{ matrix.platform.arch }}" && docker tag "$nix_tag" "$hub_tag" && docker push "$hub_tag"
+          VERSION_TAG=${GITHUB_REF_NAME#v}
+          nix_tag=${{ env.container_tag }} && hub_tag="${{ matrix.container.image }}:${VERSION_TAG}-${{ matrix.platform.arch }}" && docker tag "$nix_tag" "$hub_tag" && docker push "$hub_tag"
 
   manifest:
     if: github.repository == 'fedimint/fedimint' && (github.ref == 'refs/heads/master' || github.ref_type == 'tag')
@@ -406,13 +407,14 @@ jobs:
               docker manifest annotate "$image:${LAST_COMMIT_SHA}" "$image:${LAST_COMMIT_SHA}-aarch64-linux" --arch arm64
               docker manifest push "$image:${LAST_COMMIT_SHA}"
             elif [ "$GITHUB_REF_TYPE" = "tag" ]; then
-              echo "Creating manifest for $image:${GITHUB_REF_NAME}"
-              docker manifest create "$image:${GITHUB_REF_NAME}" \
-                "$image:${GITHUB_REF_NAME}-x86_64-linux" \
-                "$image:${GITHUB_REF_NAME}-aarch64-linux"
-              docker manifest annotate "$image:${GITHUB_REF_NAME}" "$image:${GITHUB_REF_NAME}-x86_64-linux" --arch amd64
-              docker manifest annotate "$image:${GITHUB_REF_NAME}" "$image:${GITHUB_REF_NAME}-aarch64-linux" --arch arm64
-              docker manifest push "$image:${GITHUB_REF_NAME}"
+              VERSION_TAG=${GITHUB_REF_NAME#v}
+              echo "Creating manifest for $image:${VERSION_TAG}"
+              docker manifest create "$image:${VERSION_TAG}" \
+                "$image:${VERSION_TAG}-x86_64-linux" \
+                "$image:${VERSION_TAG}-aarch64-linux"
+              docker manifest annotate "$image:${VERSION_TAG}" "$image:${VERSION_TAG}-x86_64-linux" --arch amd64
+              docker manifest annotate "$image:${VERSION_TAG}" "$image:${VERSION_TAG}-aarch64-linux" --arch arm64
+              docker manifest push "$image:${VERSION_TAG}"
             fi
           done
 
@@ -478,7 +480,8 @@ jobs:
       - name: Set BUILD_ID to tag or commit hash
         run: |
           if [[ $GITHUB_REF_TYPE == "tag" ]]; then
-            echo "BUILD_ID=${GITHUB_REF_NAME}" >> $GITHUB_ENV
+            VERSION_TAG=${GITHUB_REF_NAME#v}
+            echo "BUILD_ID=${VERSION_TAG}" >> $GITHUB_ENV
           else
             echo "BUILD_ID=${GITHUB_SHA}" >> $GITHUB_ENV
           fi

--- a/docker/README.md
+++ b/docker/README.md
@@ -57,7 +57,7 @@ Using the invite code from your guardian dashboard, join the federation using `f
 docker run -it --rm \
   -e RUST_LOG=off \
   -v "$(pwd)/mutinynet-client":/mutinynet-client \
-  fedimint/fedimint-cli:v0.7.0 \
+  fedimint/fedimint-cli:0.7.0 \
   fedimint-cli \
     --data-dir /mutinynet-client \
     join-federation <invite_code>
@@ -73,7 +73,7 @@ Get a new deposit address
 docker run -it --rm \
   -e RUST_LOG=off \
   -v "$(pwd)/mutinynet-client":/mutinynet-client \
-  fedimint/fedimint-cli:v0.7.0 \
+  fedimint/fedimint-cli:0.7.0 \
   fedimint-cli \
     --data-dir /mutinynet-client \
     module wallet new-deposit-address
@@ -87,7 +87,7 @@ Await the deposit:
 docker run -it --rm \
   -e RUST_LOG=off \
   -v "$(pwd)/mutinynet-client":/mutinynet-client \
-  fedimint/fedimint-cli:v0.7.0 \
+  fedimint/fedimint-cli:0.7.0 \
   fedimint-cli \
     --data-dir /mutinynet-client \
     module wallet await-deposit <address>
@@ -101,7 +101,7 @@ Once you've claimed the deposit, check the wallet balance in the guardian dashbo
 docker run -it --rm \
   -e RUST_LOG=off \
   -v "$(pwd)/mutinynet-client":/mutinynet-client \
-  fedimint/fedimint-cli:v0.7.0 \
+  fedimint/fedimint-cli:0.7.0 \
   fedimint-cli \
     --data-dir /mutinynet-client \
     info
@@ -115,7 +115,7 @@ When you're done experimenting with the setup, send your sats back to the friend
 docker run -it --rm \
   -e RUST_LOG=off \
   -v "$(pwd)/mutinynet-client":/mutinynet-client \
-  fedimint/fedimint-cli:v0.7.0 \
+  fedimint/fedimint-cli:0.7.0 \
   fedimint-cli \
     --data-dir /mutinynet-client \
     withdraw --amount all --address tb1qd28npep0s8frcm3y7dxqajkcy2m40eysplyr9v

--- a/docker/iroh-fedimintd/docker-compose.yaml
+++ b/docker/iroh-fedimintd/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   fedimintd:
-    image: fedimint/fedimintd:v0.7.0
+    image: fedimint/fedimintd:0.7.0
     ports:
       - 8173:8173/tcp # p2p tls
       - 8173:8173/udp # p2p iroh

--- a/fedimint-startos/Dockerfile
+++ b/fedimint-startos/Dockerfile
@@ -11,7 +11,7 @@ RUN case "$TARGETARCH" in \
     chmod +x /tmp/yq
 
 # Stage 2: Main image
-FROM fedimint/fedimintd:v0.8.0
+FROM fedimint/fedimintd:0.8.0
 
 # Copy yq from downloader stage
 COPY --from=downloader /tmp/yq /usr/local/bin/yq


### PR DESCRIPTION
Issue #4871

Strip 'v' prefix from docker tags for consistency with UI components. 

- CI: Use VERSION_TAG=${GITHUB_REF_NAME#v} in workflow 
- Update docker files to use 0.7.0 format instead of v0.7.0 
- Update documentation examples