### PR TITLE
Add support for Lightning Address payments and verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3506,6 +3506,7 @@ dependencies = [
  "itertools 0.14.0",
  "lightning-invoice",
  "lnurl-rs",
+ "once_cell",
  "rand 0.8.5",
  "reqwest 0.12.22",
  "serde",

--- a/modules/fedimint-ln-client/Cargo.toml
+++ b/modules/fedimint-ln-client/Cargo.toml
@@ -42,6 +42,7 @@ futures = { workspace = true }
 itertools = { workspace = true }
 lightning-invoice = { workspace = true, features = ["serde"] }
 lnurl-rs = { workspace = true, features = ["async"] }
+once_cell = "1.21.3"
 rand = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }

--- a/modules/fedimint-ln-client/Cargo.toml
+++ b/modules/fedimint-ln-client/Cargo.toml
@@ -42,7 +42,6 @@ futures = { workspace = true }
 itertools = { workspace = true }
 lightning-invoice = { workspace = true, features = ["serde"] }
 lnurl-rs = { workspace = true, features = ["async"] }
-once_cell = "1.21.3"
 rand = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -527,6 +527,13 @@ impl ClientModule for LightningClientModule {
                         "invoice": invoice,
                     });
                 }
+                "get_invoice" => {
+                    let req: GetInvoiceRequest = serde_json::from_value(payload)?;
+                    let invoice = get_invoice(&req.info, req.amount, req.lnurl_comment).await?;
+                    yield serde_json::json!({
+                        "invoice": invoice,
+                    });
+                }
                 "pay_bolt11_invoice" => {
                     let req: PayBolt11InvoiceRequest = serde_json::from_value(payload)?;
                     let outgoing_payment = self
@@ -621,6 +628,13 @@ struct CreateBolt11InvoiceRequest {
     expiry_time: Option<u64>,
     extra_meta: serde_json::Value,
     gateway: Option<LightningGateway>,
+}
+
+#[derive(Deserialize)]
+struct GetInvoiceRequest {
+    info: String,
+    amount: Option<Amount>,
+    lnurl_comment: Option<String>,
 }
 
 #[derive(Deserialize)]

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -247,6 +247,19 @@ fn invoice_routes_back_to_federation(
     })
 }
 
+fn extract_lnurl_description(metadata: &serde_json::Value) -> Option<String> {
+    metadata.as_array()?.iter().find_map(|entry| {
+        let mut values = entry.as_array()?.iter();
+        match (
+            values.next().and_then(serde_json::Value::as_str),
+            values.next().and_then(serde_json::Value::as_str),
+        ) {
+            (Some("text/plain"), Some(description)) => Some(description.to_owned()),
+            _ => None,
+        }
+    })
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct LightningOperationMetaPay {
@@ -506,6 +519,30 @@ impl ClientModule for LightningClientModule {
     ) -> BoxStream<'_, anyhow::Result<serde_json::Value>> {
         Box::pin(try_stream! {
             match method.as_str() {
+                "verify_lightning_address" => {
+                    let req: VerifyLightningAddressRequest = serde_json::from_value(payload)?;
+                    let verification = self
+                        .verify_lightning_address(
+                            req.lightning_address,
+                            req.amount_msats,
+                            req.comment,
+                        )
+                        .await?;
+                    yield serde_json::to_value(verification)?;
+                }
+                "pay_lightning_address" => {
+                    let req: PayLightningAddressRequest = serde_json::from_value(payload)?;
+                    let payment = self
+                        .pay_lightning_address(
+                            req.lightning_address,
+                            req.amount_msats,
+                            req.comment,
+                            req.gateway,
+                            req.extra_meta,
+                        )
+                        .await?;
+                    yield serde_json::to_value(payment)?;
+                }
                 "create_bolt11_invoice" => {
                     let req: CreateBolt11InvoiceRequest = serde_json::from_value(payload)?;
                     let (op, invoice, _) = self
@@ -621,6 +658,22 @@ struct CreateBolt11InvoiceRequest {
 }
 
 #[derive(Deserialize)]
+struct VerifyLightningAddressRequest {
+    lightning_address: String,
+    amount_msats: u64,
+    comment: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct PayLightningAddressRequest {
+    lightning_address: String,
+    amount_msats: u64,
+    comment: Option<String>,
+    gateway: Option<LightningGateway>,
+    extra_meta: Option<serde_json::Value>,
+}
+
+#[derive(Deserialize)]
 struct PayBolt11InvoiceRequest {
     maybe_gateway: Option<LightningGateway>,
     invoice: Bolt11Invoice,
@@ -676,6 +729,26 @@ struct GetGatewayRequest {
     gateway_id: Option<secp256k1::PublicKey>,
     force_internal: bool,
 }
+
+#[derive(Debug, Serialize)]
+pub struct LightningAddressInvoiceDetails {
+    pub lightning_address: String,
+    pub amount_msats: u64,
+    pub invoice: Bolt11Invoice,
+    pub min_sendable: u64,
+    pub max_sendable: u64,
+    pub description: Option<String>,
+    pub comment: Option<String>,
+    pub comment_allowed: Option<u32>,
+    pub success_action: Option<SuccessActionParams>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PayLightningAddressResponse {
+    pub invoice_details: LightningAddressInvoiceDetails,
+    pub payment: OutgoingLightningPayment,
+}
+
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
 pub enum GatewayStatus {
@@ -1259,6 +1332,106 @@ impl LightningClientModule {
             .map(|(_, gw)| gw.unanchor())
             .collect::<Vec<_>>()
             .await
+    }
+
+    async fn request_lightning_address_invoice(
+        &self,
+        lightning_address: String,
+        amount_msats: u64,
+        comment: Option<String>,
+    ) -> anyhow::Result<LightningAddressInvoiceDetails> {
+        ensure!(amount_msats > 0, "Amount must be greater than zero");
+
+        let lightning_address = lightning_address.trim().to_owned();
+        let lnurl = if lightning_address.to_lowercase().starts_with("lnurl") {
+            lnurl::lnurl::LnUrl::from_str(&lightning_address)?
+        } else {
+            lnurl::lightning_address::LightningAddress::from_str(&lightning_address)
+                .context("Invalid lightning address")?
+                .lnurl()
+        };
+
+        let async_client = lnurl::AsyncClient::from_client(reqwest::Client::new());
+        let response = async_client.make_request(&lnurl.url).await?;
+        let pay_response = match response {
+            LnUrlResponse::LnUrlPayResponse(response) => response,
+            other => bail!("Unexpected LNURL response: {other:?}"),
+        };
+
+        ensure!(
+            amount_msats >= pay_response.min_sendable && amount_msats <= pay_response.max_sendable,
+            "Amount outside of allowed range ({:?} - {:?})",
+            Amount::from_msats(pay_response.min_sendable),
+            Amount::from_msats(pay_response.max_sendable)
+        );
+
+        if let Some(comment) = comment.as_ref() {
+            let Some(comment_allowed) = pay_response.comment_allowed else {
+                bail!("Lightning address does not allow comments");
+            };
+            ensure!(
+                comment.chars().count() <= comment_allowed as usize,
+                "Comment longer than allowed (max {comment_allowed} characters)",
+            );
+        }
+
+        let invoice_response = async_client
+            .get_invoice(&pay_response, amount_msats, None, comment.as_deref())
+            .await?;
+
+        let invoice = Bolt11Invoice::from_str(invoice_response.invoice())?;
+        ensure!(
+            invoice.amount_milli_satoshis() == Some(amount_msats),
+            "Requested amount does not match generated invoice",
+        );
+
+        let success_action = invoice_response
+            .success_action()
+            .map(lnurl::pay::SuccessAction::into_params);
+
+        Ok(LightningAddressInvoiceDetails {
+            lightning_address,
+            amount_msats,
+            invoice,
+            min_sendable: pay_response.min_sendable,
+            max_sendable: pay_response.max_sendable,
+            description: extract_lnurl_description(&pay_response.metadata_json()),
+            comment,
+            comment_allowed: pay_response.comment_allowed,
+            success_action,
+        })
+    }
+
+    pub async fn verify_lightning_address(
+        &self,
+        lightning_address: String,
+        amount_msats: u64,
+        comment: Option<String>,
+    ) -> anyhow::Result<LightningAddressInvoiceDetails> {
+        self.request_lightning_address_invoice(lightning_address, amount_msats, comment)
+            .await
+    }
+
+    pub async fn pay_lightning_address(
+        &self,
+        lightning_address: String,
+        amount_msats: u64,
+        comment: Option<String>,
+        gateway: Option<LightningGateway>,
+        extra_meta: Option<serde_json::Value>,
+    ) -> anyhow::Result<PayLightningAddressResponse> {
+        let invoice_details = self
+            .request_lightning_address_invoice(lightning_address, amount_msats, comment)
+            .await?;
+
+        let payment = self
+            .pay_bolt11_invoice(gateway, invoice_details.invoice.clone(), extra_meta)
+            .await?;
+
+        Ok(PayLightningAddressResponse {
+            invoice_details,
+            payment,
+        })
     }
 
     /// Pays a LN invoice with our available funds using the supplied `gateway`

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -85,7 +85,7 @@ use itertools::Itertools;
 use lightning_invoice::{
     Bolt11Invoice, Currency, InvoiceBuilder, PaymentSecret, RouteHint, RouteHintHop, RoutingFees,
 };
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 use pay::PayInvoicePayload;
 use rand::rngs::OsRng;
 use rand::seq::IteratorRandom as _;
@@ -118,8 +118,8 @@ const OUTGOING_LN_CONTRACT_TIMELOCK: u64 = 500;
 // 24 hours. Many wallets default to 1 hour, but it's a bad user experience if
 // invoices expire too quickly
 const DEFAULT_INVOICE_EXPIRY_TIME: Duration = Duration::from_secs(60 * 60 * 24);
-static LNURL_ASYNC_CLIENT: Lazy<lnurl::AsyncClient> =
-    Lazy::new(|| lnurl::AsyncClient::from_client(reqwest::Client::new()));
+static LNURL_ASYNC_CLIENT: LazyLock<lnurl::AsyncClient> =
+    LazyLock::new(|| lnurl::AsyncClient::from_client(reqwest::Client::new()));
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Encodable, Decodable)]
 #[serde(rename_all = "snake_case")]


### PR DESCRIPTION
## Summary

This work depends on the backend changes in  
https://github.com/fedimint/fedimint-sdk/pull/225,  
which introduce the two new LN RPCs: `verify_lightning_address` and `pay_lightning_address`.

This PR adds full support for working with Lightning Addresses.  
It includes everything needed for the app to verify a Lightning Address, fetch its details, and send a payment to it.

## What’s Done

- Added new RPC handlers and request types so the LN client can verify or pay Lightning Addresses, making these features available to WASM users.
- Added structured payment details in RPC responses — invoice, limits, comments, and success actions.
- Implemented full LNURL Lightning Address resolution, including metadata extraction and validation of amount and comment.  
  The same logic is now reused in both verification and payment flows.