### PR TITLE
fix: fix parsing form when modules are disabled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -776,6 +776,7 @@ dependencies = [
  "axum-core 0.5.5",
  "bytes",
  "cookie",
+ "form_urlencoded",
  "futures-core",
  "futures-util",
  "http 1.3.1",
@@ -783,6 +784,9 @@ dependencies = [
  "http-body-util",
  "mime",
  "pin-project-lite",
+ "serde_core",
+ "serde_html_form",
+ "serde_path_to_error",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -9470,6 +9474,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "serde_html_form"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2f2d7ff8a2140333718bb329f5c40fc5f0865b84c426183ce14c97d2ab8154f"
+dependencies = [
+ "form_urlencoded",
+ "indexmap 2.9.0",
+ "itoa",
+ "ryu",
+ "serde_core",
 ]
 
 [[package]]

--- a/fedimint-server-ui/Cargo.toml
+++ b/fedimint-server-ui/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/lib.rs"
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 axum = { workspace = true, features = ["macros"] }
-axum-extra = { workspace = true, features = ["cookie"] }
+axum-extra = { workspace = true, features = ["cookie", "form"] }
 chrono = { workspace = true }
 fedimint-core = { workspace = true }
 fedimint-lnv2-server = { workspace = true }

--- a/fedimint-server-ui/src/setup.rs
+++ b/fedimint-server-ui/src/setup.rs
@@ -1,9 +1,10 @@
 use std::collections::BTreeSet;
 
 use axum::Router;
-use axum::extract::{Form, State};
+use axum::extract::State;
 use axum::response::{Html, IntoResponse, Redirect};
 use axum::routing::{get, post};
+use axum_extra::extract::Form;
 use axum_extra::extract::cookie::CookieJar;
 use fedimint_core::core::ModuleKind;
 use fedimint_core::module::ApiAuth;
@@ -155,11 +156,6 @@ async fn setup_form(State(state): State<UiState<DynSetupApi>>) -> impl IntoRespo
                         "Base fees discourage spam and wasting storage space. The typical fee is only 1-3 sats per transaction, regardless of the value transferred. We recommend enabling the base fee and it cannot be changed later."
                     }
 
-                    // Hidden inputs to ensure all modules are enabled by default
-                    @for kind in &available_modules {
-                        input type="hidden" name="enabled_modules" value=(kind.as_str());
-                    }
-
                     div class="accordion mt-3" id="modulesAccordion" {
                         div class="accordion-item" {
                             h2 class="accordion-header" {
@@ -228,7 +224,7 @@ async fn setup_submit(
         let enabled: BTreeSet<ModuleKind> = input
             .enabled_modules
             .into_iter()
-            .map(|s| ModuleKind::from_static_str(s.leak()))
+            .map(|s| ModuleKind::clone_from_str(&s))
             .collect();
 
         Some(enabled)


### PR DESCRIPTION
Currently the form parsing for disabling modules is actually broken, this fixes it.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
