### PR TITLE
chore: expose guardian connection status on the client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2776,6 +2776,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.12",
  "tokio",
+ "tokio-stream",
  "tracing",
 ]
 

--- a/fedimint-api-client/Cargo.toml
+++ b/fedimint-api-client/Cargo.toml
@@ -35,6 +35,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+tokio-stream = { workspace = true }
 tracing = { workspace = true }
 
 [lints]

--- a/fedimint-api-client/src/api/global_api/with_cache.rs
+++ b/fedimint-api-client/src/api/global_api/with_cache.rs
@@ -39,6 +39,7 @@ use fedimint_core::util::SafeUrl;
 use fedimint_core::{NumPeersExt, PeerId, TransactionId, apply, async_trait_maybe_send};
 use fedimint_logging::LOG_CLIENT_NET_API;
 use futures::future::join_all;
+use futures::stream::BoxStream;
 use itertools::Itertools;
 use rand::seq::SliceRandom;
 use serde_json::Value;
@@ -236,6 +237,10 @@ where
         params: &ApiRequestErased,
     ) -> ServerResult<Value> {
         self.inner.request_raw(peer_id, method, params).await
+    }
+
+    fn connection_status_stream(&self) -> BoxStream<'static, BTreeMap<PeerId, bool>> {
+        self.inner.connection_status_stream()
     }
 }
 

--- a/fedimint-api-client/src/api/global_api/with_request_hook.rs
+++ b/fedimint-api-client/src/api/global_api/with_request_hook.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
 use fedimint_connectors::ServerResult;
@@ -6,6 +6,7 @@ use fedimint_core::core::ModuleInstanceId;
 use fedimint_core::module::ApiRequestErased;
 use fedimint_core::task::{MaybeSend, MaybeSync};
 use fedimint_core::{PeerId, apply, async_trait_maybe_send, maybe_add_send_sync};
+use futures::stream::BoxStream;
 use serde_json::Value;
 
 use super::super::{DynModuleApi, IRawFederationApi};
@@ -84,5 +85,9 @@ impl IRawFederationApi for RawFederationApiWithRequestHook {
         params: &ApiRequestErased,
     ) -> ServerResult<Value> {
         self.inner.request_raw(peer_id, method, params).await
+    }
+
+    fn connection_status_stream(&self) -> BoxStream<'static, BTreeMap<PeerId, bool>> {
+        self.inner.connection_status_stream()
     }
 }

--- a/fedimint-client-module/src/api.rs
+++ b/fedimint-client-module/src/api.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::string::ToString;
 
 use fedimint_api_client::api::{DynModuleApi, IRawFederationApi, ServerResult};
@@ -52,6 +52,7 @@ impl Event for ApiCallDone {
 }
 
 use fedimint_eventlog::{DBTransactionEventLogExt as _, Event, EventKind, EventPersistence};
+use futures::stream::BoxStream;
 
 /// Convenience extension trait used for wrapping [`IRawFederationApi`] in
 /// a [`ClientRawFederationApi`]
@@ -162,5 +163,9 @@ where
         .await;
 
         res
+    }
+
+    fn connection_status_stream(&self) -> BoxStream<'static, BTreeMap<PeerId, bool>> {
+        self.inner.connection_status_stream()
     }
 }

--- a/fedimint-client/src/client.rs
+++ b/fedimint-client/src/client.rs
@@ -198,6 +198,12 @@ impl Client {
         self.api.clone()
     }
 
+    /// Returns a stream that emits the current connection status of all peers
+    /// whenever any peer's status changes. Emits initial state immediately.
+    pub fn connection_status_stream(&self) -> impl Stream<Item = BTreeMap<PeerId, bool>> {
+        self.api.connection_status_stream()
+    }
+
     /// Get the [`TaskGroup`] that is tied to Client's lifetime.
     pub fn task_group(&self) -> &TaskGroup {
         &self.task_group


### PR DESCRIPTION
This pr enables real-time monitoring of connection status for the client to display in the UI of example. Its already used in Conduit and works fine.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
