### PR TITLE
chore(client): speed up init by not loading config twice

### DIFF
--- a/fedimint-core/src/config.rs
+++ b/fedimint-core/src/config.rs
@@ -229,13 +229,14 @@ impl ClientConfig {
             modules: self
                 .modules
                 .into_iter()
-                .map(|(k, v)| {
+                .map(|(module_id, v)| {
                     // Assuming this isn't running in any hot path it's better to have the debug
                     // info than saving one allocation
                     let kind = v.kind.clone();
+
                     v.redecode_raw(modules)
-                        .context(format!("redecode_raw: instance: {k}, kind: {kind}"))
-                        .map(|v| (k, v))
+                        .context(format!("redecode_raw: instance: {module_id}, kind: {kind}"))
+                        .map(|v| (module_id, v))
                 })
                 .collect::<Result<_, _>>()?,
             ..self


### PR DESCRIPTION
Loading config is expensive, because decoding mint client config is expensive, because all that crypto decoing fields it has.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
