### PR TITLE
chore: automatically spawn lnurl receive task for lnv2 client module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3630,6 +3630,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bitcoin",
+ "chrono",
  "clap",
  "devimint",
  "fedimint-client",

--- a/modules/fedimint-lnv2-client/src/cli.rs
+++ b/modules/fedimint-lnv2-client/src/cli.rs
@@ -48,11 +48,6 @@ enum LnurlOpts {
         #[arg(long)]
         gateway: Option<SafeUrl>,
     },
-    /// Receive an lnurl.
-    Receive {
-        #[arg(long)]
-        batch_size: Option<usize>,
-    },
 }
 
 #[derive(Clone, Subcommand, Serialize)]
@@ -113,21 +108,10 @@ pub(crate) async fn handle_cli_command(
                 recurringd,
                 gateway,
             } => json(lightning.generate_lnurl(recurringd, gateway).await?),
-            LnurlOpts::Receive { batch_size } => {
-                json(lightning.receive_lnurl(batch_size, Value::Null).await)
-            }
         },
         Opts::Gateways(gateway_opts) => match gateway_opts {
             #[allow(clippy::unit_arg)]
-            GatewaysOpts::Map => json(
-                LightningClientModule::update_gateway_map(
-                    &lightning.federation_id,
-                    &lightning.client_ctx,
-                    &lightning.module_api,
-                    &lightning.gateway_conn,
-                )
-                .await,
-            ),
+            GatewaysOpts::Map => json(lightning.update_gateway_map().await),
             GatewaysOpts::Select { invoice } => json(lightning.select_gateway(invoice).await?.0),
             GatewaysOpts::List { peer } => match peer {
                 Some(peer) => json(lightning.module_api.gateways_from_peer(peer).await?),

--- a/modules/fedimint-lnv2-tests/Cargo.toml
+++ b/modules/fedimint-lnv2-tests/Cargo.toml
@@ -19,6 +19,7 @@ path = "tests/tests.rs"
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 bitcoin = { workspace = true }
+chrono = { workspace = true }
 clap = { workspace = true }
 devimint = { workspace = true }
 fedimint-client = { workspace = true }

--- a/modules/fedimint-lnv2-tests/tests/tests.rs
+++ b/modules/fedimint-lnv2-tests/tests/tests.rs
@@ -32,6 +32,11 @@ fn fixtures() -> Fixtures {
     fixtures.with_module(
         LightningClientInit {
             gateway_conn: Arc::new(MockGatewayConnection::default()),
+            custom_meta_fn: Arc::new(|| {
+                serde_json::json!({
+                    "timestamp": chrono::Utc::now().timestamp(),
+                })
+            }),
         },
         LightningInit,
         LightningGenParams::regtest(bitcoin_server.clone()),


### PR DESCRIPTION
This pr makes it simpler to integrate lnv2 for clients as we do not require integrators to spawn a task to monitor and receive incoming lnurl payments anymore. This is now done automatically. 

Since there is now no public method / cli command to do it manually we verify the successful receive of the payments made via lnurl via the clients balance.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
