### PR TITLE
feat: locally generate lnurl for lnv2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2386,7 +2386,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/fedimint-recurringd/src/encrypt.rs
+++ b/fedimint-recurringd/src/encrypt.rs
@@ -3,27 +3,9 @@ use chacha20poly1305::{ChaCha20Poly1305, Key, KeyInit, Nonce};
 use fedimint_core::base32;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::registry::ModuleDecoderRegistry;
-use rand::Rng;
 use serde::{Deserialize, Serialize};
 
-pub trait Encryptable {
-    fn encrypt(&self, key: &[u8; 32]) -> EncryptedData;
-}
-
-impl<T: Encodable> Encryptable for T {
-    fn encrypt(&self, key: &[u8; 32]) -> EncryptedData {
-        let nonce = rand::thread_rng().r#gen::<[u8; 12]>();
-
-        let plaintext = self.consensus_encode_to_vec();
-
-        let ciphertext = ChaCha20Poly1305::new(Key::from_slice(key))
-            .encrypt(Nonce::from_slice(&nonce), plaintext.as_slice())
-            .unwrap();
-
-        EncryptedData { nonce, ciphertext }
-    }
-}
-
+/// Legacy encrypted data format for backwards compatibility with old LNURLs.
 #[derive(Debug, Clone, Serialize, Deserialize, Encodable, Decodable)]
 pub struct EncryptedData {
     pub nonce: [u8; 12],
@@ -37,10 +19,6 @@ impl EncryptedData {
             .ok()?;
 
         T::consensus_decode_whole(&plaintext, &ModuleDecoderRegistry::default()).ok()
-    }
-
-    pub fn encode_base32(&self) -> String {
-        base32::encode(&self.consensus_encode_to_vec())
     }
 
     pub fn decode_base32(s: &str) -> Option<Self> {

--- a/fedimint-recurringd/src/main.rs
+++ b/fedimint-recurringd/src/main.rs
@@ -46,6 +46,7 @@ struct CliOpts {
     bearer_token: String,
     #[clap(long, env = "FM_RECURRING_DATA_DIR")]
     data_dir: PathBuf,
+    /// Legacy encryption key for backwards compatibility with old LNURLs.
     #[clap(long, env = "FM_RECURRING_ENCRYPTION_KEY")]
     encryption_key: Option<String>,
 }
@@ -100,9 +101,7 @@ async fn main() -> anyhow::Result<()> {
             recurring_invoice_server,
         });
 
-    if let Some(encryption_key) = cli_opts.encryption_key {
-        app = app.merge(v2::router(cli_opts.api_address, encryption_key).await?);
-    }
+    app = app.merge(v2::router(cli_opts.api_address, cli_opts.encryption_key).await?);
 
     info!(api_address = %cli_opts.bind_address, "recurringd started");
     let listener = TcpListener::bind(&cli_opts.bind_address).await?;

--- a/modules/fedimint-lnv2-client/src/lib.rs
+++ b/modules/fedimint-lnv2-client/src/lib.rs
@@ -1067,14 +1067,12 @@ impl LightningClientModule {
         };
 
         let lnurl = lnurl::generate_lnurl(
-            recurringd,
+            &recurringd,
             self.federation_id,
             self.lnurl_keypair.public_key(),
             self.cfg.tpe_agg_pk,
             gateways,
-        )
-        .await
-        .map_err(|e| GenerateLnurlError::FailedToRequestLnurl(e.to_string()))?;
+        );
 
         Ok(lnurl)
     }
@@ -1196,8 +1194,6 @@ pub enum GenerateLnurlError {
     NoGatewaysAvailable,
     #[error("Failed to request gateways")]
     FailedToRequestGateways(String),
-    #[error("Failed to request LNURL")]
-    FailedToRequestLnurl(String),
 }
 
 #[derive(Error, Debug, Clone, Eq, PartialEq)]


### PR DESCRIPTION
We had encrypted the route payload such that two lnurls from the same receiver cannot be correlated by the sender, only by the recurringd service of course. However this requires the lnv2 client to fetch a new lnurl with randomized encrypted payload from the recurringd service every time. To increase the receivers privacy towards recurringd we have removed the encryption allowing the receiver to receive lnurl payments without ever contacting recurringd. If an integrator chooses to run their own recurringd this should significantly improve their privacy declaration when publishing to an app store.

Furthermore this will eventually allow the sender to deconstruct the lnurl and translate it into an invoice itself without ever contacting the proxy in the first place.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
