### PR TITLE
chore: cleanup fedimint-fountain public API

### DIFF
--- a/fedimint-fountain/src/fountain.rs
+++ b/fedimint-fountain/src/fountain.rs
@@ -159,7 +159,7 @@ impl EncodingMetadata {
     }
 }
 
-/// A fragment emitted by a fountain [`Encoder`].
+/// A fragment emitted by a fountain encoder.
 #[derive(Clone, Debug, PartialEq, Eq, Encodable, Decodable)]
 pub struct Fragment {
     meta: EncodingMetadata,


### PR DESCRIPTION
We are removing outdated docs and reexport the Fragment type.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
