### PR TITLE
fix(tests): incorrect (harmless) `env` invocation

### DIFF
--- a/scripts/tests/large-setup-test.sh
+++ b/scripts/tests/large-setup-test.sh
@@ -13,7 +13,7 @@ export FM_FED_SIZE=7
 
 >&2 echo "Testing ${FM_FED_SIZE} peer dkg"
 
-env
+env \
   RUST_LOG="${RUST_LOG:-info,jsonrpsee-client=off}" \
   FM_EXTRA_LONG_POLL=true \
   devimint "$@" dev-fed \


### PR DESCRIPTION
Currently this `env` is just spamming the stdout. :shrug: 
<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
