### PR TITLE
[releases/v0.9] Revert "fix: reissue ecash after recovery to avoid invalid wallet states"

### DIFF
--- a/fedimint-client-module/src/module/mod.rs
+++ b/fedimint-client-module/src/module/mod.rs
@@ -372,18 +372,6 @@ where
             .await
     }
 
-    pub async fn finalize_and_submit_transaction_dbtx(
-        &self,
-        dbtx: &mut DatabaseTransaction<'_>,
-        operation_id: OperationId,
-        tx_builder: TransactionBuilder,
-    ) -> anyhow::Result<OutPointRange> {
-        self.client
-            .get()
-            .finalize_and_submit_transaction_inner(dbtx, operation_id, tx_builder)
-            .await
-    }
-
     pub async fn transaction_updates(&self, operation_id: OperationId) -> TransactionUpdates {
         self.client.get().transaction_updates(operation_id).await
     }

--- a/modules/fedimint-mint-client/src/backup/recovery.rs
+++ b/modules/fedimint-mint-client/src/backup/recovery.rs
@@ -2,24 +2,20 @@ use std::cmp::max;
 use std::collections::BTreeMap;
 use std::fmt;
 
-use anyhow::Context;
 use fedimint_client_module::module::init::ClientModuleRecoverArgs;
 use fedimint_client_module::module::init::recovery::{
     RecoveryFromHistory, RecoveryFromHistoryCommon,
 };
 use fedimint_client_module::module::{ClientContext, OutPointRange};
-use fedimint_client_module::transaction::TransactionBuilder;
 use fedimint_core::core::OperationId;
 use fedimint_core::db::{DatabaseTransaction, IDatabaseTransactionOpsCoreTyped as _};
 use fedimint_core::encoding::{Decodable, Encodable};
-use fedimint_core::module::CommonModuleInit;
 use fedimint_core::{
     Amount, NumPeersExt, OutPoint, PeerId, Tiered, TieredMulti, apply, async_trait_maybe_send,
 };
 use fedimint_derive_secret::DerivableSecret;
-use fedimint_logging::{LOG_CLIENT_RECOVERY, LOG_CLIENT_RECOVERY_MINT};
-use fedimint_mint_common::{MintCommonInit, MintInput, MintOutput, Nonce};
-use itertools::Itertools;
+use fedimint_logging::{LOG_CLIENT_MODULE_MINT, LOG_CLIENT_RECOVERY, LOG_CLIENT_RECOVERY_MINT};
+use fedimint_mint_common::{MintInput, MintOutput, Nonce};
 use serde::{Deserialize, Serialize};
 use tbs::{AggregatePublicKey, BlindedMessage, PublicKeyShare};
 use threshold_crypto::G1Affine;
@@ -28,19 +24,13 @@ use tracing::{debug, info, trace, warn};
 use super::EcashBackup;
 use crate::backup::EcashBackupV0;
 use crate::client_db::{
-    NextECashNoteIndexKey, RecoveryFinalizedKey, RecoveryStateKey, ReusedNoteIndices,
+    NextECashNoteIndexKey, NoteKey, RecoveryFinalizedKey, RecoveryStateKey, ReusedNoteIndices,
 };
-use crate::event::RecoveryReissuanceStarted;
+use crate::event::NoteCreated;
 use crate::output::{
     MintOutputCommon, MintOutputStateMachine, MintOutputStatesCreated, NoteIssuanceRequest,
 };
-use crate::{
-    MintClientInit, MintClientModule, MintClientStateMachines, MintOperationMeta,
-    MintOperationMetaVariant, NoteIndex, ReissueExternalNotesError, SpendableNote,
-    create_bundle_for_inputs,
-};
-
-const MAX_REISSUE_NOTES_PER_TX: usize = 100;
+use crate::{MintClientInit, MintClientModule, MintClientStateMachines, NoteIndex, SpendableNote};
 
 #[derive(Clone, Debug)]
 pub struct MintRecovery {
@@ -171,7 +161,6 @@ impl RecoveryFromHistory for MintRecovery {
     }
 
     /// Handle session outcome, adjusting the current state
-    #[allow(clippy::too_many_lines)]
     async fn finalize_dbtx(&self, dbtx: &mut DatabaseTransaction<'_>) -> anyhow::Result<()> {
         let finalized = self.state.clone().finalize();
 
@@ -193,69 +182,24 @@ impl RecoveryFromHistory for MintRecovery {
         debug!(
             target: LOG_CLIENT_RECOVERY_MINT,
             len = finalized.spendable_notes.count_items(),
-            "Reissuing spendable notes"
+            "Restoring spendable notes"
         );
-
-        let operation_id = OperationId::new_random();
-        let mut out_point_ranges = Vec::new();
-        let reissue_amount = finalized.spendable_notes.total_amount();
-
-        // We reissue notes in chunks to avoid hitting consensus size limits and in the
-        // future minimize transaction fees.
-        for notes in finalized
-            .spendable_notes
-            .into_iter_items()
-            .chunks(MAX_REISSUE_NOTES_PER_TX)
-            .into_iter()
-            .map(Iterator::collect::<TieredMulti<_>>)
-            .collect::<Vec<_>>()
-        {
-            let amount = notes.total_amount();
-            debug!(
-                target: LOG_CLIENT_RECOVERY_MINT,
-                len = notes.count_items(),
-                %amount,
-                ?operation_id,
-                "Reissuing chunk of spendable notes"
-            );
-
-            let mint_inputs = self.client_ctx.self_ref().create_input_from_notes(notes)?;
-
-            let tx = TransactionBuilder::new().with_inputs(
-                self.client_ctx
-                    .make_dyn(create_bundle_for_inputs(mint_inputs, operation_id)),
-            );
-
-            let out_range = self
-                .client_ctx
-                .finalize_and_submit_transaction_dbtx(dbtx, operation_id, tx)
-                .await
-                .context(ReissueExternalNotesError::AlreadyReissued)?;
-            out_point_ranges.push(out_range);
+        for (amount, note) in finalized.spendable_notes.into_iter_items() {
+            let key = NoteKey {
+                amount,
+                nonce: note.nonce(),
+            };
+            debug!(target: LOG_CLIENT_MODULE_MINT, %amount, %note, "Restoring note");
+            self.client_ctx
+                .log_event(
+                    dbtx,
+                    NoteCreated {
+                        nonce: note.nonce(),
+                    },
+                )
+                .await;
+            dbtx.insert_new_entry(&key, &note.to_undecoded()).await;
         }
-
-        self.client_ctx
-            .log_event(
-                dbtx,
-                RecoveryReissuanceStarted {
-                    amount: reissue_amount,
-                    operation_id,
-                },
-            )
-            .await;
-
-        self.client_ctx
-            .add_operation_log_entry_dbtx(
-                dbtx,
-                operation_id,
-                MintCommonInit::KIND.as_str(),
-                MintOperationMeta {
-                    variant: MintOperationMetaVariant::Recovery { out_point_ranges },
-                    amount: reissue_amount,
-                    extra_meta: serde_json::Value::Null,
-                },
-            )
-            .await;
 
         for (amount, note_idx) in finalized.next_note_idx.iter() {
             debug!(

--- a/modules/fedimint-mint-client/src/event.rs
+++ b/modules/fedimint-mint-client/src/event.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use fedimint_core::Amount;
-use fedimint_core::core::{ModuleKind, OperationId};
+use fedimint_core::core::ModuleKind;
 use fedimint_eventlog::{Event, EventKind, EventPersistence};
 use fedimint_mint_common::{KIND, Nonce};
 use serde::{Deserialize, Serialize};
@@ -68,20 +68,5 @@ pub struct OOBNotesReissued {
 impl Event for OOBNotesReissued {
     const MODULE: Option<ModuleKind> = Some(KIND);
     const KIND: EventKind = EventKind::from_static("oob-notes-reissued");
-    const PERSISTENCE: EventPersistence = EventPersistence::Persistent;
-}
-
-/// Event that is emitted when ecash is reissued as part of a recovery process
-#[derive(Serialize, Deserialize)]
-pub struct RecoveryReissuanceStarted {
-    /// The amount of ecash that was recovered and is being reissued
-    pub amount: Amount,
-    /// The operation id of the recovery process
-    pub operation_id: OperationId,
-}
-
-impl Event for RecoveryReissuanceStarted {
-    const MODULE: Option<ModuleKind> = Some(KIND);
-    const KIND: EventKind = EventKind::from_static("recovered-notes-reissued");
     const PERSISTENCE: EventPersistence = EventPersistence::Persistent;
 }

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -458,21 +458,6 @@ pub enum MintOperationMetaVariant {
         requested_amount: Amount,
         oob_notes: OOBNotes,
     },
-    /// Operation created on wallet recovery reissuing all recovered ecash
-    /// notes.
-    ///
-    /// When recovering ecash from the user's seed we can't tell if they have
-    /// spent it out of band/shared some notes with others (this isn't part of
-    /// the public mint log). This leads to a problem when a user recovers their
-    /// wallet, the recipioent of OOB ecash claims their notes (that were also
-    /// recovered by the sender) and now the recovered user/sender has invalid
-    /// ecash in their wallet. The only way to reliably prevent this is to
-    /// reissue these notes.
-    Recovery {
-        /// Out points of all the primary movdule outputs (typically new ecash
-        /// notes) issued when reissuing recovered ecash.
-        out_point_ranges: Vec<OutPointRange>,
-    },
 }
 
 #[derive(Debug, Clone)]
@@ -1554,7 +1539,6 @@ impl MintClientModule {
                 (txid, out_points)
             }
             MintOperationMetaVariant::SpendOOB { .. } => bail!("Operation is not a reissuance"),
-            MintOperationMetaVariant::Recovery { .. } => unimplemented!(),
         };
 
         let client_ctx = self.client_ctx.clone();


### PR DESCRIPTION
Reverting since it caused CI failures in Fedi's CI. We'll need to investigate separately why `fedimint/fedimint` CI didn't catch this. Tracking in https://github.com/fedimint/fedimint/issues/8042