### PR TITLE
chore(ci): disable flaky large dkg test

### DIFF
--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -362,7 +362,8 @@ tests_to_run_in_parallel+=(
   "wallet_recovery"
   "wallet_recovery_2"
   "recurringd_test"
-  "large_setup_test"
+  # disabled until flakiness is fixed
+  # "large_setup_test"
 )
 done
 


### PR DESCRIPTION
Seems like no easy fix related to async cancelation will help, so I'm debugging.
<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
