### PR TITLE
cleanup: use single status struct for p2p connection status

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -84,7 +84,7 @@ Use [github search to find more details about every API](https://github.com/sear
 ### P2P Connection Status Endpoint
 - **Endpoint**: `p2p_connection_status`
 - **Arguments**: None
-- **Returns**: `BTreeMap<PeerId, Option<Duration>>`
+- **Returns**: `BTreeMap<PeerId, Option<P2PConnectionStatus>>` where `P2PConnectionStatus` contains connection type and RTT
 - **Purpose**: Returns the connection status to other peers in the federation.
 
 ### Session Count Endpoint

--- a/fedimint-core/src/endpoint_constants.rs
+++ b/fedimint-core/src/endpoint_constants.rs
@@ -27,7 +27,6 @@ pub const RECOVER_ENDPOINT: &str = "recover";
 pub const SETUP_STATUS_ENDPOINT: &str = "setup_status";
 pub const CONSENSUS_ORD_LATENCY_ENDPOINT: &str = "consensus_ord_latency";
 pub const P2P_CONNECTION_STATUS_ENDPOINT: &str = "p2p_connection_status";
-pub const P2P_CONNECTION_TYPE_ENDPOINT: &str = "p2p_connection_type";
 pub const START_DKG_ENDPOINT: &str = "start_dkg";
 pub const RUN_DKG_ENDPOINT: &str = "run_dkg";
 pub const RESET_SETUP_ENDPOINT: &str = "reset_setup";

--- a/fedimint-server-ui/src/dashboard/mod.rs
+++ b/fedimint-server-ui/src/dashboard/mod.rs
@@ -80,7 +80,6 @@ async fn dashboard_view(
     let fedimintd_version = state.api.fedimintd_version().await;
     let consensus_ord_latency = state.api.consensus_ord_latency().await;
     let p2p_connection_status = state.api.p2p_connection_status().await;
-    let p2p_connection_type_status = state.api.p2p_connection_type_status().await;
     let invite_code = state.api.federation_invite_code().await;
     let audit_summary = state.api.federation_audit().await;
     let bitcoin_rpc_url = state.api.bitcoin_rpc_url().await;
@@ -103,7 +102,7 @@ async fn dashboard_view(
             }
 
             div class="col-lg-6" {
-                (latency::render(consensus_ord_latency, &p2p_connection_status, &p2p_connection_type_status))
+                (latency::render(consensus_ord_latency, &p2p_connection_status))
             }
         }
 

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -50,7 +50,7 @@ use crate::consensus::engine::ConsensusEngine;
 use crate::db::verify_server_db_integrity_dbtx;
 use crate::net::api::announcement::get_api_urls;
 use crate::net::api::{ApiSecrets, HasApiContext};
-use crate::net::p2p::{P2PConnectionTypeReceivers, P2PStatusReceivers};
+use crate::net::p2p::P2PStatusReceivers;
 use crate::{DashboardUiRouter, net, update_server_info_version_dbtx};
 
 /// How many txs can be stored in memory before blocking the API
@@ -61,7 +61,6 @@ pub async fn run(
     connectors: ConnectorRegistry,
     connections: DynP2PConnections<P2PMessage>,
     p2p_status_receivers: P2PStatusReceivers,
-    p2p_connection_type_receivers: P2PConnectionTypeReceivers,
     api_bind: SocketAddr,
     iroh_dns: Option<SafeUrl>,
     iroh_relays: Vec<SafeUrl>,
@@ -198,7 +197,6 @@ pub async fn run(
             &module_init_registry,
         ),
         p2p_status_receivers,
-        p2p_connection_type_receivers,
         ci_status_receivers,
         ord_latency_receiver,
         bitcoin_rpc_connection: bitcoin_rpc_connection.clone(),

--- a/fedimint-server/src/lib.rs
+++ b/fedimint-server/src/lib.rs
@@ -63,10 +63,7 @@ use crate::db::{ServerInfo, ServerInfoKey};
 use crate::fedimint_core::net::peers::IP2PConnections;
 use crate::metrics::initialize_gauge_metrics;
 use crate::net::api::announcement::start_api_announcement_service;
-use crate::net::p2p::{
-    P2PConnectionTypeReceivers, ReconnectP2PConnections, p2p_connection_type_channels,
-    p2p_status_channels,
-};
+use crate::net::p2p::{ReconnectP2PConnections, p2p_status_channels};
 use crate::net::p2p_connector::{IP2PConnector, TlsTcpConnector};
 
 pub mod metrics;
@@ -101,68 +98,58 @@ pub async fn run(
     db_checkpoint_retention: u64,
     iroh_api_limits: ConnectionLimits,
 ) -> anyhow::Result<()> {
-    let (cfg, connections, p2p_status_receivers, p2p_connection_type_receivers) =
-        match get_config(&data_dir)? {
-            Some(cfg) => {
-                let connector = if cfg.consensus.iroh_endpoints.is_empty() {
-                    TlsTcpConnector::new(
-                        cfg.tls_config(),
-                        settings.p2p_bind,
-                        cfg.local.p2p_endpoints.clone(),
-                        cfg.local.identity,
-                    )
-                    .await
-                    .into_dyn()
-                } else {
-                    IrohConnector::new(
-                        cfg.private.iroh_p2p_sk.clone().unwrap(),
-                        settings.p2p_bind,
-                        settings.iroh_dns.clone(),
-                        settings.iroh_relays.clone(),
-                        cfg.consensus
-                            .iroh_endpoints
-                            .iter()
-                            .map(|(peer, endpoints)| (*peer, endpoints.p2p_pk))
-                            .collect(),
-                    )
-                    .await?
-                    .into_dyn()
-                };
-
-                let (p2p_status_senders, p2p_status_receivers) =
-                    p2p_status_channels(connector.peers());
-                let (p2p_connection_type_senders, p2p_connection_type_receivers) =
-                    p2p_connection_type_channels(connector.peers());
-
-                let connections = ReconnectP2PConnections::new(
+    let (cfg, connections, p2p_status_receivers) = match get_config(&data_dir)? {
+        Some(cfg) => {
+            let connector = if cfg.consensus.iroh_endpoints.is_empty() {
+                TlsTcpConnector::new(
+                    cfg.tls_config(),
+                    settings.p2p_bind,
+                    cfg.local.p2p_endpoints.clone(),
                     cfg.local.identity,
-                    connector,
-                    &task_group,
-                    p2p_status_senders,
-                    p2p_connection_type_senders,
                 )
-                .into_dyn();
-
-                (
-                    cfg,
-                    connections,
-                    p2p_status_receivers,
-                    p2p_connection_type_receivers,
+                .await
+                .into_dyn()
+            } else {
+                IrohConnector::new(
+                    cfg.private.iroh_p2p_sk.clone().unwrap(),
+                    settings.p2p_bind,
+                    settings.iroh_dns.clone(),
+                    settings.iroh_relays.clone(),
+                    cfg.consensus
+                        .iroh_endpoints
+                        .iter()
+                        .map(|(peer, endpoints)| (*peer, endpoints.p2p_pk))
+                        .collect(),
                 )
-            }
-            None => {
-                Box::pin(run_config_gen(
-                    data_dir.clone(),
-                    settings.clone(),
-                    db.clone(),
-                    &task_group,
-                    code_version_str.clone(),
-                    force_api_secrets.clone(),
-                    setup_ui_router,
-                ))
                 .await?
-            }
-        };
+                .into_dyn()
+            };
+
+            let (p2p_status_senders, p2p_status_receivers) = p2p_status_channels(connector.peers());
+
+            let connections = ReconnectP2PConnections::new(
+                cfg.local.identity,
+                connector,
+                &task_group,
+                p2p_status_senders,
+            )
+            .into_dyn();
+
+            (cfg, connections, p2p_status_receivers)
+        }
+        None => {
+            Box::pin(run_config_gen(
+                data_dir.clone(),
+                settings.clone(),
+                db.clone(),
+                &task_group,
+                code_version_str.clone(),
+                force_api_secrets.clone(),
+                setup_ui_router,
+            ))
+            .await?
+        }
+    };
 
     let decoders = module_init_registry.decoders_strict(
         cfg.consensus
@@ -187,7 +174,6 @@ pub async fn run(
         connectors,
         connections,
         p2p_status_receivers,
-        p2p_connection_type_receivers,
         settings.api_bind,
         settings.iroh_dns,
         settings.iroh_relays,
@@ -252,7 +238,6 @@ pub async fn run_config_gen(
     ServerConfig,
     DynP2PConnections<P2PMessage>,
     P2PStatusReceivers,
-    P2PConnectionTypeReceivers,
 )> {
     info!(target: LOG_CONSENSUS, "Starting config gen");
 
@@ -340,15 +325,12 @@ pub async fn run_config_gen(
     };
 
     let (p2p_status_senders, p2p_status_receivers) = p2p_status_channels(connector.peers());
-    let (p2p_connection_type_senders, p2p_connection_type_receivers) =
-        p2p_connection_type_channels(connector.peers());
 
     let connections = ReconnectP2PConnections::new(
         cg_params.identity,
         connector,
         task_group,
         p2p_status_senders,
-        p2p_connection_type_senders,
     )
     .into_dyn();
 
@@ -378,10 +360,5 @@ pub async fn run_config_gen(
         api_secrets.get_active(),
     )?;
 
-    Ok((
-        cfg,
-        connections,
-        p2p_status_receivers,
-        p2p_connection_type_receivers,
-    ))
+    Ok((cfg, connections, p2p_status_receivers))
 }

--- a/fedimint-server/src/net/p2p_connection.rs
+++ b/fedimint-server/src/net/p2p_connection.rs
@@ -47,7 +47,7 @@ pub trait IP2PConnection<M>: Send + 'static {
     async fn receive(&mut self) -> anyhow::Result<DynIP2PFrame<M>>;
 
     /// Get the round-trip time of the connection.
-    fn rtt(&self) -> Duration;
+    fn rtt(&self) -> Option<Duration>;
 
     fn into_dyn(self) -> DynP2PConnection<M>
     where
@@ -98,8 +98,8 @@ where
         Ok(message)
     }
 
-    fn rtt(&self) -> Duration {
-        Duration::from_millis(0)
+    fn rtt(&self) -> Option<Duration> {
+        None
     }
 }
 
@@ -144,7 +144,7 @@ where
         Ok(self.accept_uni().await?.into_dyn())
     }
 
-    fn rtt(&self) -> Duration {
-        self.rtt()
+    fn rtt(&self) -> Option<Duration> {
+        Some(Connection::rtt(self))
     }
 }

--- a/fedimint-server/src/net/p2p_connector.rs
+++ b/fedimint-server/src/net/p2p_connector.rs
@@ -28,7 +28,7 @@ pub trait IP2PConnector<M>: Send + Sync + 'static {
     async fn accept(&self) -> anyhow::Result<(PeerId, DynP2PConnection<M>)>;
 
     /// Get the connection type for a specific peer
-    async fn connection_type(&self, peer: PeerId) -> ConnectionType;
+    fn connection_type(&self, peer: PeerId) -> Option<ConnectionType>;
 
     fn into_dyn(self) -> DynP2PConnector<M>
     where

--- a/fedimint-server/src/net/p2p_connector/tls.rs
+++ b/fedimint-server/src/net/p2p_connector/tls.rs
@@ -179,9 +179,9 @@ where
         Ok((auth_peer, framed.into_dyn()))
     }
 
-    async fn connection_type(&self, _peer: PeerId) -> ConnectionType {
+    fn connection_type(&self, _peer: PeerId) -> Option<ConnectionType> {
         // TLS connections are always direct
-        ConnectionType::Direct
+        Some(ConnectionType::Direct)
     }
 }
 

--- a/fedimint-testing/src/federation.rs
+++ b/fedimint-testing/src/federation.rs
@@ -26,9 +26,7 @@ use fedimint_rocksdb::RocksDb;
 use fedimint_server::config::ServerConfig;
 use fedimint_server::core::ServerModuleInitRegistry;
 use fedimint_server::net::api::ApiSecrets;
-use fedimint_server::net::p2p::{
-    ReconnectP2PConnections, p2p_connection_type_channels, p2p_status_channels,
-};
+use fedimint_server::net::p2p::{ReconnectP2PConnections, p2p_status_channels};
 use fedimint_server::net::p2p_connector::{IP2PConnector, TlsTcpConnector};
 use fedimint_server::{ConnectionLimits, consensus};
 use fedimint_server_core::bitcoin_rpc::DynServerBitcoinRpc;
@@ -292,15 +290,12 @@ impl FederationTestBuilder {
             .into_dyn();
 
             let (p2p_status_senders, p2p_status_receivers) = p2p_status_channels(connector.peers());
-            let (p2p_connection_type_senders, p2p_connection_type_receivers) =
-                p2p_connection_type_channels(connector.peers());
 
             let connections = ReconnectP2PConnections::new(
                 cfg.local.identity,
                 connector,
                 &task_group,
                 p2p_status_senders,
-                p2p_connection_type_senders,
             )
             .into_dyn();
 
@@ -315,7 +310,6 @@ impl FederationTestBuilder {
                         .unwrap(),
                     connections,
                     p2p_status_receivers,
-                    p2p_connection_type_receivers,
                     api_bind,
                     None,
                     vec![],


### PR DESCRIPTION
This PR consolidates the P2P connection status into a single P2PConnectionStatus struct containing both connection type and round-trip time, eliminating the need for separate API endpoints and watch channels. The ConnectionType enum now properly distinguishes between Direct, Relay, and Mixed connections instead of collapsing mixed into direct or using an ambiguous Unknown variant. The rtt() method on P2P connections now returns Option<Duration>, allowing TLS connections to properly indicate that RTT measurement is not available rather than returning a misleading zero value. The connection type polling task has been removed in favor of fetching the connection type synchronously when updating status just like we handle rtt.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
