### PR TITLE
chore: add issue remider bot to CI

### DIFF
--- a/.github/workflows/reminder-setup.yml
+++ b/.github/workflows/reminder-setup.yml
@@ -1,0 +1,17 @@
+name: 'create reminder'
+
+permissions:
+  issues: write
+  pull-requests: write
+
+on:
+  issue_comment:
+    types: [created, edited]
+
+jobs:
+  reminder:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 👀 check for reminder
+        uses: agrc/create-reminder-action@v1

--- a/.github/workflows/reminder-trigger.yml
+++ b/.github/workflows/reminder-trigger.yml
@@ -1,0 +1,18 @@
+name: 'check reminders'
+
+on:
+  schedule:
+    # Run every hour at the 10th minute
+    - cron: '10 * * * *'
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  reminder:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: check reminders and notify
+        uses: agrc/reminder-action@v1


### PR DESCRIPTION
Adds a [reminder bot action](https://github.com/agrc/reminder-action), inspired by https://github.com/fedimint/fedimint/issues/8082.

Usage:
```
    /remind me to deploy on Oct 10
    /remind me next Monday to review the requirements
    /remind me that the specs on the rotary girder need checked in 6 months
```

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
