### PR TITLE
chore: silence iroh logging by default

### DIFF
--- a/fedimint-logging/src/lib.rs
+++ b/fedimint-logging/src/lib.rs
@@ -123,13 +123,14 @@ impl TracingSetup {
             // We prefix everything with a default general log level and
             // good per-module specific default. User provided RUST_LOG
             // can override one or both
-            "{},{},{},{},{},{},{},{}",
+            "{},{},{},{},{},{},{},{},{}",
             self.base_level.as_deref().unwrap_or("info"),
             "jsonrpsee_core::client::async_client=off",
             "hyper=off",
             "h2=off",
             "jsonrpsee_server=warn,jsonrpsee_server::transport=off",
             "AlephBFT-=error",
+            "iroh=error",
             var,
             self.extra_directives.as_deref().unwrap_or(""),
         ))?;


### PR DESCRIPTION
By default it is extremely chatty, confusing users with logs full of (non-critical) errors, printed at `warn` logging level, etc.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
