### PR TITLE
fix: wrap ConnectorRegistry's OnceCell map in Arc to actually only create a single endpoint

### DIFF
--- a/fedimint-connectors/src/lib.rs
+++ b/fedimint-connectors/src/lib.rs
@@ -112,7 +112,7 @@ impl ConnectorRegistryBuilder {
         );
 
         Ok(ConnectorRegistry {
-            connectors_lazy,
+            connectors_lazy: Arc::new(connectors_lazy),
             connection_overrides: self.connection_overrides,
         })
     }
@@ -217,7 +217,8 @@ impl ConnectorRegistryBuilder {
 /// Responsibilities:
 #[derive(Clone)]
 pub struct ConnectorRegistry {
-    connectors_lazy: BTreeMap<String, (ConnectorInitFn, OnceCell<DynConnector>)>,
+    /// Wrapped in Arc so clones share the same OnceCell instances
+    connectors_lazy: Arc<BTreeMap<String, (ConnectorInitFn, OnceCell<DynConnector>)>>,
     /// Connection URL overrides for testing/custom routing
     connection_overrides: BTreeMap<SafeUrl, SafeUrl>,
 }


### PR DESCRIPTION
Currently we actually create multiple endpoints because the connector registry is cloned before the endpoint is initialized.

I have found the problem because conduit became really unreliable to connect, the logs showed four endpoints created per version. With this fix conduit works fine again and the logs only show the creation of one endpoint per version.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
