### PR TITLE
feat(gateway-ui): add ecash receive tab

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3477,6 +3477,7 @@ dependencies = [
  "fedimint-core",
  "fedimint-gateway-common",
  "fedimint-ln-common",
+ "fedimint-mint-client",
  "fedimint-ui-common",
  "fedimint-wallet-client",
  "lightning-invoice",

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -2085,6 +2085,15 @@ impl IAdminGateway for Gateway {
         self.handle_address_msg(payload).await
     }
 
+    async fn handle_receive_ecash_msg(
+        &self,
+        payload: ReceiveEcashPayload,
+    ) -> AdminResult<ReceiveEcashResponse> {
+        Self::handle_receive_ecash_msg(self, payload)
+            .await
+            .map_err(|e| AdminGatewayError::Unexpected(anyhow::anyhow!("{}", e)))
+    }
+
     /// Creates an invoice that is directly payable to the gateway's lightning
     /// node.
     async fn handle_create_invoice_for_operator_msg(

--- a/gateway/fedimint-gateway-ui/Cargo.toml
+++ b/gateway/fedimint-gateway-ui/Cargo.toml
@@ -23,6 +23,7 @@ fedimint-bitcoind = { workspace = true }
 fedimint-core = { workspace = true }
 fedimint-gateway-common = { workspace = true }
 fedimint-ln-common = { workspace = true }
+fedimint-mint-client = { workspace = true }
 fedimint-ui-common = { workspace = true }
 fedimint-wallet-client = { workspace = true }
 lightning-invoice = { workspace = true }

--- a/gateway/fedimint-gateway-ui/src/lib.rs
+++ b/gateway/fedimint-gateway-ui/src/lib.rs
@@ -26,9 +26,9 @@ use fedimint_gateway_common::{
     CreateInvoiceForOperatorPayload, DepositAddressPayload, FederationInfo, GatewayBalances,
     GatewayInfo, LeaveFedPayload, LightningMode, ListTransactionsPayload, ListTransactionsResponse,
     MnemonicResponse, OpenChannelRequest, PayInvoiceForOperatorPayload, PaymentSummaryPayload,
-    PaymentSummaryResponse, SendOnchainRequest, SetFeesPayload, SpendEcashPayload,
-    SpendEcashResponse, WithdrawPayload, WithdrawPreviewPayload, WithdrawPreviewResponse,
-    WithdrawResponse,
+    PaymentSummaryResponse, ReceiveEcashPayload, ReceiveEcashResponse, SendOnchainRequest,
+    SetFeesPayload, SpendEcashPayload, SpendEcashResponse, WithdrawPayload, WithdrawPreviewPayload,
+    WithdrawPreviewResponse, WithdrawResponse,
 };
 use fedimint_ln_common::contracts::Preimage;
 use fedimint_ui_common::assets::WithStaticRoutesExt;
@@ -42,8 +42,8 @@ use maud::html;
 
 use crate::connect_fed::connect_federation_handler;
 use crate::federation::{
-    deposit_address_handler, leave_federation_handler, set_fees_handler, spend_ecash_handler,
-    withdraw_confirm_handler, withdraw_preview_handler,
+    deposit_address_handler, leave_federation_handler, receive_ecash_handler, set_fees_handler,
+    spend_ecash_handler, withdraw_confirm_handler, withdraw_preview_handler,
 };
 use crate::lightning::{
     channels_fragment_handler, close_channel_handler, create_bolt11_invoice_handler,
@@ -68,6 +68,7 @@ pub(crate) const PAYMENTS_FRAGMENT_ROUTE: &str = "/ui/payments/fragment";
 pub(crate) const CREATE_BOLT11_INVOICE_ROUTE: &str = "/ui/payments/receive/bolt11";
 pub(crate) const PAY_BOLT11_INVOICE_ROUTE: &str = "/ui/payments/send/bolt11";
 pub(crate) const TRANSACTIONS_FRAGMENT_ROUTE: &str = "/ui/transactions/fragment";
+pub(crate) const RECEIVE_ECASH_ROUTE: &str = "/ui/federations/receive";
 pub(crate) const STOP_GATEWAY_ROUTE: &str = "/ui/stop";
 pub(crate) const WITHDRAW_PREVIEW_ROUTE: &str = "/ui/federations/withdraw-preview";
 pub(crate) const WITHDRAW_CONFIRM_ROUTE: &str = "/ui/federations/withdraw-confirm";
@@ -144,6 +145,11 @@ pub trait IAdminGateway {
         &self,
         payload: DepositAddressPayload,
     ) -> Result<Address, Self::Error>;
+
+    async fn handle_receive_ecash_msg(
+        &self,
+        payload: ReceiveEcashPayload,
+    ) -> Result<ReceiveEcashResponse, Self::Error>;
 
     async fn handle_create_invoice_for_operator_msg(
         &self,
@@ -358,6 +364,7 @@ pub fn router<E: Display + Send + Sync + std::fmt::Debug + 'static>(
         )
         .route(DEPOSIT_ADDRESS_ROUTE, post(deposit_address_handler))
         .route(SPEND_ECASH_ROUTE, post(spend_ecash_handler))
+        .route(RECEIVE_ECASH_ROUTE, post(receive_ecash_handler))
         .route(PAYMENTS_FRAGMENT_ROUTE, get(payments_fragment_handler))
         .route(
             CREATE_BOLT11_INVOICE_ROUTE,


### PR DESCRIPTION
Adds ecash receive tab to federation cards.

- Paste ecash notes string, click receive
- Shows error for invalid format, already spent, or already reissued notes
- Balance auto-refreshes after successful receive

## Successful receive
<img width="1353" height="560" alt="Screenshot_20251212_132839" src="https://github.com/user-attachments/assets/2e677e7e-db5d-451e-8523-788145e87409" />
