### PR TITLE
cleanup: make lnv2 error messages less verbose and more user friendly

### DIFF
--- a/modules/fedimint-lnv2-tests/tests/tests.rs
+++ b/modules/fedimint-lnv2-tests/tests/tests.rs
@@ -75,7 +75,7 @@ async fn can_pay_external_invoice_exactly_once() -> anyhow::Result<()> {
             .get_first_module::<LightningClientModule>()?
             .send(invoice.clone(), Some(gateway_api.clone()), Value::Null)
             .await,
-        Err(SendPaymentError::PendingPreviousPayment(operation_id)),
+        Err(SendPaymentError::PaymentInProgress(operation_id)),
     );
 
     let mut sub = client
@@ -96,7 +96,7 @@ async fn can_pay_external_invoice_exactly_once() -> anyhow::Result<()> {
             .get_first_module::<LightningClientModule>()?
             .send(invoice, Some(gateway_api), Value::Null)
             .await,
-        Err(SendPaymentError::SuccessfulPreviousPayment(operation_id)),
+        Err(SendPaymentError::InvoiceAlreadyPaid(operation_id)),
     );
 
     Ok(())


### PR DESCRIPTION
Lots of stuff can go wrong when attempting a lightning payment. This pr strives to make the errors more user friendly and avoid long errors that look ugly when displayed. This way integrators can simply call to_string() on every error and display it to the user.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
