### PR TITLE
fix: larger delay before shutting down api

### DIFF
--- a/fedimint-server/src/lib.rs
+++ b/fedimint-server/src/lib.rs
@@ -301,7 +301,7 @@ pub async fn run_config_gen(
     // HACK: The `start-dkg` API call needs to have some time to finish
     // before we shut down api handling. There's no easy and good way to do
     // that other than just giving it some grace period.
-    sleep(Duration::from_millis(10)).await;
+    sleep(Duration::from_millis(100)).await;
 
     api_handler
         .stop()


### PR DESCRIPTION
I think we've managed to still hit this flake once, though it seems to be much, much more rare now.

Let's increase the sleep by an order of magnitude still. I don't want to go to high because this is slowing down every dkg we use in our test suite, and seems like 10ms is already almost completely reliable.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
