### PR TITLE
fix: pin fs-lock to v0.1.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,7 +215,7 @@ fedimint-wallet-server = { path = "./modules/fedimint-wallet-server", version = 
 fedimintd = { path = "./fedimintd", version = "=0.10.0-alpha" }
 fedimintd-envs = { path = "./fedimintd-envs", version = "=0.10.0-alpha" }
 ff = "0.13.1"
-fs-lock = "0.1.10"
+fs-lock = "=0.1.10"
 fs2 = "0.4.3"
 futures = "0.3.31"
 futures-util = "0.3.30"


### PR DESCRIPTION
fs-lock `v0.1.11` has an issue on Android since they changed their locking mechanism

https://github.com/cargo-bins/cargo-binstall/pull/2254

We should pin our dependency to `v0.1.10` so that fedimintd can work with Android's file system