### PR TITLE
fix: skip unilateral_refund_of_outgoing_contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3690,6 +3690,7 @@ dependencies = [
  "fedimint-lnv2-client",
  "fedimint-lnv2-common",
  "fedimint-lnv2-server",
+ "fedimint-logging",
  "fedimint-testing",
  "itertools 0.14.0",
  "lightning-invoice",

--- a/modules/fedimint-lnv2-tests/Cargo.toml
+++ b/modules/fedimint-lnv2-tests/Cargo.toml
@@ -33,6 +33,7 @@ fedimint-ln-common = { workspace = true }
 fedimint-lnv2-client = { workspace = true }
 fedimint-lnv2-common = { workspace = true }
 fedimint-lnv2-server = { workspace = true }
+fedimint-logging = { workspace = true }
 fedimint-testing = { workspace = true }
 itertools = { workspace = true }
 lightning-invoice = { workspace = true }

--- a/modules/fedimint-lnv2-tests/tests/tests.rs
+++ b/modules/fedimint-lnv2-tests/tests/tests.rs
@@ -20,8 +20,10 @@ use fedimint_lnv2_common::{
     Bolt11InvoiceDescription, LightningInput, LightningInputV0, OutgoingWitness,
 };
 use fedimint_lnv2_server::LightningInit;
+use fedimint_logging::LOG_TEST;
 use fedimint_testing::fixtures::Fixtures;
 use serde_json::Value;
+use tracing::warn;
 
 use crate::mock::{MOCK_INVOICE_PREIMAGE, MockGatewayConnection};
 
@@ -141,6 +143,14 @@ async fn refund_failed_payment() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn unilateral_refund_of_outgoing_contracts() -> anyhow::Result<()> {
+    if Fixtures::is_real_test() {
+        warn!(
+            target: LOG_TEST,
+            "Skipping test as mining so many blocks is too slow in real bitcoind setup"
+        );
+        return Ok(());
+    }
+
     let fixtures = fixtures();
     let fed = fixtures.new_fed_degraded().await;
     let client = fed.new_client().await;


### PR DESCRIPTION
On real regtest bitcoind mining 1.5k blocks is too slow to be reliable.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
