### PR TITLE
refactor: cleanup unused lightning module mode env var

### DIFF
--- a/devimint/src/vars.rs
+++ b/devimint/src/vars.rs
@@ -179,7 +179,6 @@ declare_vars! {
 
         FM_GATEWAY_SKIP_WAIT_FOR_SYNC: String = "1"; env: "FM_GATEWAY_SKIP_WAIT_FOR_SYNC";
         FM_GATEWAY_NETWORK: String = "regtest"; env: "FM_GATEWAY_NETWORK";
-        FM_GATEWAY_LIGHTNING_MODULE_MODE: String = "All"; env: "FM_GATEWAY_LIGHTNING_MODULE_MODE";
 
         FM_FAUCET_BIND_ADDR: String = f!("0.0.0.0:{FM_PORT_FAUCET}"); env: "FM_FAUCET_BIND_ADDR";
 

--- a/gateway/fedimint-gateway-server/src/envs.rs
+++ b/gateway/fedimint-gateway-server/src/envs.rs
@@ -26,12 +26,6 @@ pub const FM_NUMBER_OF_ROUTE_HINTS_ENV: &str = "FM_NUMBER_OF_ROUTE_HINTS";
 /// recovering from an existing mnemonic.
 pub const FM_GATEWAY_MNEMONIC_ENV: &str = "FM_GATEWAY_MNEMONIC";
 
-/// Environment variable that specifies the "module mode" the gateway should run
-/// in. Options are "LNv1", "LNv2", or "All". It is not recommended to run "All"
-/// in production so that clients are not able to use the same gateway to create
-/// LNv1 and LNv2 invoices.
-pub const FM_GATEWAY_LIGHTNING_MODULE_MODE_ENV: &str = "FM_GATEWAY_LIGHTNING_MODULE_MODE";
-
 /// Environment variable that instructs the gateway to run in "debug mode",
 /// which allows errors to return to clients without redacting private
 /// information.


### PR DESCRIPTION
`FM_GATEWAY_LIGHTNING_MODULE_MODE` no longer does anything. There were a few spots in devimint that were not cleaned up originally.

All occurrences can be removed once `v0.9` is no longer supported.