### PR TITLE
fix(ci): actually build with CI=true in the CI

### DIFF
--- a/nix/flakebox.nix
+++ b/nix/flakebox.nix
@@ -725,6 +725,10 @@ in
           export CARGO_DENY_COMPILATION=1
           export FM_TEST_CI_ALL_TIMES=${builtins.toString times}
           export FM_TEST_CI_ALL_DISABLE_ETA=1
+
+          if [ "$CARGO_PROFILE" = "ci" ]; then
+            export CI=true
+          fi
           if [ "${builtins.toString useIroh}" == "1" ]; then
             >&2 echo "Iroh enabled"
             export FM_ENABLE_IROH=true


### PR DESCRIPTION
We don't use it heavily, but it is a convention to use `CI` env var to detect runs in the CI.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
