### PR TITLE
fix: delay shutdown of setup api to prevent failure of start dkg comm… [0.7 backport]

### DIFF
--- a/fedimint-server/src/lib.rs
+++ b/fedimint-server/src/lib.rs
@@ -28,6 +28,7 @@ use std::future::Future;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
+use std::time::Duration;
 
 use anyhow::Context;
 use config::ServerConfig;
@@ -37,7 +38,7 @@ use fedimint_core::config::P2PMessage;
 use fedimint_core::db::{Database, DatabaseTransaction, IDatabaseTransactionOpsCoreTyped as _};
 use fedimint_core::epoch::ConsensusItem;
 use fedimint_core::net::peers::DynP2PConnections;
-use fedimint_core::task::{TaskGroup, TaskHandle};
+use fedimint_core::task::{TaskGroup, TaskHandle, sleep};
 use fedimint_core::util::write_new;
 use fedimint_logging::{LOG_CONSENSUS, LOG_CORE};
 pub use fedimint_server_core as core;
@@ -274,6 +275,9 @@ pub async fn run_config_gen(
         .recv()
         .await
         .expect("Config gen params receiver closed unexpectedly");
+
+    // prevent failure of start dkg command in CI
+    sleep(Duration::from_millis(100)).await;
 
     api_handler
         .stop()


### PR DESCRIPTION
…and in CI

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
