### PR TITLE
feat: LNv2 -> LNv1 swap

### DIFF
--- a/modules/fedimint-gw-client/src/lib.rs
+++ b/modules/fedimint-gw-client/src/lib.rs
@@ -503,7 +503,7 @@ impl GatewayClientModule {
     /// Attempt buying preimage from this federation in order to fulfill a pay
     /// request in another federation served by this gateway. In direct swap
     /// scenario, the gateway DOES NOT send payment over the lightning network
-    async fn gateway_handle_direct_swap(
+    pub async fn gateway_handle_direct_swap(
         &self,
         swap_params: SwapParameters,
     ) -> anyhow::Result<OperationId> {
@@ -856,9 +856,9 @@ impl TryFrom<InterceptPaymentRequest> for Htlc {
 }
 
 #[derive(Debug, Clone)]
-struct SwapParameters {
-    payment_hash: sha256::Hash,
-    amount_msat: Amount,
+pub struct SwapParameters {
+    pub payment_hash: sha256::Hash,
+    pub amount_msat: Amount,
 }
 
 impl TryFrom<PaymentData> for SwapParameters {
@@ -932,6 +932,8 @@ pub trait IGatewayClientV1: Debug + Send + Sync {
         htlc_response: InterceptPaymentResponse,
     ) -> Result<(), LightningRpcError>;
 
+    /// Check if the gateway satisfy the LNv1 payment by funding an LNv2
+    /// `IncomingContract`
     async fn is_lnv2_direct_swap(
         &self,
         payment_hash: sha256::Hash,

--- a/modules/fedimint-gwv2-client/src/lib.rs
+++ b/modules/fedimint-gwv2-client/src/lib.rs
@@ -33,6 +33,7 @@ use fedimint_core::module::{
 };
 use fedimint_core::secp256k1::Keypair;
 use fedimint_core::time::now;
+use fedimint_core::util::Spanned;
 use fedimint_core::{Amount, PeerId, apply, async_trait_maybe_send, secp256k1};
 use fedimint_lightning::{InterceptPaymentResponse, LightningRpcError};
 use fedimint_lnv2_common::config::LightningClientConfig;
@@ -645,4 +646,6 @@ pub trait IGatewayClientV2: Debug + Send + Sync {
         federation_id: &FederationId,
         amount: u64,
     ) -> anyhow::Result<Amount>;
+
+    async fn is_lnv1_invoice(&self, invoice: &Bolt11Invoice) -> Option<Spanned<ClientHandleArc>>;
 }

--- a/modules/fedimint-gwv2-client/src/lib.rs
+++ b/modules/fedimint-gwv2-client/src/lib.rs
@@ -647,5 +647,15 @@ pub trait IGatewayClientV2: Debug + Send + Sync {
         amount: u64,
     ) -> anyhow::Result<Amount>;
 
+    /// Check if this invoice was created using LNv1 and if the gateway is
+    /// connected to the target federation.
     async fn is_lnv1_invoice(&self, invoice: &Bolt11Invoice) -> Option<Spanned<ClientHandleArc>>;
+
+    /// Perform a swap from an LNv2 `OutgoingContract` to an LNv1
+    /// `IncomingContract`
+    async fn relay_lnv1_swap(
+        &self,
+        client: &ClientHandleArc,
+        invoice: &Bolt11Invoice,
+    ) -> anyhow::Result<FinalReceiveState>;
 }

--- a/modules/fedimint-gwv2-client/src/send_sm.rs
+++ b/modules/fedimint-gwv2-client/src/send_sm.rs
@@ -172,6 +172,10 @@ impl SendStateMachine {
             return Err(Cancelled::Underfunded);
         };
 
+        if context.gateway.is_lnv1_invoice(&invoice).await.is_some() {
+            tracing::info!("LNV1 INVOICE, THIS IS POTENTIALLY SWAPPABLE");
+        }
+
         match context
             .gateway
             .is_direct_swap(&invoice)


### PR DESCRIPTION
This PR allows paying an LNv1 invoice using LNv2. This is useful because now we can remove the LNv1 vs LNv2 flag, which means gateways can service any invoice. This makes gateway operation much easier and will increase LNv2 adoption.