### PR TITLE
Update flake to Nixos 25.11

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -556,16 +556,16 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1762111121,
-        "narHash": "sha256-4vhDuZ7OZaZmKKrnDpxLZZpGIJvAeMtK6FKLJYUtAdw=",
+        "lastModified": 1764522689,
+        "narHash": "sha256-SqUuBFjhl/kpDiVaKLQBoD8TLD+/cTUzzgVFoaHrkqY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b3d51a0365f6695e7dd5cdf3e180604530ed33b4",
+        "rev": "8bb5646e0bed5dbd3ab08c7a7cc15b75ab4e1d0f",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-unstable",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,8 +1,7 @@
 {
   inputs = {
     nixpkgs = {
-      # TODO: nixos-25.11, which should be soon(TM)
-      url = "github:nixos/nixpkgs/nixos-unstable";
+      url = "github:nixos/nixpkgs/nixos-25.11";
     };
     nixpkgs-unstable = {
       url = "github:nixos/nixpkgs/nixos-unstable";


### PR DESCRIPTION
This PR updates the flake nix to use the recently released nix package release 25.11.

In my testing I found that `cargo-llvm-cov` was failing to build with some internal tests requiring write permission that was not allowed after updating to `25.11`.  This behavior was not exhibited in `25.05` or `nixos-unstable` but preventing the build checks with `doCheck = false` was my stopgap in 4d22f6ddfcaf9693c9e60ba50364696311902c95.

I searched any issues relating to this build failure on updating to 25.11 but it seems no one else has had this problem that I could find.

tested with `nix flake check`

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
