### PR TITLE
chore: more aggressive p2p reconnections

### DIFF
--- a/fedimint-server/src/net/p2p.rs
+++ b/fedimint-server/src/net/p2p.rs
@@ -14,7 +14,7 @@ use fedimint_core::PeerId;
 use fedimint_core::net::peers::{IP2PConnections, Recipient};
 use fedimint_core::task::{TaskGroup, sleep};
 use fedimint_core::util::FmtCompactAnyhow;
-use fedimint_core::util::backoff_util::{FibonacciBackoff, api_networking_backoff};
+use fedimint_core::util::backoff_util::{FibonacciBackoff, api_networking_backoff, custom_backoff};
 use fedimint_logging::{LOG_CONSENSUS, LOG_NET_PEER};
 use fedimint_server_core::dashboard_ui::ConnectionType;
 use futures::FutureExt;
@@ -228,6 +228,8 @@ impl<M: Send + 'static> P2PConnection<M> {
             format!("io-state-machine-{peer_id}"),
             async move {
                 info!(target: LOG_NET_PEER, "Starting peer connection state machine");
+                let p2p_reconnect_backoff =
+                    custom_backoff(Duration::from_millis(25), Duration::from_secs(5), None);
 
                 let mut state_machine = P2PConnectionStateMachine {
                     common: P2PConnectionSMCommon {
@@ -241,7 +243,7 @@ impl<M: Send + 'static> P2PConnection<M> {
                         incoming_connections,
                         status_sender,
                     },
-                    state: P2PConnectionSMState::Disconnected(api_networking_backoff()),
+                    state: P2PConnectionSMState::Disconnected(p2p_reconnect_backoff),
                 };
 
                 while let Some(sm) = state_machine.state_transition().await {


### PR DESCRIPTION
Peers are not outnumbering other peers as much as
clients (potentially) do, so they connectivity
retries can be more aggressive.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
