### PR TITLE
chore: expose get_finality_delay fn in wallet client

### DIFF
--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -622,6 +622,10 @@ impl WalletClientModule {
         self.cfg().network.0
     }
 
+    pub fn get_finality_delay(&self) -> u32 {
+        self.cfg().finality_delay
+    }
+
     pub fn get_fee_consensus(&self) -> FeeConsensus {
         self.cfg().fee_consensus
     }


### PR DESCRIPTION
I noticed that Harbor hardcoded their on-chain receive description to include "Requires on-chain fees and 10 block confirmations."

https://github.com/HarborWallet/harbor/blob/1191c03edfb1f9b156f9947bed3940e488766d82/harbor-ui/src/routes/receive.rs#L153

They should have a way to check a federation's settings and display the actual finality delay.