### PR TITLE
refactor: rename Connector to ConnectorType

### DIFF
--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -10,7 +10,7 @@ use std::{env, fs, iter};
 use anyhow::{Context, Result, anyhow, bail};
 use bitcoincore_rpc::bitcoin::Network;
 use fedimint_api_client::api::DynGlobalApi;
-use fedimint_api_client::api::net::Connector;
+use fedimint_api_client::api::net::ConnectorType;
 use fedimint_client_module::module::ClientModule;
 use fedimint_core::admin_client::{ServerStatusLegacy, SetupStatus};
 use fedimint_core::config::{ClientConfig, ServerModuleConfigGenParamsRegistry, load_from_file};
@@ -380,7 +380,7 @@ impl Federation {
                 .await
                 .context("Awaiting invite code file")?;
 
-                Connector::default()
+                ConnectorType::default()
                     .download_from_invite_code(&InviteCode::from_str(&invite_code)?, false, false)
                     .await?;
             }

--- a/fedimint-api-client/src/api/net.rs
+++ b/fedimint-api-client/src/api/net.rs
@@ -6,39 +6,39 @@ use serde::{Deserialize, Serialize};
 
 /// TODO: rename, or even remove?
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Encodable, Decodable, Serialize, Deserialize)]
-pub enum Connector {
+pub enum ConnectorType {
     Tcp,
     #[cfg(feature = "tor")]
     Tor,
 }
 
-impl Connector {
+impl ConnectorType {
     #[cfg(feature = "tor")]
-    pub fn tor() -> Connector {
-        Connector::Tor
+    pub fn tor() -> ConnectorType {
+        ConnectorType::Tor
     }
 }
 
-impl Default for Connector {
+impl Default for ConnectorType {
     fn default() -> Self {
         Self::Tcp
     }
 }
 
-impl fmt::Display for Connector {
+impl fmt::Display for ConnectorType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{self:?}")
     }
 }
 
-impl FromStr for Connector {
+impl FromStr for ConnectorType {
     type Err = &'static str;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
-            "tcp" => Ok(Connector::Tcp),
+            "tcp" => Ok(ConnectorType::Tcp),
             #[cfg(feature = "tor")]
-            "tor" => Ok(Connector::Tor),
+            "tor" => Ok(ConnectorType::Tor),
             _ => Err("invalid connector!"),
         }
     }

--- a/fedimint-api-client/src/lib.rs
+++ b/fedimint-api-client/src/lib.rs
@@ -6,7 +6,7 @@
 #![allow(clippy::return_self_not_must_use)]
 
 use anyhow::{Context as _, bail};
-use api::net::Connector;
+use api::net::ConnectorType;
 use api::{DynGlobalApi, FederationApiExt as _, PeerError};
 use fedimint_core::config::{ClientConfig, FederationId};
 use fedimint_core::endpoint_constants::CLIENT_CONFIG_ENDPOINT;
@@ -21,9 +21,9 @@ pub mod api;
 /// Client query system
 pub mod query;
 
-impl Connector {
+impl ConnectorType {
     /// Tries to download the [`ClientConfig`] from the federation with an
-    /// specified [`Connector`] variant, attempts to retry ten times before
+    /// specified [`ConnectorType`] variant, attempts to retry ten times before
     /// giving up.
     pub async fn download_from_invite_code(
         &self,

--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -31,7 +31,7 @@ use client::ModuleSelector;
 use envs::FM_USE_TOR_ENV;
 use envs::{FM_API_SECRET_ENV, FM_DB_BACKEND_ENV, FM_IROH_ENABLE_DHT_ENV, SALT_FILE};
 use fedimint_aead::{encrypted_read, encrypted_write, get_encryption_key};
-use fedimint_api_client::api::net::Connector;
+use fedimint_api_client::api::net::ConnectorType;
 use fedimint_api_client::api::{DynGlobalApi, FederationApiExt, FederationError};
 use fedimint_bip39::{Bip39RootSecretStrategy, Mnemonic};
 use fedimint_client::module::meta::{FetchKind, LegacyMetaSource, MetaSource};
@@ -337,15 +337,15 @@ impl Opts {
     }
 
     #[allow(clippy::unused_self)]
-    fn connector(&self) -> Connector {
+    fn connector(&self) -> ConnectorType {
         #[cfg(feature = "tor")]
         if self.use_tor {
-            Connector::tor()
+            ConnectorType::tor()
         } else {
-            Connector::default()
+            ConnectorType::default()
         }
         #[cfg(not(feature = "tor"))]
-        Connector::default()
+        ConnectorType::default()
     }
 }
 

--- a/fedimint-client/src/client.rs
+++ b/fedimint-client/src/client.rs
@@ -12,7 +12,7 @@ use bitcoin::key::Secp256k1;
 use bitcoin::key::rand::thread_rng;
 use bitcoin::secp256k1::{self, PublicKey};
 use fedimint_api_client::api::global_api::with_request_hook::ApiRequestHook;
-use fedimint_api_client::api::net::Connector;
+use fedimint_api_client::api::net::ConnectorType;
 use fedimint_api_client::api::{
     ApiVersionSet, DynGlobalApi, FederationApiExt as _, FederationResult, IGlobalFederationApi,
 };
@@ -142,7 +142,7 @@ pub struct Client {
     operation_log: OperationLog,
     secp_ctx: Secp256k1<secp256k1::All>,
     meta_service: Arc<MetaService>,
-    connector: Connector,
+    connector: ConnectorType,
 
     task_group: TaskGroup,
 

--- a/fedimint-client/src/client/builder.rs
+++ b/fedimint-client/src/client/builder.rs
@@ -10,7 +10,7 @@ use fedimint_api_client::api::global_api::with_cache::GlobalFederationApiWithCac
 use fedimint_api_client::api::global_api::with_request_hook::{
     ApiRequestHook, RawFederationApiWithRequestHookExt as _,
 };
-use fedimint_api_client::api::net::Connector;
+use fedimint_api_client::api::net::ConnectorType;
 use fedimint_api_client::api::{
     ApiVersionSet, DynClientConnector, DynGlobalApi, FederationApiExt as _, ReconnectFederationApi,
     make_admin_connector, make_connector,
@@ -119,7 +119,7 @@ pub struct ClientBuilder {
     module_inits: ClientModuleInitRegistry,
     admin_creds: Option<AdminCreds>,
     meta_service: Arc<crate::meta::MetaService>,
-    connector: Connector,
+    connector: ConnectorType,
     stopped: bool,
     log_event_added_transient_tx: broadcast::Sender<EventLogEntry>,
     request_hook: ApiRequestHook,
@@ -140,7 +140,7 @@ impl ClientBuilder {
             broadcast::channel(1024);
         ClientBuilder {
             module_inits: ModuleInitRegistry::new(),
-            connector: Connector::default(),
+            connector: ConnectorType::default(),
             admin_creds: None,
             stopped: false,
             meta_service,
@@ -269,13 +269,13 @@ impl ClientBuilder {
         self.admin_creds = Some(creds);
     }
 
-    pub fn with_connector(&mut self, connector: Connector) {
+    pub fn with_connector(&mut self, connector: ConnectorType) {
         self.connector = connector;
     }
 
     #[cfg(feature = "tor")]
     pub fn with_tor_connector(&mut self) {
-        self.with_connector(Connector::tor());
+        self.with_connector(ConnectorType::tor());
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/fedimint-load-test-tool/src/main.rs
+++ b/fedimint-load-test-tool/src/main.rs
@@ -1068,7 +1068,7 @@ fn test_download_config(
             let event_sender = event_sender.clone();
             let f: BoxFuture<_> = Box::pin(async move {
                 let m = fedimint_core::time::now();
-                let _ = fedimint_api_client::api::net::Connector::default()
+                let _ = fedimint_api_client::api::net::ConnectorType::default()
                     .download_from_invite_code(&invite_code, false, false)
                     .await?;
                 event_sender.send(MetricEvent {
@@ -1093,7 +1093,7 @@ async fn test_connect_raw_client(
     use jsonrpsee_core::client::ClientT;
     use jsonrpsee_ws_client::WsClientBuilder;
 
-    let (mut cfg, _) = fedimint_api_client::api::net::Connector::default()
+    let (mut cfg, _) = fedimint_api_client::api::net::ConnectorType::default()
         .download_from_invite_code(&invite_code, false, false)
         .await?;
 

--- a/fedimint-recurringd/src/lib.rs
+++ b/fedimint-recurringd/src/lib.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::anyhow;
-use fedimint_api_client::api::net::Connector;
+use fedimint_api_client::api::net::ConnectorType;
 use fedimint_client::{Client, ClientHandleArc, ClientModule, ClientModuleInstance};
 use fedimint_core::config::FederationId;
 use fedimint_core::core::OperationId;
@@ -136,7 +136,7 @@ impl RecurringInvoiceServer {
             .await
             .map_err(RecurringPaymentError::JoiningFederationFailed)?;
 
-        client_builder.with_connector(Connector::default());
+        client_builder.with_connector(ConnectorType::default());
         client_builder.with_module(LightningClientInit::default());
         client_builder.with_module(MintClientInit);
 

--- a/gateway/fedimint-gateway-common/src/lib.rs
+++ b/gateway/fedimint-gateway-common/src/lib.rs
@@ -9,7 +9,7 @@ use clap::Subcommand;
 use envs::{
     FM_LDK_ALIAS_ENV, FM_LND_MACAROON_ENV, FM_LND_RPC_ADDR_ENV, FM_LND_TLS_CERT_ENV, FM_PORT_LDK,
 };
-use fedimint_api_client::api::net::Connector;
+use fedimint_api_client::api::net::ConnectorType;
 use fedimint_core::config::{FederationId, JsonClientConfig};
 use fedimint_core::core::OperationId;
 use fedimint_core::encoding::{Decodable, Encodable};
@@ -114,7 +114,7 @@ pub struct FederationConfig {
     pub federation_index: u64,
     pub lightning_fee: PaymentFee,
     pub transaction_fee: PaymentFee,
-    pub connector: Connector,
+    pub connector: ConnectorType,
 }
 
 /// Information about one of the feds we are connected to

--- a/gateway/fedimint-gateway-server-db/src/lib.rs
+++ b/gateway/fedimint-gateway-server-db/src/lib.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use bitcoin::hashes::{Hash, sha256};
-use fedimint_api_client::api::net::Connector;
+use fedimint_api_client::api::net::ConnectorType;
 use fedimint_core::config::FederationId;
 use fedimint_core::db::{
     Database, DatabaseTransaction, DatabaseVersion, GeneralDbMigrationFn,
@@ -285,7 +285,7 @@ pub struct FederationConfigV1 {
     pub timelock_delta: u64,
     #[serde(with = "serde_routing_fees")]
     pub fees: RoutingFees,
-    pub connector: Connector,
+    pub connector: ConnectorType,
 }
 
 #[derive(Debug, Clone, Encodable, Decodable, Eq, PartialEq, Hash, Ord, PartialOrd)]
@@ -478,7 +478,7 @@ async fn migrate_to_v2(mut ctx: GeneralDbMigrationFnContext<'_>) -> Result<(), a
                 federation_index: old_federation_config.federation_index,
                 timelock_delta: old_federation_config.timelock_delta,
                 fees: old_federation_config.fees,
-                connector: Connector::default(),
+                connector: ConnectorType::default(),
             };
             let new_federation_key = FederationConfigKeyV1 {
                 id: old_federation_id,
@@ -524,7 +524,7 @@ async fn migrate_to_v4(mut ctx: GeneralDbMigrationFnContext<'_>) -> Result<(), a
                 federation_index: old_federation_config.federation_index,
                 lightning_fee: old_federation_config.fees.into(),
                 transaction_fee: PaymentFee::TRANSACTION_FEE_DEFAULT,
-                connector: Connector::default(),
+                connector: ConnectorType::default(),
             };
             let new_key = FederationConfigKey { id: fed_id.id };
             dbtx.insert_new_entry(&new_key, &new_fed_config).await;

--- a/gateway/fedimint-gateway-server-db/src/migration_tests.rs
+++ b/gateway/fedimint-gateway-server-db/src/migration_tests.rs
@@ -16,7 +16,7 @@ use strum::IntoEnumIterator;
 use tracing::info;
 
 use super::{
-    BTreeMap, Connector, DbKeyPrefix, Encodable, FederationConfig, FederationConfigKey,
+    BTreeMap, ConnectorType, DbKeyPrefix, Encodable, FederationConfig, FederationConfigKey,
     FederationConfigKeyPrefix, FederationConfigKeyV0, FederationConfigV0, FederationId,
     GatewayConfigurationKeyV0, GatewayConfigurationV0, GatewayDbExt, GatewayPublicKey,
     IDatabaseTransactionOpsCoreTyped, InviteCode, Keypair, NetworkLegacyEncodingWrapper, OsRng,
@@ -181,7 +181,7 @@ async fn test_isolated_db_migration() -> anyhow::Result<()> {
             federation_index: 0,
             lightning_fee: PaymentFee::TRANSACTION_FEE_DEFAULT,
             transaction_fee: PaymentFee::TRANSACTION_FEE_DEFAULT,
-            connector: Connector::Tcp,
+            connector: ConnectorType::Tcp,
         },
     )
     .await;
@@ -200,7 +200,7 @@ async fn test_isolated_db_migration() -> anyhow::Result<()> {
             federation_index: 1,
             lightning_fee: PaymentFee::TRANSACTION_FEE_DEFAULT,
             transaction_fee: PaymentFee::TRANSACTION_FEE_DEFAULT,
-            connector: Connector::Tcp,
+            connector: ConnectorType::Tcp,
         },
     )
     .await;

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -43,7 +43,7 @@ use envs::FM_GATEWAY_SKIP_WAIT_FOR_SYNC_ENV;
 use error::FederationNotConnected;
 use events::ALL_GATEWAY_EVENTS;
 use federation_manager::FederationManager;
-use fedimint_api_client::api::net::Connector;
+use fedimint_api_client::api::net::ConnectorType;
 use fedimint_bip39::{Bip39RootSecretStrategy, Language, Mnemonic};
 use fedimint_bitcoind::bitcoincore::BitcoindClient;
 use fedimint_bitcoind::{EsploraClient, IBitcoindRpc};
@@ -1166,16 +1166,16 @@ impl Gateway {
 
         #[cfg(feature = "tor")]
         let connector = match &payload.use_tor {
-            Some(true) => Connector::tor(),
-            Some(false) => Connector::default(),
+            Some(true) => ConnectorType::tor(),
+            Some(false) => ConnectorType::default(),
             None => {
                 debug!(target: LOG_GATEWAY, "Missing `use_tor` payload field, defaulting to `Connector::Tcp` variant!");
-                Connector::default()
+                ConnectorType::default()
             }
         };
 
         #[cfg(not(feature = "tor"))]
-        let connector = Connector::default();
+        let connector = ConnectorType::default();
 
         let federation_id = invite_code.federation_id();
 


### PR DESCRIPTION
Current name kind of conflicts with `ClientConnector`, and this type doesn't do much of connecting ATM anyway.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
