### PR TITLE
chore: update nixos-25.11 with new backported fix for cargo-llvm-cov

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -556,11 +556,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1764522689,
-        "narHash": "sha256-SqUuBFjhl/kpDiVaKLQBoD8TLD+/cTUzzgVFoaHrkqY=",
+        "lastModified": 1764983851,
+        "narHash": "sha256-y7RPKl/jJ/KAP/VKLMghMgXTlvNIJMHKskl8/Uuar7o=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8bb5646e0bed5dbd3ab08c7a7cc15b75ab4e1d0f",
+        "rev": "d9bc5c7dceb30d8d6fafa10aeb6aa8a48c218454",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -86,13 +86,6 @@
             (final: prev: {
               cargo-deluxe = cargo-deluxe.packages.${system}.default;
               cargo-udeps = nixpkgs-unstable.legacyPackages.${system}.cargo-udeps;
-
-              cargo-llvm-cov = (
-                # https://github.com/NixOS/nixpkgs/issues/467882
-                prev.cargo-llvm-cov.overrideAttrs (old: {
-                  doCheck = false;
-                })
-              );
             })
           ];
         };


### PR DESCRIPTION
I only used `nix flake update nixpkgs` to bring the nixpkgs to the most recent commit, I left everything else alone.

tested with `nix develop` and `nix flake check`.

follows up #8048 and should be the final change related to the update to 25.11 now that it build successfully on the standard nix release https://hydra.nixos.org/build/315952046

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
