### PR TITLE
refactor(client): improve ways client events can be consumed

### DIFF
--- a/fedimint-client/src/client.rs
+++ b/fedimint-client/src/client.rs
@@ -39,7 +39,7 @@ use fedimint_core::config::{
 };
 use fedimint_core::core::{DynInput, DynOutput, ModuleInstanceId, ModuleKind, OperationId};
 use fedimint_core::db::{
-    AutocommitError, Database, DatabaseKey, DatabaseRecord, DatabaseTransaction,
+    AutocommitError, Database, DatabaseRecord, DatabaseTransaction,
     IDatabaseTransactionOpsCore as _, IDatabaseTransactionOpsCoreTyped as _, NonCommittable,
 };
 use fedimint_core::encoding::{Decodable, Encodable};
@@ -64,8 +64,8 @@ use fedimint_core::{
 };
 use fedimint_derive_secret::DerivableSecret;
 use fedimint_eventlog::{
-    DBTransactionEventLogExt as _, Event, EventKind, EventLogEntry, EventLogId, EventLogTrimableId,
-    EventPersistence, PersistedLogEntry,
+    DBTransactionEventLogExt as _, DynEventLogTrimableTracker, Event, EventKind, EventLogEntry,
+    EventLogId, EventLogTrimableId, EventLogTrimableTracker, EventPersistence, PersistedLogEntry,
 };
 use fedimint_logging::{LOG_CLIENT, LOG_CLIENT_NET_API, LOG_CLIENT_RECOVERY};
 use futures::stream::FuturesUnordered;
@@ -79,6 +79,7 @@ use tracing::{debug, info, warn};
 use crate::ClientBuilder;
 use crate::api_announcements::{ApiAnnouncementPrefix, get_api_urls};
 use crate::backup::Metadata;
+use crate::client::event_log::DefaultApplicationEventLogKey;
 use crate::db::{
     ApiSecretKey, CachedApiVersionSet, CachedApiVersionSetKey, ChronologicalOperationLogKey,
     ClientConfigKey, ClientMetadataKey, ClientModuleRecovery, ClientModuleRecoveryState,
@@ -95,6 +96,7 @@ use crate::sm::executor::{
 };
 
 pub(crate) mod builder;
+pub(crate) mod event_log;
 pub(crate) mod global_ctx;
 pub(crate) mod handle;
 
@@ -1793,38 +1795,101 @@ impl Client {
         .await;
     }
 
-    pub async fn handle_events<F, R, K>(&self, pos_key: &K, call_fn: F) -> anyhow::Result<()>
+    /// Built in event log (trimmable) tracker
+    ///
+    /// For the convenience of downstream applications, [`Client`] can store
+    /// internally event log position for the main application using/driving it.
+    ///
+    /// Note that this position is a singleton, so this tracker should not be
+    /// used for multiple purposes or applications, etc. at the same time.
+    ///
+    /// If the application has a need to follow log using multiple trackers, it
+    /// should implement own [`DynEventLogTrimableTracker`] and store its
+    /// persient data by itself.
+    pub fn built_in_application_event_log_tracker(&self) -> DynEventLogTrimableTracker {
+        struct BuiltInApplicationEventLogTracker;
+
+        #[apply(async_trait_maybe_send!)]
+        impl EventLogTrimableTracker for BuiltInApplicationEventLogTracker {
+            // Store position in the event log
+            async fn store(
+                &mut self,
+                dbtx: &mut DatabaseTransaction<NonCommittable>,
+                pos: EventLogTrimableId,
+            ) -> anyhow::Result<()> {
+                dbtx.insert_entry(&DefaultApplicationEventLogKey, &pos)
+                    .await;
+                Ok(())
+            }
+
+            /// Load the last previous stored position (or None if never stored)
+            async fn load(
+                &mut self,
+                dbtx: &mut DatabaseTransaction<NonCommittable>,
+            ) -> anyhow::Result<Option<EventLogTrimableId>> {
+                Ok(dbtx.get_value(&DefaultApplicationEventLogKey).await)
+            }
+        }
+        Box::new(BuiltInApplicationEventLogTracker)
+    }
+
+    /// Like [`Self::handle_events`] but for historical data.
+    ///
+    ///
+    /// This function can be used to process subset of events
+    /// that is infrequent and important enough to be persisted
+    /// forever. Most applications should prefer to use [`Self::handle_events`]
+    /// which emits *all* events.
+    pub async fn handle_historical_events<F, R>(
+        &self,
+        tracker: fedimint_eventlog::DynEventLogTracker,
+        handler_fn: F,
+    ) -> anyhow::Result<()>
     where
-        K: DatabaseKey + DatabaseRecord + MaybeSend + MaybeSync,
-        K: DatabaseRecord<Value = EventLogId>,
         F: Fn(&mut DatabaseTransaction<NonCommittable>, EventLogEntry) -> R,
         R: Future<Output = anyhow::Result<()>>,
     {
         fedimint_eventlog::handle_events(
             self.db.clone(),
-            pos_key,
+            tracker,
             self.log_event_added_rx.clone(),
-            call_fn,
+            handler_fn,
         )
         .await
     }
 
-    pub async fn handle_trimable_events<F, R, K>(
+    /// Handle events emitted by the client
+    ///
+    /// This is a preferred method for reactive & asynchronous
+    /// processing of events emitted by the client.
+    ///
+    /// It needs a `tracker` that will persist the position in the log
+    /// as it is being handled. You can use the
+    /// [`Client::built_in_application_event_log_tracker`] if this call is
+    /// used for the single main application handling this instance of the
+    /// [`Client`]. Otherwise you should implement your own tracker.
+    ///
+    /// This handler will call `handle_fn` with ever event emitted by
+    /// [`Client`], including transient ones. The caller should atomically
+    /// handle each event it is interested in and ignore other ones.
+    ///
+    /// This method returns only when client is shutting down or on internal
+    /// error, so typically should be called in a background task dedicated
+    /// to handling events.
+    pub async fn handle_events<F, R>(
         &self,
-        pos_key: &K,
-        call_fn: F,
+        tracker: fedimint_eventlog::DynEventLogTrimableTracker,
+        handler_fn: F,
     ) -> anyhow::Result<()>
     where
-        K: DatabaseKey + DatabaseRecord + MaybeSend + MaybeSync,
-        K: DatabaseRecord<Value = EventLogTrimableId>,
         F: Fn(&mut DatabaseTransaction<NonCommittable>, EventLogEntry) -> R,
         R: Future<Output = anyhow::Result<()>>,
     {
         fedimint_eventlog::handle_trimable_events(
             self.db.clone(),
-            pos_key,
+            tracker,
             self.log_event_added_rx.clone(),
-            call_fn,
+            handler_fn,
         )
         .await
     }

--- a/fedimint-client/src/client/event_log.rs
+++ b/fedimint-client/src/client/event_log.rs
@@ -1,0 +1,14 @@
+use fedimint_core::encoding::{Decodable, Encodable};
+use fedimint_core::impl_db_record;
+use fedimint_eventlog::EventLogTrimableId;
+
+use crate::db::DbKeyPrefixInternalReserved;
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Encodable, Decodable)]
+pub(crate) struct DefaultApplicationEventLogKey;
+
+impl_db_record!(
+    key = DefaultApplicationEventLogKey,
+    value = EventLogTrimableId,
+    db_prefix = DbKeyPrefixInternalReserved::DefaultApplicationEventLogPos,
+);

--- a/fedimint-client/src/db.rs
+++ b/fedimint-client/src/db.rs
@@ -83,9 +83,17 @@ pub enum DbKeyPrefix {
     /// historical and future external use
     ExternalReservedEnd = 0xcf,
     /// 0xd0.. reserved for Fedimint internal use
+    // (see [`DbKeyPrefixInternalReserved`] for *internal* details)
     InternalReservedStart = 0xd0,
     /// Per-module instance data
     ModuleGlobalPrefix = 0xff,
+}
+
+#[repr(u8)]
+#[derive(Clone, EnumIter, Debug)]
+pub(crate) enum DbKeyPrefixInternalReserved {
+    /// [`crate::Client::built_in_application_event_log_tracker`]
+    DefaultApplicationEventLogPos = 0xd0,
 }
 
 pub(crate) async fn verify_client_db_integrity_dbtx(dbtx: &mut DatabaseTransaction<'_>) {


### PR DESCRIPTION
This generalized tracking to use a `EventLogTracker` trait,
so it can be implemented more flexibly, e.g. allowing storing
position in prefixed db namespaces, etc. The old method
of using a key was not very practical, as keys itself
are quite static (can't generate prefix at runtime).

A prefix was allocated for built-in event log tracker
for the main downstream application driving the Client.

Some comments and renamed were done to make handling
event log easier.

I have some ideas for better naming system:

https://github.com/fedimint/fedimint/issues/7940

but that is going to be a larger rename change, so
maybe in a different PR.

To demonstrate and test how to use `Client::handle_events`
and new CLI command was added:

```
fm-cli dev test-event-log-handling
```