### PR TITLE
chore(ci): make the Nix's pname for test-ci-all shorter

### DIFF
--- a/nix/flakebox.nix
+++ b/nix/flakebox.nix
@@ -657,7 +657,7 @@ in
         times,
         useIroh ? false,
       }:
-      craneLibTests.mkCargoDerivation {
+      (craneLibTests.mkCargoDerivation {
         pname = "${commonCliTestArgs.pname}-all";
         cargoArtifacts = craneMultiBuild.default.${craneLib.cargoProfile or "release"}.workspaceBuild;
 
@@ -696,7 +696,14 @@ in
           ./scripts/tests/test-ci-all.sh 1>/dev/null 2>/dev/null && exit 1
           cp -f scripts/tests/always-success-test.sh.bck scripts/tests/always-success-test.sh
         '';
-      };
+      }).overrideAttrs
+        (
+          final: prev: {
+            # flakebox will append wasm toolchain to the pname, which
+            # looks meh in the logs
+            pname = "test-ci-all";
+          }
+        );
 
     ciTestAll = ciTestAllBase { times = 1; };
     ciTestAllWithIroh = ciTestAllBase {


### PR DESCRIPTION
Currently all test log output is prefixed with
`fedimint-test-all-wasm32-unknown-unknown-ci> ` which is waay too long.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
