### PR TITLE
[Backport releases/v0.8] chore: use thin (instead of fat) LTO in release build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -376,6 +376,5 @@ debug = false
 opt-level = 1
 
 [profile.release]
-codegen-units = 4
 debug = "line-tables-only"
-lto = "fat"
+lto = "thin"


### PR DESCRIPTION
# Description
Backport of #7743 to `releases/v0.8`.