### PR TITLE
chore: remove `iroh_api` from `GatewayInfo`

### DIFF
--- a/gateway/fedimint-gateway-common/src/lib.rs
+++ b/gateway/fedimint-gateway-common/src/lib.rs
@@ -137,7 +137,6 @@ pub struct GatewayInfo {
     pub federation_fake_scids: Option<BTreeMap<u64, FederationId>>,
     pub gateway_state: String,
     pub lightning_info: LightningInfo,
-    pub iroh_api: SafeUrl,
     pub lightning_mode: LightningMode,
     pub registrations: BTreeMap<RegisteredProtocol, (SafeUrl, secp256k1::PublicKey)>,
 }

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -1731,8 +1731,6 @@ impl IAdminGateway for Gateway {
                 version_hash: fedimint_build_code_version_env!().to_string(),
                 gateway_state: self.state.read().await.to_string(),
                 lightning_info: LightningInfo::NotConnected,
-                iroh_api: SafeUrl::parse(&format!("iroh://{}", self.iroh_sk.public()))
-                    .expect("could not parse iroh api"),
                 lightning_mode: self.lightning_mode.clone(),
                 registrations: self
                     .registrations
@@ -1768,8 +1766,6 @@ impl IAdminGateway for Gateway {
             version_hash: fedimint_build_code_version_env!().to_string(),
             gateway_state: self.state.read().await.to_string(),
             lightning_info,
-            iroh_api: SafeUrl::parse(&format!("iroh://{}", self.iroh_sk.public()))
-                .expect("could not parse iroh api"),
             lightning_mode: self.lightning_mode.clone(),
             registrations: self
                 .registrations


### PR DESCRIPTION
This field isn't used anywhere (its duplicated in `registrations`) and I simply forgot to remove it in https://github.com/fedimint/fedimint/pull/8024