### PR TITLE
fix: dkg large setup test sometimes using fed size 4

### DIFF
--- a/scripts/tests/large-setup-test.sh
+++ b/scripts/tests/large-setup-test.sh
@@ -9,7 +9,7 @@ build_workspace
 add_target_dir_to_path
 make_fm_test_marker
 
-export FM_FED_SIZE=$(((RANDOM % 10) + 4))
+export FM_FED_SIZE=$(((RANDOM % 9) + 5))
 
 >&2 echo "Testing ${FM_FED_SIZE} peer dkg"
 


### PR DESCRIPTION
Which is not an "larger" (-er than default).

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
