### PR TITLE
[Backport releases/v0.9] fix: enable aws_lc_rs crypto provider for tokio-rustls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -304,7 +304,7 @@ threshold_crypto = { version = "0.2.1", package = "fedimint-threshold-crypto" }
 tikv-jemallocator = "0.5"
 time = "0.3.41"
 tokio = "1.46.1"
-tokio-rustls = "0.26.0"
+tokio-rustls = { version = "0.26.0", features = ["aws_lc_rs"] }
 tokio-stream = "0.1.17"
 tokio-test = "0.4.4"
 tokio-util = "0.7.15"

--- a/fedimint-core/src/rustls.rs
+++ b/fedimint-core/src/rustls.rs
@@ -9,7 +9,7 @@ pub async fn install_crypto_provider() {
 
     INSTALL_CRYPTO
         .get_or_init(|| async {
-            if tokio_rustls::rustls::crypto::ring::default_provider()
+            if tokio_rustls::rustls::crypto::aws_lc_rs::default_provider()
                 .install_default()
                 .is_err()
             {


### PR DESCRIPTION
# Description
Backport of #7813 to `releases/v0.9`.