### PR TITLE
cleanup: use standard endless retry method variant instead of manual loop

### DIFF
--- a/fedimint-server/src/consensus/engine.rs
+++ b/fedimint-server/src/consensus/engine.rs
@@ -1090,25 +1090,13 @@ impl ConsensusEngine {
             }
         };
 
-        let mut backoff = fedimint_core::util::backoff_util::api_networking_backoff();
-        loop {
-            let result = federation_api
-                .request_with_strategy(
-                    FilterMap::new(filter_map.clone()),
-                    AWAIT_SIGNED_SESSION_OUTCOME_ENDPOINT.to_string(),
-                    ApiRequestErased::new(index),
-                )
-                .await;
-
-            match result {
-                Ok(signed_session_outcome) => return signed_session_outcome,
-                Err(error) => {
-                    error.report_if_unusual("Requesting Session Outcome");
-                }
-            }
-
-            sleep(backoff.next().expect("infinite retries")).await;
-        }
+        federation_api
+            .request_with_strategy_retry(
+                FilterMap::new(filter_map.clone()),
+                AWAIT_SIGNED_SESSION_OUTCOME_ENDPOINT.to_string(),
+                ApiRequestErased::new(index),
+            )
+            .await
     }
 
     /// Returns the number of sessions already saved in the database. This count


### PR DESCRIPTION
Use standard endless retry method variant instead of manual loop to fetch the signed session outcomes.
<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
