### PR TITLE
feat: implement fountain codes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -939,7 +939,7 @@ dependencies = [
  "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "log",
@@ -2101,7 +2101,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357422a457ccb850dc8f1c1680e0670079560feaad6c2e247e3f345c4fab8a3f"
 dependencies = [
  "heck 0.5.0",
- "indexmap 1.9.3",
+ "indexmap 2.9.0",
  "itertools 0.14.0",
  "proc-macro-crate",
  "proc-macro2",
@@ -2119,7 +2119,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea41269bd490d251b9eca50ccb43117e641cc68b129849757c15ece88fe0574"
 dependencies = [
  "heck 0.5.0",
- "indexmap 1.9.3",
+ "indexmap 2.9.0",
  "itertools 0.14.0",
  "proc-macro-crate",
  "proc-macro2",
@@ -3165,6 +3165,17 @@ dependencies = [
  "test-log",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "fedimint-fountain"
+version = "0.10.0-alpha"
+dependencies = [
+ "anyhow",
+ "bitcoin_hashes 0.14.0",
+ "fedimint-core",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
 ]
 
 [[package]]
@@ -5398,7 +5409,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.59.0",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -6379,7 +6390,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -9717,7 +9728,7 @@ dependencies = [
  "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
- "windows 0.59.0",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -11785,7 +11796,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
   "fedimint-dbtool",
   "fedimint-derive",
   "fedimint-eventlog",
+  "fedimint-fountain",
   "fedimint-load-test-tool",
   "fedimint-logging",
   "fedimint-metrics",

--- a/fedimint-fountain/Cargo.toml
+++ b/fedimint-fountain/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+authors = { workspace = true }
+description = "Fountain encoder/decoder for splitting and recombining byte payloads"
+edition = { workspace = true }
+license = { workspace = true }
+name = "fedimint-fountain"
+readme = { workspace = true }
+repository = { workspace = true }
+version = { workspace = true }
+
+[lib]
+name = "fedimint_fountain"
+path = "./src/lib.rs"
+
+[dependencies]
+anyhow = { workspace = true }
+bitcoin_hashes = { workspace = true }
+fedimint-core = { workspace = true }
+rand = { workspace = true }
+rand_chacha = { workspace = true }
+
+[lints]
+workspace = true

--- a/fedimint-fountain/src/fountain.rs
+++ b/fedimint-fountain/src/fountain.rs
@@ -1,0 +1,375 @@
+use std::collections::BTreeMap;
+
+use bitcoin_hashes::Hash;
+use fedimint_core::encoding::{Decodable, Encodable};
+use rand::distributions::{Distribution, WeightedIndex};
+use rand::seq::IteratorRandom;
+use rand_chacha::ChaCha20Rng;
+use rand_chacha::rand_core::SeedableRng;
+
+fn checksum(data: &[u8]) -> [u8; 4] {
+    bitcoin_hashes::sha256::Hash::hash(data).to_byte_array()[..4]
+        .try_into()
+        .unwrap()
+}
+
+#[derive(Debug)]
+pub enum Error {
+    /// Received fragment is invalid.
+    InvalidFragment,
+    /// Received fragment is inconsistent with previous ones.
+    InconsistentFragment,
+}
+
+impl core::fmt::Display for Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::InvalidFragment => write!(f, "received invalid fragment"),
+            Self::InconsistentFragment => write!(f, "fragment is inconsistent with previous ones"),
+        }
+    }
+}
+
+/// An encoder capable of emitting fountain-encoded transmissions.
+#[derive(Debug)]
+pub struct Encoder {
+    fragments: Vec<Vec<u8>>,
+    message_length: usize,
+    checksum: [u8; 4],
+    index: u32,
+}
+
+impl Encoder {
+    pub fn new(message: &[u8], max_fragment_length: usize) -> Self {
+        assert!(!message.is_empty());
+        assert!(max_fragment_length > 0);
+
+        let fragment_length = fragment_length(message.len(), max_fragment_length);
+
+        let fragments = partition(message.to_vec(), fragment_length);
+
+        Self {
+            fragments,
+            message_length: message.len(),
+            checksum: checksum(message),
+            index: 0,
+        }
+    }
+
+    /// Returns the next fragment to be emitted by the fountain encoder.
+    /// After all fragments of the original message have been emitted once,
+    /// the fountain encoder will emit the result of xoring together the
+    /// fragments selected by the Xoshiro RNG (which could be a single
+    /// fragment).
+    pub fn next_fragment(&mut self) -> Fragment {
+        let index = self.index;
+
+        self.index += 1;
+
+        let indexes = choose_fragments(self.fragments.len(), self.checksum, index);
+
+        let mut data = vec![0; self.fragments[0].len()];
+
+        for item in indexes {
+            xor(&mut data, &self.fragments[item]);
+        }
+
+        Fragment {
+            meta: EncodingMetadata::new(self.fragments.len(), self.message_length, self.checksum),
+            index,
+            data,
+        }
+    }
+}
+
+pub const fn fragment_length(data_length: usize, max_fragment_length: usize) -> usize {
+    data_length.div_ceil(data_length.div_ceil(max_fragment_length))
+}
+
+pub fn partition(mut data: Vec<u8>, fragment_length: usize) -> Vec<Vec<u8>> {
+    let mut padding = vec![0; (fragment_length - (data.len() % fragment_length)) % fragment_length];
+
+    data.append(&mut padding);
+
+    data.chunks(fragment_length).map(<[u8]>::to_vec).collect()
+}
+
+fn choose_fragments(fragment_count: usize, checksum: [u8; 4], index: u32) -> Vec<usize> {
+    if (index as usize) < fragment_count {
+        return vec![index as usize];
+    }
+
+    let seed = (checksum, index).consensus_hash_sha256();
+
+    let mut rng = ChaCha20Rng::from_seed(seed.to_byte_array());
+
+    // Sample degree from Ideal Soliton Distribution: P(degree = k) ∝ 1/k
+    let degree = WeightedIndex::new((0..fragment_count).map(|x| 1.0 / (x + 1) as f64))
+        .unwrap()
+        .sample(&mut rng)
+        + 1;
+
+    // Choose degree random fragments
+    (0..fragment_count).choose_multiple(&mut rng, degree)
+}
+
+fn xor(v1: &mut [u8], v2: &[u8]) {
+    assert_eq!(v1.len(), v2.len());
+
+    for (x1, &x2) in v1.iter_mut().zip(v2.iter()) {
+        *x1 ^= x2;
+    }
+}
+
+/// Encoding metadata for a fragment.
+#[derive(Clone, Debug, PartialEq, Eq, Encodable, Decodable)]
+pub struct EncodingMetadata {
+    simple_fragments: u32,
+    message_length: u32,
+    checksum: [u8; 4],
+}
+
+impl EncodingMetadata {
+    pub fn new(simple_fragments: usize, message_length: usize, checksum: [u8; 4]) -> Self {
+        Self {
+            simple_fragments: simple_fragments as u32,
+            message_length: message_length as u32,
+            checksum,
+        }
+    }
+
+    pub fn fragment_length(&self) -> usize {
+        self.message_length().div_ceil(self.simple_fragments())
+    }
+
+    pub fn message_length(&self) -> usize {
+        self.message_length as usize
+    }
+
+    pub fn checksum(&self) -> [u8; 4] {
+        self.checksum
+    }
+
+    fn simple_fragments(&self) -> usize {
+        self.simple_fragments as usize
+    }
+
+    fn verify(&self) -> bool {
+        self.simple_fragments() > 0 && self.message_length() > 0 && self.fragment_length() > 0
+    }
+}
+
+/// A fragment emitted by a fountain [`Encoder`].
+#[derive(Clone, Debug, PartialEq, Eq, Encodable, Decodable)]
+pub struct Fragment {
+    meta: EncodingMetadata,
+    index: u32,
+    data: Vec<u8>,
+}
+
+impl Fragment {
+    /// Returns the indexes of the message segments that were combined.
+    pub fn indexes(&self) -> Vec<usize> {
+        choose_fragments(
+            self.meta.simple_fragments(),
+            self.meta.checksum(),
+            self.index,
+        )
+    }
+}
+
+/// A decoder capable of receiving and recombining fountain-encoded
+/// transmissions.
+#[derive(Default)]
+pub struct Decoder {
+    decoded: BTreeMap<usize, Vec<u8>>,
+    buffer: BTreeMap<Vec<usize>, Vec<u8>>,
+    meta: Option<EncodingMetadata>,
+}
+
+impl Decoder {
+    /// If the message is available, returns it, `None` otherwise.
+    pub fn message(&self) -> Option<Vec<u8>> {
+        if self.decoded.len() < self.meta.as_ref()?.simple_fragments() {
+            return None;
+        }
+
+        let message = self
+            .decoded
+            .values()
+            .flat_map(|data| data.clone())
+            .take(self.meta.as_ref()?.message_length())
+            .collect();
+
+        Some(message)
+    }
+
+    /// Receives a fountain-encoded fragment into the decoder.
+    pub fn receive(&mut self, fragment: Fragment) -> Result<Option<Vec<u8>>, Error> {
+        if let Some(message) = self.message() {
+            return Ok(Some(message));
+        }
+
+        if !fragment.meta.verify() {
+            return Err(Error::InvalidFragment);
+        }
+
+        if fragment.data.len() != fragment.meta.fragment_length() {
+            return Err(Error::InvalidFragment);
+        }
+
+        match self.meta.as_ref() {
+            None => {
+                self.meta = Some(fragment.meta.clone());
+            }
+            Some(meta) => {
+                if meta != &fragment.meta {
+                    return Err(Error::InconsistentFragment);
+                }
+            }
+        }
+
+        if let [index] = fragment.indexes().as_slice() {
+            self.process_simple(*index, fragment.data.clone());
+        } else {
+            self.process_complex(fragment.indexes(), fragment.data.clone());
+        }
+
+        Ok(self.message())
+    }
+
+    fn process_simple(&mut self, index: usize, data: Vec<u8>) {
+        self.decoded.insert(index, data.clone());
+
+        let mut queue = self.decoded.clone().into_iter().collect::<Vec<_>>();
+
+        while let Some((index, simple)) = queue.pop() {
+            for (mut indexes, mut data) in self
+                .buffer
+                .clone()
+                .into_iter()
+                .filter(|entry| entry.0.contains(&index))
+            {
+                self.buffer.remove(&indexes).unwrap();
+
+                indexes.retain(|&i| i != index);
+
+                xor(&mut data, &simple);
+
+                if let [index] = indexes.as_slice() {
+                    self.decoded.insert(*index, data.clone());
+                    queue.push((*index, data));
+                } else {
+                    self.buffer.insert(indexes, data);
+                }
+            }
+        }
+    }
+
+    fn process_complex(&mut self, mut indexes: Vec<usize>, mut data: Vec<u8>) {
+        let to_remove: Vec<usize> = indexes
+            .clone()
+            .into_iter()
+            .filter(|i| self.decoded.keys().any(|k| k == i))
+            .collect();
+
+        if indexes.len() == to_remove.len() {
+            return;
+        }
+
+        for remove in &to_remove {
+            xor(&mut data, self.decoded.get(remove).unwrap());
+        }
+
+        indexes.retain(|&i| !to_remove.contains(&i));
+
+        if let [index] = indexes.as_slice() {
+            self.decoded.insert(*index, data.clone());
+        } else {
+            self.buffer.insert(indexes, data);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_fragment_length() {
+        assert_eq!(fragment_length(12345, 1955), 1764);
+        assert_eq!(fragment_length(12345, 30000), 12345);
+
+        assert_eq!(fragment_length(10, 4), 4);
+        assert_eq!(fragment_length(10, 5), 5);
+        assert_eq!(fragment_length(10, 6), 5);
+        assert_eq!(fragment_length(10, 10), 10);
+    }
+
+    #[test]
+    #[should_panic(expected = "assertion failed")]
+    fn test_fountain_encoder_zero_max_length() {
+        Encoder::new(b"foo", 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "assertion failed")]
+    fn test_empty_encoder() {
+        Encoder::new(&[], 1);
+    }
+
+    #[test]
+    fn test_decoder_fragment_validation() {
+        let mut encoder1 = Encoder::new(b"foo", 2);
+        let mut encoder2 = Encoder::new(b"bar", 2);
+        let mut decoder = Decoder::default();
+
+        // Receive first fragment from encoder1 - not complete yet
+        assert_eq!(decoder.receive(encoder1.next_fragment()).unwrap(), None);
+
+        // Try to receive fragment from encoder2 with different metadata - should reject
+        assert!(matches!(
+            decoder.receive(encoder2.next_fragment()),
+            Err(Error::InconsistentFragment)
+        ));
+
+        // Receiving another fragment from encoder1 should work and complete
+        assert_eq!(
+            decoder.receive(encoder1.next_fragment()).unwrap(),
+            Some(b"foo".to_vec())
+        );
+    }
+
+    #[test]
+    fn test_empty_decoder_empty_fragment() {
+        let mut decoder = Decoder::default();
+        let mut fragment = Fragment {
+            meta: EncodingMetadata::new(8, 100, [0x12, 0x34, 0x56, 0x78]),
+            index: 12,
+            data: vec![1, 5, 3, 3, 5],
+        };
+
+        // Check simple_fragments.
+        fragment.meta.simple_fragments = 0;
+        assert!(matches!(
+            decoder.receive(fragment.clone()),
+            Err(Error::InvalidFragment)
+        ));
+        fragment.meta.simple_fragments = 8;
+
+        // Check message_length.
+        fragment.meta.message_length = 0;
+        assert!(matches!(
+            decoder.receive(fragment.clone()),
+            Err(Error::InvalidFragment)
+        ));
+        fragment.meta.message_length = 100;
+
+        // Check data.
+        fragment.data = vec![];
+        assert!(matches!(
+            decoder.receive(fragment.clone()),
+            Err(Error::InvalidFragment)
+        ));
+    }
+}

--- a/fedimint-fountain/src/lib.rs
+++ b/fedimint-fountain/src/lib.rs
@@ -1,0 +1,115 @@
+//! Fountain encoder/decoder for splitting and recombining byte payloads
+//!
+//! This is an inline fork of the fountain module from ur-rs,
+//! providing rateless fountain codes for efficient data transmission.
+//!
+//! The fountain encoder splits a byte payload into multiple segments
+//! and emits an unbounded stream of parts which can be recombined at
+//! the receiving decoder side. The emitted parts are either original
+//! payload segments, or constructed by xor-ing a certain set of payload
+//! segments.
+
+mod fountain;
+
+use std::marker::PhantomData;
+
+use fedimint_core::encoding::{Decodable, Encodable};
+use fedimint_core::module::registry::ModuleDecoderRegistry;
+
+pub struct FountainEncoder {
+    encoder: fountain::Encoder,
+}
+
+impl FountainEncoder {
+    pub fn new(encodable: impl Encodable, max_fragment_length: usize) -> Self {
+        Self {
+            encoder: fountain::Encoder::new(
+                encodable.consensus_encode_to_vec().as_slice(),
+                max_fragment_length,
+            ),
+        }
+    }
+
+    /// Fragments never repeat, so this can be called indefinitely
+    pub fn next_fragment(&mut self) -> fountain::Fragment {
+        self.encoder.next_fragment()
+    }
+}
+
+/// Decoder for fountain-encoded encodable types
+pub struct FountainDecoder<E: Decodable> {
+    decoder: fountain::Decoder,
+    _pd: PhantomData<E>,
+}
+
+impl<E: Decodable> Default for FountainDecoder<E> {
+    fn default() -> Self {
+        Self {
+            decoder: fountain::Decoder::default(),
+            _pd: PhantomData,
+        }
+    }
+}
+
+impl<E: Decodable> FountainDecoder<E> {
+    /// Add a scanned fragment. Returns Some(E) when decoding is complete
+    pub fn add_fragment(&mut self, fragment: &fountain::Fragment) -> Option<E> {
+        // Try to receive the fragment
+        match self.decoder.receive(fragment.clone()) {
+            Ok(Some(bytes)) => {
+                // Decoding complete!
+                Decodable::consensus_decode_whole(&bytes, &ModuleDecoderRegistry::default()).ok()
+            }
+            Ok(None) => {
+                // Not done yet
+                None
+            }
+            Err(_) => {
+                // Invalid fragment, reset decoder
+                self.decoder = fountain::Decoder::default();
+                None
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_fountain_encode_decode() {
+        for n in 0..10000 {
+            test_fountain_encode_decode_for_n(n);
+        }
+    }
+
+    fn test_fountain_encode_decode_for_n(n: usize) {
+        let original = (0..n).map(|i| i as u8).collect::<Vec<u8>>();
+
+        let mut encoder = FountainEncoder::new(&original, 1000);
+
+        let mut decoder: FountainDecoder<Vec<u8>> = FountainDecoder::default();
+
+        for k in 0..30 {
+            let fragment = encoder.next_fragment();
+
+            if let Some(data) = decoder.add_fragment(&fragment) {
+                assert_eq!(data, original);
+                if n % 100 == 0 {
+                    println!("Decoded {} bytes within {} fragments", n, k + 1);
+                }
+                return;
+            }
+
+            assert!(
+                decoder.add_fragment(&fragment).is_none(),
+                "Should not decode yet"
+            );
+
+            let _ = encoder.next_fragment();
+        }
+
+        panic!("Decoder did not decode the original data within 25 fragments");
+    }
+}


### PR DESCRIPTION
When I started to work on my own Fedimint App one rough edge I have encountered is that there is no standard way to encode the eCash within an animated QR code.

I have taken a look at the uniform resources fountain codes which are used in cashu. The algebraic construction fits our use case quite well, however, the available crate that implements it encodes the fragments / frames to a final string in a very inefficient manner. Hence, I have opted for an inline fork, such that the Fragment struct simply derives our own custom binary encoding and can then be encoded to our standard base32 encoding with fedimint prefix.

I have also discovered that base32 can store around 50 % more binary data in a QR code than base64, but only if the base32 string is uppercase. Hence combined with the fountain codes in this pr it should lead to a close to optimal data transmission rate in animated qt codes.

To create this pr I have started out with the existing ur crate, and have then replaced their dependencies for a checksum and randomness generation with dependency options we already pull in anyways. Furthermore I have made significant refactors here, so the final implementation looks quite different from the original, but the most complex part, the decoder, remains functionally unchanged.

### How Fountain Codes Work

Fountain codes are a rateless erasure coding scheme that enables reliable data transmission even when frames can be lost, corrupted, or received out of order—ideal for animated QR codes where users may miss frames while scanning.
The encoder splits the message into N "simple fragments" (the original data chunks). It first emits these N fragments sequentially, then continues generating infinite "mixed fragments"—each being the XOR of several randomly selected simple fragments. The randomness is seeded deterministically per frame index, ensuring reproducibility and avoiding the need to transmit the combined indices alongside the fragment.

The decoder uses a "peeling" algorithm: it starts by receiving simple fragments directly. When it receives a mixed fragment (e.g., fragment 3 ⊕ fragment 7), it XORs away any already-decoded fragments to simplify it. If this reduces it to a single unknown fragment, that fragment is "peeled off" and decoded. This newly decoded fragment can then be used to simplify other mixed fragments in the buffer, potentially triggering a cascade of further decodings.

The key property is that any sufficiently large subset of fragments (slightly more than N) is likely to decode the entire message, regardless of which specific fragments were received. This makes fountain codes particularly robust for lossy or interrupted transmissions like QR code scanning.

### Mathematical Perspective: Linear Algebra over GF(2)

From a linear algebra viewpoint, fountain codes can be understood as solving a system of linear equations over the Galois field GF(2) (the field with two elements {0,1}, where addition is XOR).

Let the message be split into N simple fragments (original chunks). These represent N unknown variables x₁, x₂, ..., xₙ in GF(2)^L (where L is the fragment length in bytes). Each received fragment corresponds to a linear equation:
Simple fragments (degree 1): equations like xᵢ = bᵢ (directly gives one unknown)
Mixed fragments (degree k): equations like xᵢ ⊕ xⱼ ⊕ xₖ = bₘ (XOR of k unknowns)

The encoder generates random linear combinations where the "degree" k (number of fragments XORed together) is sampled from the Ideal Soliton Distribution: P(k=1) = 1/N and P(k) = 1/(k(k-1)) for k > 1. This distribution is specifically designed to ensure efficient decoding: it produces enough degree-1 equations to bootstrap the peeling process, while higher-degree equations provide redundancy.

The decoder performs online Gaussian elimination: instead of collecting all equations and solving in batch, it processes fragments incrementally. The "peeling" algorithm is a specialized form of Gaussian elimination that exploits the sparse structure. This online approach is optimal for streaming scenarios like animated QR codes, where the decoder must process frames as they arrive without knowing how many total frames will be received.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
