### PR TITLE
chore(test): more informative error message

### DIFF
--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -968,8 +968,9 @@ pub async fn cli_tests(dev_fed: DevFed) -> Result<()> {
 
             if fed.members.len() != initial_announcements.len() {
                 bail!(
-                    "Not all announcements ready: {}",
-                    initial_announcements.len()
+                    "Not all announcements ready; got: {}, expected: {}",
+                    initial_announcements.len(),
+                    fed.members.len()
                 )
             }
 


### PR DESCRIPTION
In

https://github.com/fedimint/fedimint/actions/runs/19976014735/job/57292258559

I see a flake that errors out with:

```
Error: Not all announcements ready: 4
```

which is weird, because we do run with 4 peers, right? So what else would it expect?

I suspect the condition there should be `<` than instead of `!=`, but I can't find where in the code we would actually have a different peer number, so a simple approach is to print that number to verify.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
