### PR TITLE
Start9 v0.9.1

### DIFF
--- a/fedimint-startos/Dockerfile
+++ b/fedimint-startos/Dockerfile
@@ -11,7 +11,7 @@ RUN case "$TARGETARCH" in \
     chmod +x /tmp/yq
 
 # Stage 2: Main image
-FROM fedimint/fedimintd:v0.9.0
+FROM fedimint/fedimintd:v0.9.1
 
 # Copy yq from downloader stage
 COPY --from=downloader /tmp/yq /usr/local/bin/yq

--- a/fedimint-startos/docker_entrypoint.sh
+++ b/fedimint-startos/docker_entrypoint.sh
@@ -63,6 +63,11 @@ else
     exit 1
 fi
 
+# Read and set RUST_LOG from config
+RUST_LOG_LEVEL=$(yq '.advanced.rust-log-level' /start-os/start9/config.yaml)
+export RUST_LOG="${RUST_LOG_LEVEL}"
+echo "Setting RUST_LOG=${RUST_LOG}"
+
 # Create .backupignore to exclude files that shouldn't be backed up:
 #
 # We exclude the active database because:

--- a/fedimint-startos/manifest.yaml
+++ b/fedimint-startos/manifest.yaml
@@ -1,8 +1,8 @@
 id: fedimintd
 title: "Fedimint"
-version: 0.9.0
+version: 0.9.1
 release-notes: |
-  Read more about the release [here](https://github.com/fedimint/fedimint/releases/tag/v0.9.0)
+  Read more about the release [here](https://github.com/fedimint/fedimint/releases/tag/v0.9.1)
 license: MIT
 wrapper-repo: "https://github.com/fedimint/fedimint/tree/master/fedimint-startos"
 upstream-repo: "https://github.com/fedimint/fedimint"

--- a/fedimint-startos/scripts/constants.ts
+++ b/fedimint-startos/scripts/constants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_RUST_LOG = "info,jsonrpsee_core::client::async_client=off,hyper=off,h2=off,jsonrpsee_server=warn,jsonrpsee_server::transport=off,AlephBFT-=error,iroh=error";

--- a/fedimint-startos/scripts/procedures/getConfig.ts
+++ b/fedimint-startos/scripts/procedures/getConfig.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_RUST_LOG } from "../constants.ts";
 import { types as T, compat } from "../deps.ts";
 
 export const getConfig: T.ExpectedExports.getConfig = compat.getConfig({
@@ -47,6 +48,23 @@ export const getConfig: T.ExpectedExports.getConfig = compat.getConfig({
           pattern: "^https?://.*",
           "pattern-description": "Must be a valid HTTP(S) URL"
         }
+      }
+    }
+  },
+  "advanced": {
+    type: "object",
+    name: "Advanced Settings",
+    description: "Optional configuration for debugging and development",
+    nullable: false,
+    spec: {
+      "rust-log-level": {
+        type: "string",
+        name: "Rust Log Directives",
+        description: "Rust logging directives (e.g., 'info,fm=debug'). Only modify if debugging.",
+        nullable: false,
+        default: DEFAULT_RUST_LOG,
+        pattern: ".*",
+        "pattern-description": "Any valid Rust log directive string"
       }
     }
   }

--- a/fedimint-startos/scripts/procedures/migrations.ts
+++ b/fedimint-startos/scripts/procedures/migrations.ts
@@ -1,4 +1,28 @@
+import { DEFAULT_RUST_LOG } from "../constants.ts";
 import { compat, types as T } from "../deps.ts";
 
-export const migration: T.ExpectedExports.migration = compat.migrations
-    .fromMapping({}, "0.9.0" );
+export const migration: T.ExpectedExports.migration = compat.migrations.fromMapping(
+  {
+    "0.9.1": {
+      up: compat.migrations.updateConfig(
+        (config) => {
+          if (!config.advanced) {
+            config.advanced = {};
+          }
+          if (!config.advanced["rust-log-level"]) {
+            config.advanced["rust-log-level"] = DEFAULT_RUST_LOG;
+          }
+          return config;
+        },
+        true,
+        { version: "0.9.1", type: "up" }
+      ),
+      down: compat.migrations.updateConfig(
+        (config) => config,
+        true,
+        { version: "0.9.1", type: "down" }
+      ),
+    },
+  },
+  "0.9.1"
+);


### PR DESCRIPTION
Working towards https://github.com/fedimint/fedimint/issues/7953

- Bumps the Start9 package to `v0.9.1`
- Adds an advanced setting in the dashboard that updates the rust log directive
- Tested fresh install
- Tested `v0.9.0 -> v0.9.1` upgrade

New config in advanced settings

<img width="894" height="591" alt="image" src="https://github.com/user-attachments/assets/1418e9d1-448a-4a3e-b9dc-05fad254b250" />
