### PR TITLE
chore(ci): bump nix closure size limit to 280MB

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -500,7 +500,7 @@ jobs:
               closure_size=$(nix path-info -rS --json .#$bin | nix run nixpkgs#jq '. | to_entries[] | select(.value.ultimate == true) | .value.narSize')
               >&2 echo "$bin's Nix closure size: $closure_size"
 
-              if [ 220000000 -lt $closure_size ]; then
+              if [ 280000000 -lt $closure_size ]; then
                 >&2 echo "$bin's Nix closure size seems too big: $closure_size"
                 exit 1
               fi


### PR DESCRIPTION
`v0.8.2-beta.0` failed with

```
gatewayd's Nix closure size: 262335208
gatewayd's Nix closure size seems too big: 262335208
Error: Process completed with exit code 1.
```

https://github.com/fedimint/fedimint/actions/runs/18011155168/job/51243898889#step:6:1068

That's quite the jump. The culprit is https://github.com/fedimint/fedimint/commit/aeae5a1871 along with before/after stats
```
Binary                       Fat(MB)   Thin(MB)        +MB        +MB        %
                             narSize    narSize    narSize    closure increase
------------------------- ---------- ---------- ---------- ---------- --------
fedimintd                        161        202        +41        +41      25%
fedimint-cli                     159        200        +41        +41      25%
fedimint-dbtool                  107        128        +21        +21      19%
fedimint-recoverytool             59         66         +7         +7      11%
gateway-cli                       18         24         +6         +6      33%
gatewayd                         212        262        +50        +50      23%
devimint                          80        110        +30        +31      37%
```

To unblock the release process we can simply increase the closure size limit, but we should consider alternative approaches. The decision is easily reversible so I propose unblocking and finding a better solution later.