### PR TITLE
chore(ci): disable iroh next stack during tests

### DIFF
--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -12,8 +12,9 @@ if [ "$(ulimit -Sn)" -lt "10000" ]; then
   ulimit -Sn 10000
 fi
 
->&2 echo "Iroh DHT is disabled"
+>&2 echo "Iroh DHT & Iroh next-stack are disabled during tests"
 export FM_IROH_ENABLE_DHT=false
+export FM_IROH_ENABLE_NEXT=false
 
 # https://stackoverflow.com/a/72183258/134409
 # this hangs in CI (no tty?)


### PR DESCRIPTION
It basically doubles Iroh's heaviness.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
