### PR TITLE
chore: prepare to transition from bincode to the fedimint encoding in the p2p layer

### DIFF
--- a/fedimint-core/src/config.rs
+++ b/fedimint-core/src/config.rs
@@ -852,6 +852,11 @@ pub enum P2PMessage {
     Checksum(sha256::Hash),
     Dkg(DkgMessage),
     Encodable(Vec<u8>),
+    #[encodable_default]
+    Default {
+        variant: u64,
+        bytes: Vec<u8>,
+    },
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Encodable, Decodable)]


### PR DESCRIPTION
This has already been prepared during the DKG cleanups I made in spring. Switching to the consensus encoding will halve the message size during DKG and allows us to remove the custom serde Implementation for the DKG messages.


<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
