### PR TITLE
chore: improve decoding error on enums

### DIFF
--- a/fedimint-derive/src/lib.rs
+++ b/fedimint-derive/src/lib.rs
@@ -307,7 +307,10 @@ fn derive_enum_decode(ident: &Ident, variants: &Punctuated<Variant, Comma>) -> T
                         ))?;
                     let mut cursor = std::io::Cursor::new(&bytes);
 
-                    let decoded = #decode_block;
+                    let decoded = anyhow::Context::context(
+                        (|| -> anyhow::Result<_> {
+                          Ok(#decode_block)
+                        })(), concat!("Decoding variant ", stringify!(#variant_ident), " (idx: ", #variant_idx, ")"))?;
 
                     let read_bytes = cursor.position();
                     let total_bytes = bytes.len() as u64;


### PR DESCRIPTION
```
thread 'fedimint_migration_tests::test_client_db_migrations' panicked at /home/dpc/lab/fedimint/fedimint/fedimint-core/s
rc/db/mod.rs:1619:9:
Unrecoverable decoding DatabaseKey as fedimint_client::sm::executor::ActiveStateKeyDb; err=Other decoding error: Decodin
g tuple block ActiveStateKeyDb field field_0: while decoding Dyn type module_id=0: Decoding variant OutputDone (idx: 3): Deco
ding tuple block DummyStateMachine field field_3: Decoding tuple block OperationId field field_0: failed to fill whole buffe
r; bytes=a1ac723a09bfbe6ee56f3f09391f9b001151dcd9d9572bc0c04493562f72528561000345fe000f4240000000000000000000000000000000000
0000000000000-106
```

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
