### PR TITLE
feat: make absolute base fees configurable by the leading guardian

### DIFF
--- a/devimint/src/federation/config.rs
+++ b/devimint/src/federation/config.rs
@@ -43,7 +43,7 @@ pub fn attach_default_module_init_params(
             local: EmptyGenParams::default(),
             consensus: MintGenParamsConsensus::new(
                 2,
-                fedimint_mint_common::config::FeeConsensus::zero(),
+                Some(fedimint_mint_common::config::FeeConsensus::zero()),
             ),
         },
     );
@@ -74,8 +74,10 @@ pub fn attach_default_module_init_params(
                     bitcoin_rpc: bitcoin_rpc.clone(),
                 },
                 consensus: fedimint_lnv2_common::config::LightningGenParamsConsensus {
-                    fee_consensus: fedimint_lnv2_common::config::FeeConsensus::new(1000)
-                        .expect("Relative fee is within range"),
+                    fee_consensus: Some(
+                        fedimint_lnv2_common::config::FeeConsensus::new(1000)
+                            .expect("Relative fee is within range"),
+                    ),
                     network,
                 },
             },

--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -11,9 +11,7 @@ use bitcoin::Txid;
 use clap::Subcommand;
 use fedimint_core::core::LEGACY_HARDCODED_INSTANCE_ID_WALLET;
 use fedimint_core::encoding::{Decodable, Encodable};
-use fedimint_core::envs::{
-    FM_ENABLE_MINT_BASE_FEES_ENV, FM_ENABLE_MODULE_LNV2_ENV, is_env_var_set,
-};
+use fedimint_core::envs::{FM_DISABLE_BASE_FEES_ENV, FM_ENABLE_MODULE_LNV2_ENV, is_env_var_set};
 use fedimint_core::module::registry::ModuleRegistry;
 use fedimint_core::net::api_announcement::SignedApiAnnouncement;
 use fedimint_core::task::block_in_place;
@@ -2212,9 +2210,6 @@ pub enum TestCmd {
 }
 
 pub async fn handle_command(cmd: TestCmd, common_args: CommonArgs) -> Result<()> {
-    // Always enable mint base fees in devimint for testing
-    unsafe { std::env::set_var(FM_ENABLE_MINT_BASE_FEES_ENV, "1") };
-
     match cmd {
         TestCmd::WasmTestSetup { exec } => {
             let (process_mgr, task_group) = setup(common_args).await?;
@@ -2277,8 +2272,8 @@ pub async fn handle_command(cmd: TestCmd, common_args: CommonArgs) -> Result<()>
         }
         TestCmd::LoadTestToolTest => {
             // For the load test tool test, explicitly disable mint base fees
-            // (override the default set at function entry)
-            unsafe { std::env::set_var(FM_ENABLE_MINT_BASE_FEES_ENV, "0") };
+            unsafe { std::env::set_var(FM_DISABLE_BASE_FEES_ENV, "1") };
+
             let (process_mgr, _) = setup(common_args).await?;
             let dev_fed = dev_fed(&process_mgr).await?;
             cli_load_test_tool_test(dev_fed).await?;

--- a/fedimint-api-client/src/api/global_api/with_cache.rs
+++ b/fedimint-api-client/src/api/global_api/with_cache.rs
@@ -364,6 +364,7 @@ where
         &self,
         name: String,
         federation_name: Option<String>,
+        disable_base_fees: Option<bool>,
         auth: ApiAuth,
     ) -> FederationResult<String> {
         self.request_admin(
@@ -371,6 +372,7 @@ where
             ApiRequestErased::new(SetLocalParamsRequest {
                 name,
                 federation_name,
+                disable_base_fees,
             }),
             auth,
         )

--- a/fedimint-api-client/src/api/mod.rs
+++ b/fedimint-api-client/src/api/mod.rs
@@ -504,6 +504,7 @@ pub trait IGlobalFederationApi: IRawFederationApi {
         &self,
         name: String,
         federation_name: Option<String>,
+        disable_base_fees: Option<bool>,
         auth: ApiAuth,
     ) -> FederationResult<String>;
 

--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -1356,7 +1356,7 @@ impl FedimintCli {
                 federation_name,
             } => {
                 let info = client
-                    .set_local_params(name.clone(), federation_name.clone(), cli.auth()?)
+                    .set_local_params(name.clone(), federation_name.clone(), None, cli.auth()?)
                     .await?;
 
                 Ok(serde_json::to_value(info).expect("JSON serialization failed"))

--- a/fedimint-core/src/admin_client.rs
+++ b/fedimint-core/src/admin_client.rs
@@ -61,6 +61,8 @@ pub struct SetLocalParamsRequest {
     pub name: String,
     /// Federation name set by the leader
     pub federation_name: Option<String>,
+    /// Whether to disable base fees, set by the leader
+    pub disable_base_fees: Option<bool>,
 }
 
 /// Archive of all the guardian config files that can be used to recover a lost

--- a/fedimint-core/src/envs.rs
+++ b/fedimint-core/src/envs.rs
@@ -18,8 +18,8 @@ pub const FM_USE_UNKNOWN_MODULE_ENV: &str = "FM_USE_UNKNOWN_MODULE";
 
 pub const FM_ENABLE_MODULE_LNV2_ENV: &str = "FM_ENABLE_MODULE_LNV2";
 
-/// Enable mint base fees for testing and development environments
-pub const FM_ENABLE_MINT_BASE_FEES_ENV: &str = "FM_ENABLE_MINT_BASE_FEES";
+/// Disable mint base fees for testing and development environments
+pub const FM_DISABLE_BASE_FEES_ENV: &str = "FM_DISABLE_BASE_FEES";
 
 /// Print sensitive secrets without redacting them. Use only for debugging.
 pub const FM_DEBUG_SHOW_SECRETS_ENV: &str = "FM_DEBUG_SHOW_SECRETS";

--- a/fedimint-core/src/setup_code.rs
+++ b/fedimint-core/src/setup_code.rs
@@ -15,6 +15,8 @@ pub struct PeerSetupCode {
     pub endpoints: PeerEndpoints,
     /// Federation name set by the leader
     pub federation_name: Option<String>,
+    /// Whether to disable base fees, set by the leader
+    pub disable_base_fees: Option<bool>,
 }
 
 impl PeerSetupCode {

--- a/fedimint-server-core/src/init.rs
+++ b/fedimint-server-core/src/init.rs
@@ -62,12 +62,14 @@ pub trait IServerModuleInit: IDynCommonModuleInit {
         &self,
         peers: &[PeerId],
         params: &ConfigGenModuleParams,
+        disable_base_fees: bool,
     ) -> BTreeMap<PeerId, ServerModuleConfig>;
 
     async fn distributed_gen(
         &self,
         peers: &(dyn PeerHandleOps + Send + Sync),
         params: &ConfigGenModuleParams,
+        disable_base_fees: bool,
     ) -> anyhow::Result<ServerModuleConfig>;
 
     fn validate_config(&self, identity: &PeerId, config: ServerModuleConfig) -> anyhow::Result<()>;
@@ -183,12 +185,14 @@ pub trait ServerModuleInit: ModuleInit + Sized {
         &self,
         peers: &[PeerId],
         params: &ConfigGenModuleParams,
+        disable_base_fees: bool,
     ) -> BTreeMap<PeerId, ServerModuleConfig>;
 
     async fn distributed_gen(
         &self,
         peers: &(dyn PeerHandleOps + Send + Sync),
         params: &ConfigGenModuleParams,
+        disable_base_fees: bool,
     ) -> anyhow::Result<ServerModuleConfig>;
 
     fn validate_config(&self, identity: &PeerId, config: ServerModuleConfig) -> anyhow::Result<()>;
@@ -272,16 +276,18 @@ where
         &self,
         peers: &[PeerId],
         params: &ConfigGenModuleParams,
+        disable_base_fees: bool,
     ) -> BTreeMap<PeerId, ServerModuleConfig> {
-        <Self as ServerModuleInit>::trusted_dealer_gen(self, peers, params)
+        <Self as ServerModuleInit>::trusted_dealer_gen(self, peers, params, disable_base_fees)
     }
 
     async fn distributed_gen(
         &self,
         peers: &(dyn PeerHandleOps + Send + Sync),
         params: &ConfigGenModuleParams,
+        disable_base_fees: bool,
     ) -> anyhow::Result<ServerModuleConfig> {
-        <Self as ServerModuleInit>::distributed_gen(self, peers, params).await
+        <Self as ServerModuleInit>::distributed_gen(self, peers, params, disable_base_fees).await
     }
 
     fn validate_config(&self, identity: &PeerId, config: ServerModuleConfig) -> anyhow::Result<()> {

--- a/fedimint-server-core/src/setup_ui.rs
+++ b/fedimint-server-core/src/setup_ui.rs
@@ -27,6 +27,7 @@ pub trait ISetupApi {
         auth: ApiAuth,
         name: String,
         federation_name: Option<String>,
+        disable_base_fees: Option<bool>,
     ) -> Result<String>;
 
     /// Add peer connection info

--- a/fedimint-server/src/config/mod.rs
+++ b/fedimint-server/src/config/mod.rs
@@ -238,6 +238,8 @@ pub struct ConfigGenParams {
     pub peers: BTreeMap<PeerId, PeerSetupCode>,
     /// Guardian-defined key-value pairs that will be passed to the client
     pub meta: BTreeMap<String, String>,
+    /// Whether to disable base fees for this federation
+    pub disable_base_fees: bool,
 }
 
 impl ServerConfigConsensus {
@@ -491,7 +493,11 @@ impl ServerConfig {
                     registry
                         .get(kind)
                         .expect("Module not registered")
-                        .trusted_dealer_gen(&peer0.peer_ids(), module_params),
+                        .trusted_dealer_gen(
+                            &peer0.peer_ids(),
+                            module_params,
+                            params[&PeerId::from(0)].disable_base_fees,
+                        ),
                 )
             })
             .collect();
@@ -611,7 +617,7 @@ impl ServerConfig {
             let cfg = registry
                 .get(kind)
                 .with_context(|| format!("Module of kind {kind} not found"))?
-                .distributed_gen(&handle, module_params)
+                .distributed_gen(&handle, module_params, params.disable_base_fees)
                 .await?;
 
             module_cfgs.insert(module_id, cfg);

--- a/fedimint-testing-core/src/config.rs
+++ b/fedimint-testing-core/src/config.rs
@@ -51,6 +51,7 @@ pub fn local_config_gen_params(
                     cert: tls_keys[peer].0.as_ref().to_vec(),
                 },
                 federation_name: None,
+                disable_base_fees: None,
             };
             (*peer, params)
         })
@@ -67,6 +68,7 @@ pub fn local_config_gen_params(
                 iroh_p2p_sk: None,
                 peers: connections.clone(),
                 meta: BTreeMap::new(),
+                disable_base_fees: false,
             };
             Ok((*peer, params))
         })

--- a/fedimintd/src/lib.rs
+++ b/fedimintd/src/lib.rs
@@ -21,8 +21,8 @@ use envs::FM_BITCOIND_URL_PASSWORD_FILE_ENV;
 use fedimint_core::config::{EmptyGenParams, ServerModuleConfigGenParamsRegistry};
 use fedimint_core::db::Database;
 use fedimint_core::envs::{
-    BitcoinRpcConfig, FM_ENABLE_MINT_BASE_FEES_ENV, FM_ENABLE_MODULE_LNV2_ENV, FM_IROH_DNS_ENV,
-    FM_IROH_RELAY_ENV, FM_USE_UNKNOWN_MODULE_ENV, is_env_var_set,
+    BitcoinRpcConfig, FM_ENABLE_MODULE_LNV2_ENV, FM_IROH_DNS_ENV, FM_IROH_RELAY_ENV,
+    FM_USE_UNKNOWN_MODULE_ENV, is_env_var_set,
 };
 use fedimint_core::module::registry::ModuleRegistry;
 use fedimint_core::rustls::install_crypto_provider;
@@ -451,15 +451,7 @@ pub fn default_modules(
         MintInit::kind(),
         MintGenParams {
             local: EmptyGenParams::default(),
-            consensus: MintGenParamsConsensus::new(
-                2,
-                if is_env_var_set(FM_ENABLE_MINT_BASE_FEES_ENV) {
-                    fedimint_mint_common::config::FeeConsensus::new(0)
-                        .expect("Relative fee is within range")
-                } else {
-                    fedimint_mint_common::config::FeeConsensus::zero()
-                },
-            ),
+            consensus: MintGenParamsConsensus::new(2, None),
         },
     );
 
@@ -494,8 +486,7 @@ pub fn default_modules(
                     bitcoin_rpc: bitcoin_rpc_config.clone(),
                 },
                 consensus: fedimint_lnv2_common::config::LightningGenParamsConsensus {
-                    // TODO: actually make the relative fee configurable
-                    fee_consensus: fedimint_lnv2_common::config::FeeConsensus::new(0).unwrap(),
+                    fee_consensus: None,
                     network,
                 },
             },

--- a/modules/fedimint-dummy-server/src/lib.rs
+++ b/modules/fedimint-dummy-server/src/lib.rs
@@ -122,6 +122,7 @@ impl ServerModuleInit for DummyInit {
         &self,
         peers: &[PeerId],
         params: &ConfigGenModuleParams,
+        _disable_base_fees: bool,
     ) -> BTreeMap<PeerId, ServerModuleConfig> {
         let params = self.parse_params(params).unwrap();
         // Generate a config for each peer
@@ -144,6 +145,7 @@ impl ServerModuleInit for DummyInit {
         &self,
         _peers: &(dyn PeerHandleOps + Send + Sync),
         params: &ConfigGenModuleParams,
+        _disable_base_fees: bool,
     ) -> anyhow::Result<ServerModuleConfig> {
         let params = self.parse_params(params).unwrap();
 

--- a/modules/fedimint-empty-server/src/lib.rs
+++ b/modules/fedimint-empty-server/src/lib.rs
@@ -106,6 +106,7 @@ impl ServerModuleInit for EmptyInit {
         &self,
         peers: &[PeerId],
         params: &ConfigGenModuleParams,
+        _disable_base_fees: bool,
     ) -> BTreeMap<PeerId, ServerModuleConfig> {
         let _params = self.parse_params(params).unwrap();
         // Generate a config for each peer
@@ -126,6 +127,7 @@ impl ServerModuleInit for EmptyInit {
         &self,
         _peers: &(dyn PeerHandleOps + Send + Sync),
         params: &ConfigGenModuleParams,
+        _disable_base_fees: bool,
     ) -> anyhow::Result<ServerModuleConfig> {
         let _params = self.parse_params(params).unwrap();
 

--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -228,6 +228,7 @@ impl ServerModuleInit for LightningInit {
         &self,
         peers: &[PeerId],
         params: &ConfigGenModuleParams,
+        _disable_base_fees: bool,
     ) -> BTreeMap<PeerId, ServerModuleConfig> {
         let params = self.parse_params(params).unwrap();
         let sks = threshold_crypto::SecretKeySet::random(peers.to_num_peers().degree(), &mut OsRng);
@@ -260,6 +261,7 @@ impl ServerModuleInit for LightningInit {
         &self,
         peers: &(dyn PeerHandleOps + Send + Sync),
         params: &ConfigGenModuleParams,
+        _disable_base_fees: bool,
     ) -> anyhow::Result<ServerModuleConfig> {
         let params = self.parse_params(params).unwrap();
 
@@ -1323,6 +1325,7 @@ mod tests {
                 },
             })
             .expect("valid config params"),
+            false, // disable_base_fees
         );
 
         let client_cfg = ServerModuleInit::get_client_config(

--- a/modules/fedimint-lnv2-common/src/config.rs
+++ b/modules/fedimint-lnv2-common/src/config.rs
@@ -23,7 +23,7 @@ impl LightningGenParams {
         Self {
             local: LightningGenParamsLocal { bitcoin_rpc },
             consensus: LightningGenParamsConsensus {
-                fee_consensus: FeeConsensus::new(1000).expect("Relative fee is within range"),
+                fee_consensus: Some(FeeConsensus::new(1000).expect("Relative fee is within range")),
                 network: Network::Regtest,
             },
         }
@@ -32,7 +32,7 @@ impl LightningGenParams {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LightningGenParamsConsensus {
-    pub fee_consensus: FeeConsensus,
+    pub fee_consensus: Option<FeeConsensus>,
     pub network: Network,
 }
 
@@ -118,6 +118,13 @@ impl FeeConsensus {
             base: Amount::from_sats(1),
             parts_per_million,
         })
+    }
+
+    pub fn zero() -> Self {
+        Self {
+            base: Amount::ZERO,
+            parts_per_million: 0,
+        }
     }
 
     pub fn fee(&self, amount: Amount) -> Amount {

--- a/modules/fedimint-lnv2-tests/bin/tests.rs
+++ b/modules/fedimint-lnv2-tests/bin/tests.rs
@@ -555,9 +555,6 @@ async fn test_lnurl_pay(dev_fed: &DevJitFed) -> anyhow::Result<()> {
     federation.pegin_client(10_000, &client_a).await?;
     federation.pegin_client(10_000, &client_b).await?;
 
-    assert_eq!(client_a.balance().await?, 10_000 * 1000);
-    assert_eq!(client_b.balance().await?, 10_000 * 1000);
-
     for (gw_send, gw_receive) in gateway_matrix {
         info!(
             "Testing lnurl payments: client -> {} -> {} -> client",

--- a/modules/fedimint-meta-server/src/lib.rs
+++ b/modules/fedimint-meta-server/src/lib.rs
@@ -154,6 +154,7 @@ impl ServerModuleInit for MetaInit {
         &self,
         peers: &[PeerId],
         params: &ConfigGenModuleParams,
+        _disable_base_fees: bool,
     ) -> BTreeMap<PeerId, ServerModuleConfig> {
         let _params = self.parse_params(params).unwrap();
         // Generate a config for each peer
@@ -174,6 +175,7 @@ impl ServerModuleInit for MetaInit {
         &self,
         _peers: &(dyn PeerHandleOps + Send + Sync),
         params: &ConfigGenModuleParams,
+        _disable_base_fees: bool,
     ) -> anyhow::Result<ServerModuleConfig> {
         let _params = self.parse_params(params).unwrap();
 

--- a/modules/fedimint-mint-common/src/config.rs
+++ b/modules/fedimint-mint-common/src/config.rs
@@ -19,7 +19,7 @@ pub struct MintGenParams {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MintGenParamsConsensus {
     denomination_base: u16,
-    fee_consensus: FeeConsensus,
+    fee_consensus: Option<FeeConsensus>,
 }
 
 // The maximum size of an E-Cash note (1,000,000 coins)
@@ -28,7 +28,7 @@ pub struct MintGenParamsConsensus {
 const MAX_DENOMINATION_SIZE: Amount = Amount::from_bitcoins(1_000_000);
 
 impl MintGenParamsConsensus {
-    pub fn new(denomination_base: u16, fee_consensus: FeeConsensus) -> Self {
+    pub fn new(denomination_base: u16, fee_consensus: Option<FeeConsensus>) -> Self {
         Self {
             denomination_base,
             fee_consensus,
@@ -39,7 +39,7 @@ impl MintGenParamsConsensus {
         self.denomination_base
     }
 
-    pub fn fee_consensus(&self) -> FeeConsensus {
+    pub fn fee_consensus(&self) -> Option<FeeConsensus> {
         self.fee_consensus.clone()
     }
 

--- a/modules/fedimint-mint-server/src/test.rs
+++ b/modules/fedimint-mint-server/src/test.rs
@@ -25,10 +25,11 @@ fn build_configs() -> (Vec<ServerModuleConfig>, ClientModuleConfig) {
             local: EmptyGenParams::default(),
             consensus: MintGenParamsConsensus::new(
                 2,
-                FeeConsensus::new(1000).expect("Relative fee is within range"),
+                Some(FeeConsensus::new(1000).expect("Relative fee is within range")),
             ),
         })
         .unwrap(),
+        false,
     );
     let client_cfg = ClientModuleConfig::from_typed(
         0,

--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -38,7 +38,7 @@ fn fixtures() -> Fixtures {
         MintGenParams {
             consensus: MintGenParamsConsensus::new(
                 2,
-                FeeConsensus::new(1_000).expect("Relative fee is within range"),
+                Some(FeeConsensus::new(1_000).expect("Relative fee is within range")),
             ),
 
             local: EmptyGenParams {},

--- a/modules/fedimint-unknown-server/src/lib.rs
+++ b/modules/fedimint-unknown-server/src/lib.rs
@@ -82,6 +82,7 @@ impl ServerModuleInit for UnknownInit {
         &self,
         peers: &[PeerId],
         params: &ConfigGenModuleParams,
+        _disable_base_fees: bool,
     ) -> BTreeMap<PeerId, ServerModuleConfig> {
         let _params = self.parse_params(params).unwrap();
         // Generate a config for each peer
@@ -102,6 +103,7 @@ impl ServerModuleInit for UnknownInit {
         &self,
         _peers: &(dyn PeerHandleOps + Send + Sync),
         params: &ConfigGenModuleParams,
+        _disable_base_fees: bool,
     ) -> anyhow::Result<ServerModuleConfig> {
         let _params = self.parse_params(params).unwrap();
 

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -313,6 +313,7 @@ impl ServerModuleInit for WalletInit {
         &self,
         peers: &[PeerId],
         params: &ConfigGenModuleParams,
+        _disable_base_fees: bool,
     ) -> BTreeMap<PeerId, ServerModuleConfig> {
         let params = self.parse_params(params).unwrap();
         let secp = bitcoin::secp256k1::Secp256k1::new();
@@ -351,6 +352,7 @@ impl ServerModuleInit for WalletInit {
         &self,
         peers: &(dyn PeerHandleOps + Send + Sync),
         params: &ConfigGenModuleParams,
+        _disable_base_fees: bool,
     ) -> anyhow::Result<ServerModuleConfig> {
         let params = self.parse_params(params).unwrap();
         let secp = secp256k1::Secp256k1::new();

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -1139,6 +1139,7 @@ fn build_wallet_server_configs(
                 fee_consensus: Default::default(),
             },
         })?,
+        false,
     );
     let client_cfg = fedimint_core::config::ClientModuleConfig::from_typed(
         0,


### PR DESCRIPTION
As requested in the Monday call we make the mint ecash note base fee of 100msat configurable by the leading guardian. For consistency we also toggle the 1sat per contract lnv2 base fee as well to achieve true zero fee operation.

Right now we default to enabling the base fee so it needs to be manually disabled by the setup leader by setting a checkmark in the UI. Under the checkmark we render and explainer with the implications of disabling the base fee.
<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
