### PR TITLE
chore: allow to retrieve raw log entries

### DIFF
--- a/fedimint-client/src/client.rs
+++ b/fedimint-client/src/client.rs
@@ -1876,6 +1876,27 @@ impl Client {
         dbtx.get_event_log_trimable(pos, limit).await
     }
 
+    pub async fn get_event_log_raw(
+        &self,
+        pos: Option<EventLogId>,
+        limit: u64,
+    ) -> Vec<(EventLogId, EventLogEntry)> {
+        self.get_event_log_raw_dbtx(&mut self.db.begin_transaction_nc().await, pos, limit)
+            .await
+    }
+
+    pub async fn get_event_log_raw_dbtx<Cap>(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_, Cap>,
+        pos: Option<EventLogId>,
+        limit: u64,
+    ) -> Vec<(EventLogId, EventLogEntry)>
+    where
+        Cap: Send,
+    {
+        dbtx.get_event_log_raw(pos, limit).await
+    }
+
     /// Register to receiver all new transient (unpersisted) events
     pub fn get_event_log_transient_receiver(&self) -> broadcast::Receiver<EventLogEntry> {
         self.log_event_added_transient_tx.subscribe()


### PR DESCRIPTION
 - Add get_event_log_raw method to retrieve event log entries as raw EventLogEntry structs without converting
   to PersistedLogEntry
  - Make EventLogEntry::ts_usecs field public for external access

This will make it easier to maintain a subsequence of the events that interest us outside of the client.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
