### PR TITLE
fix(client): disconnect before going to sleep

### DIFF
--- a/fedimint-api-client/src/api/mod.rs
+++ b/fedimint-api-client/src/api/mod.rs
@@ -1194,6 +1194,8 @@ impl ClientConnection {
                         Err(e) => {
                             trace!(target: LOG_CLIENT_NET_API, "Failed to connect to peer api {e}");
 
+                            drop(senders);
+
                             fedimint_core::task::sleep(
                                 backoff.next().expect("No limit to the number of retries"),
                             )


### PR DESCRIPTION
If there are any requestors that wanted to make a connection and we were not able to, it's better to tell them right away, instead of waiting the whole backoff time. Some of them might actually not immediately retry.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
