### PR TITLE
`recurringd`: simplify invoice generation 

### DIFF
--- a/fedimint-client/src/client.rs
+++ b/fedimint-client/src/client.rs
@@ -550,24 +550,14 @@ impl Client {
                     let tx_builder = tx_builder.clone();
                     let operation_meta_gen = operation_meta_gen.clone();
                     Box::pin(async move {
-                        if Client::operation_exists_dbtx(dbtx, operation_id).await {
-                            bail!("There already exists an operation with id {operation_id:?}")
-                        }
-
-                        let out_point_range = self
-                            .finalize_and_submit_transaction_inner(dbtx, operation_id, tx_builder)
-                            .await?;
-
-                        self.operation_log()
-                            .add_operation_log_entry_dbtx(
-                                dbtx,
-                                operation_id,
-                                &operation_type,
-                                operation_meta_gen(out_point_range),
-                            )
-                            .await;
-
-                        Ok(out_point_range)
+                        self.finalize_and_submit_transaction_dbtx(
+                            dbtx,
+                            operation_id,
+                            &operation_type,
+                            operation_meta_gen,
+                            tx_builder,
+                        )
+                        .await
                     })
                 },
                 Some(100), // TODO: handle what happens after 100 retries
@@ -584,6 +574,40 @@ impl Client {
                 "Failed to commit tx submission dbtx after {attempts} attempts: {last_error}"
             ),
         }
+    }
+
+    /// Same as [`Self::finalize_and_submit_transaction`] but runs inside an
+    /// externally supplied database transaction.
+    pub async fn finalize_and_submit_transaction_dbtx<F, M>(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        operation_id: OperationId,
+        operation_type: &str,
+        operation_meta_gen: F,
+        tx_builder: TransactionBuilder,
+    ) -> anyhow::Result<OutPointRange>
+    where
+        F: Fn(OutPointRange) -> M + Clone + MaybeSend + MaybeSync,
+        M: serde::Serialize + MaybeSend,
+    {
+        if Client::operation_exists_dbtx(dbtx, operation_id).await {
+            bail!("There already exists an operation with id {operation_id:?}")
+        }
+
+        let out_point_range = self
+            .finalize_and_submit_transaction_inner(dbtx, operation_id, tx_builder)
+            .await?;
+
+        self.operation_log()
+            .add_operation_log_entry_dbtx(
+                dbtx,
+                operation_id,
+                operation_type,
+                operation_meta_gen(out_point_range),
+            )
+            .await;
+
+        Ok(out_point_range)
     }
 
     async fn finalize_and_submit_transaction_inner(
@@ -1943,15 +1967,17 @@ impl ClientContextIface for Client {
         Client::decoders(self)
     }
 
-    async fn finalize_and_submit_transaction(
+    async fn finalize_and_submit_transaction_dbtx(
         &self,
+        dbtx: &mut DatabaseTransaction<'_>,
         operation_id: OperationId,
         operation_type: &str,
         operation_meta_gen: Box<maybe_add_send_sync!(dyn Fn(OutPointRange) -> serde_json::Value)>,
         tx_builder: TransactionBuilder,
     ) -> anyhow::Result<OutPointRange> {
-        Client::finalize_and_submit_transaction(
+        Client::finalize_and_submit_transaction_dbtx(
             self,
+            dbtx,
             operation_id,
             operation_type,
             // |out_point_range| operation_meta_gen(out_point_range),

--- a/fedimint-recurringd-tests/src/bin/fedimint-recurringd-tests.rs
+++ b/fedimint-recurringd-tests/src/bin/fedimint-recurringd-tests.rs
@@ -12,6 +12,7 @@ async fn main() -> anyhow::Result<()> {
         .call(|dev_fed, process_mgr| async move {
             log_binary_versions().await?;
 
+            info!("Setting up development federation...");
             let DevFed {
                 fed,
                 gw_lnd,
@@ -19,12 +20,16 @@ async fn main() -> anyhow::Result<()> {
                 recurringd,
                 ..
             } = dev_fed.to_dev_fed(&process_mgr).await?;
+            info!("Development federation setup complete");
 
             // Test admin auth is checked
+            info!("Testing admin authentication...");
             {
                 let dummy_invite = "fed114znk7uk7ppugdjuytr8venqf2tkywd65cqvg3u93um64tu5cw4yr0n3fvn7qmwvm4g48cpndgnm4gqq4waen5te0xyerwt3s9cczuvf6xyurzde597s7crdvsk2vmyarjw9gwyqjdzj";
                 let url = format!("{}lnv1/federations", recurringd.api_url);
                 let client = reqwest::Client::new();
+
+                info!("Testing request without authentication...");
                 let response_no_auth = client
                     .put(&url)
                     .header("Content-Type", "application/json")
@@ -32,7 +37,9 @@ async fn main() -> anyhow::Result<()> {
                     .send()
                     .await?;
                 assert!(response_no_auth.status().is_client_error());
+                info!("✓ Request without auth correctly rejected with status: {}", response_no_auth.status());
 
+                info!("Testing request with wrong authentication...");
                 let response_with_wrong_auth = client
                     .put(&url)
                     .header("Authorization", "Bearer wrong-token")
@@ -41,14 +48,21 @@ async fn main() -> anyhow::Result<()> {
                     .send()
                     .await?;
                 assert!(response_with_wrong_auth.status().is_client_error());
+                info!("✓ Request with wrong auth correctly rejected with status: {}", response_with_wrong_auth.status());
             }
+            info!("Admin authentication tests completed successfully");
 
             // Give the LND Gateway a balance, it's the only GW serving LNv1 and recurringd
             // is currently LNv1-only
+            info!("Funding LND Gateway with 10,000,000 msats...");
             fed.pegin_gateways(10_000_000, vec![&gw_lnd]).await?;
+            info!("✓ LND Gateway funded successfully");
 
+            info!("Creating new fedimint client...");
             let client = fed.new_joined_client("recurringd-test-client").await?;
+            info!("✓ Client 'recurringd-test-client' created and joined federation");
 
+            info!("Registering LNURL with recurringd...");
             let lnurl = cmd!(
                 client,
                 "module",
@@ -62,28 +76,37 @@ async fn main() -> anyhow::Result<()> {
                 .as_str()
                 .unwrap()
                 .to_owned();
+            info!("✓ LNURL registered: {}", lnurl);
 
+            info!("Listing registered LNURLs...");
             let lnurl_list = cmd!(client, "module", "ln", "lnurl", "list")
                 .out_json()
                 .await?["codes"]
                 .as_object()
                 .unwrap()
                 .clone();
+            info!("Found {} registered LNURL(s)", lnurl_list.len());
 
             assert_eq!(lnurl_list.len(), 1);
 
             let listed_lnurl = lnurl_list["0"].clone();
             assert_eq!(listed_lnurl["lnurl"].as_str().unwrap(), &lnurl);
             assert_eq!(listed_lnurl["last_derivation_index"].as_i64().unwrap(), 0);
+            info!("✓ LNURL list verification passed - derivation index: {}", listed_lnurl["last_derivation_index"].as_i64().unwrap());
 
+            info!("Creating invoice for 1000 sats using LNURL...");
             let invoice = cmd!("lnurlp", "--amount", "1000sat", lnurl)
                 .out_string()
                 .await?
                 .parse::<Bolt11Invoice>()
                 .unwrap();
+            info!("✓ Invoice created: {}", invoice.to_string());
 
+            info!("Paying invoice with LDK gateway...");
             gw_ldk_second.pay_invoice(invoice.clone()).await?;
+            info!("✓ Invoice payment initiated");
 
+            info!("Polling for invoice recognition...");
             let invoice_op_id = poll("lnurl_receive", || async {
                 cmd!(client, "dev", "wait", "2")
                     .run()
@@ -110,7 +133,9 @@ async fn main() -> anyhow::Result<()> {
                     .to_owned())
             })
             .await?;
+            info!("✓ Invoice recognized with operation ID: {}", invoice_op_id);
 
+            info!("Waiting for invoice payment confirmation...");
             let await_invoice_result = cmd!(
                 client,
                 "module",
@@ -121,7 +146,9 @@ async fn main() -> anyhow::Result<()> {
             )
             .out_json()
             .await?;
+            info!("✓ Invoice payment confirmed");
 
+            info!("Verifying payment details...");
             assert_eq!(
                 await_invoice_result["amount_msat"].as_i64().unwrap(),
                 1_000_000
@@ -130,11 +157,14 @@ async fn main() -> anyhow::Result<()> {
                 await_invoice_result["invoice"].as_str().unwrap(),
                 &invoice.to_string()
             );
+            info!("✓ Payment verification passed - amount: {} msats", await_invoice_result["amount_msat"].as_i64().unwrap());
 
+            info!("Checking final client balance...");
             let client_balance = client.balance().await?;
             almost_equal(client_balance, 1_000_000, 5_000).unwrap();
-            info!("Client balance: {client_balance}");
+            info!("✓ Client balance verified: {} msats", client_balance);
 
+            info!("🎉 All recurringd tests completed successfully!");
             Ok(())
         })
         .await

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -1722,6 +1722,36 @@ impl LightningClientModule {
         let receiving_key =
             ReceivingKey::Personal(Keypair::new(&self.secp, &mut rand::rngs::OsRng));
         self.create_bolt11_invoice_internal(
+            None,
+            amount,
+            description,
+            expiry_time,
+            receiving_key,
+            extra_meta,
+            gateway,
+        )
+        .await
+    }
+
+    /// Receive over LN with a new invoice for another user, tweaking their key
+    /// by the given index. This method takes a dbtx as argument so it can be
+    /// used atomically in a database transaction.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn create_bolt11_invoice_for_user_tweaked_dbtx<M: Serialize + Send + Sync>(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        amount: Amount,
+        description: lightning_invoice::Bolt11InvoiceDescription,
+        expiry_time: Option<u64>,
+        user_key: PublicKey,
+        index: u64,
+        extra_meta: M,
+        gateway: Option<LightningGateway>,
+    ) -> anyhow::Result<(OperationId, Bolt11Invoice, [u8; 32])> {
+        let tweaked_key = tweak_user_key(&self.secp, user_key, index);
+        let receiving_key = ReceivingKey::External(tweaked_key);
+        self.create_bolt11_invoice_internal(
+            Some(dbtx),
             amount,
             description,
             expiry_time,
@@ -1746,18 +1776,18 @@ impl LightningClientModule {
         gateway: Option<LightningGateway>,
     ) -> anyhow::Result<(OperationId, Bolt11Invoice, [u8; 32])> {
         let tweaked_key = tweak_user_key(&self.secp, user_key, index);
-        self.create_bolt11_invoice_for_user(
+        self.create_bolt11_invoice_internal(
+            None,
             amount,
             description,
             expiry_time,
-            tweaked_key,
+            ReceivingKey::External(tweaked_key),
             extra_meta,
             gateway,
         )
         .await
     }
 
-    /// Receive over LN with a new invoice for another user
     pub async fn create_bolt11_invoice_for_user<M: Serialize + Send + Sync>(
         &self,
         amount: Amount,
@@ -1767,12 +1797,12 @@ impl LightningClientModule {
         extra_meta: M,
         gateway: Option<LightningGateway>,
     ) -> anyhow::Result<(OperationId, Bolt11Invoice, [u8; 32])> {
-        let receiving_key = ReceivingKey::External(user_key);
         self.create_bolt11_invoice_internal(
+            None,
             amount,
             description,
             expiry_time,
-            receiving_key,
+            ReceivingKey::External(user_key),
             extra_meta,
             gateway,
         )
@@ -1780,8 +1810,13 @@ impl LightningClientModule {
     }
 
     /// Receive over LN with a new invoice
+    #[allow(clippy::too_many_arguments)]
     async fn create_bolt11_invoice_internal<M: Serialize + Send + Sync>(
         &self,
+        // We don't have access to a global DB handle in the module scope, so we can't just make
+        // this fn always accept a dbtx and then have module-internal callers use autocommit.
+        // Hence, to reduce duplicate code, an optional dbtx is passed in.
+        maybe_dbtx: Option<&mut DatabaseTransaction<'_>>,
         amount: Amount,
         description: lightning_invoice::Bolt11InvoiceDescription,
         expiry_time: Option<u64>,
@@ -1833,28 +1868,28 @@ impl LightningClientModule {
                 extra_meta: extra_meta.clone(),
             }
         };
-        let change_range = self
-            .client_ctx
-            .finalize_and_submit_transaction(
-                operation_id,
-                LightningCommonInit::KIND.as_str(),
-                operation_meta_gen,
-                tx,
-            )
-            .await?;
+        let change_range = if let Some(dbtx) = maybe_dbtx {
+            self.client_ctx
+                .finalize_and_submit_transaction_dbtx(
+                    dbtx,
+                    operation_id,
+                    LightningCommonInit::KIND.as_str(),
+                    operation_meta_gen,
+                    tx,
+                )
+                .await?
+        } else {
+            self.client_ctx
+                .finalize_and_submit_transaction(
+                    operation_id,
+                    LightningCommonInit::KIND.as_str(),
+                    operation_meta_gen,
+                    tx,
+                )
+                .await?
+        };
 
         debug!(target: LOG_CLIENT_MODULE_LN, txid = ?change_range.txid(), ?operation_id, "Waiting for LN invoice to be confirmed");
-
-        // Wait for the transaction to be accepted by the federation, otherwise the
-        // invoice will not be able to be paid
-        self.client_ctx
-            .transaction_updates(operation_id)
-            .await
-            .await_tx_accepted(change_range.txid())
-            .await
-            .map_err(|e| anyhow!("Offer transaction was not accepted: {e:?}"))?;
-
-        debug!(target: LOG_CLIENT_MODULE_LN, %invoice, "Invoice confirmed");
 
         Ok((operation_id, invoice, preimage))
     }


### PR DESCRIPTION
In #7653 I implemented a quick fix against atomicity issues in `recurringd`'s invoice generation. The fix itself is quite complex and hard to test though. This PR attempts to simplify the invoice generation by making our `finalize_and_submit_transaction` API accept a DB transaction as input.

Builds on https://github.com/fedimint/fedimint/pull/7671.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
