### PR TITLE
chore: enable gateway to serve federations without lnv1

### DIFF
--- a/devimint/src/util.rs
+++ b/devimint/src/util.rs
@@ -11,7 +11,7 @@ use std::{env, unreachable};
 use anyhow::{Context, Result, anyhow, bail, format_err};
 use fedimint_core::PeerId;
 use fedimint_core::admin_client::SetupStatus;
-use fedimint_core::envs::{FM_ENABLE_MODULE_LNV2_ENV, is_env_var_set};
+use fedimint_core::envs::{FM_ENABLE_MODULE_LNV1_ENV, FM_ENABLE_MODULE_LNV2_ENV, is_env_var_set};
 use fedimint_core::module::ApiAuth;
 use fedimint_core::task::{self, block_in_place, block_on};
 use fedimint_core::time::now;
@@ -1009,6 +1009,11 @@ fn to_command(cli: Vec<String>) -> Command {
         cmd,
         args_debug: cli,
     }
+}
+
+pub fn supports_lnv1() -> bool {
+    std::env::var_os(FM_ENABLE_MODULE_LNV1_ENV).is_none()
+        || is_env_var_set(FM_ENABLE_MODULE_LNV1_ENV)
 }
 
 pub fn supports_lnv2() -> bool {

--- a/fedimint-core/src/envs.rs
+++ b/fedimint-core/src/envs.rs
@@ -16,6 +16,7 @@ use crate::util::FmtCompact as _;
 /// all client code handles correct modules that client doesn't know about.
 pub const FM_USE_UNKNOWN_MODULE_ENV: &str = "FM_USE_UNKNOWN_MODULE";
 
+pub const FM_ENABLE_MODULE_LNV1_ENV: &str = "FM_ENABLE_MODULE_LNV1";
 pub const FM_ENABLE_MODULE_LNV2_ENV: &str = "FM_ENABLE_MODULE_LNV2";
 
 /// Disable mint base fees for testing and development environments

--- a/fedimintd/src/lib.rs
+++ b/fedimintd/src/lib.rs
@@ -18,8 +18,8 @@ use bitcoin::Network;
 use clap::{ArgGroup, Parser};
 use fedimint_core::db::Database;
 use fedimint_core::envs::{
-    FM_ENABLE_MODULE_LNV2_ENV, FM_IROH_DNS_ENV, FM_IROH_RELAY_ENV, FM_USE_UNKNOWN_MODULE_ENV,
-    is_env_var_set, is_env_var_set_opt,
+    FM_ENABLE_MODULE_LNV1_ENV, FM_ENABLE_MODULE_LNV2_ENV, FM_IROH_DNS_ENV, FM_IROH_RELAY_ENV,
+    FM_USE_UNKNOWN_MODULE_ENV, is_env_var_set, is_env_var_set_opt,
 };
 use fedimint_core::module::registry::ModuleRegistry;
 use fedimint_core::rustls::install_crypto_provider;
@@ -406,9 +406,12 @@ pub async fn run(
 pub fn default_modules() -> ServerModuleInitRegistry {
     let mut server_gens = ServerModuleInitRegistry::new();
 
-    server_gens.attach(LightningInit);
     server_gens.attach(MintInit);
     server_gens.attach(WalletInit);
+
+    if is_env_var_set_opt(FM_ENABLE_MODULE_LNV1_ENV).unwrap_or(true) {
+        server_gens.attach(LightningInit);
+    }
 
     if is_env_var_set_opt(FM_ENABLE_MODULE_LNV2_ENV).unwrap_or(true) {
         server_gens.attach(fedimint_lnv2_server::LightningInit);

--- a/gateway/fedimint-gateway-server/src/federation_manager.rs
+++ b/gateway/fedimint-gateway-server/src/federation_manager.rs
@@ -149,13 +149,14 @@ impl FederationManager {
         let removal_futures = self
             .clients
             .values()
-            .map(|client| async {
+            .filter_map(|client| {
                 client
                     .value()
                     .get_first_module::<GatewayClientModule>()
-                    .expect("Must have client module")
-                    .remove_from_federation(gateway_keypair)
-                    .await;
+                    .ok()
+                    .map(|lnv1| async move {
+                        lnv1.remove_from_federation(gateway_keypair).await;
+                    })
             })
             .collect::<Vec<_>>();
 

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -895,12 +895,15 @@ impl Gateway {
                 let htlc = htlc_request.clone().try_into();
                 match htlc {
                     Ok(htlc) => {
-                        match client
-                            .get_first_module::<GatewayClientModule>()
-                            .expect("Must have client module")
-                            .gateway_handle_intercepted_htlc(htlc)
-                            .await
-                        {
+                        let lnv1 =
+                            client
+                                .get_first_module::<GatewayClientModule>()
+                                .map_err(|_| {
+                                    PublicGatewayError::LNv1(LNv1Error::IncomingPayment(
+                                        "Federation does not have LNv1 module".to_string(),
+                                    ))
+                                })?;
+                        match lnv1.gateway_handle_intercepted_htlc(htlc).await {
                             Ok(_) => Ok(()),
                             Err(e) => Err(PublicGatewayError::LNv1(LNv1Error::IncomingPayment(
                                 format!("Error intercepting lightning payment {e:?}"),
@@ -1411,9 +1414,11 @@ impl Gateway {
                     register_task_group.spawn_cancellable_silent(
                         "register federation",
                         async move {
-                            let gateway_client = client_arc
-                                .get_first_module::<GatewayClientModule>()
-                                .expect("No GatewayClientModule exists");
+                            let Ok(gateway_client) =
+                                client_arc.get_first_module::<GatewayClientModule>()
+                            else {
+                                return;
+                            };
 
                             for registration in registrations {
                                 gateway_client
@@ -1553,54 +1558,52 @@ impl Gateway {
         }
     }
 
-    /// Verifies that the supplied `network` matches the Bitcoin network in the
-    /// connected client's LNv1 configuration.
-    async fn check_lnv1_federation_network(
+    /// Verifies that the federation has at least one lightning module (LNv1 or
+    /// LNv2) and that the network matches the gateway's network.
+    async fn check_federation_network(
         client: &ClientHandleArc,
         network: Network,
     ) -> AdminResult<()> {
         let federation_id = client.federation_id();
         let config = client.config().await;
-        let cfg = config
+
+        let lnv1_cfg = config
             .modules
             .values()
-            .find(|m| LightningCommonInit::KIND == m.kind)
-            .ok_or(AdminGatewayError::ClientCreationError(anyhow!(format!(
-                "Federation {federation_id} does not have an LNv1 module"
-            ))))?;
-        let ln_cfg: &LightningClientConfig = cfg.cast()?;
+            .find(|m| LightningCommonInit::KIND == m.kind);
 
-        if ln_cfg.network.0 != network {
-            crit!(
-                target: LOG_GATEWAY,
-                federation_id = %federation_id,
-                network = %network,
-                "Incorrect network for federation",
-            );
-            return Err(AdminGatewayError::ClientCreationError(anyhow!(format!(
-                "Unsupported network {}",
-                ln_cfg.network
-            ))));
-        }
-
-        Ok(())
-    }
-
-    /// Verifies that the supplied `network` matches the Bitcoin network in the
-    /// connected client's LNv2 configuration.
-    async fn check_lnv2_federation_network(
-        client: &ClientHandleArc,
-        network: Network,
-    ) -> AdminResult<()> {
-        let federation_id = client.federation_id();
-        let config = client.config().await;
-        let cfg = config
+        let lnv2_cfg = config
             .modules
             .values()
             .find(|m| fedimint_lnv2_common::LightningCommonInit::KIND == m.kind);
 
-        // If the federation does not have LNv2, we don't need to verify the network
-        if let Some(cfg) = cfg {
+        // Ensure the federation has at least one lightning module
+        if lnv1_cfg.is_none() && lnv2_cfg.is_none() {
+            return Err(AdminGatewayError::ClientCreationError(anyhow!(
+                "Federation {federation_id} does not have any lightning module (LNv1 or LNv2)"
+            )));
+        }
+
+        // Verify the LNv1 network if present
+        if let Some(cfg) = lnv1_cfg {
+            let ln_cfg: &LightningClientConfig = cfg.cast()?;
+
+            if ln_cfg.network.0 != network {
+                crit!(
+                    target: LOG_GATEWAY,
+                    federation_id = %federation_id,
+                    network = %network,
+                    "Incorrect LNv1 network for federation",
+                );
+                return Err(AdminGatewayError::ClientCreationError(anyhow!(format!(
+                    "Unsupported LNv1 network {}",
+                    ln_cfg.network
+                ))));
+            }
+        }
+
+        // Verify the LNv2 network if present
+        if let Some(cfg) = lnv2_cfg {
             let ln_cfg: &fedimint_lnv2_common::config::LightningClientConfig = cfg.cast()?;
 
             if ln_cfg.network != network {
@@ -1608,10 +1611,10 @@ impl Gateway {
                     target: LOG_GATEWAY,
                     federation_id = %federation_id,
                     network = %network,
-                    "Incorrect network for federation",
+                    "Incorrect LNv2 network for federation",
                 );
                 return Err(AdminGatewayError::ClientCreationError(anyhow!(format!(
-                    "Unsupported network {}",
+                    "Unsupported LNv2 network {}",
                     ln_cfg.network
                 ))));
             }
@@ -1915,22 +1918,21 @@ impl IAdminGateway for Gateway {
             last_backup_time: None,
         };
 
-        Self::check_lnv1_federation_network(&client, self.network).await?;
-        Self::check_lnv2_federation_network(&client, self.network).await?;
-        if matches!(self.lightning_mode, LightningMode::Lnd { .. }) {
+        Self::check_federation_network(&client, self.network).await?;
+        if matches!(self.lightning_mode, LightningMode::Lnd { .. })
+            && let Ok(lnv1) = client.get_first_module::<GatewayClientModule>()
+        {
             for registration in self.registrations.values() {
-                client
-                    .get_first_module::<GatewayClientModule>()?
-                    .try_register_with_federation(
-                        // Route hints will be updated in the background
-                        Vec::new(),
-                        GW_ANNOUNCEMENT_TTL,
-                        federation_config.lightning_fee.into(),
-                        lightning_context.clone(),
-                        registration.endpoint_url.clone(),
-                        registration.keypair.public_key(),
-                    )
-                    .await;
+                lnv1.try_register_with_federation(
+                    // Route hints will be updated in the background
+                    Vec::new(),
+                    GW_ANNOUNCEMENT_TTL,
+                    federation_config.lightning_fee.into(),
+                    lightning_context.clone(),
+                    registration.endpoint_url.clone(),
+                    registration.keypair.public_key(),
+                )
+                .await;
             }
         }
 

--- a/modules/fedimint-lnv2-tests/Cargo.toml
+++ b/modules/fedimint-lnv2-tests/Cargo.toml
@@ -11,6 +11,10 @@ version = { workspace = true }
 name = "lnv2-module-tests"
 path = "bin/tests.rs"
 
+[[bin]]
+name = "lnv1-lnv2-swap-tests"
+path = "bin/swap_tests.rs"
+
 [[test]]
 name = "fedimint_lnv2_tests"
 path = "tests/tests.rs"

--- a/modules/fedimint-lnv2-tests/bin/common.rs
+++ b/modules/fedimint-lnv2-tests/bin/common.rs
@@ -1,0 +1,83 @@
+use devimint::cmd;
+use devimint::federation::Client;
+use fedimint_core::core::OperationId;
+use fedimint_lnv2_client::{FinalReceiveOperationState, FinalSendOperationState};
+use lightning_invoice::Bolt11Invoice;
+use substring::Substring;
+
+pub async fn receive(
+    client: &Client,
+    gateway: &str,
+    amount: u64,
+) -> anyhow::Result<(Bolt11Invoice, OperationId)> {
+    Ok(serde_json::from_value::<(Bolt11Invoice, OperationId)>(
+        cmd!(
+            client,
+            "module",
+            "lnv2",
+            "receive",
+            amount,
+            "--gateway",
+            gateway
+        )
+        .out_json()
+        .await?,
+    )?)
+}
+
+pub async fn send(
+    client: &Client,
+    gateway: &str,
+    invoice: &str,
+    final_state: FinalSendOperationState,
+) -> anyhow::Result<()> {
+    let send_op = serde_json::from_value::<OperationId>(
+        cmd!(
+            client,
+            "module",
+            "lnv2",
+            "send",
+            invoice,
+            "--gateway",
+            gateway
+        )
+        .out_json()
+        .await?,
+    )?;
+
+    assert_eq!(
+        cmd!(
+            client,
+            "module",
+            "lnv2",
+            "await-send",
+            serde_json::to_string(&send_op)?.substring(1, 65)
+        )
+        .out_json()
+        .await?,
+        serde_json::to_value(final_state).expect("JSON serialization failed"),
+    );
+
+    Ok(())
+}
+
+pub async fn await_receive_claimed(
+    client: &Client,
+    operation_id: OperationId,
+) -> anyhow::Result<()> {
+    assert_eq!(
+        cmd!(
+            client,
+            "module",
+            "lnv2",
+            "await-receive",
+            serde_json::to_string(&operation_id)?.substring(1, 65)
+        )
+        .out_json()
+        .await?,
+        serde_json::to_value(FinalReceiveOperationState::Claimed)
+            .expect("JSON serialization failed"),
+    );
+
+    Ok(())
+}

--- a/modules/fedimint-lnv2-tests/bin/swap_tests.rs
+++ b/modules/fedimint-lnv2-tests/bin/swap_tests.rs
@@ -1,0 +1,123 @@
+use devimint::federation::Client;
+use devimint::version_constants::VERSION_0_9_0_ALPHA;
+use devimint::{cmd, util};
+use fedimint_core::core::OperationId;
+use fedimint_lnv2_client::FinalSendOperationState;
+use lightning_invoice::Bolt11Invoice;
+use tracing::info;
+
+#[path = "common.rs"]
+mod common;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    devimint::run_devfed_test()
+        .call(|dev_fed, _process_mgr| async move {
+            if !util::supports_lnv2() {
+                info!("lnv2 is disabled, skipping");
+                return Ok(());
+            }
+
+            let federation = dev_fed.fed().await?;
+
+            let client = federation
+                .new_joined_client("lnv1-lnv2-swap-test-client")
+                .await?;
+
+            federation.pegin_client(10_000, &client).await?;
+
+            let gw_lnd = dev_fed.gw_lnd().await?;
+
+            let gatewayd_version = util::Gatewayd::version_or_default().await;
+            let gateway_cli_version = util::GatewayCli::version_or_default().await;
+
+            if gatewayd_version < *VERSION_0_9_0_ALPHA || gateway_cli_version < *VERSION_0_9_0_ALPHA
+            {
+                info!("Gateway version too old for swap tests, skipping");
+                return Ok(());
+            }
+
+            info!("Pegging-in gateway...");
+            federation.pegin_gateways(1_000_000, vec![gw_lnd]).await?;
+
+            info!("Testing LNv1 client can pay LNv2 invoice...");
+            let lnd_gw_id = gw_lnd.gateway_id.clone();
+            let (invoice, receive_op) = common::receive(&client, &gw_lnd.addr, 1_000_000).await?;
+            send_lnv1(&client, &lnd_gw_id, &invoice.to_string()).await?;
+            common::await_receive_claimed(&client, receive_op).await?;
+
+            info!("Testing LNv2 client can pay LNv1 invoice...");
+            let (invoice, receive_op) = receive_lnv1(&client, &lnd_gw_id, 1_000_000).await?;
+            common::send(
+                &client,
+                &gw_lnd.addr,
+                &invoice.to_string(),
+                FinalSendOperationState::Success,
+            )
+            .await?;
+            await_receive_lnv1(&client, receive_op).await?;
+
+            info!("LNv1 <-> LNv2 swap tests complete!");
+
+            Ok(())
+        })
+        .await
+}
+
+async fn receive_lnv1(
+    client: &Client,
+    gateway_id: &String,
+    amount_msats: u64,
+) -> anyhow::Result<(Bolt11Invoice, OperationId)> {
+    let invoice_response = cmd!(
+        client,
+        "module",
+        "ln",
+        "invoice",
+        amount_msats,
+        "--gateway-id",
+        gateway_id
+    )
+    .out_json()
+    .await?;
+    let invoice = serde_json::from_value::<Bolt11Invoice>(
+        invoice_response
+            .get("invoice")
+            .expect("Invoice should be present")
+            .clone(),
+    )?;
+    let operation_id = serde_json::from_value::<OperationId>(
+        invoice_response
+            .get("operation_id")
+            .expect("OperationId should be present")
+            .clone(),
+    )?;
+    Ok((invoice, operation_id))
+}
+
+async fn send_lnv1(client: &Client, gateway_id: &str, invoice: &str) -> anyhow::Result<()> {
+    let payment_result = cmd!(
+        client,
+        "module",
+        "ln",
+        "pay",
+        invoice,
+        "--gateway-id",
+        gateway_id
+    )
+    .out_json()
+    .await?;
+    assert!(
+        payment_result.get("Success").is_some() || payment_result.get("preimage").is_some(),
+        "LNv1 payment failed: {payment_result:?}"
+    );
+    Ok(())
+}
+
+async fn await_receive_lnv1(client: &Client, operation_id: OperationId) -> anyhow::Result<()> {
+    let lnv1_response = cmd!(client, "await-invoice", operation_id.fmt_full())
+        .out_json()
+        .await?;
+    assert!(lnv1_response.get("total_amount_msat").is_some());
+    Ok(())
+}

--- a/scripts/tests/lnv1-lnv2-swap-test.sh
+++ b/scripts/tests/lnv1-lnv2-swap-test.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+export RUST_LOG="${RUST_LOG:-info}"
+
+source scripts/_common.sh
+build_workspace
+add_target_dir_to_path
+
+lnv1-lnv2-swap-tests

--- a/scripts/tests/lnv2-module-test.sh
+++ b/scripts/tests/lnv2-module-test.sh
@@ -7,4 +7,13 @@ source scripts/_common.sh
 build_workspace
 add_target_dir_to_path
 
+# Disable LNv1 module if not in backwards compat test, or if gateway version >= 0.10.0
+# Old gateways (< 0.10.0) require LNv1 module to be present
+if [[ -z "${FM_BACKWARDS_COMPATIBILITY_TEST:-}" ]]; then
+    export FM_ENABLE_MODULE_LNV1=0
+elif [[ "${FM_GATEWAYD_BASE_IMAGE_VERSION:-}" == "v0.10"* ]] || \
+     [[ "${FM_GATEWAYD_BASE_IMAGE_VERSION:-}" > "v0.10" ]]; then
+    export FM_ENABLE_MODULE_LNV1=0
+fi
+
 lnv2-module-tests

--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -131,6 +131,11 @@ function lnv2_module() {
 }
 export -f lnv2_module
 
+function lnv1_lnv2_swap() {
+  fm-run-test "${FUNCNAME[0]}" env FM_OFFLINE_NODES=0 ./scripts/tests/lnv1-lnv2-swap-test.sh
+}
+export -f lnv1_lnv2_swap
+
 function mint_client_sanity() {
   fm-run-test "${FUNCNAME[0]}" env FM_OFFLINE_NODES=0 ./scripts/tests/mint-client-sanity.sh
 }
@@ -358,6 +363,7 @@ tests_to_run_in_parallel+=(
   "gw_restore_test"
   "gw_liquidity_test"
   "lnv2_module"
+  "lnv1_lnv2_swap"
   "devimint_cli_test"
   "devimint_cli_test_single"
   "load_test_tool_test"


### PR DESCRIPTION
Eventually guardians might want to run federations without lightning v1. Right now the gateway does nut support that yet as it still expects the lightning v1 module in a few places. We fix these, split out the lnv2 to lnv1 swap tests into its own binary, and then always run the lnv2 module test without the lightning v1 module present.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
