### PR TITLE
 chore(client): Iroh connection reuse 

### DIFF
--- a/fedimint-api-client/src/api/iroh.rs
+++ b/fedimint-api-client/src/api/iroh.rs
@@ -1,6 +1,7 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::pin::Pin;
 use std::str::FromStr;
+use std::sync::Arc;
 
 use anyhow::Context;
 use async_trait::async_trait;
@@ -38,6 +39,13 @@ pub struct IrohConnector {
     /// This is useful for testing, or forcing non-default network
     /// connectivity.
     pub connection_overrides: BTreeMap<NodeId, NodeAddr>,
+
+    /// Connection pool for stable endpoint connections
+    connections_stable: Arc<tokio::sync::Mutex<HashMap<NodeId, Connection>>>,
+
+    /// Connection pool for next endpoint connections  
+    next_connections:
+        Arc<tokio::sync::Mutex<HashMap<iroh_next::NodeId, iroh_next::endpoint::Connection>>>,
 }
 
 impl IrohConnector {
@@ -216,12 +224,102 @@ impl IrohConnector {
             endpoint_stable,
             endpoint_next,
             connection_overrides: BTreeMap::new(),
+            connections_stable: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+            next_connections: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
         })
     }
 
     pub fn with_connection_override(mut self, node: NodeId, addr: NodeAddr) -> Self {
         self.connection_overrides.insert(node, addr);
         self
+    }
+
+    async fn get_or_create_connection_stable(
+        &self,
+        node_id: NodeId,
+        node_addr: Option<NodeAddr>,
+    ) -> PeerResult<Connection> {
+        // Check if we have an existing connection
+        if let Some(conn) = self.connections_stable.lock().await.get(&node_id) {
+            if conn.close_reason().is_none() {
+                trace!(target: LOG_NET_IROH, %node_id, "Using existing stable connection");
+                return Ok(conn.clone());
+            }
+        }
+
+        trace!(target: LOG_NET_IROH, %node_id, "Creating new stable connection");
+        let conn = match node_addr {
+            Some(node_addr) => {
+                trace!(target: LOG_NET_IROH, %node_id, "Using a connectivity override for connection");
+                let conn = self.endpoint_stable
+                    .connect(node_addr.clone(), FEDIMINT_API_ALPN)
+                    .await;
+
+                #[cfg(not(target_family = "wasm"))]
+                if conn.is_ok() {
+                    Self::spawn_connection_monitoring_stable(&self.endpoint_stable, node_id);
+                }
+                conn
+            }
+            None => self.endpoint_stable.connect(node_id, FEDIMINT_API_ALPN).await,
+        }.map_err(PeerError::Connection)?;
+
+        // Add to connection pool
+        self.connections_stable
+            .lock()
+            .await
+            .insert(node_id, conn.clone());
+
+        Ok(conn)
+    }
+
+    async fn get_or_create_connection_next(
+        &self,
+        endpoint_next: &iroh_next::Endpoint,
+        node_id: NodeId,
+        node_addr: Option<NodeAddr>,
+    ) -> PeerResult<iroh_next::endpoint::Connection> {
+        let next_node_id = iroh_next::NodeId::from_bytes(node_id.as_bytes()).expect("Can't fail");
+
+        // Check if we have an existing connection
+        if let Some(conn) = self.next_connections.lock().await.get(&next_node_id) {
+            if conn.close_reason().is_none() {
+                trace!(target: LOG_NET_IROH, %node_id, "Using existing next connection");
+                return Ok(conn.clone());
+            }
+        }
+
+        trace!(target: LOG_NET_IROH, %node_id, "Creating new next connection");
+        let conn = match node_addr {
+            Some(node_addr) => {
+                trace!(target: LOG_NET_IROH, %node_id, "Using a connectivity override for connection");
+                let node_addr = node_addr_stable_to_next(&node_addr);
+                let conn = endpoint_next
+                    .connect(node_addr.clone(), FEDIMINT_API_ALPN)
+                    .await;
+
+                #[cfg(not(target_family = "wasm"))]
+                if conn.is_ok() {
+                    Self::spawn_connection_monitoring_next(endpoint_next, &node_addr);
+                }
+
+                conn
+            }
+            None => endpoint_next.connect(
+                next_node_id,
+                FEDIMINT_API_ALPN
+            ).await,
+        }
+        .map_err(Into::into)
+        .map_err(PeerError::Connection)?;
+
+        // Add to connection pool
+        self.next_connections
+            .lock()
+            .await
+            .insert(next_node_id, conn.clone());
+
+        Ok(conn)
     }
 }
 
@@ -241,59 +339,35 @@ impl IClientConnector for IrohConnector {
             Pin<Box<dyn Future<Output = (PeerResult<DynClientConnection>, &'static str)> + Send>>,
         >::new();
         let connection_override = self.connection_overrides.get(&node_id).cloned();
-        let endpoint_stable = self.endpoint_stable.clone();
-        let endpoint_next = self.endpoint_next.clone();
 
+        // Use connection pool for stable endpoint
+        let self_clone = self.clone();
         futures.push(Box::pin({
             let connection_override = connection_override.clone();
-            async move {(
-                match connection_override {
-                    Some(node_addr) => {
-                        trace!(target: LOG_NET_IROH, %node_id, "Using a connectivity override for connection");
-                        let conn = endpoint_stable
-                            .connect(node_addr.clone(), FEDIMINT_API_ALPN)
-                            .await;
+            async move {
+                (
+                    self_clone
+                        .get_or_create_connection_stable(node_id, connection_override)
+                        .await
+                        .map(super::IClientConnection::into_dyn),
+                    "stable",
+                )
+            }
+        }));
 
-                        #[cfg(not(target_family = "wasm"))]
-                        if conn.is_ok() {
-                            Self::spawn_connection_monitoring_stable(&endpoint_stable, node_id);
-                        }
-                        conn
-
-                    }
-                    None => endpoint_stable.connect(node_id, FEDIMINT_API_ALPN).await,
-                }.map_err(PeerError::Connection)
-                .map(super::IClientConnection::into_dyn)
-            , "stable")
-        }}));
-
-        if let Some(endpoint_next) = endpoint_next {
-            futures.push(Box::pin(async move {(
-                match connection_override {
-                    Some(node_addr) => {
-                        trace!(target: LOG_NET_IROH, %node_id, "Using a connectivity override for connection");
-                        let node_addr = node_addr_stable_to_next(&node_addr);
-                        let conn = endpoint_next
-                            .connect(node_addr.clone(), FEDIMINT_API_ALPN)
-                            .await;
-
-                        #[cfg(not(target_family = "wasm"))]
-                        if conn.is_ok() {
-                            Self::spawn_connection_monitoring_next(&endpoint_next, &node_addr);
-                        }
-
-                        conn
-                    }
-                    None => endpoint_next.connect(
-                            iroh_next::NodeId::from_bytes(node_id.as_bytes()).expect("Can't fail"),
-                            FEDIMINT_API_ALPN
-                        ).await,
-                    }
-                    .map_err(Into::into)
-                    .map_err(PeerError::Connection)
-                    .map(super::IClientConnection::into_dyn),
-                    "next"
-            )}));
+        // Use connection pool for next endpoint if available
+        if let Some(endpoint_next) = &self.endpoint_next {
+            let self_clone = self.clone();
+            let endpoint_next = endpoint_next.clone();
+            futures.push(Box::pin(async move {
+                (
+                    self_clone
+                        .get_or_create_connection_next(&endpoint_next, node_id, connection_override)
+                        .await
+                        .map(super::IClientConnection::into_dyn),
+                    "next",
+                )
+            }));
         }
 
         // Remember last error, so we have something to return if


### PR DESCRIPTION
On top of #7785 

These are actually costly, as they might require new relay connections, which can lead to rate limiting.

We are already doing reconnections and connection reuse on the api level, but these are not reused between preview and join, which seems to be causing rate limiting on relays for users, as public relays might be quite stingy with limits.

After #7785 we do preserve the connector itself between preview and join, etc. so reusing connections at the connector level will reuse them preview and join.


Things to consider:

* These do not use any backoff - it is already done at the api layer, where it seems to belong better.
* jsonrpsee_core::Client can be shared between threads with `Arc<Client> and also has ability to check if the Client is connected, so could apply the same method; should it?
* This is somewhat redundant now with `struct ClientConnection` and `ReconnectClientConnections`, though these also do the connection attempts backoff now. Should we get rid of these now or leave only backoff there?

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
