### PR TITLE
chore: keep retrying if the client can't negotiate initial api version

### DIFF
--- a/fedimint-client/src/client.rs
+++ b/fedimint-client/src/client.rs
@@ -939,6 +939,7 @@ impl Client {
                         &api,
                         &db,
                         task_group,
+                        false,
                     )
                     .await
                     {
@@ -952,12 +953,19 @@ impl Client {
             return Ok(v.0);
         }
 
-        debug!(
+        info!(
             target: LOG_CLIENT,
-            "No existing cached common api versions found, waiting for initial discovery"
+            "Fetching initial API versions "
         );
-        Self::refresh_common_api_version_static(config, module_init, api, db, task_group.clone())
-            .await
+        Self::refresh_common_api_version_static(
+            config,
+            module_init,
+            api,
+            db,
+            task_group.clone(),
+            true,
+        )
+        .await
     }
 
     async fn refresh_common_api_version_static(
@@ -966,6 +974,7 @@ impl Client {
         api: &DynGlobalApi,
         db: &Database,
         task_group: TaskGroup,
+        block_until_ok: bool,
     ) -> anyhow::Result<ApiVersionSet> {
         debug!(
             target: LOG_CLIENT,
@@ -984,26 +993,38 @@ impl Client {
             )
         });
 
-        // Wait at most 15 seconds before calculating a set of common api versions to
-        // use. Note that all peers individual responses from previous attempts
-        // are still being used, and requests, or even retries for response of
-        // peers are not actually cancelled, as they are happening on a separate
-        // task. This is all just to bound the time user can be waiting
-        // for the join operation to finish, at the risk of picking wrong version in
-        // very rare circumstances.
-        let _: Result<_, Elapsed> = runtime::timeout(
-            Duration::from_secs(15),
-            num_responses_receiver.wait_for(|num| num_peers.threshold() <= *num),
-        )
-        .await;
+        let common_api_versions = loop {
+            // Wait to collect enough answers before calculating a set of common api
+            // versions to use. Note that all peers individual responses from
+            // previous attempts are still being used, and requests, or even
+            // retries for response of peers are not actually cancelled, as they
+            // are happening on a separate task. This is all just to bound the
+            // time user can be waiting for the join operation to finish, at the
+            // risk of picking wrong version in very rare circumstances.
+            let _: Result<_, Elapsed> = runtime::timeout(
+                Duration::from_secs(30),
+                num_responses_receiver.wait_for(|num| num_peers.threshold() <= *num),
+            )
+            .await;
 
-        let peer_api_version_sets = Self::load_peers_last_api_versions(db, num_peers).await;
+            let peer_api_version_sets = Self::load_peers_last_api_versions(db, num_peers).await;
 
-        let common_api_versions =
-            fedimint_client_module::api_version_discovery::discover_common_api_versions_set(
+            match fedimint_client_module::api_version_discovery::discover_common_api_versions_set(
                 &Self::supported_api_versions_summary_static(config, client_module_init),
                 &peer_api_version_sets,
-            )?;
+            ) {
+                Ok(o) => break o,
+                Err(err) if block_until_ok => {
+                    warn!(
+                        target: LOG_CLIENT,
+                        err = %err.fmt_compact_anyhow(),
+                        "Failed to discover API version to use. Retrying..."
+                    );
+                    continue;
+                }
+                Err(e) => return Err(e),
+            }
+        };
 
         debug!(
             target: LOG_CLIENT,

--- a/fedimint-client/src/client/builder.rs
+++ b/fedimint-client/src/client/builder.rs
@@ -559,7 +559,7 @@ impl ClientBuilder {
         )
         .await
         .inspect_err(|err| {
-            warn!(target: LOG_CLIENT, err = %err.fmt_compact_anyhow(), "Failed to discover initial API version to use.");
+            warn!(target: LOG_CLIENT, err = %err.fmt_compact_anyhow(), "Failed to discover API version to use.");
         })
         .unwrap_or(ApiVersionSet {
             core: ApiVersion::new(0, 0),


### PR DESCRIPTION
Block indefinitely client initialization if the initial api version can't be discovered.

Seems like it's preferable than just initializing client with disabled modules.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
