### PR TITLE
chore: set lnv2 relative in prod to zero until we make it configurable

### DIFF
--- a/fedimintd/src/lib.rs
+++ b/fedimintd/src/lib.rs
@@ -492,7 +492,7 @@ pub fn default_modules(
                 },
                 consensus: fedimint_lnv2_common::config::LightningGenParamsConsensus {
                     // TODO: actually make the relative fee configurable
-                    fee_consensus: fedimint_lnv2_common::config::FeeConsensus::new(100).unwrap(),
+                    fee_consensus: fedimint_lnv2_common::config::FeeConsensus::new(0).unwrap(),
                     network,
                 },
             },


### PR DESCRIPTION
As some operators might take issue with taking a relative fee and we do not allow for its configuration yet we set it to zero for now.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
