### PR TITLE
chore: use thin (instead of fat) LTO in release build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -382,6 +382,5 @@ debug = false
 opt-level = 1
 
 [profile.release]
-codegen-units = 4
 debug = "line-tables-only"
-lto = "fat"
+lto = "thin"


### PR DESCRIPTION
These changes cut memory usage like 8 times, and built time by at least 2.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
