### PR TITLE
fix: enable mint base fees by default

### DIFF
--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -12,7 +12,7 @@ use clap::Subcommand;
 use fedimint_core::core::LEGACY_HARDCODED_INSTANCE_ID_WALLET;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::envs::{
-    FM_ENABLE_MINT_BASE_FEES_ENV, FM_ENABLE_MODULE_LNV2_ENV, is_env_var_set,
+    FM_DISABLE_MINT_BASE_FEES_ENV, FM_ENABLE_MODULE_LNV2_ENV, is_env_var_set,
 };
 use fedimint_core::module::registry::ModuleRegistry;
 use fedimint_core::net::api_announcement::SignedApiAnnouncement;
@@ -2212,9 +2212,6 @@ pub enum TestCmd {
 }
 
 pub async fn handle_command(cmd: TestCmd, common_args: CommonArgs) -> Result<()> {
-    // Always enable mint base fees in devimint for testing
-    unsafe { std::env::set_var(FM_ENABLE_MINT_BASE_FEES_ENV, "1") };
-
     match cmd {
         TestCmd::WasmTestSetup { exec } => {
             let (process_mgr, task_group) = setup(common_args).await?;
@@ -2277,8 +2274,8 @@ pub async fn handle_command(cmd: TestCmd, common_args: CommonArgs) -> Result<()>
         }
         TestCmd::LoadTestToolTest => {
             // For the load test tool test, explicitly disable mint base fees
-            // (override the default set at function entry)
-            unsafe { std::env::set_var(FM_ENABLE_MINT_BASE_FEES_ENV, "0") };
+            unsafe { std::env::set_var(FM_DISABLE_MINT_BASE_FEES_ENV, "1") };
+
             let (process_mgr, _) = setup(common_args).await?;
             let dev_fed = dev_fed(&process_mgr).await?;
             cli_load_test_tool_test(dev_fed).await?;

--- a/fedimint-core/src/envs.rs
+++ b/fedimint-core/src/envs.rs
@@ -18,8 +18,8 @@ pub const FM_USE_UNKNOWN_MODULE_ENV: &str = "FM_USE_UNKNOWN_MODULE";
 
 pub const FM_ENABLE_MODULE_LNV2_ENV: &str = "FM_ENABLE_MODULE_LNV2";
 
-/// Enable mint base fees for testing and development environments
-pub const FM_ENABLE_MINT_BASE_FEES_ENV: &str = "FM_ENABLE_MINT_BASE_FEES";
+/// Disable mint base fees for testing and development environments
+pub const FM_DISABLE_MINT_BASE_FEES_ENV: &str = "FM_DISABLE_MINT_BASE_FEES";
 
 /// Print sensitive secrets without redacting them. Use only for debugging.
 pub const FM_DEBUG_SHOW_SECRETS_ENV: &str = "FM_DEBUG_SHOW_SECRETS";

--- a/fedimintd/src/lib.rs
+++ b/fedimintd/src/lib.rs
@@ -21,7 +21,7 @@ use envs::FM_BITCOIND_URL_PASSWORD_FILE_ENV;
 use fedimint_core::config::{EmptyGenParams, ServerModuleConfigGenParamsRegistry};
 use fedimint_core::db::Database;
 use fedimint_core::envs::{
-    BitcoinRpcConfig, FM_ENABLE_MINT_BASE_FEES_ENV, FM_ENABLE_MODULE_LNV2_ENV, FM_IROH_DNS_ENV,
+    BitcoinRpcConfig, FM_DISABLE_MINT_BASE_FEES_ENV, FM_ENABLE_MODULE_LNV2_ENV, FM_IROH_DNS_ENV,
     FM_IROH_RELAY_ENV, FM_USE_UNKNOWN_MODULE_ENV, is_env_var_set,
 };
 use fedimint_core::module::registry::ModuleRegistry;
@@ -453,11 +453,11 @@ pub fn default_modules(
             local: EmptyGenParams::default(),
             consensus: MintGenParamsConsensus::new(
                 2,
-                if is_env_var_set(FM_ENABLE_MINT_BASE_FEES_ENV) {
+                if is_env_var_set(FM_DISABLE_MINT_BASE_FEES_ENV) {
+                    fedimint_mint_common::config::FeeConsensus::zero()
+                } else {
                     fedimint_mint_common::config::FeeConsensus::new(0)
                         .expect("Relative fee is within range")
-                } else {
-                    fedimint_mint_common::config::FeeConsensus::zero()
                 },
             ),
         },

--- a/modules/fedimint-lnv2-tests/bin/tests.rs
+++ b/modules/fedimint-lnv2-tests/bin/tests.rs
@@ -555,9 +555,6 @@ async fn test_lnurl_pay(dev_fed: &DevJitFed) -> anyhow::Result<()> {
     federation.pegin_client(10_000, &client_a).await?;
     federation.pegin_client(10_000, &client_b).await?;
 
-    assert_eq!(client_a.balance().await?, 10_000 * 1000);
-    assert_eq!(client_b.balance().await?, 10_000 * 1000);
-
     for (gw_send, gw_receive) in gateway_matrix {
         info!(
             "Testing lnurl payments: client -> {} -> {} -> client",


### PR DESCRIPTION
The base fee is necessary to prevent excessive use of ecash only transactions to exhaust the guardians disk space. 100msat per ecash output / input roughly equals 1 msat per byte hence 1 million sats per gigabyte of disk space. Since ecash transactions are quite large and need to be downloaded by every user in recovery a gigabyte of additional transaction data is a considerable cost to the system.

This is a follow up to: https://github.com/fedimint/fedimint/pull/7725. The previous pr enabled the fee only in devimint testing via an environment variable called FM_ENABLE_MINT_BASE_FEES_ENV. We invert this, enable the base fee of 100msat by default and allow for disabling it through FM_DISABLE_MINT_BASE_FEES_ENV. This is used in the load test tool test which is the only test that has not been migrated to work with a nonzero ecash base fee.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
