### PR TITLE
chore: avoid to sync more then five blocks in a single database transaction

### DIFF
--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -1288,9 +1288,10 @@ impl Wallet {
     ) {
         info!(
             target: LOG_MODULE_WALLET,
+            old_count,
             new_count,
             blocks_to_go = new_count - old_count,
-            "New block count consensus, syncing up",
+            "New block count consensus, initiating sync",
         );
 
         // Before we can safely call our bitcoin backend to process the new consensus
@@ -1298,12 +1299,11 @@ impl Wallet {
         self.wait_for_finality_confs_or_shutdown(new_count).await;
 
         for height in old_count..new_count {
-            if height % 100 == 0 {
-                debug!(
-                    target: LOG_MODULE_WALLET,
-                    "Caught up to block {height}"
-                );
-            }
+            info!(
+                target: LOG_MODULE_WALLET,
+                height,
+                "Processing block of height {height}",
+            );
 
             // TODO: use batching for mainnet syncing
             trace!(block = height, "Fetching block hash");
@@ -1410,6 +1410,13 @@ impl Wallet {
                 &BlockHashByHeightValue(block_hash),
             )
             .await;
+
+            info!(
+                target: LOG_MODULE_WALLET,
+                height,
+                ?block_hash,
+                "Successfully processed block of height {height}",
+            );
         }
     }
 


### PR DESCRIPTION
I want to avoid syncing potentially hundreds of blocks in a single database transaction. If there is any issue during the sync, like calls failing due to congestion or higher level timeouts not expecting the processing of a consensus item to take minutes we would make zero progress. By breaking it up into at most five blocks at the time every sync is not that different from the normal case of syncing one block.

Furthermore I have increased the amount of logging during the sync. I am aware that this is now quite verbose, however, the wallet sync calling into the bitcoin backend is the only external dependency we have that the operator has to keep functioning hence this is highly relevant information to the guardian attempting to debug.


<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
