### PR TITLE
chore(client): delay all thread until something else makes a call 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1462,7 +1462,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -5925,17 +5925,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-uring"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
-dependencies = [
- "bitflags 2.9.1",
- "cfg-if",
- "libc",
-]
-
-[[package]]
 name = "ipconfig"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10319,30 +10308,27 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.46.1"
+version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
+checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
 dependencies = [
- "backtrace",
  "bytes",
- "io-uring",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "slab",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tokio-macros",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12315,7 +12301,7 @@ dependencies = [
  "windows-collections",
  "windows-core 0.61.2",
  "windows-future",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-numerics",
 ]
 
@@ -12349,7 +12335,7 @@ checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement 0.60.0",
  "windows-interface",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-result",
  "windows-strings 0.4.2",
 ]
@@ -12361,7 +12347,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core 0.61.2",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-threading",
 ]
 
@@ -12405,13 +12391,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-numerics"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -12420,7 +12412,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -12429,7 +12421,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -12438,7 +12430,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -12475,6 +12467,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -12530,7 +12531,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -313,7 +313,7 @@ thiserror = "2.0.12"
 threshold_crypto = { version = "0.2.1", package = "fedimint-threshold-crypto" }
 tikv-jemallocator = "0.5"
 time = "0.3.41"
-tokio = "1.46.1"
+tokio = "1.48.0"
 tokio-rustls = { version = "0.26.0", features = ["aws_lc_rs"] }
 tokio-stream = "0.1.17"
 tokio-test = "0.4.4"

--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -974,7 +974,7 @@ pub async fn cli_tests(dev_fed: DevFed) -> Result<()> {
             }
 
             // Give the client some time to fetch updates
-            cmd!(client, "dev", "wait", "3").run().await?;
+            cmd!(client, "dev", "wait", "1").run().await?;
 
             if !initial_announcements
                 .values()

--- a/fedimint-connectors/src/lib.rs
+++ b/fedimint-connectors/src/lib.rs
@@ -21,7 +21,7 @@ use fedimint_core::{apply, async_trait_maybe_send};
 use fedimint_logging::{LOG_CLIENT_NET_API, LOG_NET};
 use reqwest::Method;
 use serde_json::Value;
-use tokio::sync::{OnceCell, broadcast};
+use tokio::sync::{OnceCell, SetOnce, broadcast};
 use tracing::trace;
 
 use crate::error::ServerError;
@@ -115,6 +115,7 @@ impl ConnectorRegistryBuilder {
             inner: ConnectorRegistryInner {
                 connectors_lazy,
                 connection_overrides: self.connection_overrides,
+                initialized: SetOnce::new(),
             }
             .into(),
         })
@@ -212,6 +213,11 @@ struct ConnectorRegistryInner {
     connectors_lazy: BTreeMap<String, (ConnectorInitFn, OnceCell<DynConnector>)>,
     /// Connection URL overrides for testing/custom routing
     connection_overrides: BTreeMap<SafeUrl, SafeUrl>,
+    /// Set on first connection attempt
+    ///
+    /// This is used for functionality that wants to avoid making
+    /// network connections if nothing else did network request.
+    initialized: tokio::sync::SetOnce<()>,
 }
 
 /// A set of available connectivity protocols a client can use to make
@@ -312,6 +318,11 @@ impl ConnectorRegistry {
         Ok(builder)
     }
 
+    /// Wait until some connections have been made
+    pub async fn wait_for_initialized_connections(&self) {
+        self.inner.initialized.wait().await;
+    }
+
     /// Connect to a given `url` using matching [`Connector`]
     ///
     /// This is the main function consumed by the downstream use for making
@@ -324,8 +335,10 @@ impl ConnectorRegistry {
         trace!(
             target: LOG_NET,
             %url,
-            "Connection requested"
+            "Connection requested to guardian"
         );
+        let _ = self.inner.initialized.set(());
+
         let url = match self.inner.connection_overrides.get(url) {
             Some(replacement) => {
                 trace!(
@@ -386,6 +399,13 @@ impl ConnectorRegistry {
     /// This is the main function consumed by the downstream use for making
     /// connection.
     pub async fn connect_gateway(&self, url: &SafeUrl) -> anyhow::Result<DynGatewayConnection> {
+        trace!(
+            target: LOG_NET,
+            %url,
+            "Connection requested to gateway"
+        );
+        let _ = self.inner.initialized.set(());
+
         let url = match self.inner.connection_overrides.get(url) {
             Some(replacement) => {
                 trace!(
@@ -412,7 +432,7 @@ impl ConnectorRegistry {
         // Clone the init function to use in the async block
         let init_fn = connector_lazy.0.clone();
 
-        connector_lazy
+        let conn = connector_lazy
             .1
             .get_or_try_init(|| async move { init_fn().await })
             .await
@@ -423,7 +443,9 @@ impl ConnectorRegistry {
                 ))
             })?
             .connect_gateway(url)
-            .await
+            .await?;
+
+        Ok(conn)
     }
 }
 pub type DynConnector = Arc<dyn Connector>;


### PR DESCRIPTION
This seems better than a fixed delay like in https://github.com/fedimint/fedimint/pull/7946 and https://github.com/fedimint/fedimint/pull/7985,
as for commands that actually make network calls, it will start
work immediately.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
