### PR TITLE
chore(docker): bump docker compose image to v0.9.0

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   fedimintd:
-    image: fedimint/fedimintd:v0.8.1
+    image: fedimint/fedimintd:v0.9.0
     ports:
       - 8173:8173/tcp # p2p tls
       - 8173:8173/udp # p2p iroh


### PR DESCRIPTION
Followup to https://github.com/fedimint/fedimint/issues/7812

We released `v0.9.0` so we can bump the image used in docker compose.