### PR TITLE
chore(audit): ignore atomic-polyfill unmaintained warning

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -29,4 +29,6 @@ ignore = [
   "RUSTSEC-2025-0012",
   # `protobuf` crash on untrusted data
   "RUSTSEC-2024-0437",
+  # atomic-polyfill is unmaintained, waiting for the update chain to reach iroh
+  "RUSTSEC-2023-0089",
 ]


### PR DESCRIPTION
It's a deep transitive dependency, eventually iroh will be updated and then this will become obsolete.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
