### PR TITLE
fix: make P2P connection reads cancel-safe

### DIFF
--- a/fedimint-server/src/net/p2p.rs
+++ b/fedimint-server/src/net/p2p.rs
@@ -332,7 +332,12 @@ impl<M: Send + 'static> P2PConnectionSMCommon<M> {
                 Some(P2PConnectionSMState::Connected(connection.ok()?))
             },
             message = connection.receive() => {
-                match message {
+                let mut message = match message {
+                    Ok(message) => message,
+                    Err(e) => return Some(self.disconnect(e)),
+                };
+
+                match message.read_to_end().await {
                     Ok(message) => {
                         PEER_MESSAGES_COUNT
                             .with_label_values(&[self.our_id_str.as_str(), self.peer_id_str.as_str(), "incoming"])


### PR DESCRIPTION
Make P2P connection reads cancel-safe to prevent message loss in tokio::select!

The iroh Connection implementation's receive() method was not cancel-safe because accept_uni().await could be dropped mid-execution when used in a tokio::select! block, causing messages to be lost. We split the receive operation into two steps: accept() returns a Message<M> handle (cancel-safe point), and read() deserializes the message from that handle. This pattern is implemented uniformly for both TLS Framed streams (using BytesMut) and iroh QUIC connections (using RecvStream), ensuring no messages are lost. The Message<M> trait provides an into_dyn() helper following the existing codebase patterns for ergonomic boxing into trait objects.

This fixes the dkg failure with federations of six peers or more. Dkg over iroh now passes reliably for up to 19 peers.

```bash
FM_ENABLE_IROH=true just mprocs -n 19
```

If you double `DEFAULT_POLL_TIMEOUT` to 120s you can also get the following command to pass reliably.

```bash
FM_ENABLE_IROH=true just mprocs -n 20
```


<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
