### PR TITLE
[Backport releases/v0.8] chore: bump docker compose fedimintd version to v0.8.1

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   fedimintd:
-    image: fedimint/fedimintd:v0.8.0
+    image: fedimint/fedimintd:v0.8.1
     ports:
       - 8173:8173/tcp # p2p tls
       - 8173:8173/udp # p2p iroh


### PR DESCRIPTION
# Description
Backport of #7712 to `releases/v0.8`.