### PR TITLE
docs: improve Nix setup instructions for Determinate Nix and WSL users

### DIFF
--- a/docs/dev-env.md
+++ b/docs/dev-env.md
@@ -77,7 +77,7 @@ for `nix develop`.
 Fedimint uses a [Cachix](https://www.cachix.org/) binary cache to cache builds.
 To benefit from this cache and avoid building everything from scratch, you must
 ensure that your user is a [trusted user](https://nix.dev/manual/nix/stable/command-ref/conf-file.html#conf-trusted-users).
-You can do this by modifying `/etc/nix/nix.conf`, adding the following line.
+You can do this by modifying `/etc/nix/nix.conf` (or `/etc/nix/nix.custom.conf` when using the Determinate Nix installer), adding the following line.
 
 ```
 trusted-users = the_name_of_your_user


### PR DESCRIPTION
Adds clarification for users installing Nix using the Determinate Systems installer
and for contributors running Fedimint inside WSL.

This update explains:
- where to configure `trusted-users`
- why `/etc/nix/nix.conf` should not be edited for Determinate Nix
- how to restart the Nix daemon
- alternative workaround for WSL when daemon restart is unavailable

This helps avoid the “ignoring untrusted substituter / trusted-public-keys” errors
and failed builds that new contributors commonly experience during setup.
