### PR TITLE
chore: print devimint data dir when ready

### DIFF
--- a/devimint/src/cli.rs
+++ b/devimint/src/cli.rs
@@ -159,7 +159,7 @@ pub async fn setup(arg: CommonArgs) -> Result<(ProcessManager, TaskGroup)> {
     if let Some(link_test_dir) = arg.link_test_dir.as_ref() {
         update_test_dir_link(link_test_dir, &arg.test_dir()).await?;
     }
-    info!(target: LOG_DEVIMINT, path=%globals.FM_DATA_DIR.display() , "Devimint data dir");
+    info!(target: LOG_DEVIMINT, path = %globals.FM_DATA_DIR.display(), "Devimint data dir");
 
     let mut env_string = String::new();
     for (var, value) in globals.vars() {
@@ -362,7 +362,12 @@ pub async fn handle_command(cmd: Cmd, common_args: CommonArgs) -> Result<()> {
 
                     let daemons = write_ready_file(&process_mgr.globals, Ok(dev_fed)).await?;
 
-                    info!(target: LOG_DEVIMINT, elapsed_ms = %start_time.elapsed().as_millis(), "Devfed ready");
+                    info!(
+                        target: LOG_DEVIMINT,
+                        elapsed_ms = %start_time.elapsed().as_millis(),
+                        path = %process_mgr.globals.FM_DATA_DIR.display(),
+                        "Devfed ready"
+                    );
                     if let Some(exec) = exec {
                         debug!(target: LOG_DEVIMINT, "Starting exec command");
                         exec_user_command(exec).await?;


### PR DESCRIPTION
This is where the logs and other files are, and when using debug logs, it is inconvenient to scroll to the top to look it up.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
