### PR TITLE
refactor(core): DatabaseError instead of anyhow::Error

### DIFF
--- a/fedimint-client/src/db.rs
+++ b/fedimint-client/src/db.rs
@@ -728,7 +728,9 @@ pub async fn apply_migrations_client_module(
         module_instance_id,
     )
     .await?;
-    dbtx.commit_tx_result().await
+    dbtx.commit_tx_result()
+        .await
+        .map_err(|e| anyhow::Error::msg(e.to_string()))
 }
 
 pub async fn apply_migrations_client_module_dbtx(

--- a/fedimint-client/src/sm/executor.rs
+++ b/fedimint-client/src/sm/executor.rs
@@ -197,7 +197,7 @@ impl Executor {
                 AutocommitError::CommitFailed {
                     last_error,
                     attempts,
-                } => last_error.context(format!("Failed to commit after {attempts} attempts")),
+                } => anyhow!("Failed to commit after {attempts} attempts: {last_error}"),
                 AutocommitError::ClosureError { error, .. } => anyhow!("{error:?}"),
             })?;
 

--- a/fedimint-core/src/db/notifications.rs
+++ b/fedimint-core/src/db/notifications.rs
@@ -93,7 +93,7 @@ impl NotifyQueue {
 
     pub fn add<K>(&mut self, key: &K)
     where
-        K: Hash,
+        K: Hash + ?Sized,
     {
         self.buckets.set(slot_index_for_key(key), true);
     }

--- a/fedimint-core/src/module/mod.rs
+++ b/fedimint-core/src/module/mod.rs
@@ -29,7 +29,6 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use fedimint_logging::LOG_NET_API;
-use fedimint_util_error::FmtCompactAnyhow as _;
 use futures::Future;
 use jsonrpsee_core::JsonValue;
 use registry::ModuleRegistry;
@@ -469,7 +468,7 @@ impl<'a> ApiEndpointContext<'a> {
         self.dbtx.commit_tx_result().await.map_err(|err| {
             tracing::warn!(
                 target: fedimint_logging::LOG_NET_API,
-                err = %err.fmt_compact_anyhow(),
+                err = %err.fmt_compact(),
                 %path,
                 "API server error when writing to database",
             );

--- a/fedimint-cursed-redb/src/native.rs
+++ b/fedimint-cursed-redb/src/native.rs
@@ -20,7 +20,7 @@ impl MemAndRedb {
         )?;
         LockedBuilder::new(db_path)?.with_db(|| {
             let db = Database::create(db_path).context("Failed to create/open redb database")?;
-            Self::new_from_redb(db)
+            Self::new_from_redb(db).map_err(|e| anyhow::Error::msg(e.to_string()))
         })
     }
 }

--- a/fedimint-cursed-redb/src/wasm.rs
+++ b/fedimint-cursed-redb/src/wasm.rs
@@ -93,6 +93,6 @@ impl MemAndRedb {
         let db = Database::builder()
             .create_with_backend(backend)
             .context("Failed to create/open redb database")?;
-        Self::new_from_redb(db)
+        Ok(Self::new_from_redb(db)?)
     }
 }

--- a/fedimint-db-locked/src/lib.rs
+++ b/fedimint-db-locked/src/lib.rs
@@ -75,7 +75,7 @@ where
         self.inner.begin_transaction().await
     }
 
-    fn checkpoint(&self, backup_path: &Path) -> anyhow::Result<()> {
+    fn checkpoint(&self, backup_path: &Path) -> fedimint_core::db::DatabaseResult<()> {
         self.inner.checkpoint(backup_path)
     }
 }

--- a/fedimint-recurringd/src/lib.rs
+++ b/fedimint-recurringd/src/lib.rs
@@ -214,7 +214,7 @@ impl RecurringInvoiceServer {
             &0,
         )
         .await;
-        dbtx.commit_tx_result().await?;
+        dbtx.commit_tx_result().await.map_err(anyhow::Error::from)?;
 
         Ok(payment_code)
     }

--- a/fedimint-server-core/src/migration.rs
+++ b/fedimint-server-core/src/migration.rs
@@ -157,7 +157,10 @@ pub async fn apply_migrations_server(
     let mut global_dbtx = db.begin_transaction().await;
     global_dbtx.ensure_global()?;
     apply_migrations_server_dbtx(&mut global_dbtx.to_ref_nc(), ctx, kind, migrations).await?;
-    global_dbtx.commit_tx_result().await
+    global_dbtx
+        .commit_tx_result()
+        .await
+        .map_err(|e| anyhow::Error::msg(e.to_string()))
 }
 
 /// Applies the database migrations to a non-isolated database.

--- a/fedimint-server/src/consensus/engine.rs
+++ b/fedimint-server/src/consensus/engine.rs
@@ -826,7 +826,7 @@ impl ConsensusEngine {
                     debug!(target: LOG_CONSENSUS, ?session_checkpoint_dir, ?session_index, "Created db checkpoint");
                 }
                 Err(err) => {
-                    warn!(target: LOG_CONSENSUS, ?session_checkpoint_dir, ?session_index, err = %err.fmt_compact_anyhow(), "Could not create db checkpoint");
+                    warn!(target: LOG_CONSENSUS, ?session_checkpoint_dir, ?session_index, err = %err.fmt_compact(), "Could not create db checkpoint");
                 }
             }
         }

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -920,7 +920,7 @@ impl WalletClientModule {
                 AutocommitError::CommitFailed {
                     last_error,
                     attempts,
-                } => last_error.context(format!("Failed to commit after {attempts} attempts")),
+                } => anyhow!("Failed to commit after {attempts} attempts: {last_error}"),
                 AutocommitError::ClosureError { error, .. } => error,
             })?;
 

--- a/modules/fedimint-wallet-client/src/pegin_monitor.rs
+++ b/modules/fedimint-wallet-client/src/pegin_monitor.rs
@@ -1,6 +1,7 @@
 use std::cmp;
 use std::time::{Duration, SystemTime};
 
+use anyhow::anyhow;
 use bitcoin::ScriptBuf;
 use fedimint_api_client::api::DynModuleApi;
 use fedimint_bitcoind::DynBitcoindRpc;
@@ -535,7 +536,7 @@ async fn claim_peg_in(
             AutocommitError::CommitFailed {
                 last_error,
                 attempts,
-            } => last_error.context(format!("Failed to commit after {attempts} attempts")),
+            } => anyhow!("Failed to commit after {attempts} attempts: {last_error}"),
             AutocommitError::ClosureError { error, .. } => error,
         })?;
 


### PR DESCRIPTION
We're using `anyhow::Error` because we're kind of lazy. Making it typed
will make it easier to convert to ApiError in a PR I'm working on.
<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
