### PR TITLE
chore: enable decoding of commonly used base32 encoding prefixed with fedimint for OOBNotes

### DIFF
--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -48,7 +48,9 @@ use fedimint_core::module::{ApiAuth, ApiRequestErased};
 use fedimint_core::setup_code::PeerSetupCode;
 use fedimint_core::transaction::Transaction;
 use fedimint_core::util::{SafeUrl, backoff_util, handle_version_hash_command, retry};
-use fedimint_core::{Amount, PeerId, TieredMulti, fedimint_build_code_version_env, runtime};
+use fedimint_core::{
+    Amount, PeerId, TieredMulti, base32, fedimint_build_code_version_env, runtime,
+};
 use fedimint_eventlog::{EventLogId, EventLogTrimableId};
 use fedimint_ln_client::LightningClientInit;
 use fedimint_logging::{LOG_CLIENT, TracingSetup};
@@ -1110,7 +1112,7 @@ impl FedimintCli {
                     })
                 }
                 DecodeType::SetupCode { setup_code } => {
-                    let setup_code = PeerSetupCode::decode_base32(&setup_code)
+                    let setup_code = base32::decode_oob(&setup_code)
                         .map_err_cli_msg("failed to decode setup code")?;
 
                     Ok(CliOutput::SetupCode { setup_code })

--- a/fedimint-core/src/setup_code.rs
+++ b/fedimint-core/src/setup_code.rs
@@ -1,9 +1,6 @@
-use anyhow::ensure;
 use serde::Serialize;
 
-use crate::base32;
 use crate::encoding::{Decodable, Encodable};
-use crate::module::registry::ModuleDecoderRegistry;
 use crate::util::SafeUrl;
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Encodable, Decodable, Serialize)]
@@ -15,26 +12,6 @@ pub struct PeerSetupCode {
     pub endpoints: PeerEndpoints,
     /// Federation name set by the leader
     pub federation_name: Option<String>,
-}
-
-impl PeerSetupCode {
-    pub fn encode_base32(&self) -> String {
-        format!(
-            "fedimint{}",
-            base32::encode(&self.consensus_encode_to_vec())
-        )
-    }
-
-    pub fn decode_base32(s: &str) -> anyhow::Result<Self> {
-        ensure!(s.starts_with("fedimint"), "Invalid Prefix");
-
-        let params = Self::consensus_decode_whole(
-            &base32::decode(&s[8..])?,
-            &ModuleDecoderRegistry::default(),
-        )?;
-
-        Ok(params)
-    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Encodable, Decodable, Serialize)]


### PR DESCRIPTION
After long back and forth on how to balance simplicity, readability and efficiency I have settled on the combination of our custom binary encoding combined with a base32 encoding and prefixed with fedimint. I have already started transitioning the invite code in prior versions and it's used for the setup codes exchanged prior to dkg as well. Therefore you can find the methods encode_base32 and decode_base32 for the invite code and setup code already.

We now enable the decoding and then have to wait for our compatibility window to pass until we can change the encoding as well. We have already done this transition once moving from base 64 to base 64 url safe. Since this transition has been completed over a year ago already we now take the opportunity to remove the ability to decode the legacy non url safe decoding.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
