### PR TITLE
[Backport releases/v0.8] chore: bump start9 to v0.8.1

### DIFF
--- a/fedimint-startos/Dockerfile
+++ b/fedimint-startos/Dockerfile
@@ -11,7 +11,7 @@ RUN case "$TARGETARCH" in \
     chmod +x /tmp/yq
 
 # Stage 2: Main image
-FROM fedimint/fedimintd:v0.8.0
+FROM fedimint/fedimintd:v0.8.1
 
 # Copy yq from downloader stage
 COPY --from=downloader /tmp/yq /usr/local/bin/yq

--- a/fedimint-startos/manifest.yaml
+++ b/fedimint-startos/manifest.yaml
@@ -1,8 +1,8 @@
 id: fedimintd
 title: "Fedimint"
-version: 0.8.0
+version: 0.8.1
 release-notes: |
-  https://github.com/fedimint/fedimint/releases/tag/v0.8.0
+  https://github.com/fedimint/fedimint/releases/tag/v0.8.1
   This release includes support for sideloading fedimintd.
 license: MIT
 wrapper-repo: "https://github.com/fedimint/fedimint/fedimint-startos"


### PR DESCRIPTION
# Description
Backport of #7711 to `releases/v0.8`.