### PR TITLE
chore: rm deprecated version codepaths

### DIFF
--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -43,7 +43,7 @@ use super::util::{Command, ProcessHandle, ProcessManager, cmd};
 use super::vars::utf8;
 use crate::envs::{FM_CLIENT_DIR_ENV, FM_DATA_DIR_ENV};
 use crate::util::{FedimintdCmd, poll, poll_simple, poll_with_timeout};
-use crate::version_constants::{VERSION_0_6_0_ALPHA, VERSION_0_7_0_ALPHA};
+use crate::version_constants::VERSION_0_7_0_ALPHA;
 use crate::{poll_eq, vars};
 
 // TODO: Are we still using the 3rd port for anything?
@@ -865,29 +865,17 @@ impl Federation {
     }
 
     pub async fn await_all_peers(&self) -> Result<()> {
-        let fedimin_cli_version = crate::util::FedimintCli::version_or_default().await;
         poll("Waiting for all peers to be online", || async {
-            if fedimin_cli_version < *VERSION_0_6_0_ALPHA {
-                cmd!(
-                    self.internal_client()
-                        .await
-                        .map_err(ControlFlow::Continue)?,
-                    "dev",
-                    "api",
-                    "module_{LEGACY_HARDCODED_INSTANCE_ID_WALLET}_block_count"
-                )
-            } else {
-                cmd!(
-                    self.internal_client()
-                        .await
-                        .map_err(ControlFlow::Continue)?,
-                    "dev",
-                    "api",
-                    "--module",
-                    LEGACY_HARDCODED_INSTANCE_ID_WALLET,
-                    "block_count"
-                )
-            }
+            cmd!(
+                self.internal_client()
+                    .await
+                    .map_err(ControlFlow::Continue)?,
+                "dev",
+                "api",
+                "--module",
+                LEGACY_HARDCODED_INSTANCE_ID_WALLET,
+                "block_count"
+            )
             .run()
             .await
             .map_err(ControlFlow::Continue)?;

--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -34,7 +34,7 @@ use crate::envs::{FM_DATA_DIR_ENV, FM_DEVIMINT_RUN_DEPRECATED_TESTS_ENV, FM_PASS
 use crate::federation::Client;
 use crate::gatewayd::LdkChainSource;
 use crate::util::{LoadTestTool, ProcessManager, poll};
-use crate::version_constants::{VERSION_0_6_0_ALPHA, VERSION_0_7_0_ALPHA, VERSION_0_9_0_ALPHA};
+use crate::version_constants::{VERSION_0_7_0_ALPHA, VERSION_0_9_0_ALPHA};
 use crate::{DevFed, Gatewayd, LightningNode, Lnd, cmd, dev_fed, poll_eq};
 
 pub struct Stats {
@@ -1611,7 +1611,6 @@ pub async fn recoverytool_test(dev_fed: DevFed) -> Result<()> {
 }
 
 pub async fn guardian_backup_test(dev_fed: DevFed, process_mgr: &ProcessManager) -> Result<()> {
-    let fedimint_cli_version = crate::util::FedimintCli::version_or_default().await;
     const PEER_TO_TEST: u16 = 0;
 
     log_binary_versions().await?;
@@ -1623,27 +1622,16 @@ pub async fn guardian_backup_test(dev_fed: DevFed, process_mgr: &ProcessManager)
         .expect("Awaiting federation coming online failed");
 
     let client = fed.new_joined_client("guardian-client").await?;
-    let old_block_count = if fedimint_cli_version < *VERSION_0_6_0_ALPHA {
-        cmd!(
-            client,
-            "dev",
-            "api",
-            "--peer-id",
-            PEER_TO_TEST.to_string(),
-            "module_{LEGACY_HARDCODED_INSTANCE_ID_WALLET}_block_count",
-        )
-    } else {
-        cmd!(
-            client,
-            "dev",
-            "api",
-            "--peer-id",
-            PEER_TO_TEST.to_string(),
-            "--module",
-            "wallet",
-            "block_count",
-        )
-    }
+    let old_block_count = cmd!(
+        client,
+        "dev",
+        "api",
+        "--peer-id",
+        PEER_TO_TEST.to_string(),
+        "--module",
+        "wallet",
+        "block_count",
+    )
     .out_json()
     .await?["value"]
         .as_u64()

--- a/devimint/src/version_constants.rs
+++ b/devimint/src/version_constants.rs
@@ -2,8 +2,6 @@ use std::sync::LazyLock;
 
 use semver::Version;
 
-pub static VERSION_0_6_0_ALPHA: LazyLock<Version> =
-    LazyLock::new(|| Version::parse("0.6.0-alpha").expect("version is parsable"));
 pub static VERSION_0_7_0_ALPHA: LazyLock<Version> =
     LazyLock::new(|| Version::parse("0.7.0-alpha").expect("version is parsable"));
 pub static VERSION_0_8_0_ALPHA: LazyLock<Version> =

--- a/modules/fedimint-wallet-tests/src/bin/wallet-module-tests.rs
+++ b/modules/fedimint-wallet-tests/src/bin/wallet-module-tests.rs
@@ -8,7 +8,7 @@ use clap::Parser;
 use devimint::cmd;
 use devimint::federation::Client;
 use devimint::util::FedimintCli;
-use devimint::version_constants::{VERSION_0_6_0_ALPHA, VERSION_0_8_0_ALPHA};
+use devimint::version_constants::VERSION_0_8_0_ALPHA;
 use fedimint_core::encoding::Decodable;
 use fedimint_core::module::serde_json;
 use fedimint_core::util::{backoff_util, retry};
@@ -37,8 +37,6 @@ async fn main() -> anyhow::Result<()> {
 async fn wallet_recovery_test_1() -> anyhow::Result<()> {
     devimint::run_devfed_test()
         .call(|dev_fed, _process_mgr| async move {
-            let fedimint_cli_version = FedimintCli::version_or_default().await;
-
             let (fed, _bitcoind) = try_join!(dev_fed.fed(), dev_fed.bitcoind())?;
 
             let peg_in_amount_sats = 100_000;
@@ -68,22 +66,16 @@ async fn wallet_recovery_test_1() -> anyhow::Result<()> {
                     .new_restored("restored-without-backup", fed.invite_code()?)
                     .await?;
 
-                if fedimint_cli_version < *VERSION_0_6_0_ALPHA {
-                    cmd!(restored, "module", "wallet", "await-deposit", operation_id)
-                        .run()
-                        .await?;
-                } else {
-                    cmd!(
-                        restored,
-                        "module",
-                        "wallet",
-                        "await-deposit",
-                        "--operation-id",
-                        operation_id
-                    )
-                    .run()
-                    .await?;
-                }
+                cmd!(
+                    restored,
+                    "module",
+                    "wallet",
+                    "await-deposit",
+                    "--operation-id",
+                    operation_id
+                )
+                .run()
+                .await?;
 
                 info!("Check if claimed");
                 assert_eq!(peg_in_amount_sats * 1000, restored.balance().await?);
@@ -112,22 +104,16 @@ async fn wallet_recovery_test_1() -> anyhow::Result<()> {
                     .new_restored("restored-with-backup", fed.invite_code()?)
                     .await?;
 
-                if fedimint_cli_version < *VERSION_0_6_0_ALPHA {
-                    cmd!(restored, "module", "wallet", "await-deposit", operation_id)
-                        .run()
-                        .await?;
-                } else {
-                    cmd!(
-                        restored,
-                        "module",
-                        "wallet",
-                        "await-deposit",
-                        "--operation-id",
-                        operation_id
-                    )
-                    .run()
-                    .await?;
-                }
+                cmd!(
+                    restored,
+                    "module",
+                    "wallet",
+                    "await-deposit",
+                    "--operation-id",
+                    operation_id
+                )
+                .run()
+                .await?;
 
                 info!("Check if claimed");
                 assert_eq!(peg_in_amount_sats * 1000 * 2, restored.balance().await?);
@@ -159,22 +145,16 @@ async fn wallet_recovery_test_1() -> anyhow::Result<()> {
                     .new_restored("client-slow-restored-without-backup", fed.invite_code()?)
                     .await?;
 
-                if fedimint_cli_version < *VERSION_0_6_0_ALPHA {
-                    cmd!(restored, "module", "wallet", "await-deposit", operation_id)
-                        .run()
-                        .await?;
-                } else {
-                    cmd!(
-                        restored,
-                        "module",
-                        "wallet",
-                        "await-deposit",
-                        "--operation-id",
-                        operation_id
-                    )
-                    .run()
-                    .await?;
-                }
+                cmd!(
+                    restored,
+                    "module",
+                    "wallet",
+                    "await-deposit",
+                    "--operation-id",
+                    operation_id
+                )
+                .run()
+                .await?;
 
                 info!("Client slow: Check if claimed");
                 assert_eq!(peg_in_amount_sats * 1000 * 2, restored.balance().await?);


### PR DESCRIPTION
Followup to https://github.com/fedimint/fedimint/issues/7560

After releasing `v0.8.0`, we dropped support for `v0.5` and older. We already updated the versions we test in CI with https://github.com/fedimint/fedimint/pull/7634, so we can now cleanup the codepaths for testing deprecated versions.