### PR TITLE
fix: dont await gateway registration future

### DIFF
--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -1782,8 +1782,9 @@ impl Gateway {
                     let api = self.versioned_api.clone();
                     let gateway_id = self.gateway_id;
 
-                    if let Err(err) = register_task_group
-                        .spawn_cancellable("register_federation", async move {
+                    register_task_group.spawn_cancellable_silent(
+                        "register federation",
+                        async move {
                             let gateway_client = client_arc
                                 .get_first_module::<GatewayClientModule>()
                                 .expect("No GatewayClientModule exists");
@@ -1797,11 +1798,8 @@ impl Gateway {
                                     gateway_id,
                                 )
                                 .await;
-                        })
-                        .await
-                    {
-                        warn!(target: LOG_GATEWAY, err = %err.fmt_compact(), "Failed to shutdown register federation task");
-                    }
+                        },
+                    );
                 }
             }
         }


### PR DESCRIPTION
We have a bug in registration logic for LNv1, where we `await` the spawned future for registering a federation. These futures are supposed to run in parallel, but if we `await` one, the other federations will not be registered if one registration fails.