### PR TITLE
[Backport releases/v0.9] fix(client): disconnect before going to sleep

### DIFF
--- a/fedimint-api-client/src/api/mod.rs
+++ b/fedimint-api-client/src/api/mod.rs
@@ -1194,6 +1194,8 @@ impl ClientConnection {
                         Err(e) => {
                             trace!(target: LOG_CLIENT_NET_API, "Failed to connect to peer api {e}");
 
+                            drop(senders);
+
                             fedimint_core::task::sleep(
                                 backoff.next().expect("No limit to the number of retries"),
                             )


### PR DESCRIPTION
# Description
Backport of #7808 to `releases/v0.9`.