### PR TITLE
chore: enable base32 decoding of `OOBNotes`

### DIFF
--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -39,6 +39,7 @@ use fedimint_client::module::module::init::ClientModuleInit;
 use fedimint_client::module_init::ClientModuleInitRegistry;
 use fedimint_client::secret::RootSecretStrategy;
 use fedimint_client::{AdminCreds, Client, ClientBuilder, ClientHandleArc, RootSecret};
+use fedimint_core::base32::FEDIMINT_PREFIX;
 use fedimint_core::config::{FederationId, FederationIdPrefix};
 use fedimint_core::core::{ModuleInstanceId, OperationId};
 use fedimint_core::db::{Database, DatabaseValue};
@@ -48,7 +49,9 @@ use fedimint_core::module::{ApiAuth, ApiRequestErased};
 use fedimint_core::setup_code::PeerSetupCode;
 use fedimint_core::transaction::Transaction;
 use fedimint_core::util::{SafeUrl, backoff_util, handle_version_hash_command, retry};
-use fedimint_core::{Amount, PeerId, TieredMulti, fedimint_build_code_version_env, runtime};
+use fedimint_core::{
+    Amount, PeerId, TieredMulti, base32, fedimint_build_code_version_env, runtime,
+};
 use fedimint_eventlog::{EventLogId, EventLogTrimableId};
 use fedimint_ln_client::LightningClientInit;
 use fedimint_logging::{LOG_CLIENT, TracingSetup};
@@ -1148,7 +1151,7 @@ impl FedimintCli {
                     })
                 }
                 DecodeType::SetupCode { setup_code } => {
-                    let setup_code = PeerSetupCode::decode_base32(&setup_code)
+                    let setup_code = base32::decode_prefixed(FEDIMINT_PREFIX, &setup_code)
                         .map_err_cli_msg("failed to decode setup code")?;
 
                     Ok(CliOutput::SetupCode { setup_code })

--- a/fedimint-core/src/invite_code.rs
+++ b/fedimint-core/src/invite_code.rs
@@ -9,11 +9,12 @@ use anyhow::ensure;
 use bech32::{Bech32m, Hrp};
 use serde::{Deserialize, Serialize};
 
+use crate::base32::FEDIMINT_PREFIX;
 use crate::config::FederationId;
 use crate::encoding::{Decodable, DecodeError, Encodable};
 use crate::module::registry::{ModuleDecoderRegistry, ModuleRegistry};
 use crate::util::SafeUrl;
-use crate::{NumPeersExt, PeerId, base32};
+use crate::{NumPeersExt, PeerId};
 
 /// Information required for client to join Federation
 ///
@@ -170,24 +171,6 @@ impl InviteCode {
             })
             .expect("Ensured by constructor")
     }
-
-    pub fn encode_base32(&self) -> String {
-        format!(
-            "fedimint{}",
-            base32::encode(&self.consensus_encode_to_vec())
-        )
-    }
-
-    pub fn decode_base32(s: &str) -> anyhow::Result<Self> {
-        ensure!(s.starts_with("fedimint"), "Invalid Prefix");
-
-        let params = Self::consensus_decode_whole(
-            &base32::decode(&s[8..])?,
-            &ModuleDecoderRegistry::default(),
-        )?;
-
-        Ok(params)
-    }
 }
 
 /// For extendability [`InviteCode`] consists of parts, where client can ignore
@@ -232,7 +215,7 @@ impl FromStr for InviteCode {
     type Err = anyhow::Error;
 
     fn from_str(encoded: &str) -> Result<Self, Self::Err> {
-        if let Ok(invite_code) = Self::decode_base32(encoded) {
+        if let Ok(invite_code) = crate::base32::decode_prefixed(FEDIMINT_PREFIX, encoded) {
             return Ok(invite_code);
         }
 
@@ -279,6 +262,7 @@ mod tests {
     use std::str::FromStr;
 
     use fedimint_core::PeerId;
+    use fedimint_core::base32::FEDIMINT_PREFIX;
 
     use crate::config::FederationId;
     use crate::invite_code::InviteCode;
@@ -288,8 +272,11 @@ mod tests {
         let invite_code_str = "fed11qgqpu8rhwden5te0vejkg6tdd9h8gepwd4cxcumxv4jzuen0duhsqqfqh6nl7sgk72caxfx8khtfnn8y436q3nhyrkev3qp8ugdhdllnh86qmp42pm";
         let invite_code = InviteCode::from_str(invite_code_str).expect("valid invite code");
 
-        InviteCode::from_str(&invite_code.encode_base32())
-            .expect("Failed to parse base 32 invite code");
+        InviteCode::from_str(&crate::base32::encode_prefixed(
+            FEDIMINT_PREFIX,
+            &invite_code,
+        ))
+        .expect("Failed to parse base 32 invite code");
 
         assert_eq!(invite_code.to_string(), invite_code_str);
         assert_eq!(

--- a/fedimint-core/src/setup_code.rs
+++ b/fedimint-core/src/setup_code.rs
@@ -1,9 +1,6 @@
-use anyhow::ensure;
 use serde::Serialize;
 
-use crate::base32;
 use crate::encoding::{Decodable, Encodable};
-use crate::module::registry::ModuleDecoderRegistry;
 use crate::util::SafeUrl;
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Encodable, Decodable, Serialize)]
@@ -17,26 +14,6 @@ pub struct PeerSetupCode {
     pub federation_name: Option<String>,
     /// Whether to disable base fees, set by the leader
     pub disable_base_fees: Option<bool>,
-}
-
-impl PeerSetupCode {
-    pub fn encode_base32(&self) -> String {
-        format!(
-            "fedimint{}",
-            base32::encode(&self.consensus_encode_to_vec())
-        )
-    }
-
-    pub fn decode_base32(s: &str) -> anyhow::Result<Self> {
-        ensure!(s.starts_with("fedimint"), "Invalid Prefix");
-
-        let params = Self::consensus_decode_whole(
-            &base32::decode(&s[8..])?,
-            &ModuleDecoderRegistry::default(),
-        )?;
-
-        Ok(params)
-    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Encodable, Decodable, Serialize)]

--- a/fedimint-server/src/config/setup.rs
+++ b/fedimint-server/src/config/setup.rs
@@ -6,8 +6,8 @@ use std::sync::Arc;
 
 use anyhow::{Context, ensure};
 use async_trait::async_trait;
-use fedimint_core::PeerId;
 use fedimint_core::admin_client::{SetLocalParamsRequest, SetupStatus};
+use fedimint_core::base32::FEDIMINT_PREFIX;
 use fedimint_core::config::META_FEDERATION_NAME_KEY;
 use fedimint_core::core::ModuleInstanceId;
 use fedimint_core::db::Database;
@@ -23,6 +23,7 @@ use fedimint_core::module::{
     ApiAuth, ApiEndpoint, ApiEndpointContext, ApiError, ApiRequestErased, ApiVersion, api_endpoint,
 };
 use fedimint_core::setup_code::PeerEndpoints;
+use fedimint_core::{PeerId, base32};
 use fedimint_logging::LOG_SERVER;
 use fedimint_server_core::net::check_auth;
 use fedimint_server_core::setup_ui::ISetupApi;
@@ -117,7 +118,7 @@ impl ISetupApi for SetupApi {
             .await
             .local_params
             .as_ref()
-            .map(|lp| lp.setup_code().encode_base32())
+            .map(|lp| base32::encode_prefixed(FEDIMINT_PREFIX, &lp.setup_code()))
     }
 
     async fn auth(&self) -> Option<ApiAuth> {
@@ -157,7 +158,10 @@ impl ISetupApi for SetupApi {
             && existing_local_parameters.federation_name == federation_name
             && existing_local_parameters.disable_base_fees == disable_base_fees
         {
-            return Ok(existing_local_parameters.setup_code().encode_base32());
+            return Ok(base32::encode_prefixed(
+                FEDIMINT_PREFIX,
+                &existing_local_parameters.setup_code(),
+            ));
         }
 
         ensure!(!name.is_empty(), "The guardian name is empty");
@@ -241,11 +245,11 @@ impl ISetupApi for SetupApi {
 
         state.local_params = Some(lp.clone());
 
-        Ok(lp.setup_code().encode_base32())
+        Ok(base32::encode_prefixed(FEDIMINT_PREFIX, &lp.setup_code()))
     }
 
     async fn add_peer_setup_code(&self, info: String) -> anyhow::Result<String> {
-        let info = PeerSetupCode::decode_base32(&info)?;
+        let info = base32::decode_prefixed(FEDIMINT_PREFIX, &info)?;
 
         let mut state = self.state.lock().await;
 

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -58,6 +58,7 @@ use fedimint_client_module::transaction::{
     ClientOutputSM, TransactionBuilder,
 };
 use fedimint_client_module::{DynGlobalClientContext, sm_enum_variant_translation};
+use fedimint_core::base32::FEDIMINT_PREFIX;
 use fedimint_core::config::{FederationId, FederationIdPrefix};
 use fedimint_core::core::{Decoder, IntoDynInstance, ModuleInstanceId, ModuleKind, OperationId};
 use fedimint_core::db::{
@@ -74,7 +75,7 @@ use fedimint_core::secp256k1::{All, Keypair, Secp256k1};
 use fedimint_core::util::{BoxFuture, BoxStream, NextOrPending, SafeUrl};
 use fedimint_core::{
     Amount, OutPoint, PeerId, Tiered, TieredCounts, TieredMulti, TransactionId, apply,
-    async_trait_maybe_send, push_db_pair_items,
+    async_trait_maybe_send, base32, push_db_pair_items,
 };
 use fedimint_derive_secret::{ChildId, DerivableSecret};
 use fedimint_logging::LOG_CLIENT_MODULE_MINT;
@@ -329,17 +330,24 @@ const BASE64_URL_SAFE: base64::engine::GeneralPurpose = base64::engine::GeneralP
 impl FromStr for OOBNotes {
     type Err = anyhow::Error;
 
-    /// Decode a set of out-of-band e-cash notes from a base64 string.
+    /// Decode a set of out-of-band e-cash notes from a base64 or base32 string.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let s: String = s.chars().filter(|&c| !c.is_whitespace()).collect();
 
-        let bytes = if let Ok(bytes) = BASE64_URL_SAFE.decode(&s) {
-            bytes
+        let oob_notes_bytes = if let Ok(oob_notes_bytes) =
+            base32::decode_prefixed_bytes(FEDIMINT_PREFIX, &s)
+        {
+            oob_notes_bytes
+        } else if let Ok(oob_notes_bytes) = BASE64_URL_SAFE.decode(&s) {
+            oob_notes_bytes
+        } else if let Ok(oob_notes_bytes) = base64::engine::general_purpose::STANDARD.decode(&s) {
+            oob_notes_bytes
         } else {
-            base64::engine::general_purpose::STANDARD.decode(&s)?
+            bail!("OOBNotes were not a well-formed base64(URL-safe) or base32 string");
         };
-        let oob_notes: OOBNotes =
-            Decodable::consensus_decode_whole(&bytes, &ModuleDecoderRegistry::default())?;
+
+        let oob_notes =
+            OOBNotes::consensus_decode_whole(&oob_notes_bytes, &ModuleDecoderRegistry::default())?;
 
         ensure!(!oob_notes.notes().is_empty(), "OOBNotes cannot be empty");
 
@@ -2435,6 +2443,7 @@ mod tests {
     use std::str::FromStr;
 
     use bitcoin_hashes::Hash;
+    use fedimint_core::base32::FEDIMINT_PREFIX;
     use fedimint_core::config::FederationId;
     use fedimint_core::encoding::Decodable;
     use fedimint_core::invite_code::InviteCode;
@@ -2618,14 +2627,21 @@ mod tests {
 
     fn test_roundtrip_serialize_str<T, F>(data: T, assertions: F)
     where
-        T: FromStr + Display,
+        T: FromStr + Display + crate::Encodable + crate::Decodable,
         <T as FromStr>::Err: std::fmt::Debug,
         F: Fn(T),
     {
-        let data_str = data.to_string();
-        assertions(data);
-        let data_parsed = data_str.parse().expect("Deserialization failed");
+        let data_parsed = data.to_string().parse().expect("Deserialization failed");
+
         assertions(data_parsed);
+
+        let data_parsed = crate::base32::encode_prefixed(FEDIMINT_PREFIX, &data)
+            .parse()
+            .expect("Deserialization failed");
+
+        assertions(data_parsed);
+
+        assertions(data);
     }
 
     #[test]


### PR DESCRIPTION
Slightly modified version of #7752 keeping the base64 compatibility.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
