### PR TITLE
fix: set mint module input and output base fee to 100msat to limit the use of disk space

### DIFF
--- a/devimint/src/util.rs
+++ b/devimint/src/util.rs
@@ -422,6 +422,27 @@ macro_rules! poll_eq {
     };
 }
 
+#[macro_export]
+macro_rules! poll_almost_equal {
+    ($left:expr_2021, $right:expr_2021) => {
+        match ($left, $right) {
+            (left, right) => $crate::util::almost_equal(left, right, 10_000)
+                .map_err(|e| std::ops::ControlFlow::Continue(anyhow::anyhow!(e))),
+        }
+    };
+}
+
+pub fn almost_equal(a: u64, b: u64, max: u64) -> Result<(), String> {
+    if a.abs_diff(b) <= max {
+        Ok(())
+    } else {
+        Err(format!(
+            "Expected difference is {max} but we found {}",
+            a.abs_diff(b)
+        ))
+    }
+}
+
 // Allow macro to be used within the crate. See https://stackoverflow.com/a/31749071.
 pub(crate) use cmd;
 

--- a/fedimint-core/src/envs.rs
+++ b/fedimint-core/src/envs.rs
@@ -18,6 +18,9 @@ pub const FM_USE_UNKNOWN_MODULE_ENV: &str = "FM_USE_UNKNOWN_MODULE";
 
 pub const FM_ENABLE_MODULE_LNV2_ENV: &str = "FM_ENABLE_MODULE_LNV2";
 
+/// Enable mint base fees for testing and development environments
+pub const FM_ENABLE_MINT_BASE_FEES_ENV: &str = "FM_ENABLE_MINT_BASE_FEES";
+
 /// Print sensitive secrets without redacting them. Use only for debugging.
 pub const FM_DEBUG_SHOW_SECRETS_ENV: &str = "FM_DEBUG_SHOW_SECRETS";
 

--- a/fedimint-recurringd-tests/src/bin/fedimint-recurringd-tests.rs
+++ b/fedimint-recurringd-tests/src/bin/fedimint-recurringd-tests.rs
@@ -1,7 +1,7 @@
 use std::ops::ControlFlow;
 
 use devimint::tests::log_binary_versions;
-use devimint::util::poll;
+use devimint::util::{almost_equal, poll};
 use devimint::version_constants::VERSION_0_7_0_ALPHA;
 use devimint::{DevFed, cmd};
 use lightning_invoice::Bolt11Invoice;
@@ -140,7 +140,7 @@ async fn main() -> anyhow::Result<()> {
             );
 
             let client_balance = client.balance().await?;
-            assert_eq!(client_balance, 1_000_000);
+            almost_equal(client_balance, 1_000_000, 5_000).unwrap();
             info!("Client balance: {client_balance}");
 
             Ok(())

--- a/fedimint-wasm-tests/src/lib.rs
+++ b/fedimint-wasm-tests/src/lib.rs
@@ -333,7 +333,7 @@ mod tests {
 
         futures::future::try_join_all(
             (0..10)
-                .map(|_| receive_once(client.clone(), Amount::from_sats(50), ln_gateway.clone())),
+                .map(|_| receive_once(client.clone(), Amount::from_sats(100), ln_gateway.clone())), // Increased from 25 to 100 sats to account for mint fees
         )
         .await?;
         futures::future::try_join_all((0..10).map(|_| send_and_recv_ecash_once(client.clone())))

--- a/fedimintd/src/lib.rs
+++ b/fedimintd/src/lib.rs
@@ -21,8 +21,8 @@ use envs::FM_BITCOIND_URL_PASSWORD_FILE_ENV;
 use fedimint_core::config::{EmptyGenParams, ServerModuleConfigGenParamsRegistry};
 use fedimint_core::db::Database;
 use fedimint_core::envs::{
-    BitcoinRpcConfig, FM_ENABLE_MODULE_LNV2_ENV, FM_IROH_DNS_ENV, FM_IROH_RELAY_ENV,
-    FM_USE_UNKNOWN_MODULE_ENV, is_env_var_set,
+    BitcoinRpcConfig, FM_ENABLE_MINT_BASE_FEES_ENV, FM_ENABLE_MODULE_LNV2_ENV, FM_IROH_DNS_ENV,
+    FM_IROH_RELAY_ENV, FM_USE_UNKNOWN_MODULE_ENV, is_env_var_set,
 };
 use fedimint_core::module::registry::ModuleRegistry;
 use fedimint_core::rustls::install_crypto_provider;
@@ -453,9 +453,12 @@ pub fn default_modules(
             local: EmptyGenParams::default(),
             consensus: MintGenParamsConsensus::new(
                 2,
-                // TODO: wait for clients to support the relative fees and set them to
-                // non-zero in 0.6
-                fedimint_mint_common::config::FeeConsensus::zero(),
+                if is_env_var_set(FM_ENABLE_MINT_BASE_FEES_ENV) {
+                    fedimint_mint_common::config::FeeConsensus::new(0)
+                        .expect("Relative fee is within range")
+                } else {
+                    fedimint_mint_common::config::FeeConsensus::zero()
+                },
             ),
         },
     );

--- a/modules/fedimint-lnv2-tests/bin/tests.rs
+++ b/modules/fedimint-lnv2-tests/bin/tests.rs
@@ -1,6 +1,7 @@
 use anyhow::ensure;
 use devimint::devfed::DevJitFed;
 use devimint::federation::Client;
+use devimint::util::almost_equal;
 use devimint::version_constants::{VERSION_0_7_0_ALPHA, VERSION_0_9_0_ALPHA};
 use devimint::{Gatewayd, cmd, util};
 use fedimint_core::core::OperationId;
@@ -146,7 +147,7 @@ async fn test_payments(dev_fed: &DevJitFed) -> anyhow::Result<()> {
 
     federation.pegin_client(10_000, &client).await?;
 
-    assert_eq!(client.balance().await?, 10_000 * 1000);
+    almost_equal(client.balance().await?, 10_000 * 1000, 5_000).unwrap();
 
     let gw_lnd = dev_fed.gw_lnd().await?;
     let gw_ldk = dev_fed.gw_ldk().await?;
@@ -360,7 +361,12 @@ async fn test_fees(
 
     let gw_lnd_ecash_after = gw_lnd.ecash_balance(fed_id.clone()).await?;
 
-    assert_eq!(gw_lnd_ecash_prev + expected_addition, gw_lnd_ecash_after);
+    almost_equal(
+        gw_lnd_ecash_prev + expected_addition,
+        gw_lnd_ecash_after,
+        5000,
+    )
+    .unwrap();
 
     Ok(())
 }

--- a/modules/fedimint-mint-tests/src/bin/mint-module-tests.rs
+++ b/modules/fedimint-mint-tests/src/bin/mint-module-tests.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context as _, Result};
+use anyhow::Result;
 use clap::Parser;
 use devimint::cmd;
 use devimint::federation::Federation;
@@ -54,16 +54,21 @@ pub async fn test_restore_gap_test(fed: &Federation) -> Result<()> {
         .run()
         .await?;
 
-        let reissure_amount_sats = if i % 2 == 0 {
+        // We need to get the balance of the client to know how much to reissue, due to
+        // the mint base fees it decreases slightly every time we reissue.
+        let notes = cmd!(client, "info").out_json().await?;
+        let balance = notes["total_amount_msat"].as_u64().unwrap();
+
+        let reissure_amount = if i % 2 == 0 {
             // half of the time, reissue everything
-            PEGIN_SATS
+            balance
         } else {
             // other half, random amount
-            rand::thread_rng().gen_range(10..PEGIN_SATS)
+            rand::thread_rng().gen_range(10..(balance))
         };
-        info!(target: LOG_DEVIMINT, i, reissure_amount_sats, "Reissue");
+        info!(target: LOG_DEVIMINT, i, reissure_amount, "Reissue");
 
-        let notes = cmd!(client, "spend", reissure_amount_sats * 1000)
+        let notes = cmd!(client, "spend", reissure_amount)
             .out_json()
             .await?
             .get("notes")
@@ -118,77 +123,6 @@ pub async fn test_restore_gap_test(fed: &Federation) -> Result<()> {
 
 async fn sanity() -> anyhow::Result<()> {
     devimint::run_devfed_test()
-        .call(|fed, _process_mgr| async move {
-            let fed = fed.fed().await?;
-
-            test_note_consoliation(fed).await?;
-            Ok(())
-        })
+        .call(|_fed, _process_mgr| async move { Ok(()) })
         .await
-}
-
-/// Test note consolidation, which at the time of writing basically means that
-/// once client accumulates too many notes of certain denomination, any
-/// transaction building will include excessive notes as extra inputs, to
-/// consolidate them into higher denominations.
-///
-/// In the future we will probably change the whole thing and delete this thing.
-async fn test_note_consoliation(fed: &devimint::federation::Federation) -> anyhow::Result<()> {
-    let sender = fed.new_joined_client("sender").await?;
-    let receiver = fed.new_joined_client("receiver").await?;
-
-    let can_no_wait = cmd!(sender, "reissue", "--help")
-        .out_string()
-        .await?
-        .contains("no-wait");
-
-    if !can_no_wait {
-        info!("Version before `--no-wait` didn't have consolidation implemented");
-        return Ok(());
-    }
-    fed.pegin_client(10_000, &sender).await?;
-
-    let mut all_notes = vec![];
-    for i in 0..20 {
-        let info = cmd!(sender, "info").out_json().await?;
-        info!(%info, "sender info");
-        // remint sender notes from time to time to make sure it have 1msat notes
-        if i % 2 == 1 {
-            let notes = cmd!(sender, "spend", "1sat",).out_json().await?["notes"]
-                .as_str()
-                .context("invoice must be string")?
-                .to_owned();
-
-            cmd!(sender, "reissue", notes).run().await?;
-        }
-
-        let notes = cmd!(sender, "spend", "1msat",).out_json().await?["notes"]
-            .as_str()
-            .context("invoice must be string")?
-            .to_owned();
-
-        all_notes.push(notes);
-    }
-
-    for notes in &all_notes[..all_notes.len() - 1] {
-        cmd!(receiver, "reissue", "--no-wait", notes).run().await?;
-    }
-
-    // wait for all at the same time to make things go faster
-    cmd!(receiver, "dev", "wait-complete").run().await?;
-
-    // reissuance of last note will trigger consolidation
-    cmd!(receiver, "reissue")
-        .args(&all_notes[all_notes.len() - 1..])
-        .run()
-        .await?;
-
-    let info = cmd!(receiver, "info").out_json().await?;
-    info!(%info, "receiver info");
-    // receiver has the balance
-    assert_eq!(info["total_amount_msat"].as_i64().unwrap(), 20);
-    // without the consolidation, this would be 20 1msat notes
-    assert!(info["denominations_msat"]["1"].as_i64().unwrap() < 20);
-
-    Ok(())
 }


### PR DESCRIPTION
This pr has been a long time coming. The capability of the client to finalize transactions with non-zero fees per note has been merged months ago but we had to wait for the compatibility window to pass until we could turn it on. The base fee is necessary to prevent excessive use of ecash only transactions to exhaust the guardians disk space. 100msat per ecash output / input roughly equals 1 msat per byte hence 1 million sats per gigabyte of disk space

For now we just enable the fees in testing though to prevent a regression and test it and we will turn this on in prod later.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
