### PR TITLE
chore: disable Iroh DHT when running tests

### DIFF
--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -12,6 +12,9 @@ if [ "$(ulimit -Sn)" -lt "10000" ]; then
   ulimit -Sn 10000
 fi
 
+>&2 echo "Iroh DHT is disabled"
+export FM_IROH_ENABLE_DHT=false
+
 # https://stackoverflow.com/a/72183258/134409
 # this hangs in CI (no tty?)
 # yes 'will cite' | parallel --citation 2>/dev/null 1>/dev/null || true


### PR DESCRIPTION
Even when federations under test are not using Iroh, the client will
initialize Iroh endpoint in case it needs to connect to Iroh-enabled
federations.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
