### PR TITLE
fix: flaky latency tests

### DIFF
--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -124,7 +124,7 @@ pub async fn latency_tests(
         ..
     } = dev_fed;
 
-    let max_p90_factor = 5.0;
+    let max_p90_factor = 10.0;
     let p90_median_factor = 10;
 
     let client = match upgrade_clients {


### PR DESCRIPTION
Like

https://github.com/fedimint/fedimint/actions/runs/19373880222/job/55436331714

The CI is too heavy to be so tight on tail latency asserts.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
