### PR TITLE
chore(ci): on failure output logs from services with a prefix

### DIFF
--- a/scripts/dev/run-test/fm-run-test
+++ b/scripts/dev/run-test/fm-run-test
@@ -30,23 +30,23 @@ on_error() {
   echo
   echo
   echo "## LOG FEDIMINTD-0:"
-  cat "$FM_RUN_TEST_TMPDIR"/devimint-*/logs/fedimintd-default-0.log || true
+  { cat "$FM_RUN_TEST_TMPDIR"/devimint-*/logs/fedimintd-default-0.log | sed 's/^/fm0 /'; } || true
   echo
   echo
   echo "## LOG LND GATEWAY:"
-  cat "$FM_RUN_TEST_TMPDIR"/devimint-*/logs/gatewayd-lnd.log || true
+  { cat "$FM_RUN_TEST_TMPDIR"/devimint-*/logs/gatewayd-lnd.log | sed 's/^/lng /'; } || true
   echo
   echo
   echo "## LOG LND NODE:"
-  cat "$FM_RUN_TEST_TMPDIR"/devimint-*/logs/lnd.log || true
+  { cat "$FM_RUN_TEST_TMPDIR"/devimint-*/logs/lnd.log | sed 's/^/lnn /'; } || true
   echo
   echo
   echo "## LOG LDK-0 GATEWAY:"
-  cat "$FM_RUN_TEST_TMPDIR"/devimint-*/logs/gatewayd-ldk-0.log || true
+  { cat "$FM_RUN_TEST_TMPDIR"/devimint-*/logs/gatewayd-ldk-0.log | sed 's/^/ldg /'; } || true
   echo
   echo
   echo "## LOG LDK-0 NODE:"
-  { cat  "$FM_RUN_TEST_TMPDIR"/devimint-*/gatewayd-ldk-0/ldk_node/ldk_node.log || true; } | grep -v "Failed to retrieve fee rate estimates" || true
+  { { cat  "$FM_RUN_TEST_TMPDIR"/devimint-*/gatewayd-ldk-0/ldk_node/ldk_node.log | sed 's/^/ldn /'; } || true; } | grep -v "Failed to retrieve fee rate estimates" || true
   echo
   echo "## FAIL END $test_name$version_str."
 }


### PR DESCRIPTION
When scrolling in the github UI to quickly evaluate failure I have a hard time finding the beginning and the end and figoure out which output I'm looking at. By prefixing them with a short string I'm hoping it will be easier to tell when scrolling what are we looking at.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
