### PR TITLE
feat(mint): add send_oob_notes that automatically reissues denominations if required

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3893,6 +3893,7 @@ dependencies = [
  "test-log",
  "thiserror 2.0.12",
  "tokio",
+ "tokio-stream",
  "tracing",
 ]
 

--- a/modules/fedimint-mint-client/Cargo.toml
+++ b/modules/fedimint-mint-client/Cargo.toml
@@ -59,6 +59,7 @@ tbs = { workspace = true }
 thiserror = { workspace = true }
 threshold_crypto = { workspace = true }
 tokio = { workspace = true }
+tokio-stream = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Adds a new send_oob_notes method to MintClientModule that simplifies sending e-cash notes by automatically handling denomination availability.

- Offline: If exact denominations are available, spends them immediately without contacting the federation
- Online: If exact denominations aren't available, automatically triggers a reissuance transaction to obtain the required denominations
- Amount is rounded up to the nearest 512 msat multiple
- Cancellation-safe: if cancelled during online mode, reissued notes are automatically returned to the wallet
- Emits SendPaymentEvent for tracking

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
