### PR TITLE
feat: add 24 hour payment summary to UI

### DIFF
--- a/gateway/fedimint-gateway-ui/src/lib.rs
+++ b/gateway/fedimint-gateway-ui/src/lib.rs
@@ -1,6 +1,7 @@
 mod federation;
 mod general;
 mod lightning;
+mod payment_summary;
 
 use std::fmt::Display;
 use std::sync::Arc;
@@ -12,7 +13,7 @@ use axum::routing::get;
 use axum::{Form, Router};
 use axum_extra::extract::CookieJar;
 use axum_extra::extract::cookie::{Cookie, SameSite};
-use fedimint_gateway_common::GatewayInfo;
+use fedimint_gateway_common::{GatewayInfo, PaymentSummaryPayload, PaymentSummaryResponse};
 use fedimint_ui_common::assets::WithStaticRoutesExt;
 use fedimint_ui_common::auth::UserAuth;
 use fedimint_ui_common::{
@@ -36,6 +37,14 @@ pub trait IAdminGateway {
     async fn handle_list_channels_msg(
         &self,
     ) -> Result<Vec<fedimint_gateway_common::ChannelInfo>, Self::Error>;
+
+    async fn handle_payment_summary_msg(
+        &self,
+        PaymentSummaryPayload {
+            start_millis,
+            end_millis,
+        }: PaymentSummaryPayload,
+    ) -> Result<PaymentSummaryResponse, Self::Error>;
 
     fn get_password_hash(&self) -> String;
 
@@ -102,8 +111,11 @@ where
 
     let content = html! {
         div class="row gy-4" {
-            div class="col-md-12" {
+            div class="col-md-6" {
                 (general::render(&gateway_info))
+            }
+            div class="col-md-6" {
+                (payment_summary::render(&state.api).await)
             }
         }
 

--- a/gateway/fedimint-gateway-ui/src/payment_summary.rs
+++ b/gateway/fedimint-gateway-ui/src/payment_summary.rs
@@ -1,0 +1,120 @@
+use std::time::{Duration, UNIX_EPOCH};
+
+use fedimint_core::time::now;
+use fedimint_gateway_common::{PaymentStats, PaymentSummaryPayload, PaymentSummaryResponse};
+use maud::{Markup, html};
+
+use crate::DynGatewayApi;
+
+pub async fn render<E>(api: &DynGatewayApi<E>) -> Markup
+where
+    E: std::fmt::Display,
+{
+    let now = now();
+    let now_millis = now
+        .duration_since(UNIX_EPOCH)
+        .expect("Before unix epoch")
+        .as_millis() as u64;
+
+    let one_day_ago = now
+        .checked_sub(Duration::from_secs(60 * 60 * 24))
+        .expect("Before unix epoch");
+    let one_day_ago_millis = one_day_ago
+        .duration_since(UNIX_EPOCH)
+        .expect("Before unix epoch")
+        .as_millis() as u64;
+
+    // Fetch payment summary safely
+    let payment_summary = api
+        .handle_payment_summary_msg(PaymentSummaryPayload {
+            start_millis: one_day_ago_millis,
+            end_millis: now_millis,
+        })
+        .await;
+
+    match payment_summary {
+        Ok(summary) => render_summary(&summary),
+        Err(e) => html! {
+            div class="card h-100 border-danger" {
+                div class="card-header dashboard-header bg-danger text-white" {
+                    "Payment Summary"
+                }
+                div class="card-body" {
+                    div class="alert alert-danger mb-0" {
+                        strong { "Failed to fetch payment summary: " }
+                        (e.to_string())
+                    }
+                }
+            }
+        },
+    }
+}
+
+fn render_summary(summary: &PaymentSummaryResponse) -> Markup {
+    html! {
+        div class="card h-100" {
+            div class="card-header dashboard-header" { "Payment Summary (Last 24h)" }
+            div class="card-body" {
+                div class="row" {
+                    div class="col-md-6" {
+                        (render_stats_table("Outgoing Payments", &summary.outgoing, "text-danger"))
+                    }
+                    div class="col-md-6" {
+                        (render_stats_table("Incoming Payments", &summary.incoming, "text-success"))
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn render_stats_table(title: &str, stats: &PaymentStats, title_class: &str) -> Markup {
+    html! {
+        div {
+            h5 class=(format!("{} mb-3", title_class)) { (title) }
+
+            table class="table table-sm mb-0" {
+                tbody {
+                    tr {
+                        th { "✅ Total Success" }
+                        td { (stats.total_success) }
+                    }
+                    tr {
+                        th { "❌ Total Failure" }
+                        td { (stats.total_failure) }
+                    }
+                    tr {
+                        th { "💸 Total Fees" }
+                        td { (format!("{} msats", stats.total_fees.msats)) }
+                    }
+                    tr {
+                        th { "⚡ Average Latency" }
+                        td {
+                            (match stats.average_latency {
+                                Some(d) => format_duration(d),
+                                None => "—".into(),
+                            })
+                        }
+                    }
+                    tr {
+                        th { "📈 Median Latency" }
+                        td {
+                            (match stats.median_latency {
+                                Some(d) => format_duration(d),
+                                None => "—".into(),
+                            })
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn format_duration(d: Duration) -> String {
+    if d.as_secs() > 0 {
+        format!("{:.2}s", d.as_secs_f64())
+    } else {
+        format!("{} ms", d.as_millis())
+    }
+}


### PR DESCRIPTION
Adds 24 hour payment summary to the gateway UI. Pretty cool for monitoring the payments that your gateway has facilitated.

<img width="2705" height="1408" alt="image" src="https://github.com/user-attachments/assets/8adb1b0d-aa4c-4c51-9cae-9e6a771c3000" />
