### PR TITLE
chore: make sure that calls to disconnected peers fail immediatly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2762,6 +2762,7 @@ version = "0.10.0-alpha"
 dependencies = [
  "anyhow",
  "async-channel",
+ "async-stream",
  "async-trait",
  "bitcoin",
  "fedimint-connectors",
@@ -2776,6 +2777,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.12",
  "tokio",
+ "tokio-stream",
  "tracing",
 ]
 

--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -335,7 +335,7 @@ impl Federation {
                 .await?,
             );
             let admin_client = DynGlobalApi::new_admin_setup(
-                connectors.clone(),
+                &connectors,
                 SafeUrl::parse(&peer_env_vars.FM_API_URL)?,
                 // TODO: will need it somewhere
                 // &process_mgr.globals.FM_FORCE_API_SECRETS.get_active(),

--- a/fedimint-api-client/Cargo.toml
+++ b/fedimint-api-client/Cargo.toml
@@ -21,6 +21,7 @@ path = "src/lib.rs"
 [dependencies]
 anyhow = { workspace = true }
 async-channel = { workspace = true }
+async-stream = { workspace = true }
 async-trait = { workspace = true }
 bitcoin = { workspace = true }
 fedimint-connectors = { workspace = true }
@@ -35,6 +36,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+tokio-stream = { workspace = true }
 tracing = { workspace = true }
 
 [lints]

--- a/fedimint-api-client/src/api/global_api/with_cache.rs
+++ b/fedimint-api-client/src/api/global_api/with_cache.rs
@@ -39,6 +39,7 @@ use fedimint_core::util::SafeUrl;
 use fedimint_core::{NumPeersExt, PeerId, TransactionId, apply, async_trait_maybe_send};
 use fedimint_logging::LOG_CLIENT_NET_API;
 use futures::future::join_all;
+use futures::stream::BoxStream;
 use itertools::Itertools;
 use rand::seq::SliceRandom;
 use serde_json::Value;
@@ -236,6 +237,10 @@ where
         params: &ApiRequestErased,
     ) -> ServerResult<Value> {
         self.inner.request_raw(peer_id, method, params).await
+    }
+
+    fn connection_status_stream(&self) -> BoxStream<'static, BTreeMap<PeerId, bool>> {
+        self.inner.connection_status_stream()
     }
 }
 

--- a/fedimint-api-client/src/api/global_api/with_request_hook.rs
+++ b/fedimint-api-client/src/api/global_api/with_request_hook.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
 use fedimint_connectors::ServerResult;
@@ -6,6 +6,7 @@ use fedimint_core::core::ModuleInstanceId;
 use fedimint_core::module::ApiRequestErased;
 use fedimint_core::task::{MaybeSend, MaybeSync};
 use fedimint_core::{PeerId, apply, async_trait_maybe_send, maybe_add_send_sync};
+use futures::stream::BoxStream;
 use serde_json::Value;
 
 use super::super::{DynModuleApi, IRawFederationApi};
@@ -84,5 +85,9 @@ impl IRawFederationApi for RawFederationApiWithRequestHook {
         params: &ApiRequestErased,
     ) -> ServerResult<Value> {
         self.inner.request_raw(peer_id, method, params).await
+    }
+
+    fn connection_status_stream(&self) -> BoxStream<'static, BTreeMap<PeerId, bool>> {
+        self.inner.connection_status_stream()
     }
 }

--- a/fedimint-api-client/src/lib.rs
+++ b/fedimint-api-client/src/lib.rs
@@ -40,11 +40,8 @@ impl ConnectorType {
         );
 
         let federation_id = invite.federation_id();
-        let api_from_invite = DynGlobalApi::new(
-            endpoints.clone(),
-            invite.peers(),
-            invite.api_secret().as_deref(),
-        )?;
+        let api_from_invite =
+            DynGlobalApi::new(endpoints, invite.peers(), invite.api_secret().as_deref())?;
         let api_secret = invite.api_secret();
 
         fedimint_core::util::retry(
@@ -99,7 +96,7 @@ impl ConnectorType {
 
         debug!(target: LOG_CLIENT_NET, "Verifying client config with all peers");
 
-        let api_full = DynGlobalApi::new(endpoints.clone(), api_endpoints, api_secret.as_deref())?;
+        let api_full = DynGlobalApi::new(endpoints, api_endpoints, api_secret.as_deref())?;
         let client_config = api_full
             .request_current_consensus::<ClientConfig>(
                 CLIENT_CONFIG_ENDPOINT.to_owned(),

--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -300,11 +300,12 @@ impl Opts {
         api_secret: Option<&str>,
     ) -> CliResult<DynGlobalApi> {
         let our_id = self.our_id.ok_or_cli_msg("Admin client needs our-id set")?;
+        let connectors = self.make_endpoints().await.map_err(|e| CliError {
+            error: e.to_string(),
+        })?;
 
         DynGlobalApi::new_admin(
-            self.make_endpoints().await.map_err(|e| CliError {
-                error: e.to_string(),
-            })?,
+            &connectors,
             our_id,
             peer_urls
                 .get(&our_id)
@@ -1456,8 +1457,8 @@ impl FedimintCli {
         cli: Opts,
         args: SetupAdminArgs,
     ) -> anyhow::Result<Value> {
-        let client =
-            DynGlobalApi::new_admin_setup(cli.make_endpoints().await?, args.endpoint.clone())?;
+        let connectors = cli.make_endpoints().await?;
+        let client = DynGlobalApi::new_admin_setup(&connectors, args.endpoint.clone())?;
 
         match &args.subcommand {
             SetupAdminCmd::Status => {

--- a/fedimint-client-module/src/api.rs
+++ b/fedimint-client-module/src/api.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::string::ToString;
 
 use fedimint_api_client::api::{DynModuleApi, IRawFederationApi, ServerResult};
@@ -7,6 +7,7 @@ use fedimint_core::db::{Database, DatabaseTransaction};
 use fedimint_core::module::ApiRequestErased;
 use fedimint_core::task::{MaybeSend, MaybeSync};
 use fedimint_core::{PeerId, apply, async_trait_maybe_send};
+use futures::stream::BoxStream;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tokio::sync::watch;
@@ -162,5 +163,9 @@ where
         .await;
 
         res
+    }
+
+    fn connection_status_stream(&self) -> BoxStream<'static, BTreeMap<PeerId, bool>> {
+        self.inner.connection_status_stream()
     }
 }

--- a/fedimint-client/src/client.rs
+++ b/fedimint-client/src/client.rs
@@ -198,6 +198,12 @@ impl Client {
         self.api.clone()
     }
 
+    /// Returns a stream that emits the current connection status of all peers
+    /// whenever any peer's status changes. Emits initial state immediately.
+    pub fn connection_status_stream(&self) -> impl Stream<Item = BTreeMap<PeerId, bool>> {
+        self.api.connection_status_stream()
+    }
+
     /// Get the [`TaskGroup`] that is tied to Client's lifetime.
     pub fn task_group(&self) -> &TaskGroup {
         &self.task_group

--- a/fedimint-client/src/client/builder.rs
+++ b/fedimint-client/src/client/builder.rs
@@ -557,7 +557,7 @@ impl ClientBuilder {
         let peer_urls = get_api_urls(&db, &config).await;
         let api = match self.admin_creds.as_ref() {
             Some(admin_creds) => FederationApi::new(
-                connectors.clone(),
+                &connectors,
                 peer_urls,
                 Some(admin_creds.peer_id),
                 Some(&admin_creds.auth.0),
@@ -566,7 +566,7 @@ impl ClientBuilder {
             .with_request_hook(&request_hook)
             .with_cache()
             .into(),
-            None => FederationApi::new(connectors.clone(), peer_urls, None, api_secret.as_deref())
+            None => FederationApi::new(&connectors, peer_urls, None, api_secret.as_deref())
                 .with_client_ext(db.clone(), log_ordering_wakeup_tx.clone())
                 .with_request_hook(&request_hook)
                 .with_cache()
@@ -1309,7 +1309,7 @@ impl ClientPreview {
     ) -> anyhow::Result<Option<ClientBackup>> {
         let pre_root_secret = pre_root_secret.to_inner(self.config.calculate_federation_id());
         let api = DynGlobalApi::new(
-            self.connectors.clone(),
+            &self.connectors,
             // TODO: change join logic to use FederationId v2
             self.config
                 .global

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -99,7 +99,7 @@ pub async fn run(
 
     // TODO: make it work with all transports and federation secrets
     let global_api = DynGlobalApi::new(
-        connectors.clone(),
+        &connectors,
         cfg.consensus
             .api_endpoints()
             .iter()
@@ -291,7 +291,7 @@ pub async fn run(
     ConsensusEngine {
         db,
         federation_api: DynGlobalApi::new(
-            connectors,
+            &connectors,
             api_urls,
             force_api_secrets.get_active().as_deref(),
         )?,

--- a/fedimint-server/src/net/api/announcement.rs
+++ b/fedimint-server/src/net/api/announcement.rs
@@ -50,9 +50,10 @@ pub async fn start_api_announcement_service(
 
     let db = db.clone();
     // FIXME: (@leonardo) how should we handle the connector here ?
+    // TODO: get from somewhere/unify?
+    let connectors = ConnectorRegistry::build_from_server_env()?.bind().await?;
     let api_client = DynGlobalApi::new(
-        // TODO: get from somewhere/unify?
-        ConnectorRegistry::build_from_server_env()?.bind().await?,
+        &connectors,
         get_api_urls(&db, &cfg.consensus).await,
         api_secret.as_deref(),
     )?;

--- a/fedimint-testing/src/federation.rs
+++ b/fedimint-testing/src/federation.rs
@@ -83,9 +83,10 @@ impl FederationTest {
     /// Create a new admin api for the given PeerId
     pub async fn new_admin_api(&self, peer_id: PeerId) -> anyhow::Result<DynGlobalApi> {
         let config = self.configs.get(&peer_id).expect("peer to have config");
+        let connectors = ConnectorRegistry::build_from_testing_env()?.bind().await?;
 
         DynGlobalApi::new_admin(
-            ConnectorRegistry::build_from_testing_env()?.bind().await?,
+            &connectors,
             peer_id,
             config.consensus.api_endpoints()[&peer_id].url.clone(),
             None,
@@ -345,7 +346,7 @@ impl FederationTestBuilder {
                 .await
                 .unwrap();
             let api = DynGlobalApi::new_admin(
-                connectors,
+                &connectors,
                 peer_id,
                 config.consensus.api_endpoints()[&peer_id].url.clone(),
                 None,

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -710,7 +710,7 @@ async fn peg_ins_that_are_unconfirmed_are_rejected() -> anyhow::Result<()> {
         PeerId::from(0),
         // FIXME: use proper mock
         DynGlobalApi::new(
-            ConnectorRegistry::build_from_testing_env()?.bind().await?,
+            &ConnectorRegistry::build_from_testing_env()?.bind().await?,
             [(
                 PeerId::from(0),
                 SafeUrl::from_str("ws://dummy.xyz").unwrap(),


### PR DESCRIPTION
A request to a guardian now only awaits the first connection attempt to a guardian. Afterwards, a request fails immediately when a guardian is not connected. Otherwise client actions might be loading for 10-20s waiting for the next connection attempt just to eventually fail because the client or the federation is offline. Instead I want the request to fail immediately. I see this in Conduit all the time and it is bad UX. The implementation with a separate task makes the connection behavior independent of requests and therefore imo easier to reason about. 

Furthermore we now expose a method on the client to reliably return the connection status to every guardian in realtime. I expose this in conduit in the app bar as an array of dots indicating the connection status by opacity. Hence on opening the app this results in a pretty visual as the dots light up one by one as we are connecting to the guardians.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
