### PR TITLE
chore(devimint): parallelize peer setup during DKG

### DIFF
--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -1154,56 +1154,83 @@ pub async fn run_cli_dkg_v2(
 ) -> Result<()> {
     let auth_for = |peer: &PeerId| -> &ApiAuth { &params[peer].api_auth };
 
-    for (peer, endpoint) in &endpoints {
-        let status = poll("awaiting-setup-status-awaiting-local-params", || async {
-            crate::util::FedimintCli
-                .setup_status(auth_for(peer), endpoint)
-                .await
-                .map_err(ControlFlow::Continue)
-        })
-        .await
-        .unwrap();
+    // Parallelize setup status checks
+    let status_futures = endpoints.iter().map(|(peer, endpoint)| {
+        let peer = *peer;
+        let endpoint = endpoint.clone();
+        async move {
+            let status = poll("awaiting-setup-status-awaiting-local-params", || async {
+                crate::util::FedimintCli
+                    .setup_status(auth_for(&peer), &endpoint)
+                    .await
+                    .map_err(ControlFlow::Continue)
+            })
+            .await
+            .unwrap();
 
-        assert_eq!(status, SetupStatus::AwaitingLocalParams);
-    }
+            assert_eq!(status, SetupStatus::AwaitingLocalParams);
+        }
+    });
+    join_all(status_futures).await;
 
     debug!(target: LOG_DEVIMINT, "Setting local parameters...");
 
-    let mut connection_info = BTreeMap::new();
-
-    for (peer, endpoint) in &endpoints {
-        let info = if peer.to_usize() == 0 {
-            crate::util::FedimintCli
-                .set_local_params_leader(peer, auth_for(peer), endpoint)
-                .await?
-        } else {
-            crate::util::FedimintCli
-                .set_local_params_follower(peer, auth_for(peer), endpoint)
-                .await?
-        };
-
-        connection_info.insert(peer, info);
-    }
+    // Parallelize setting local parameters
+    let local_params_futures = endpoints.iter().map(|(peer, endpoint)| {
+        let peer = *peer;
+        let endpoint = endpoint.clone();
+        async move {
+            let info = if peer.to_usize() == 0 {
+                crate::util::FedimintCli
+                    .set_local_params_leader(&peer, auth_for(&peer), &endpoint)
+                    .await
+            } else {
+                crate::util::FedimintCli
+                    .set_local_params_follower(&peer, auth_for(&peer), &endpoint)
+                    .await
+            };
+            info.map(|i| (peer, i))
+        }
+    });
+    let connection_info: BTreeMap<_, _> = try_join_all(local_params_futures)
+        .await?
+        .into_iter()
+        .collect();
 
     debug!(target: LOG_DEVIMINT, "Exchanging peer connection info...");
 
-    for (peer, info) in connection_info {
-        for (p, endpoint) in &endpoints {
-            if p != peer {
-                crate::util::FedimintCli
-                    .add_peer(&info, auth_for(p), endpoint)
-                    .await?;
-            }
-        }
-    }
+    // Parallelize peer addition - flatten the nested loop into a single parallel
+    // operation
+    let add_peer_futures = connection_info.iter().flat_map(|(peer, info)| {
+        endpoints
+            .iter()
+            .filter(move |(p, _)| *p != peer)
+            .map(move |(p, endpoint)| {
+                let p = *p;
+                let endpoint = endpoint.clone();
+                let info = info.clone();
+                async move {
+                    crate::util::FedimintCli
+                        .add_peer(&info, auth_for(&p), &endpoint)
+                        .await
+                }
+            })
+    });
+    try_join_all(add_peer_futures).await?;
 
     debug!(target: LOG_DEVIMINT, "Starting DKG...");
 
-    for (peer, endpoint) in &endpoints {
-        crate::util::FedimintCli
-            .start_dkg(auth_for(peer), endpoint)
-            .await?;
-    }
+    // Parallelize DKG start
+    let start_dkg_futures = endpoints.iter().map(|(peer, endpoint)| {
+        let peer = *peer;
+        let endpoint = endpoint.clone();
+        async move {
+            crate::util::FedimintCli
+                .start_dkg(auth_for(&peer), &endpoint)
+                .await
+        }
+    });
+    try_join_all(start_dkg_futures).await?;
 
     Ok(())
 }


### PR DESCRIPTION
This greatly improves the time it takes to start devimint, especially when there's a lot of peers (as it is quadratic to peer_num).

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
