### PR TITLE
feat: Cache ClientPreview on fedimint-client-rpc

### DIFF
--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -96,7 +96,7 @@ pub mod module_init;
 
 pub mod sm;
 pub use client::Client;
-pub use client::builder::{ClientBuilder, RootSecret};
+pub use client::builder::{ClientBuilder, ClientPreview, RootSecret};
 pub use client::handle::{ClientHandle, ClientHandleArc};
 pub use fedimint_client_module as module;
 /// Re-exporting of everything from `fedimint_client_module`


### PR DESCRIPTION
Resolves #7858 

- ~~implemented Clone for ClientPreview and ClientBuilder so it can be cached and reused~~
-  cache last fetched ClientPreview(only one) by preview_federation, and use it for joining the fed if join is called upon the same as cached one.

