### PR TITLE
fix(ui): clarify all guardians must confirm readiness during setup

### DIFF
--- a/fedimint-server-ui/src/setup.rs
+++ b/fedimint-server-ui/src/setup.rs
@@ -264,13 +264,16 @@ async fn federation_setup(
 
         section class="mb-4" {
             div class="alert alert-warning mb-4" {
-                "Make sure all information is correct and every guardian is ready before launching the federation. This process cannot be reversed once started."
+                "1. All guardians exchange setup codes" br;
+                "2. All guardians click 'I'm Ready'" br;
+                br;
+                "Warning: 'I'm Ready' is final. Verify all setup codes are correct first."
             }
 
             div class="text-center" {
                 form method="post" action=(START_DKG_ROUTE) {
                     button type="submit" class="btn btn-warning setup-btn" {
-                        "🚀 Launch Federation"
+                        "I'm Ready"
                     }
                 }
             }


### PR DESCRIPTION
The language in the setup UI is not clear and has caused confusion for users. Who clicks "Launch Federation?" Just the leader? Everyone? Intuitively, it makes sense that the leader would be the only one that needs to launch the federation.

This confusion has led to users clicking "Launch Federation" on only the leader, causing the federation setup to hang indefinitely with DNS resolution errors.

This updates the language so it's clear that all guardians need to indicate they're ready, along with a clear ordering of events.

**Before**
<img width="992" height="1122" alt="Screenshot_20250923_123907" src="https://github.com/user-attachments/assets/bcd5cbbf-1dfb-4536-95b6-2c82de9ff3df" />

**After**
<img width="992" height="1122" alt="Screenshot_20250923_123822" src="https://github.com/user-attachments/assets/ecf21ca3-72f8-487b-bc99-aff0d6c47257" />