### PR TITLE
cleanup: split DKG over G1xG2 into seperate protocols for G1 and G2

### DIFF
--- a/fedimint-server/src/config/dkg.rs
+++ b/fedimint-server/src/config/dkg.rs
@@ -1,212 +1,18 @@
 use std::collections::BTreeMap;
-use std::iter::once;
 
-use anyhow::{Context, bail, ensure};
+use anyhow::Context;
 use async_trait::async_trait;
 use bls12_381::{G1Projective, G2Projective, Scalar};
-use fedimint_core::bitcoin::hashes::sha256;
-use fedimint_core::config::{DkgMessage, P2PMessage};
-use fedimint_core::encoding::Encodable as _;
-use fedimint_core::net::peers::{DynP2PConnections, Recipient};
+use fedimint_core::config::P2PMessage;
+use fedimint_core::net::peers::Recipient;
 use fedimint_core::{NumPeers, PeerId};
 use fedimint_logging::LOG_NET_PEER_DKG;
-use fedimint_server_core::config::{PeerHandleOps, g1, g2, scalar};
-use group::ff::Field;
-use rand::rngs::OsRng;
-use tracing::{info, trace};
+use fedimint_server_core::config::PeerHandleOps;
+use tracing::info;
 
+use super::dkg_g1::run_dkg_g1;
+use super::dkg_g2::run_dkg_g2;
 use super::peer_handle::PeerHandle;
-
-// Implementation of the classic Pedersen DKG.
-
-struct Dkg {
-    num_peers: NumPeers,
-    identity: PeerId,
-    polynomial: Vec<Scalar>,
-    hash_commitments: BTreeMap<PeerId, sha256::Hash>,
-    commitments: BTreeMap<PeerId, Vec<(G1Projective, G2Projective)>>,
-    sk_shares: BTreeMap<PeerId, Scalar>,
-}
-
-impl Dkg {
-    fn new(num_peers: NumPeers, identity: PeerId) -> Self {
-        let polynomial = (0..num_peers.threshold())
-            .map(|_| Scalar::random(&mut OsRng))
-            .collect::<Vec<Scalar>>();
-
-        let commitment = polynomial
-            .iter()
-            .map(|f| (g1(f), g2(f)))
-            .collect::<Vec<(G1Projective, G2Projective)>>();
-
-        Dkg {
-            num_peers,
-            identity,
-            polynomial,
-            hash_commitments: once((identity, commitment.consensus_hash_sha256())).collect(),
-            commitments: once((identity, commitment)).collect(),
-            sk_shares: BTreeMap::new(),
-        }
-    }
-
-    fn commitment(&self) -> Vec<(G1Projective, G2Projective)> {
-        self.polynomial.iter().map(|f| (g1(f), g2(f))).collect()
-    }
-
-    fn initial_message(&self) -> DkgMessage {
-        DkgMessage::Hash(self.commitment().consensus_hash_sha256())
-    }
-
-    /// Runs a single step of the DKG algorithm
-    fn step(&mut self, peer: PeerId, msg: DkgMessage) -> anyhow::Result<DkgStep> {
-        trace!(?peer, ?msg, "Running DKG step");
-        match msg {
-            DkgMessage::Hash(hash) => {
-                ensure!(
-                    self.hash_commitments.insert(peer, hash).is_none(),
-                    "DKG: peer {peer} sent us two hash commitments."
-                );
-
-                if self.hash_commitments.len() == self.num_peers.total() {
-                    return Ok(DkgStep::Broadcast(DkgMessage::Commitment(
-                        self.commitment(),
-                    )));
-                }
-            }
-            DkgMessage::Commitment(polynomial) => {
-                ensure!(
-                    *self.hash_commitments.get(&peer).with_context(|| format!(
-                        "DKG: hash commitment not found for peer {peer}"
-                    ))? == polynomial.consensus_hash_sha256(),
-                    "DKG: polynomial commitment from peer {peer} is of wrong degree."
-                );
-
-                ensure!(
-                    self.num_peers.threshold() == polynomial.len(),
-                    "DKG: polynomial commitment from peer {peer} is of wrong degree."
-                );
-
-                ensure!(
-                    self.commitments.insert(peer, polynomial).is_none(),
-                    "DKG: peer {peer} sent us two commitments."
-                );
-
-                // Once everyone has send their commitments, send out the key shares...
-
-                if self.commitments.len() == self.num_peers.total() {
-                    let mut messages = vec![];
-
-                    for peer in self.num_peers.peer_ids() {
-                        let s = eval_poly_scalar(&self.polynomial, &scalar(&peer));
-
-                        if peer == self.identity {
-                            self.sk_shares.insert(self.identity, s);
-                        } else {
-                            messages.push((peer, DkgMessage::Share(s)));
-                        }
-                    }
-
-                    return Ok(DkgStep::Messages(messages));
-                }
-            }
-            DkgMessage::Share(s) => {
-                let polynomial = self.commitments.get(&peer).with_context(|| {
-                    format!("DKG: polynomial commitment not found for peer {peer}.")
-                })?;
-
-                let checksum: (G1Projective, G2Projective) = polynomial
-                    .iter()
-                    .zip((0..).map(|k| scalar(&self.identity).pow(&[k, 0, 0, 0])))
-                    .map(|(c, x)| (c.0 * x, c.1 * x))
-                    .reduce(|(a1, a2), (b1, b2)| (a1 + b1, a2 + b2))
-                    .expect("DKG: polynomial commitment from peer is empty.");
-
-                ensure!(
-                    (g1(&s), g2(&s)) == checksum,
-                    "DKG: share from {peer} is invalid."
-                );
-
-                ensure!(
-                    self.sk_shares.insert(peer, s).is_none(),
-                    "Peer {peer} sent us two sk shares."
-                );
-
-                if self.sk_shares.len() == self.num_peers.total() {
-                    let sks = self.sk_shares.values().sum();
-
-                    let pks = (0..self.num_peers.threshold())
-                        .map(|i| {
-                            self.commitments
-                                .values()
-                                .map(|coefficients| coefficients[i])
-                                .reduce(|(a1, a2), (b1, b2)| (a1 + b1, a2 + b2))
-                                .expect("DKG: polynomial commitments are empty.")
-                        })
-                        .collect();
-
-                    return Ok(DkgStep::Result((pks, sks)));
-                }
-            }
-        }
-
-        Ok(DkgStep::Messages(vec![]))
-    }
-}
-
-/// Runs the DKG algorithms with our peers. We do not handle any unexpected
-/// messages and all peers are expected to be cooperative.
-pub async fn run_dkg(
-    num_peers: NumPeers,
-    identity: PeerId,
-    connections: &DynP2PConnections<P2PMessage>,
-) -> anyhow::Result<(Vec<(G1Projective, G2Projective)>, Scalar)> {
-    let mut dkg = Dkg::new(num_peers, identity);
-
-    connections.send(Recipient::Everyone, P2PMessage::Dkg(dkg.initial_message()));
-
-    loop {
-        for peer in num_peers.peer_ids().filter(|p| *p != identity) {
-            let message = connections
-                .receive_from_peer(peer)
-                .await
-                .context("Unexpected shutdown of p2p connections during dkg")?;
-
-            let message = match message {
-                P2PMessage::Dkg(message) => message,
-                _ => bail!("Received unexpected message: {message:?}"),
-            };
-
-            match dkg.step(peer, message)? {
-                DkgStep::Broadcast(message) => {
-                    connections.send(Recipient::Everyone, P2PMessage::Dkg(message));
-                }
-                DkgStep::Messages(messages) => {
-                    for (peer, message) in messages {
-                        connections.send(Recipient::Peer(peer), P2PMessage::Dkg(message));
-                    }
-                }
-                DkgStep::Result(result) => {
-                    return Ok(result);
-                }
-            }
-        }
-    }
-}
-
-fn eval_poly_scalar(coefficients: &[Scalar], x: &Scalar) -> Scalar {
-    coefficients
-        .iter()
-        .copied()
-        .rev()
-        .reduce(|acc, coefficient| acc * x + coefficient)
-        .expect("We have at least one coefficient")
-}
-
-enum DkgStep {
-    Broadcast(DkgMessage),
-    Messages(Vec<(PeerId, DkgMessage)>),
-    Result((Vec<(G1Projective, G2Projective)>, Scalar)),
-}
 
 #[async_trait]
 impl PeerHandleOps for PeerHandle<'_> {
@@ -220,9 +26,7 @@ impl PeerHandleOps for PeerHandle<'_> {
             "Running distributed key generation for group G1..."
         );
 
-        run_dkg(self.num_peers, self.identity, self.connections)
-            .await
-            .map(|(poly, sk)| (poly.into_iter().map(|c| c.0).collect(), sk))
+        run_dkg_g1(self.num_peers, self.identity, self.connections).await
     }
 
     async fn run_dkg_g2(&self) -> anyhow::Result<(Vec<G2Projective>, Scalar)> {
@@ -231,9 +35,7 @@ impl PeerHandleOps for PeerHandle<'_> {
             "Running distributed key generation for group G2..."
         );
 
-        run_dkg(self.num_peers, self.identity, self.connections)
-            .await
-            .map(|(poly, sk)| (poly.into_iter().map(|c| c.1).collect(), sk))
+        run_dkg_g2(self.num_peers, self.identity, self.connections).await
     }
 
     async fn exchange_bytes(&self, bytes: Vec<u8>) -> anyhow::Result<BTreeMap<PeerId, Vec<u8>>> {
@@ -267,75 +69,5 @@ impl PeerHandleOps for PeerHandle<'_> {
         }
 
         Ok(peer_data)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::collections::{BTreeMap, VecDeque};
-
-    use bls12_381::{G1Projective, G2Projective};
-    use fedimint_core::{NumPeersExt, PeerId};
-    use fedimint_server_core::config::{eval_poly_g1, eval_poly_g2, g1, g2};
-    use group::Curve;
-
-    use crate::config::dkg::{Dkg, DkgStep};
-
-    #[test_log::test]
-    fn test_dkg() {
-        let peers = (0..7_u16).map(PeerId::from).collect::<Vec<PeerId>>();
-
-        let mut dkgs = peers
-            .iter()
-            .map(|peer| (*peer, Dkg::new(peers.to_num_peers(), *peer)))
-            .collect::<BTreeMap<PeerId, Dkg>>();
-
-        let mut steps = dkgs
-            .iter()
-            .map(|(peer, dkg)| (*peer, DkgStep::Broadcast(dkg.initial_message())))
-            .collect::<VecDeque<(PeerId, DkgStep)>>();
-
-        let mut keys = BTreeMap::new();
-
-        while keys.len() < peers.len() {
-            match steps.pop_front().unwrap() {
-                (send_peer, DkgStep::Broadcast(message)) => {
-                    for receive_peer in peers.iter().filter(|p| **p != send_peer) {
-                        let step = dkgs
-                            .get_mut(receive_peer)
-                            .unwrap()
-                            .step(send_peer, message.clone());
-
-                        steps.push_back((*receive_peer, step.unwrap()));
-                    }
-                }
-                (send_peer, DkgStep::Messages(messages)) => {
-                    for (receive_peer, messages) in messages {
-                        let step = dkgs
-                            .get_mut(&receive_peer)
-                            .unwrap()
-                            .step(send_peer, messages);
-
-                        steps.push_back((receive_peer, step.unwrap()));
-                    }
-                }
-                (send_peer, DkgStep::Result(step_keys)) => {
-                    keys.insert(send_peer, step_keys);
-                }
-            }
-        }
-
-        assert!(steps.is_empty());
-
-        for (peer, (poly, sks)) in keys {
-            let poly_g1: Vec<G1Projective> = poly.clone().into_iter().map(|c| c.0).collect();
-            let poly_g2: Vec<G2Projective> = poly.clone().into_iter().map(|c| c.1).collect();
-
-            assert_eq!(poly_g1.len(), 5);
-            assert_eq!(eval_poly_g1(&poly_g1, &peer), g1(&sks).to_affine());
-
-            assert_eq!(poly_g2.len(), 5);
-            assert_eq!(eval_poly_g2(&poly_g2, &peer), g2(&sks).to_affine());
-        }
     }
 }

--- a/fedimint-server/src/config/dkg_g1.rs
+++ b/fedimint-server/src/config/dkg_g1.rs
@@ -1,0 +1,265 @@
+use std::collections::BTreeMap;
+use std::iter::once;
+
+use anyhow::{Context, bail, ensure};
+use bls12_381::{G1Projective, Scalar};
+use fedimint_core::bitcoin::hashes::sha256;
+use fedimint_core::config::{DkgMessageG1, P2PMessage};
+use fedimint_core::encoding::Encodable as _;
+use fedimint_core::net::peers::{DynP2PConnections, Recipient};
+use fedimint_core::{NumPeers, PeerId};
+use fedimint_server_core::config::{g1, scalar};
+use group::ff::Field;
+use rand::rngs::OsRng;
+use tracing::trace;
+
+// Implementation of the classic Pedersen DKG for G1.
+
+struct DkgG1 {
+    num_peers: NumPeers,
+    identity: PeerId,
+    polynomial: Vec<Scalar>,
+    hash_commitments: BTreeMap<PeerId, sha256::Hash>,
+    commitments: BTreeMap<PeerId, Vec<G1Projective>>,
+    sk_shares: BTreeMap<PeerId, Scalar>,
+}
+
+impl DkgG1 {
+    fn new(num_peers: NumPeers, identity: PeerId) -> Self {
+        let polynomial = (0..num_peers.threshold())
+            .map(|_| Scalar::random(&mut OsRng))
+            .collect::<Vec<Scalar>>();
+
+        let commitment = polynomial.iter().map(g1).collect::<Vec<G1Projective>>();
+
+        DkgG1 {
+            num_peers,
+            identity,
+            polynomial,
+            hash_commitments: once((identity, commitment.consensus_hash_sha256())).collect(),
+            commitments: once((identity, commitment)).collect(),
+            sk_shares: BTreeMap::new(),
+        }
+    }
+
+    fn commitment(&self) -> Vec<G1Projective> {
+        self.polynomial.iter().map(g1).collect()
+    }
+
+    fn initial_message(&self) -> DkgMessageG1 {
+        DkgMessageG1::Hash(self.commitment().consensus_hash_sha256())
+    }
+
+    /// Runs a single step of the DKG algorithm
+    fn step(&mut self, peer: PeerId, msg: DkgMessageG1) -> anyhow::Result<DkgStepG1> {
+        trace!(?peer, ?msg, "Running DKG G1 step");
+        match msg {
+            DkgMessageG1::Hash(hash) => {
+                ensure!(
+                    self.hash_commitments.insert(peer, hash).is_none(),
+                    "DKG G1: peer {peer} sent us two hash commitments."
+                );
+
+                if self.hash_commitments.len() == self.num_peers.total() {
+                    return Ok(DkgStepG1::Broadcast(DkgMessageG1::Commitment(
+                        self.commitment(),
+                    )));
+                }
+            }
+            DkgMessageG1::Commitment(polynomial) => {
+                ensure!(
+                    *self.hash_commitments.get(&peer).with_context(|| format!(
+                        "DKG G1: hash commitment not found for peer {peer}"
+                    ))? == polynomial.consensus_hash_sha256(),
+                    "DKG G1: polynomial commitment from peer {peer} is of wrong degree."
+                );
+
+                ensure!(
+                    self.num_peers.threshold() == polynomial.len(),
+                    "DKG G1: polynomial commitment from peer {peer} is of wrong degree."
+                );
+
+                ensure!(
+                    self.commitments.insert(peer, polynomial).is_none(),
+                    "DKG G1: peer {peer} sent us two commitments."
+                );
+
+                // Once everyone has send their commitments, send out the key shares...
+
+                if self.commitments.len() == self.num_peers.total() {
+                    let mut messages = vec![];
+
+                    for peer in self.num_peers.peer_ids() {
+                        let s = eval_poly_scalar(&self.polynomial, &scalar(&peer));
+
+                        if peer == self.identity {
+                            self.sk_shares.insert(self.identity, s);
+                        } else {
+                            messages.push((peer, DkgMessageG1::Share(s)));
+                        }
+                    }
+
+                    return Ok(DkgStepG1::Messages(messages));
+                }
+            }
+            DkgMessageG1::Share(s) => {
+                let polynomial = self.commitments.get(&peer).with_context(|| {
+                    format!("DKG G1: polynomial commitment not found for peer {peer}.")
+                })?;
+
+                let checksum: G1Projective = polynomial
+                    .iter()
+                    .zip((0..).map(|k| scalar(&self.identity).pow(&[k, 0, 0, 0])))
+                    .map(|(c, x)| c * x)
+                    .reduce(|a, b| a + b)
+                    .expect("DKG G1: polynomial commitment from peer is empty.");
+
+                ensure!(g1(&s) == checksum, "DKG G1: share from {peer} is invalid.");
+
+                ensure!(
+                    self.sk_shares.insert(peer, s).is_none(),
+                    "Peer {peer} sent us two sk shares."
+                );
+
+                if self.sk_shares.len() == self.num_peers.total() {
+                    let sks = self.sk_shares.values().sum();
+
+                    let pks = (0..self.num_peers.threshold())
+                        .map(|i| {
+                            self.commitments
+                                .values()
+                                .map(|coefficients| coefficients[i])
+                                .reduce(|a, b| a + b)
+                                .expect("DKG G1: polynomial commitments are empty.")
+                        })
+                        .collect();
+
+                    return Ok(DkgStepG1::Result((pks, sks)));
+                }
+            }
+        }
+
+        Ok(DkgStepG1::Messages(vec![]))
+    }
+}
+
+/// Runs the DKG G1 algorithm with our peers. We do not handle any unexpected
+/// messages and all peers are expected to be cooperative.
+pub async fn run_dkg_g1(
+    num_peers: NumPeers,
+    identity: PeerId,
+    connections: &DynP2PConnections<P2PMessage>,
+) -> anyhow::Result<(Vec<G1Projective>, Scalar)> {
+    let mut dkg = DkgG1::new(num_peers, identity);
+
+    connections.send(
+        Recipient::Everyone,
+        P2PMessage::DkgG1(dkg.initial_message()),
+    );
+
+    loop {
+        for peer in num_peers.peer_ids().filter(|p| *p != identity) {
+            let message = connections
+                .receive_from_peer(peer)
+                .await
+                .context("Unexpected shutdown of p2p connections during dkg g1")?;
+
+            let message = match message {
+                P2PMessage::DkgG1(message) => message,
+                _ => bail!("Received unexpected message during DKG G1: {message:?}"),
+            };
+
+            match dkg.step(peer, message)? {
+                DkgStepG1::Broadcast(message) => {
+                    connections.send(Recipient::Everyone, P2PMessage::DkgG1(message));
+                }
+                DkgStepG1::Messages(messages) => {
+                    for (peer, message) in messages {
+                        connections.send(Recipient::Peer(peer), P2PMessage::DkgG1(message));
+                    }
+                }
+                DkgStepG1::Result(result) => {
+                    return Ok(result);
+                }
+            }
+        }
+    }
+}
+
+fn eval_poly_scalar(coefficients: &[Scalar], x: &Scalar) -> Scalar {
+    coefficients
+        .iter()
+        .copied()
+        .rev()
+        .reduce(|acc, coefficient| acc * x + coefficient)
+        .expect("We have at least one coefficient")
+}
+
+enum DkgStepG1 {
+    Broadcast(DkgMessageG1),
+    Messages(Vec<(PeerId, DkgMessageG1)>),
+    Result((Vec<G1Projective>, Scalar)),
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{BTreeMap, VecDeque};
+
+    use fedimint_core::{NumPeersExt, PeerId};
+    use fedimint_server_core::config::{eval_poly_g1, g1};
+    use group::Curve;
+
+    use super::{DkgG1, DkgStepG1};
+
+    #[test_log::test]
+    fn test_dkg_g1() {
+        let peers = (0..7_u16).map(PeerId::from).collect::<Vec<PeerId>>();
+
+        let mut dkgs = peers
+            .iter()
+            .map(|peer| (*peer, DkgG1::new(peers.to_num_peers(), *peer)))
+            .collect::<BTreeMap<PeerId, DkgG1>>();
+
+        let mut steps = dkgs
+            .iter()
+            .map(|(peer, dkg)| (*peer, DkgStepG1::Broadcast(dkg.initial_message())))
+            .collect::<VecDeque<(PeerId, DkgStepG1)>>();
+
+        let mut keys = BTreeMap::new();
+
+        while keys.len() < peers.len() {
+            match steps.pop_front().unwrap() {
+                (send_peer, DkgStepG1::Broadcast(message)) => {
+                    for receive_peer in peers.iter().filter(|p| **p != send_peer) {
+                        let step = dkgs
+                            .get_mut(receive_peer)
+                            .unwrap()
+                            .step(send_peer, message.clone());
+
+                        steps.push_back((*receive_peer, step.unwrap()));
+                    }
+                }
+                (send_peer, DkgStepG1::Messages(messages)) => {
+                    for (receive_peer, message) in messages {
+                        let step = dkgs
+                            .get_mut(&receive_peer)
+                            .unwrap()
+                            .step(send_peer, message);
+
+                        steps.push_back((receive_peer, step.unwrap()));
+                    }
+                }
+                (send_peer, DkgStepG1::Result(step_keys)) => {
+                    keys.insert(send_peer, step_keys);
+                }
+            }
+        }
+
+        assert!(steps.is_empty());
+
+        for (peer, (poly_g1, sks)) in keys {
+            assert_eq!(poly_g1.len(), 5);
+            assert_eq!(eval_poly_g1(&poly_g1, &peer), g1(&sks).to_affine());
+        }
+    }
+}

--- a/fedimint-server/src/config/dkg_g2.rs
+++ b/fedimint-server/src/config/dkg_g2.rs
@@ -1,0 +1,265 @@
+use std::collections::BTreeMap;
+use std::iter::once;
+
+use anyhow::{Context, bail, ensure};
+use bls12_381::{G2Projective, Scalar};
+use fedimint_core::bitcoin::hashes::sha256;
+use fedimint_core::config::{DkgMessageG2, P2PMessage};
+use fedimint_core::encoding::Encodable as _;
+use fedimint_core::net::peers::{DynP2PConnections, Recipient};
+use fedimint_core::{NumPeers, PeerId};
+use fedimint_server_core::config::{g2, scalar};
+use group::ff::Field;
+use rand::rngs::OsRng;
+use tracing::trace;
+
+// Implementation of the classic Pedersen DKG for G2.
+
+struct DkgG2 {
+    num_peers: NumPeers,
+    identity: PeerId,
+    polynomial: Vec<Scalar>,
+    hash_commitments: BTreeMap<PeerId, sha256::Hash>,
+    commitments: BTreeMap<PeerId, Vec<G2Projective>>,
+    sk_shares: BTreeMap<PeerId, Scalar>,
+}
+
+impl DkgG2 {
+    fn new(num_peers: NumPeers, identity: PeerId) -> Self {
+        let polynomial = (0..num_peers.threshold())
+            .map(|_| Scalar::random(&mut OsRng))
+            .collect::<Vec<Scalar>>();
+
+        let commitment = polynomial.iter().map(g2).collect::<Vec<G2Projective>>();
+
+        DkgG2 {
+            num_peers,
+            identity,
+            polynomial,
+            hash_commitments: once((identity, commitment.consensus_hash_sha256())).collect(),
+            commitments: once((identity, commitment)).collect(),
+            sk_shares: BTreeMap::new(),
+        }
+    }
+
+    fn commitment(&self) -> Vec<G2Projective> {
+        self.polynomial.iter().map(g2).collect()
+    }
+
+    fn initial_message(&self) -> DkgMessageG2 {
+        DkgMessageG2::Hash(self.commitment().consensus_hash_sha256())
+    }
+
+    /// Runs a single step of the DKG algorithm
+    fn step(&mut self, peer: PeerId, msg: DkgMessageG2) -> anyhow::Result<DkgStepG2> {
+        trace!(?peer, ?msg, "Running DKG G2 step");
+        match msg {
+            DkgMessageG2::Hash(hash) => {
+                ensure!(
+                    self.hash_commitments.insert(peer, hash).is_none(),
+                    "DKG G2: peer {peer} sent us two hash commitments."
+                );
+
+                if self.hash_commitments.len() == self.num_peers.total() {
+                    return Ok(DkgStepG2::Broadcast(DkgMessageG2::Commitment(
+                        self.commitment(),
+                    )));
+                }
+            }
+            DkgMessageG2::Commitment(polynomial) => {
+                ensure!(
+                    *self.hash_commitments.get(&peer).with_context(|| format!(
+                        "DKG G2: hash commitment not found for peer {peer}"
+                    ))? == polynomial.consensus_hash_sha256(),
+                    "DKG G2: polynomial commitment from peer {peer} is of wrong degree."
+                );
+
+                ensure!(
+                    self.num_peers.threshold() == polynomial.len(),
+                    "DKG G2: polynomial commitment from peer {peer} is of wrong degree."
+                );
+
+                ensure!(
+                    self.commitments.insert(peer, polynomial).is_none(),
+                    "DKG G2: peer {peer} sent us two commitments."
+                );
+
+                // Once everyone has send their commitments, send out the key shares...
+
+                if self.commitments.len() == self.num_peers.total() {
+                    let mut messages = vec![];
+
+                    for peer in self.num_peers.peer_ids() {
+                        let s = eval_poly_scalar(&self.polynomial, &scalar(&peer));
+
+                        if peer == self.identity {
+                            self.sk_shares.insert(self.identity, s);
+                        } else {
+                            messages.push((peer, DkgMessageG2::Share(s)));
+                        }
+                    }
+
+                    return Ok(DkgStepG2::Messages(messages));
+                }
+            }
+            DkgMessageG2::Share(s) => {
+                let polynomial = self.commitments.get(&peer).with_context(|| {
+                    format!("DKG G2: polynomial commitment not found for peer {peer}.")
+                })?;
+
+                let checksum: G2Projective = polynomial
+                    .iter()
+                    .zip((0..).map(|k| scalar(&self.identity).pow(&[k, 0, 0, 0])))
+                    .map(|(c, x)| c * x)
+                    .reduce(|a, b| a + b)
+                    .expect("DKG G2: polynomial commitment from peer is empty.");
+
+                ensure!(g2(&s) == checksum, "DKG G2: share from {peer} is invalid.");
+
+                ensure!(
+                    self.sk_shares.insert(peer, s).is_none(),
+                    "Peer {peer} sent us two sk shares."
+                );
+
+                if self.sk_shares.len() == self.num_peers.total() {
+                    let sks = self.sk_shares.values().sum();
+
+                    let pks = (0..self.num_peers.threshold())
+                        .map(|i| {
+                            self.commitments
+                                .values()
+                                .map(|coefficients| coefficients[i])
+                                .reduce(|a, b| a + b)
+                                .expect("DKG G2: polynomial commitments are empty.")
+                        })
+                        .collect();
+
+                    return Ok(DkgStepG2::Result((pks, sks)));
+                }
+            }
+        }
+
+        Ok(DkgStepG2::Messages(vec![]))
+    }
+}
+
+/// Runs the DKG G2 algorithm with our peers. We do not handle any unexpected
+/// messages and all peers are expected to be cooperative.
+pub async fn run_dkg_g2(
+    num_peers: NumPeers,
+    identity: PeerId,
+    connections: &DynP2PConnections<P2PMessage>,
+) -> anyhow::Result<(Vec<G2Projective>, Scalar)> {
+    let mut dkg = DkgG2::new(num_peers, identity);
+
+    connections.send(
+        Recipient::Everyone,
+        P2PMessage::DkgG2(dkg.initial_message()),
+    );
+
+    loop {
+        for peer in num_peers.peer_ids().filter(|p| *p != identity) {
+            let message = connections
+                .receive_from_peer(peer)
+                .await
+                .context("Unexpected shutdown of p2p connections during dkg g2")?;
+
+            let message = match message {
+                P2PMessage::DkgG2(message) => message,
+                _ => bail!("Received unexpected message during DKG G2: {message:?}"),
+            };
+
+            match dkg.step(peer, message)? {
+                DkgStepG2::Broadcast(message) => {
+                    connections.send(Recipient::Everyone, P2PMessage::DkgG2(message));
+                }
+                DkgStepG2::Messages(messages) => {
+                    for (peer, message) in messages {
+                        connections.send(Recipient::Peer(peer), P2PMessage::DkgG2(message));
+                    }
+                }
+                DkgStepG2::Result(result) => {
+                    return Ok(result);
+                }
+            }
+        }
+    }
+}
+
+fn eval_poly_scalar(coefficients: &[Scalar], x: &Scalar) -> Scalar {
+    coefficients
+        .iter()
+        .copied()
+        .rev()
+        .reduce(|acc, coefficient| acc * x + coefficient)
+        .expect("We have at least one coefficient")
+}
+
+enum DkgStepG2 {
+    Broadcast(DkgMessageG2),
+    Messages(Vec<(PeerId, DkgMessageG2)>),
+    Result((Vec<G2Projective>, Scalar)),
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{BTreeMap, VecDeque};
+
+    use fedimint_core::{NumPeersExt, PeerId};
+    use fedimint_server_core::config::{eval_poly_g2, g2};
+    use group::Curve;
+
+    use super::{DkgG2, DkgStepG2};
+
+    #[test_log::test]
+    fn test_dkg_g2() {
+        let peers = (0..7_u16).map(PeerId::from).collect::<Vec<PeerId>>();
+
+        let mut dkgs = peers
+            .iter()
+            .map(|peer| (*peer, DkgG2::new(peers.to_num_peers(), *peer)))
+            .collect::<BTreeMap<PeerId, DkgG2>>();
+
+        let mut steps = dkgs
+            .iter()
+            .map(|(peer, dkg)| (*peer, DkgStepG2::Broadcast(dkg.initial_message())))
+            .collect::<VecDeque<(PeerId, DkgStepG2)>>();
+
+        let mut keys = BTreeMap::new();
+
+        while keys.len() < peers.len() {
+            match steps.pop_front().unwrap() {
+                (send_peer, DkgStepG2::Broadcast(message)) => {
+                    for receive_peer in peers.iter().filter(|p| **p != send_peer) {
+                        let step = dkgs
+                            .get_mut(receive_peer)
+                            .unwrap()
+                            .step(send_peer, message.clone());
+
+                        steps.push_back((*receive_peer, step.unwrap()));
+                    }
+                }
+                (send_peer, DkgStepG2::Messages(messages)) => {
+                    for (receive_peer, message) in messages {
+                        let step = dkgs
+                            .get_mut(&receive_peer)
+                            .unwrap()
+                            .step(send_peer, message);
+
+                        steps.push_back((receive_peer, step.unwrap()));
+                    }
+                }
+                (send_peer, DkgStepG2::Result(step_keys)) => {
+                    keys.insert(send_peer, step_keys);
+                }
+            }
+        }
+
+        assert!(steps.is_empty());
+
+        for (peer, (poly_g2, sks)) in keys {
+            assert_eq!(poly_g2.len(), 5);
+            assert_eq!(eval_poly_g2(&poly_g2, &peer), g2(&sks).to_affine());
+        }
+    }
+}

--- a/fedimint-server/src/config/mod.rs
+++ b/fedimint-server/src/config/mod.rs
@@ -40,6 +40,8 @@ use crate::net::p2p::P2PStatusReceivers;
 use crate::net::p2p_connector::TlsConfig;
 
 pub mod dkg;
+pub mod dkg_g1;
+pub mod dkg_g2;
 pub mod io;
 pub mod peer_handle;
 pub mod setup;


### PR DESCRIPTION
We split DKG over G1xG2 into separate protocols for G1 and G2. We accept the code duplication here because working with generics here is just a mess, especially around the encoding and group ops. This therefore avoids the need to generate public key material that is only thrown away directly after the dkg, make the algorithm even more standard and simpler to verify, and also reduces maximum message size during dkg by 1/3.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
