### PR TITLE
feat: enable setup leader to disable modules in UI

### DIFF
--- a/fedimint-api-client/src/api/global_api/with_cache.rs
+++ b/fedimint-api-client/src/api/global_api/with_cache.rs
@@ -8,8 +8,8 @@ use bitcoin::secp256k1;
 use fedimint_connectors::ServerResult;
 use fedimint_core::admin_client::{GuardianConfigBackup, SetLocalParamsRequest, SetupStatus};
 use fedimint_core::backup::{BackupStatistics, ClientBackupSnapshot};
-use fedimint_core::core::ModuleInstanceId;
 use fedimint_core::core::backup::SignedBackupRequest;
+use fedimint_core::core::{ModuleInstanceId, ModuleKind};
 use fedimint_core::endpoint_constants::{
     ADD_PEER_SETUP_CODE_ENDPOINT, API_ANNOUNCEMENTS_ENDPOINT, AUDIT_ENDPOINT, AUTH_ENDPOINT,
     AWAIT_SESSION_OUTCOME_ENDPOINT, AWAIT_TRANSACTION_ENDPOINT, BACKUP_ENDPOINT,
@@ -373,6 +373,7 @@ where
         name: String,
         federation_name: Option<String>,
         disable_base_fees: Option<bool>,
+        enabled_modules: Option<BTreeSet<ModuleKind>>,
         auth: ApiAuth,
     ) -> FederationResult<String> {
         self.request_admin(
@@ -381,6 +382,7 @@ where
                 name,
                 federation_name,
                 disable_base_fees,
+                enabled_modules,
             }),
             auth,
         )

--- a/fedimint-api-client/src/api/mod.rs
+++ b/fedimint-api-client/src/api/mod.rs
@@ -20,7 +20,7 @@ use fedimint_connectors::{
 use fedimint_core::admin_client::{GuardianConfigBackup, ServerStatusLegacy, SetupStatus};
 use fedimint_core::backup::{BackupStatistics, ClientBackupSnapshot};
 use fedimint_core::core::backup::SignedBackupRequest;
-use fedimint_core::core::{Decoder, DynOutputOutcome, ModuleInstanceId, OutputOutcome};
+use fedimint_core::core::{Decoder, DynOutputOutcome, ModuleInstanceId, ModuleKind, OutputOutcome};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::invite_code::InviteCode;
 use fedimint_core::module::audit::AuditSummary;
@@ -483,6 +483,7 @@ pub trait IGlobalFederationApi: IRawFederationApi {
         name: String,
         federation_name: Option<String>,
         disable_base_fees: Option<bool>,
+        enabled_modules: Option<BTreeSet<ModuleKind>>,
         auth: ApiAuth,
     ) -> FederationResult<String>;
 

--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -1470,7 +1470,13 @@ impl FedimintCli {
                 federation_name,
             } => {
                 let info = client
-                    .set_local_params(name.clone(), federation_name.clone(), None, cli.auth()?)
+                    .set_local_params(
+                        name.clone(),
+                        federation_name.clone(),
+                        None,
+                        None,
+                        cli.auth()?,
+                    )
                     .await?;
 
                 Ok(serde_json::to_value(info).expect("JSON serialization failed"))

--- a/fedimint-core/src/admin_client.rs
+++ b/fedimint-core/src/admin_client.rs
@@ -1,7 +1,9 @@
+use std::collections::BTreeSet;
 use std::fmt::Debug;
 
 use serde::{Deserialize, Serialize};
 
+use crate::core::ModuleKind;
 use crate::encoding::{Decodable, Encodable};
 
 /// The state of the server returned via APIs
@@ -47,6 +49,9 @@ pub struct SetLocalParamsRequest {
     pub federation_name: Option<String>,
     /// Whether to disable base fees, set by the leader
     pub disable_base_fees: Option<bool>,
+    /// Modules enabled by the leader (if None, all available modules are
+    /// enabled)
+    pub enabled_modules: Option<BTreeSet<ModuleKind>>,
 }
 
 /// Archive of all the guardian config files that can be used to recover a lost

--- a/fedimint-core/src/setup_code.rs
+++ b/fedimint-core/src/setup_code.rs
@@ -1,5 +1,8 @@
+use std::collections::BTreeSet;
+
 use serde::Serialize;
 
+use crate::core::ModuleKind;
 use crate::encoding::{Decodable, Encodable};
 use crate::util::SafeUrl;
 
@@ -14,6 +17,9 @@ pub struct PeerSetupCode {
     pub federation_name: Option<String>,
     /// Whether to disable base fees, set by the leader
     pub disable_base_fees: Option<bool>,
+    /// Modules enabled by the leader (if None, all available modules are
+    /// enabled)
+    pub enabled_modules: Option<BTreeSet<ModuleKind>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Encodable, Decodable, Serialize)]

--- a/fedimint-server-core/src/setup_ui.rs
+++ b/fedimint-server-core/src/setup_ui.rs
@@ -1,7 +1,9 @@
+use std::collections::BTreeSet;
 use std::sync::Arc;
 
 use anyhow::Result;
 use async_trait::async_trait;
+use fedimint_core::core::ModuleKind;
 use fedimint_core::module::ApiAuth;
 
 pub type DynSetupApi = Arc<dyn ISetupApi + Send + Sync + 'static>;
@@ -18,6 +20,9 @@ pub trait ISetupApi {
     /// Get list of names of connected peers
     async fn connected_peers(&self) -> Vec<String>;
 
+    /// Get the available modules that can be enabled during setup
+    fn available_modules(&self) -> BTreeSet<ModuleKind>;
+
     /// Reset the set of other guardians
     async fn reset_setup_codes(&self);
 
@@ -28,6 +33,7 @@ pub trait ISetupApi {
         name: String,
         federation_name: Option<String>,
         disable_base_fees: Option<bool>,
+        enabled_modules: Option<BTreeSet<ModuleKind>>,
     ) -> Result<String>;
 
     /// Add peer connection info

--- a/fedimint-testing-core/src/config.rs
+++ b/fedimint-testing-core/src/config.rs
@@ -53,6 +53,7 @@ pub fn local_config_gen_params(
                 },
                 federation_name: None,
                 disable_base_fees: Some(!enable_mint_fees),
+                enabled_modules: None,
             };
             (*peer, params)
         })
@@ -70,6 +71,7 @@ pub fn local_config_gen_params(
                 peers: connections.clone(),
                 meta: BTreeMap::new(),
                 disable_base_fees: !enable_mint_fees,
+                enabled_modules: Default::default(),
                 network: bitcoin::Network::Regtest,
             };
             Ok((*peer, params))

--- a/fedimint-testing-core/src/config.rs
+++ b/fedimint-testing-core/src/config.rs
@@ -1,10 +1,12 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::sync::{Arc, LazyLock};
 
 use fedimint_core::PeerId;
+use fedimint_core::core::ModuleKind;
 use fedimint_core::module::ApiAuth;
 use fedimint_core::setup_code::{PeerEndpoints, PeerSetupCode};
 use fedimint_server::config::ConfigGenParams;
+use fedimint_server::core::ServerModuleInitRegistry;
 use fedimint_server::net::p2p_connector::gen_cert_and_key;
 use tokio_rustls::rustls;
 
@@ -17,7 +19,11 @@ pub fn local_config_gen_params(
     peers: &[PeerId],
     base_port: u16,
     enable_mint_fees: bool,
+    registry: &ServerModuleInitRegistry,
 ) -> anyhow::Result<HashMap<PeerId, ConfigGenParams>> {
+    let enabled_modules: BTreeSet<ModuleKind> =
+        registry.iter().map(|(kind, _)| kind.clone()).collect();
+
     // Generate TLS cert and private key
     let tls_keys: HashMap<
         PeerId,
@@ -71,7 +77,7 @@ pub fn local_config_gen_params(
                 peers: connections.clone(),
                 meta: BTreeMap::new(),
                 disable_base_fees: !enable_mint_fees,
-                enabled_modules: Default::default(),
+                enabled_modules: enabled_modules.clone(),
                 network: bitcoin::Network::Regtest,
             };
             Ok((*peer, params))

--- a/fedimint-testing/src/federation.rs
+++ b/fedimint-testing/src/federation.rs
@@ -247,8 +247,13 @@ impl FederationTestBuilder {
             "too many peers offline ({num_offline}) to reach consensus"
         );
         let peers = (0..self.num_peers).map(PeerId::from).collect::<Vec<_>>();
-        let params = local_config_gen_params(&peers, self.base_port, self.enable_mint_fees)
-            .expect("Generates local config");
+        let params = local_config_gen_params(
+            &peers,
+            self.base_port,
+            self.enable_mint_fees,
+            &self.server_init,
+        )
+        .expect("Generates local config");
 
         let configs =
             ServerConfig::trusted_dealer_gen(&params, &self.server_init, &self.version_hash);

--- a/fedimintd/src/lib.rs
+++ b/fedimintd/src/lib.rs
@@ -233,7 +233,7 @@ impl ServerOpts {
 ///
 /// # Arguments
 ///
-/// * `modules_fn` - A function to initialize the modules.
+/// * `module_init_registry` - The registry of available modules.
 ///
 /// * `code_version_hash` - The git hash of the code that the `fedimintd` binary
 ///   is being built from. This is used mostly for information purposes
@@ -303,6 +303,7 @@ pub async fn run(
         iroh_dns: server_opts.iroh_dns.clone(),
         iroh_relays: server_opts.iroh_relays.clone(),
         network: server_opts.bitcoin_network,
+        available_modules: module_init_registry.kinds(),
     };
 
     let db = Database::new(


### PR DESCRIPTION
Eventually guardians might want to run federations with only a subset of modules we provide. We now allow the guardian leading the setup to disable individual modules. I took the liberty to include some minor touch ups on the configuration screen into this pr.

<img width="486" height="836" alt="Bildschirmfoto 2025-12-12 um 19 39 06" src="https://github.com/user-attachments/assets/1aa72ba1-4649-4b5f-bf52-93f0048d616c" />


<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
