### PR TITLE
chore(ci): skip building some stuff in the CI to make it more lightweight

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -261,7 +261,9 @@ jobs:
           nix build -L .#ci.cargoDeny
 
   cross:
-    if: github.repository == 'fedimint/fedimint' && (github.event_name == 'merge_group' || github.event_name == 'pull_request')
+    # we run it in the MQ, not in PR itself, because other than Nix/nixpkgs/toolchain
+    # changes, it is unlikely to be broken by normal dev work
+    if: github.repository == 'fedimint/fedimint' && (github.event_name == 'merge_group')
     name: "Cross-compile on ${{ matrix.host }} to ${{ matrix.toolchain }}"
     needs: [lint, shell]
 


### PR DESCRIPTION
In particular, building and publishg releases for every commit in master branch is *very* heavy.

https://github.com/fedimint/fedimint/actions/runs/19973840069/job/57284938310

I think we want to do it only on release branches and tags, where people are expected to might want to try the artefacts.

The other steps are more about dev, and probably caching will make them relatively fast, but there is really no point in running them - merge queue running serially, guarantees that everything was verified already, so we just waste couple of minutes of runner's time where it could be doing something more useful.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
