### PR TITLE
feat: add fedimintd version tag to guardian dashboard

### DIFF
--- a/fedimint-server-core/src/dashboard_ui.rs
+++ b/fedimint-server-core/src/dashboard_ui.rs
@@ -57,6 +57,9 @@ pub trait IDashboardApi {
     /// Get reference to a server module instance by module kind
     fn get_module_by_kind(&self, kind: ModuleKind) -> Option<&DynServerModule>;
 
+    /// Get the fedimintd version
+    async fn fedimintd_version(&self) -> String;
+
     /// Create a trait object
     fn into_dyn(self) -> DynDashboardApi
     where

--- a/fedimint-server-ui/src/dashboard/consensus_explorer.rs
+++ b/fedimint-server-ui/src/dashboard/consensus_explorer.rs
@@ -135,7 +135,7 @@ pub async fn consensus_explorer_view(
         }
     };
 
-    Html(dashboard_layout(content).into_string()).into_response()
+    Html(dashboard_layout(content, None).into_string()).into_response()
 }
 
 /// Format the type of consensus item for display

--- a/fedimint-server-ui/src/dashboard/mod.rs
+++ b/fedimint-server-ui/src/dashboard/mod.rs
@@ -24,7 +24,7 @@ use crate::{
     login_form_response, login_submit_response,
 };
 
-pub fn dashboard_layout(content: Markup) -> Markup {
+pub fn dashboard_layout(content: Markup, fedimintd_version: Option<&str>) -> Markup {
     html! {
         (DOCTYPE)
         html {
@@ -33,8 +33,13 @@ pub fn dashboard_layout(content: Markup) -> Markup {
             }
             body {
                 div class="container" {
-                    header class="text-center" {
-                        h1 class="header-title" { "Fedimint Guardian UI" }
+                    header class="text-center mb-4" {
+                        h1 class="header-title mb-1" { "Fedimint Guardian UI" }
+                        @if let Some(version) = fedimintd_version {
+                            div {
+                                small class="text-muted" { "v" (version) }
+                            }
+                        }
                     }
 
                     (content)
@@ -74,6 +79,7 @@ async fn dashboard_view(
     let guardian_names = state.api.guardian_names().await;
     let federation_name = state.api.federation_name().await;
     let session_count = state.api.session_count().await;
+    let fedimintd_version = state.api.fedimintd_version().await;
     let consensus_ord_latency = state.api.consensus_ord_latency().await;
     let p2p_connection_status = state.api.p2p_connection_status().await;
     let invite_code = state.api.federation_invite_code().await;
@@ -136,7 +142,7 @@ async fn dashboard_view(
         }
     };
 
-    Html(dashboard_layout(content).into_string()).into_response()
+    Html(dashboard_layout(content, Some(&fedimintd_version)).into_string()).into_response()
 }
 
 pub fn router(api: DynDashboardApi) -> Router {

--- a/fedimint-server/src/consensus/api.rs
+++ b/fedimint-server/src/consensus/api.rs
@@ -614,6 +614,10 @@ impl IDashboardApi for ConsensusApi {
                 }
             })
     }
+
+    async fn fedimintd_version(&self) -> String {
+        self.code_version_str.clone()
+    }
 }
 
 pub fn server_endpoints() -> Vec<ApiEndpoint<ConsensusApi>> {


### PR DESCRIPTION
It's useful to know at a glance what version you're running from the guardian dashboard. This adds the version tag to the dashboard below the header.
<img width="1920" height="995" alt="Screenshot 2025-09-02 at 15-46-24 Guardian Dashboard" src="https://github.com/user-attachments/assets/06a135f4-15fe-4c79-a88e-f6e3ea71defa" />
