### PR TITLE
fix: too strict test check

### DIFF
--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -966,7 +966,7 @@ pub async fn cli_tests(dev_fed: DevFed) -> Result<()> {
                 )
                 .expect("failed to parse API announcements");
 
-            if fed.members.len() != initial_announcements.len() {
+            if initial_announcements.len() < fed.members.len() {
                 bail!(
                     "Not all announcements ready: {}",
                     initial_announcements.len()


### PR DESCRIPTION
The guardian that is being shut-down is online long enough to actually get its announcement broadcasted.
<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
