### PR TITLE
refactor: list channels

### DIFF
--- a/devimint/src/external.rs
+++ b/devimint/src/external.rs
@@ -747,14 +747,14 @@ async fn wait_for_ready_channel_on_gateway_with_counterparty(
         &format!("Wait for {} channel update", gw.gw_name),
         || async {
             let channels = gw
-                .list_active_channels()
+                .list_channels()
                 .await
                 .context("list channels")
                 .map_err(ControlFlow::Break)?;
 
             if channels
                 .iter()
-                .any(|channel| channel.remote_pubkey == counterparty_lightning_node_pubkey)
+                .any(|channel| channel.remote_pubkey == counterparty_lightning_node_pubkey && channel.is_active)
             {
                 return Ok(());
             }

--- a/fedimint-testing/src/ln.rs
+++ b/fedimint-testing/src/ln.rs
@@ -17,7 +17,7 @@ use fedimint_gateway_common::{
 use fedimint_lightning::{
     CreateInvoiceRequest, CreateInvoiceResponse, GetBalancesResponse, GetLnOnchainAddressResponse,
     GetNodeInfoResponse, GetRouteHintsResponse, ILnRpcClient, InterceptPaymentRequest,
-    InterceptPaymentResponse, LightningRpcError, ListActiveChannelsResponse, OpenChannelResponse,
+    InterceptPaymentResponse, LightningRpcError, ListChannelsResponse, OpenChannelResponse,
     PayInvoiceResponse, RouteHtlcStream, SendOnchainResponse,
 };
 use fedimint_ln_common::PrunedInvoice;
@@ -284,8 +284,8 @@ impl ILnRpcClient for FakeLightningTest {
         })
     }
 
-    async fn list_active_channels(&self) -> Result<ListActiveChannelsResponse, LightningRpcError> {
-        Err(LightningRpcError::FailedToListActiveChannels {
+    async fn list_channels(&self) -> Result<ListChannelsResponse, LightningRpcError> {
+        Err(LightningRpcError::FailedToListChannels {
             failure_reason: "FakeLightningTest does not support listing active channels"
                 .to_string(),
         })

--- a/gateway/fedimint-gateway-client/src/lib.rs
+++ b/gateway/fedimint-gateway-client/src/lib.rs
@@ -10,7 +10,7 @@ use fedimint_gateway_common::{
     DepositAddressPayload, DepositAddressRecheckPayload, FederationInfo, GATEWAY_INFO_ENDPOINT,
     GATEWAY_INFO_POST_ENDPOINT, GET_BALANCES_ENDPOINT, GET_INVOICE_ENDPOINT,
     GET_LN_ONCHAIN_ADDRESS_ENDPOINT, GatewayBalances, GatewayFedConfig, GatewayInfo,
-    GetInvoiceRequest, GetInvoiceResponse, LEAVE_FED_ENDPOINT, LIST_ACTIVE_CHANNELS_ENDPOINT,
+    GetInvoiceRequest, GetInvoiceResponse, LEAVE_FED_ENDPOINT, LIST_CHANNELS_ENDPOINT,
     LIST_TRANSACTIONS_ENDPOINT, LeaveFedPayload, ListTransactionsPayload, ListTransactionsResponse,
     MNEMONIC_ENDPOINT, MnemonicResponse, OPEN_CHANNEL_ENDPOINT, OpenChannelRequest,
     PAY_INVOICE_FOR_OPERATOR_ENDPOINT, PAY_OFFER_FOR_OPERATOR_ENDPOINT, PAYMENT_LOG_ENDPOINT,
@@ -180,10 +180,10 @@ impl GatewayRpcClient {
         self.call_post(url, payload).await
     }
 
-    pub async fn list_active_channels(&self) -> GatewayRpcResult<Vec<ChannelInfo>> {
+    pub async fn list_channels(&self) -> GatewayRpcResult<Vec<ChannelInfo>> {
         let url = self
             .base_url
-            .join(LIST_ACTIVE_CHANNELS_ENDPOINT)
+            .join(LIST_CHANNELS_ENDPOINT)
             .expect("invalid base url");
         self.call_get(url).await
     }

--- a/gateway/fedimint-gateway-client/src/lightning_commands.rs
+++ b/gateway/fedimint-gateway-client/src/lightning_commands.rs
@@ -53,8 +53,8 @@ pub enum LightningCommands {
         #[clap(long)]
         pubkey: bitcoin::secp256k1::PublicKey,
     },
-    /// List active channels.
-    ListActiveChannels,
+    /// List channels.
+    ListChannels,
     /// List the Lightning transactions that the Lightning node has received and
     /// sent
     ListTransactions {
@@ -155,8 +155,8 @@ impl LightningCommands {
                     .await?;
                 print_response(response);
             }
-            Self::ListActiveChannels => {
-                let response = create_client().list_active_channels().await?;
+            Self::ListChannels => {
+                let response = create_client().list_channels().await?;
                 print_response(response);
             }
             Self::GetInvoice { payment_hash } => {

--- a/gateway/fedimint-gateway-common/src/lib.rs
+++ b/gateway/fedimint-gateway-common/src/lib.rs
@@ -40,7 +40,7 @@ pub const GET_BALANCES_ENDPOINT: &str = "/balances";
 pub const GET_INVOICE_ENDPOINT: &str = "/get_invoice";
 pub const GET_LN_ONCHAIN_ADDRESS_ENDPOINT: &str = "/get_ln_onchain_address";
 pub const LEAVE_FED_ENDPOINT: &str = "/leave_fed";
-pub const LIST_ACTIVE_CHANNELS_ENDPOINT: &str = "/list_active_channels";
+pub const LIST_CHANNELS_ENDPOINT: &str = "/list_channels";
 pub const LIST_TRANSACTIONS_ENDPOINT: &str = "/list_transactions";
 pub const MNEMONIC_ENDPOINT: &str = "/mnemonic";
 pub const OPEN_CHANNEL_ENDPOINT: &str = "/open_channel";
@@ -300,6 +300,7 @@ pub struct ChannelInfo {
     pub channel_size_sats: u64,
     pub outbound_liquidity_sats: u64,
     pub inbound_liquidity_sats: u64,
+    pub is_active: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -1429,11 +1429,11 @@ impl Gateway {
 
     /// Returns a list of Lightning network channels from the Gateway's
     /// Lightning node.
-    pub async fn handle_list_active_channels_msg(
+    pub async fn handle_list_channels_msg(
         &self,
     ) -> AdminResult<Vec<fedimint_gateway_common::ChannelInfo>> {
         let context = self.get_lightning_context().await?;
-        let response = context.lnrpc.list_active_channels().await?;
+        let response = context.lnrpc.list_channels().await?;
         Ok(response.channels)
     }
 

--- a/gateway/fedimint-gateway-server/src/rpc_server.rs
+++ b/gateway/fedimint-gateway-server/src/rpc_server.rs
@@ -17,7 +17,7 @@ use fedimint_gateway_common::{
     CreateInvoiceForOperatorPayload, CreateOfferPayload, DepositAddressPayload,
     DepositAddressRecheckPayload, GATEWAY_INFO_ENDPOINT, GATEWAY_INFO_POST_ENDPOINT,
     GET_BALANCES_ENDPOINT, GET_INVOICE_ENDPOINT, GET_LN_ONCHAIN_ADDRESS_ENDPOINT,
-    GetInvoiceRequest, InfoPayload, LEAVE_FED_ENDPOINT, LIST_ACTIVE_CHANNELS_ENDPOINT,
+    GetInvoiceRequest, InfoPayload, LEAVE_FED_ENDPOINT, LIST_CHANNELS_ENDPOINT,
     LIST_TRANSACTIONS_ENDPOINT, LeaveFedPayload, ListTransactionsPayload, MNEMONIC_ENDPOINT,
     OPEN_CHANNEL_ENDPOINT, OpenChannelRequest, PAY_INVOICE_FOR_OPERATOR_ENDPOINT,
     PAY_OFFER_FOR_OPERATOR_ENDPOINT, PAYMENT_LOG_ENDPOINT, PAYMENT_SUMMARY_ENDPOINT,
@@ -173,7 +173,7 @@ fn v1_routes(gateway: Arc<Gateway>, task_group: TaskGroup) -> Router {
             CLOSE_CHANNELS_WITH_PEER_ENDPOINT,
             post(close_channels_with_peer),
         )
-        .route(LIST_ACTIVE_CHANNELS_ENDPOINT, get(list_active_channels))
+        .route(LIST_CHANNELS_ENDPOINT, get(list_channels))
         .route(LIST_TRANSACTIONS_ENDPOINT, post(list_transactions))
         .route(SEND_ONCHAIN_ENDPOINT, post(send_onchain))
         .route(ADDRESS_RECHECK_ENDPOINT, post(recheck_address))
@@ -346,10 +346,10 @@ async fn close_channels_with_peer(
 }
 
 #[instrument(target = LOG_GATEWAY, skip_all, err)]
-async fn list_active_channels(
+async fn list_channels(
     Extension(gateway): Extension<Arc<Gateway>>,
 ) -> Result<impl IntoResponse, AdminGatewayError> {
-    let channels = gateway.handle_list_active_channels_msg().await?;
+    let channels = gateway.handle_list_channels_msg().await?;
     Ok(Json(json!(channels)))
 }
 

--- a/gateway/fedimint-lightning/src/lib.rs
+++ b/gateway/fedimint-lightning/src/lib.rs
@@ -62,7 +62,7 @@ pub enum LightningRpcError {
     #[error("Failed to connect to peer: {failure_reason}")]
     FailedToConnectToPeer { failure_reason: String },
     #[error("Failed to list active channels: {failure_reason}")]
-    FailedToListActiveChannels { failure_reason: String },
+    FailedToListChannels { failure_reason: String },
     #[error("Failed to get balances: {failure_reason}")]
     FailedToGetBalances { failure_reason: String },
     #[error("Failed to sync to chain: {failure_reason}")]
@@ -213,7 +213,7 @@ pub trait ILnRpcClient: Debug + Send + Sync {
     ) -> Result<CloseChannelsWithPeerResponse, LightningRpcError>;
 
     /// Lists the lightning node's active channels with all peers.
-    async fn list_active_channels(&self) -> Result<ListActiveChannelsResponse, LightningRpcError>;
+    async fn list_channels(&self) -> Result<ListChannelsResponse, LightningRpcError>;
 
     /// Returns a summary of the lightning node's balance, including the onchain
     /// wallet, outbound liquidity, and inbound liquidity.
@@ -389,7 +389,7 @@ pub struct OpenChannelResponse {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct ListActiveChannelsResponse {
+pub struct ListChannelsResponse {
     pub channels: Vec<ChannelInfo>,
 }
 


### PR DESCRIPTION
It is silly that the Gateway's `list_active_channels` endpoint filters based on whether the channel is active or not, since when debugging we'd ideally still like to be able to know about channels that are not active. 

This PR changes the filtering and returns it as a boolean in the response.