### PR TITLE
feat: customize default gateway fees

### DIFF
--- a/gateway/fedimint-gateway-server/src/config.rs
+++ b/gateway/fedimint-gateway-server/src/config.rs
@@ -6,6 +6,7 @@ use bitcoin::Network;
 use clap::{ArgGroup, Parser};
 use fedimint_core::util::SafeUrl;
 use fedimint_gateway_common::{LightningMode, V1_API_ENDPOINT};
+use fedimint_lnv2_common::gateway_api::PaymentFee;
 
 use super::envs;
 use crate::envs::{
@@ -98,6 +99,14 @@ pub struct GatewayOpts {
     /// Esplora HTTP base URL, e.g. <https://mempool.space/api>
     #[arg(long, env = FM_ESPLORA_URL_ENV)]
     pub esplora_url: Option<SafeUrl>,
+
+    /// The default routing fees that are applied to new federations
+    #[arg(long = "default-routing-fees", env = envs::FM_DEFAULT_ROUTING_FEES_ENV, default_value_t = PaymentFee::TRANSACTION_FEE_DEFAULT)]
+    default_routing_fees: PaymentFee,
+
+    /// The default transaction fees that are applied to new federations
+    #[arg(long = "default-transaction-fees", env = envs::FM_DEFAULT_TRANSACTION_FEES_ENV, default_value_t = PaymentFee::TRANSACTION_FEE_DEFAULT)]
+    default_transaction_fees: PaymentFee,
 }
 
 impl GatewayOpts {
@@ -119,6 +128,8 @@ impl GatewayOpts {
             bcrypt_password_hash,
             network: self.network,
             num_route_hints: self.num_route_hints,
+            default_routing_fees: self.default_routing_fees,
+            default_transaction_fees: self.default_transaction_fees,
         })
     }
 }
@@ -136,4 +147,6 @@ pub struct GatewayParameters {
     pub bcrypt_password_hash: bcrypt::HashParts,
     pub network: Network,
     pub num_route_hints: u32,
+    pub default_routing_fees: PaymentFee,
+    pub default_transaction_fees: PaymentFee,
 }

--- a/gateway/fedimint-gateway-server/src/envs.rs
+++ b/gateway/fedimint-gateway-server/src/envs.rs
@@ -44,10 +44,22 @@ pub const FM_GATEWAY_SKIP_WAIT_FOR_SYNC_ENV: &str = "FM_GATEWAY_SKIP_WAIT_FOR_SY
 /// Environment variable to select database backend (rocksdb or cursed-redb)
 pub const FM_DB_BACKEND_ENV: &str = "FM_DB_BACKEND";
 
+/// The username to use when connecting to a bitcoin node over RPC
 pub const FM_BITCOIND_USERNAME_ENV: &str = "FM_BITCOIND_USERNAME";
 
+/// The password to use when connecting to a bitcoin node over RPC
 pub const FM_BITCOIND_PASSWORD_ENV: &str = "FM_BITCOIND_PASSWORD";
 
+/// The URL to use when connecting to a bitcoin node over RPC.
+/// Should not include authentication parameters: (e.g `http://127.0.0.1:8332`)
 pub const FM_BITCOIND_URL_ENV: &str = "FM_BITCOIND_URL";
 
+/// The URL to use when connecting to an Esplora server for bitcoin blockchain
+/// data
 pub const FM_ESPLORA_URL_ENV: &str = "FM_ESPLORA_URL";
+
+/// Environment variable for customizing the default routing fees
+pub const FM_DEFAULT_ROUTING_FEES_ENV: &str = "FM_DEFAULT_ROUTING_FEES";
+
+/// Environment variable for customizing the default transaction fees
+pub const FM_DEFAULT_TRANSACTION_FEES_ENV: &str = "FM_DEFAULT_TRANSACTION_FEES";

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -228,8 +228,14 @@ pub struct Gateway {
     /// The Bitcoin network that the Lightning network is configured to.
     network: Network,
 
-    // The source of the Bitcoin blockchain data
+    /// The source of the Bitcoin blockchain data
     chain_source: ChainSource,
+
+    /// The default routing fees for new federations
+    default_routing_fees: PaymentFee,
+
+    /// The default transaction fees for new federations
+    default_transaction_fees: PaymentFee,
 }
 
 impl std::fmt::Debug for Gateway {
@@ -273,6 +279,8 @@ impl Gateway {
                 bcrypt_password_hash,
                 network,
                 num_route_hints,
+                default_routing_fees: PaymentFee::TRANSACTION_FEE_DEFAULT,
+                default_transaction_fees: PaymentFee::TRANSACTION_FEE_DEFAULT,
             },
             gateway_db,
             client_builder,
@@ -430,6 +438,8 @@ impl Gateway {
             num_route_hints,
             network,
             chain_source,
+            default_routing_fees: gateway_parameters.default_routing_fees,
+            default_transaction_fees: gateway_parameters.default_transaction_fees,
         })
     }
 
@@ -1177,8 +1187,8 @@ impl Gateway {
         let federation_config = FederationConfig {
             invite_code,
             federation_index,
-            lightning_fee: PaymentFee::TRANSACTION_FEE_DEFAULT,
-            transaction_fee: PaymentFee::TRANSACTION_FEE_DEFAULT,
+            lightning_fee: self.default_routing_fees,
+            transaction_fee: self.default_transaction_fees,
             connector,
         };
 


### PR DESCRIPTION
Fixes: https://github.com/fedimint/fedimint/issues/7582

Pretty straightforward. Just takes the fees from the command line or environment variable and makes those the default when joining a new federation. There is a separate parameter for the routing fees vs transaction fees.