### PR TITLE
chore: bump version to v0.8.2-alpha

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2219,7 +2219,7 @@ dependencies = [
 
 [[package]]
 name = "devimint"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -2693,7 +2693,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fedimint-aead"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "argon2",
@@ -2725,7 +2725,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-api-client"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "arti-client",
@@ -2762,7 +2762,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-bip39"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "bip39",
  "fedimint-client",
@@ -2773,7 +2773,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-bitcoind"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2786,14 +2786,14 @@ dependencies = [
 
 [[package]]
 name = "fedimint-build"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "fedimint-cli"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2832,7 +2832,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2860,7 +2860,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client-module"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -2889,7 +2889,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client-wasm"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2914,7 +2914,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-core"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "async-channel 2.3.1",
@@ -2975,7 +2975,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-cursed-redb"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2994,7 +2994,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-db-locked"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3006,7 +3006,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dbtool"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3041,7 +3041,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-derive"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
@@ -3051,7 +3051,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-derive-secret"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "bitcoin_hashes 0.14.0",
@@ -3063,11 +3063,11 @@ dependencies = [
 
 [[package]]
 name = "fedimint-docs"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 
 [[package]]
 name = "fedimint-dummy-client"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3087,7 +3087,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dummy-common"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -3097,7 +3097,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dummy-server"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3113,7 +3113,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dummy-tests"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "fedimint-client",
@@ -3134,7 +3134,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-empty-client"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3151,7 +3151,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-empty-common"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -3161,7 +3161,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-empty-server"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3177,7 +3177,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-eventlog"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3194,7 +3194,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-fuzz"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "fedimint-core",
  "fedimint-ln-common",
@@ -3207,7 +3207,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-client"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "bcrypt",
@@ -3231,7 +3231,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-common"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "bitcoin",
  "clap",
@@ -3248,7 +3248,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-server"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3318,7 +3318,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-server-db"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -3345,7 +3345,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gw-client"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gwv2-client"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3399,14 +3399,14 @@ dependencies = [
 
 [[package]]
 name = "fedimint-hkdf"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "bitcoin_hashes 0.14.0",
 ]
 
 [[package]]
 name = "fedimint-lightning"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3432,7 +3432,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-client"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3464,7 +3464,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-common"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -3481,7 +3481,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-server"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3506,7 +3506,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-tests"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3535,7 +3535,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-client"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3564,7 +3564,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-common"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3583,7 +3583,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-server"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3607,7 +3607,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-tests"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3634,7 +3634,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-load-test-tool"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "clap",
@@ -3661,7 +3661,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-logging"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "console-subscriber",
@@ -3673,7 +3673,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-client"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3694,7 +3694,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-common"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -3708,7 +3708,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-server"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3727,7 +3727,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-tests"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "clap",
@@ -3741,7 +3741,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-metrics"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -3753,7 +3753,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-client"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3792,7 +3792,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-common"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "bitcoin_hashes 0.14.0",
@@ -3805,7 +3805,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-server"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3831,7 +3831,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-tests"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "bitcoin_hashes 0.14.0",
@@ -3864,7 +3864,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-portalloc"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "dirs 6.0.0",
@@ -3878,7 +3878,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-recoverytool"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -3901,7 +3901,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-recurringd"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -3928,7 +3928,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-recurringd-tests"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "devimint",
@@ -3941,7 +3941,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-rocksdb"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3957,7 +3957,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "async-channel 2.3.1",
@@ -4010,7 +4010,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server-bitcoin-rpc"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4025,7 +4025,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server-core"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4041,7 +4041,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server-tests"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "bitcoin",
  "fedimint-api-client",
@@ -4061,7 +4061,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server-ui"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4083,7 +4083,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-tbs"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "bls12_381",
  "criterion",
@@ -4098,7 +4098,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-testing"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4134,7 +4134,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-testing-core"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "fedimint-client",
@@ -4195,7 +4195,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-tpe"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "bitcoin_hashes 0.14.0",
  "bls12_381",
@@ -4209,7 +4209,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-unknown-common"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -4219,7 +4219,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-unknown-server"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4233,7 +4233,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-client"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -4262,7 +4262,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-common"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -4278,7 +4278,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-server"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4305,7 +4305,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-tests"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4337,7 +4337,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wasm-tests"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "fedimint-api-client",
@@ -4358,7 +4358,7 @@ dependencies = [
 
 [[package]]
 name = "fedimintd"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -4690,7 +4690,7 @@ dependencies = [
 
 [[package]]
 name = "gateway-tests"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "clap",
@@ -6604,7 +6604,7 @@ dependencies = [
 
 [[package]]
 name = "lnurlp"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ keywords = ["bitcoin", "lightning", "chaumian", "e-cash", "federated"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/fedimint/fedimint"
-version = "0.8.1-rc.0"
+version = "0.8.2-alpha"
 
 [workspace.metadata]
 authors = ["The Fedimint Developers"]
@@ -147,63 +147,63 @@ criterion = "0.5.1"
 # We need to pin this arti's `curve25519-dalek` dependency, due to `https://rustsec.org/advisories/RUSTSEC-2024-0344` vulnerability
 # It's been updated by https://gitlab.torproject.org/tpo/core/arti/-/merge_requests/2211, should be removed in next release.
 curve25519-dalek = ">=4.1.3"
-devimint = { path = "./devimint", version = "=0.8.1-rc.0" }
+devimint = { path = "./devimint", version = "=0.8.2-alpha" }
 dirs = "6.0.0"
 erased-serde = "0.4"
 esplora-client = { version = "0.10.0", default-features = false, features = [
   "async-https-rustls",
 ] }
-fedimint-aead = { path = "./crypto/aead", version = "=0.8.1-rc.0" }
-fedimint-api-client = { path = "./fedimint-api-client", version = "=0.8.1-rc.0" }
-fedimint-bip39 = { path = "./fedimint-bip39", version = "=0.8.1-rc.0" }
-fedimint-bitcoind = { path = "./fedimint-bitcoind", version = "=0.8.1-rc.0" }
-fedimint-build = { path = "./fedimint-build", version = "=0.8.1-rc.0" }
-fedimint-client = { path = "./fedimint-client", version = "=0.8.1-rc.0" }
-fedimint-client-module = { path = "./fedimint-client-module", version = "=0.8.1-rc.0" }
-fedimint-core = { path = "./fedimint-core", version = "=0.8.1-rc.0" }
-fedimint-cursed-redb = { path = "./fedimint-cursed-redb", version = "=0.8.1-rc.0" }
-fedimint-db-locked = { path = "./fedimint-db-locked", version = "=0.8.1-rc.0" }
-fedimint-derive = { path = "./fedimint-derive", version = "=0.8.1-rc.0" }
-fedimint-derive-secret = { path = "./crypto/derive-secret", version = "=0.8.1-rc.0" }
-fedimint-dummy-client = { path = "./modules/fedimint-dummy-client", version = "=0.8.1-rc.0" }
-fedimint-dummy-common = { path = "./modules/fedimint-dummy-common", version = "=0.8.1-rc.0" }
-fedimint-dummy-server = { path = "./modules/fedimint-dummy-server", version = "=0.8.1-rc.0" }
-fedimint-empty-common = { path = "./modules/fedimint-empty-common", version = "=0.8.1-rc.0" }
-fedimint-eventlog = { path = "./fedimint-eventlog", version = "=0.8.1-rc.0" }
-fedimint-gateway-common = { package = "fedimint-gateway-common", path = "./gateway/fedimint-gateway-common", version = "=0.8.1-rc.0" }
-fedimint-gateway-server = { package = "fedimint-gateway-server", path = "./gateway/fedimint-gateway-server", version = "=0.8.1-rc.0" }
-fedimint-gateway-server-db = { package = "fedimint-gateway-server-db", path = "./gateway/fedimint-gateway-server-db", version = "=0.8.1-rc.0" }
-fedimint-gw-client = { path = "./modules/fedimint-gw-client", version = "=0.8.1-rc.0" }
-fedimint-gwv2-client = { path = "./modules/fedimint-gwv2-client", version = "=0.8.1-rc.0" }
-fedimint-lightning = { package = "fedimint-lightning", path = "./gateway/fedimint-lightning", version = "=0.8.1-rc.0" }
-fedimint-ln-client = { path = "./modules/fedimint-ln-client", version = "=0.8.1-rc.0" }
-fedimint-ln-common = { path = "./modules/fedimint-ln-common", version = "=0.8.1-rc.0" }
-fedimint-ln-server = { path = "./modules/fedimint-ln-server", version = "=0.8.1-rc.0" }
-fedimint-lnv2-client = { path = "./modules/fedimint-lnv2-client", version = "=0.8.1-rc.0" }
-fedimint-lnv2-common = { path = "./modules/fedimint-lnv2-common", version = "=0.8.1-rc.0" }
-fedimint-lnv2-server = { path = "./modules/fedimint-lnv2-server", version = "=0.8.1-rc.0" }
-fedimint-logging = { path = "./fedimint-logging", version = "=0.8.1-rc.0" }
-fedimint-meta-client = { path = "./modules/fedimint-meta-client", version = "=0.8.1-rc.0" }
-fedimint-meta-common = { path = "./modules/fedimint-meta-common", version = "=0.8.1-rc.0" }
-fedimint-meta-server = { path = "./modules/fedimint-meta-server", version = "=0.8.1-rc.0" }
-fedimint-metrics = { path = "./fedimint-metrics", version = "=0.8.1-rc.0" }
-fedimint-mint-client = { path = "./modules/fedimint-mint-client", version = "=0.8.1-rc.0" }
-fedimint-mint-common = { path = "./modules/fedimint-mint-common", version = "=0.8.1-rc.0" }
-fedimint-mint-server = { path = "./modules/fedimint-mint-server", version = "=0.8.1-rc.0" }
-fedimint-portalloc = { path = "utils/portalloc", version = "=0.8.1-rc.0" }
-fedimint-rocksdb = { path = "./fedimint-rocksdb", version = "=0.8.1-rc.0" }
-fedimint-server = { path = "./fedimint-server", version = "=0.8.1-rc.0" }
-fedimint-server-bitcoin-rpc = { path = "./fedimint-server-bitcoin-rpc", version = "=0.8.1-rc.0" }
-fedimint-server-core = { path = "./fedimint-server-core", version = "=0.8.1-rc.0" }
-fedimint-server-ui = { path = "./fedimint-server-ui", version = "=0.8.1-rc.0" }
-fedimint-testing = { path = "./fedimint-testing", version = "=0.8.1-rc.0" }
-fedimint-testing-core = { path = "./fedimint-testing-core", version = "=0.8.1-rc.0" }
-fedimint-unknown-common = { path = "./modules/fedimint-unknown-common", version = "=0.8.1-rc.0" }
-fedimint-unknown-server = { path = "./modules/fedimint-unknown-server", version = "=0.8.1-rc.0" }
-fedimint-wallet-client = { path = "./modules/fedimint-wallet-client", version = "=0.8.1-rc.0" }
-fedimint-wallet-common = { path = "./modules/fedimint-wallet-common", version = "=0.8.1-rc.0" }
-fedimint-wallet-server = { path = "./modules/fedimint-wallet-server", version = "=0.8.1-rc.0" }
-fedimintd = { path = "./fedimintd", version = "=0.8.1-rc.0" }
+fedimint-aead = { path = "./crypto/aead", version = "=0.8.2-alpha" }
+fedimint-api-client = { path = "./fedimint-api-client", version = "=0.8.2-alpha" }
+fedimint-bip39 = { path = "./fedimint-bip39", version = "=0.8.2-alpha" }
+fedimint-bitcoind = { path = "./fedimint-bitcoind", version = "=0.8.2-alpha" }
+fedimint-build = { path = "./fedimint-build", version = "=0.8.2-alpha" }
+fedimint-client = { path = "./fedimint-client", version = "=0.8.2-alpha" }
+fedimint-client-module = { path = "./fedimint-client-module", version = "=0.8.2-alpha" }
+fedimint-core = { path = "./fedimint-core", version = "=0.8.2-alpha" }
+fedimint-cursed-redb = { path = "./fedimint-cursed-redb", version = "=0.8.2-alpha" }
+fedimint-db-locked = { path = "./fedimint-db-locked", version = "=0.8.2-alpha" }
+fedimint-derive = { path = "./fedimint-derive", version = "=0.8.2-alpha" }
+fedimint-derive-secret = { path = "./crypto/derive-secret", version = "=0.8.2-alpha" }
+fedimint-dummy-client = { path = "./modules/fedimint-dummy-client", version = "=0.8.2-alpha" }
+fedimint-dummy-common = { path = "./modules/fedimint-dummy-common", version = "=0.8.2-alpha" }
+fedimint-dummy-server = { path = "./modules/fedimint-dummy-server", version = "=0.8.2-alpha" }
+fedimint-empty-common = { path = "./modules/fedimint-empty-common", version = "=0.8.2-alpha" }
+fedimint-eventlog = { path = "./fedimint-eventlog", version = "=0.8.2-alpha" }
+fedimint-gateway-common = { package = "fedimint-gateway-common", path = "./gateway/fedimint-gateway-common", version = "=0.8.2-alpha" }
+fedimint-gateway-server = { package = "fedimint-gateway-server", path = "./gateway/fedimint-gateway-server", version = "=0.8.2-alpha" }
+fedimint-gateway-server-db = { package = "fedimint-gateway-server-db", path = "./gateway/fedimint-gateway-server-db", version = "=0.8.2-alpha" }
+fedimint-gw-client = { path = "./modules/fedimint-gw-client", version = "=0.8.2-alpha" }
+fedimint-gwv2-client = { path = "./modules/fedimint-gwv2-client", version = "=0.8.2-alpha" }
+fedimint-lightning = { package = "fedimint-lightning", path = "./gateway/fedimint-lightning", version = "=0.8.2-alpha" }
+fedimint-ln-client = { path = "./modules/fedimint-ln-client", version = "=0.8.2-alpha" }
+fedimint-ln-common = { path = "./modules/fedimint-ln-common", version = "=0.8.2-alpha" }
+fedimint-ln-server = { path = "./modules/fedimint-ln-server", version = "=0.8.2-alpha" }
+fedimint-lnv2-client = { path = "./modules/fedimint-lnv2-client", version = "=0.8.2-alpha" }
+fedimint-lnv2-common = { path = "./modules/fedimint-lnv2-common", version = "=0.8.2-alpha" }
+fedimint-lnv2-server = { path = "./modules/fedimint-lnv2-server", version = "=0.8.2-alpha" }
+fedimint-logging = { path = "./fedimint-logging", version = "=0.8.2-alpha" }
+fedimint-meta-client = { path = "./modules/fedimint-meta-client", version = "=0.8.2-alpha" }
+fedimint-meta-common = { path = "./modules/fedimint-meta-common", version = "=0.8.2-alpha" }
+fedimint-meta-server = { path = "./modules/fedimint-meta-server", version = "=0.8.2-alpha" }
+fedimint-metrics = { path = "./fedimint-metrics", version = "=0.8.2-alpha" }
+fedimint-mint-client = { path = "./modules/fedimint-mint-client", version = "=0.8.2-alpha" }
+fedimint-mint-common = { path = "./modules/fedimint-mint-common", version = "=0.8.2-alpha" }
+fedimint-mint-server = { path = "./modules/fedimint-mint-server", version = "=0.8.2-alpha" }
+fedimint-portalloc = { path = "utils/portalloc", version = "=0.8.2-alpha" }
+fedimint-rocksdb = { path = "./fedimint-rocksdb", version = "=0.8.2-alpha" }
+fedimint-server = { path = "./fedimint-server", version = "=0.8.2-alpha" }
+fedimint-server-bitcoin-rpc = { path = "./fedimint-server-bitcoin-rpc", version = "=0.8.2-alpha" }
+fedimint-server-core = { path = "./fedimint-server-core", version = "=0.8.2-alpha" }
+fedimint-server-ui = { path = "./fedimint-server-ui", version = "=0.8.2-alpha" }
+fedimint-testing = { path = "./fedimint-testing", version = "=0.8.2-alpha" }
+fedimint-testing-core = { path = "./fedimint-testing-core", version = "=0.8.2-alpha" }
+fedimint-unknown-common = { path = "./modules/fedimint-unknown-common", version = "=0.8.2-alpha" }
+fedimint-unknown-server = { path = "./modules/fedimint-unknown-server", version = "=0.8.2-alpha" }
+fedimint-wallet-client = { path = "./modules/fedimint-wallet-client", version = "=0.8.2-alpha" }
+fedimint-wallet-common = { path = "./modules/fedimint-wallet-common", version = "=0.8.2-alpha" }
+fedimint-wallet-server = { path = "./modules/fedimint-wallet-server", version = "=0.8.2-alpha" }
+fedimintd = { path = "./fedimintd", version = "=0.8.2-alpha" }
 ff = "0.13.1"
 fs-lock = "0.1.10"
 fs2 = "0.4.3"
@@ -215,7 +215,7 @@ gloo-timers = "0.3.0"
 group = "0.13.0"
 hex = "0.4.3"
 hex-conservative = "0.3.0"
-hkdf = { package = "fedimint-hkdf", path = "./crypto/hkdf", version = "=0.8.1-rc.0" }
+hkdf = { package = "fedimint-hkdf", path = "./crypto/hkdf", version = "=0.8.2-alpha" }
 honggfuzz = { version = "=0.5.55", default-features = false } # needs to be pinned to the same version `cargo-fuzz` binary uses
 hyper = "1.6"
 imbl = "5.0.0"
@@ -286,7 +286,7 @@ substring = "1.4.5"
 subtle = "2.6.1"
 syn = "2.0"
 tar = "0.4.44"
-tbs = { package = "fedimint-tbs", path = "./crypto/tbs", version = "=0.8.1-rc.0" }
+tbs = { package = "fedimint-tbs", path = "./crypto/tbs", version = "=0.8.2-alpha" }
 tempfile = "3.20.0"
 test-log = { version = "0.2", features = ["trace"], default-features = false }
 thiserror = "2.0.12"
@@ -305,7 +305,7 @@ tonic_lnd = { version = "0.2.0", package = "fedimint-tonic-lnd", features = [
 ] }
 tower = { version = "0.4.13", default-features = false }
 tower-http = { version = "0.6.6", features = ["cors"] }
-tpe = { package = "fedimint-tpe", path = "./crypto/tpe", version = "=0.8.1-rc.0" }
+tpe = { package = "fedimint-tpe", path = "./crypto/tpe", version = "=0.8.2-alpha" }
 tracing = "0.1.41"
 tracing-opentelemetry = "0.24.0"
 tracing-subscriber = "0.3.19"


### PR DESCRIPTION
Re: https://github.com/fedimint/fedimint/issues/7665

We released `v0.8.1` so we can bump to `v0.8.2-alpha`.