### PR TITLE
 refactor: endpoints to handle dbtx manually 

### DIFF
--- a/fedimint-core/src/db/mod.rs
+++ b/fedimint-core/src/db/mod.rs
@@ -3537,6 +3537,8 @@ mod test_utils {
         #[async_trait]
         impl IRawDatabaseTransaction for FakeTransaction<'_> {
             async fn commit_tx(self) -> DatabaseResult<()> {
+                use crate::db::DatabaseError;
+
                 Err(DatabaseError::Other(anyhow::anyhow!("Can't commit!")))
             }
         }

--- a/fedimint-server-core/src/lib.rs
+++ b/fedimint-server-core/src/lib.rs
@@ -491,7 +491,7 @@ where
                 path,
                 handler: Box::new(
                     move |module: &DynServerModule,
-                          context: ApiEndpointContext<'_>,
+                          context: ApiEndpointContext,
                           value: ApiRequestErased| {
                         let typed_module = module
                             .as_any()

--- a/fedimint-server/src/config/setup.rs
+++ b/fedimint-server/src/config/setup.rs
@@ -396,11 +396,10 @@ impl HasApiContext<SetupApi> for SetupApi {
         &self,
         request: &ApiRequestErased,
         id: Option<ModuleInstanceId>,
-    ) -> (&SetupApi, ApiEndpointContext<'_>) {
+    ) -> (&SetupApi, ApiEndpointContext) {
         assert!(id.is_none());
 
         let db = self.db.clone();
-        let dbtx = self.db.begin_transaction().await;
 
         let is_authenticated = match self.state.lock().await.local_params {
             None => false,
@@ -410,7 +409,7 @@ impl HasApiContext<SetupApi> for SetupApi {
             },
         };
 
-        let context = ApiEndpointContext::new(db, dbtx, is_authenticated, request.auth.clone());
+        let context = ApiEndpointContext::new(db, is_authenticated, request.auth.clone());
 
         (self, context)
     }

--- a/fedimint-server/src/net/api/mod.rs
+++ b/fedimint-server/src/net/api/mod.rs
@@ -89,7 +89,7 @@ pub trait HasApiContext<State> {
         &self,
         request: &ApiRequestErased,
         id: Option<ModuleInstanceId>,
-    ) -> (&State, ApiEndpointContext<'_>);
+    ) -> (&State, ApiEndpointContext);
 }
 
 pub async fn spawn<T>(

--- a/modules/fedimint-mint-server/src/lib.rs
+++ b/modules/fedimint-mint-server/src/lib.rs
@@ -650,14 +650,18 @@ impl ServerModule for Mint {
                 NOTE_SPENT_ENDPOINT,
                 ApiVersion::new(0, 1),
                 async |_module: &Mint, context, nonce: Nonce| -> bool {
-                    Ok(context.dbtx().get_value(&NonceKey(nonce)).await.is_some())
+                    let db = context.db();
+                    let mut dbtx = db.begin_transaction_nc().await;
+                    Ok(dbtx.get_value(&NonceKey(nonce)).await.is_some())
                 }
             },
             api_endpoint! {
                 BLIND_NONCE_USED_ENDPOINT,
                 ApiVersion::new(0, 1),
                 async |_module: &Mint, context, blind_nonce: BlindNonce| -> bool {
-                    Ok(context.dbtx().get_value(&BlindNonceKey(blind_nonce)).await.is_some())
+                    let db = context.db();
+                    let mut dbtx = db.begin_transaction_nc().await;
+                    Ok(dbtx.get_value(&BlindNonceKey(blind_nonce)).await.is_some())
                 }
             },
         ]


### PR DESCRIPTION
Re #7866 

We keep hitting write-write conflicts in api conflicts, and in general I don't like the current api handler strategy w.r.t the db. We open db transaction for every call, even if it won't do anything w.r.t the database (not common, but happens) which is wasteful.

I think it's better to just let handlers deal with their database needs. Ones that can't have db conflicts, can just do a single dbtx. Ones that can, can do autocommit. Ones that don't do anything w.r.t. db, will just not open any dbtx. Sure it's a bit of extra code in most handlers, but it doesn't matter in a bigger picture.
<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
