### PR TITLE
chore(core): use non-async rwlock in MemDatabase

### DIFF
--- a/fedimint-core/src/db/mem_impl.rs
+++ b/fedimint-core/src/db/mem_impl.rs
@@ -4,7 +4,6 @@ use std::path::Path;
 
 use anyhow::Result;
 use futures::{StreamExt, stream};
-use hex::ToHex;
 use imbl::OrdMap;
 use macro_rules_attribute::apply;
 
@@ -72,17 +71,6 @@ pub struct DummyError;
 impl MemDatabase {
     pub fn new() -> Self {
         Self::default()
-    }
-
-    pub async fn dump_db(&self) {
-        #[allow(clippy::significant_drop_in_scrutinee)]
-        for (key, value) in self.data.read().expect("Poisoned rwlock").iter() {
-            println!(
-                "{}: {}",
-                key.encode_hex::<String>(),
-                value.encode_hex::<String>()
-            );
-        }
     }
 }
 


### PR DESCRIPTION
There's no need for async in there, and I'm seeing weird hangs on db operations that go away if I change this one detail.

#7806 does not work without this change (hangs 95% of the time) in the same spot when trying to open database transaction, and while the `db.begin_database_transaction().await` returns inside `begin_database_transaction`, it never moves past that `.await` calling it (according to `dbg!()` statements I added everywhere hunting for it). This looks like either some miscompilation or tokio's malfunction. But this change fixes it.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
