### PR TITLE
fix(ci): flaky large dkg test

### DIFF
--- a/devimint/src/util.rs
+++ b/devimint/src/util.rs
@@ -528,6 +528,7 @@ where
 }
 
 const DEFAULT_POLL_TIMEOUT: Duration = Duration::from_secs(60);
+const EXTRA_LONG_POLL_TIMEOUT: Duration = Duration::from_secs(90);
 
 /// Retry until `f` succeeds or default timeout is reached
 ///
@@ -539,7 +540,16 @@ pub async fn poll<Fut, R>(name: &str, f: impl Fn() -> Fut) -> Result<R>
 where
     Fut: Future<Output = Result<R, ControlFlow<anyhow::Error, anyhow::Error>>>,
 {
-    poll_with_timeout(name, DEFAULT_POLL_TIMEOUT, f).await
+    poll_with_timeout(
+        name,
+        if is_env_var_set("FM_EXTRA_LONG_POLL") {
+            EXTRA_LONG_POLL_TIMEOUT
+        } else {
+            DEFAULT_POLL_TIMEOUT
+        },
+        f,
+    )
+    .await
 }
 
 pub async fn poll_simple<Fut, R>(name: &str, f: impl Fn() -> Fut) -> Result<R>

--- a/scripts/tests/large-setup-test.sh
+++ b/scripts/tests/large-setup-test.sh
@@ -9,10 +9,12 @@ build_workspace
 add_target_dir_to_path
 make_fm_test_marker
 
-export FM_FED_SIZE=$(((RANDOM % 10) + 4))
+export FM_FED_SIZE=$(((RANDOM % 7) + 5))
 
 >&2 echo "Testing ${FM_FED_SIZE} peer dkg"
 
-env RUST_LOG="${RUST_LOG:-info,jsonrpsee-client=off}" \
+env
+  RUST_LOG="${RUST_LOG:-info,jsonrpsee-client=off}" \
+  FM_EXTRA_LONG_POLL=true \
   devimint "$@" dev-fed \
     --exec true


### PR DESCRIPTION
So far it looks to me that this test just becomes too slow with a lot of peers.

To counter it:

* Increase the time we wait for it finish.
* Cap the number of peers. Complexity there increases quadratically and very large number of peers, add much less value.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
