### PR TITLE
[Backport releases/v0.8] chore(start9): correct wrapper-repo URL and add docs link

### DIFF
--- a/fedimint-startos/instructions.md
+++ b/fedimint-startos/instructions.md
@@ -5,3 +5,7 @@
 3. Wait until the web interface health check indicates that Fedimint is ready
 4. Open the Fedimint UI
 5. Follow the guided setup steps in the UI, coordinating with other guardians
+
+## Learn More
+
+Visit [fedimint.org](https://fedimint.org) for comprehensive documentation about the Fedimint protocol, federation concepts, and setup guidance.

--- a/fedimint-startos/manifest.yaml
+++ b/fedimint-startos/manifest.yaml
@@ -5,7 +5,7 @@ release-notes: |
   https://github.com/fedimint/fedimint/releases/tag/v0.8.0
   This release includes support for sideloading fedimintd.
 license: MIT
-wrapper-repo: "https://github.com/fedimint/fedimint/fedimint-start9"
+wrapper-repo: "https://github.com/fedimint/fedimint/fedimint-startos"
 upstream-repo: "https://github.com/fedimint/fedimint"
 support-site: "https://github.com/fedimint/fedimint/issues"
 marketing-site: "https://fedimint.org/"


### PR DESCRIPTION
# Description
Backport of #7662 to `releases/v0.8`.