### PR TITLE
 chore(client): add connection reuse to WebsocketConnector 

### DIFF
--- a/fedimint-api-client/src/api/mod.rs
+++ b/fedimint-api-client/src/api/mod.rs
@@ -698,12 +698,11 @@ impl WebsocketConnector {
             .entry(peer_id)
             .and_modify(|entry_arc| {
                 // Check if existing connection is disconnected and remove it
-                if let Some(existing_conn) = entry_arc.get() {
-                    if !existing_conn.is_connected() {
+                if let Some(existing_conn) = entry_arc.get()
+                    && !existing_conn.is_connected() {
                         trace!(target: LOG_NET_WS, %peer_id, "Existing connection is disconnected, removing from pool");
                         *entry_arc = Arc::new(OnceCell::new());
                     }
-                }
             })
             .or_insert_with(|| Arc::new(OnceCell::new()))
             .clone();


### PR DESCRIPTION
Analogous to Iroh change in https://github.com/fedimint/fedimint/pull/7804, that should help with preview & join flow on non-Iroh federations, as with the #7804 it was reported that Iroh federations are  faster to join than non-Iroh ones. :D

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
