### PR TITLE
fix(wallet-server): process more block when running tests

### DIFF
--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -466,7 +466,17 @@ impl ServerModule for Wallet {
                 // This will prevent that more then five blocks are synced in a single database
                 // transaction if the federation was offline for a prolonged period of time.
                 if current_consensus_block_count != 0 {
-                    block_count_vote = min(block_count_vote, current_consensus_block_count + 5);
+                    block_count_vote = min(
+                        block_count_vote,
+                        current_consensus_block_count
+                            + if is_running_in_test_env() {
+                                // We have some tests that mine *a lot* of blocks (empty)
+                                // and need them processed fast, so we raise the max.
+                                100
+                            } else {
+                                5
+                            },
+                    );
                 }
 
                 let current_vote = dbtx


### PR DESCRIPTION
We have some tests that rely on mining and processing a lot of blocks at once fast (`unilateral_refund_of_outgoing_contracts`).

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
