### PR TITLE
chore: use new encoding for oob notes in mint send payment event

### DIFF
--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -61,7 +61,7 @@ use fedimint_client_module::transaction::{
     ClientOutputSM, TransactionBuilder,
 };
 use fedimint_client_module::{DynGlobalClientContext, sm_enum_variant_translation};
-use fedimint_core::base32::FEDIMINT_PREFIX;
+use fedimint_core::base32::{FEDIMINT_PREFIX, encode_prefixed};
 use fedimint_core::config::{FederationId, FederationIdPrefix};
 use fedimint_core::core::{Decoder, IntoDynInstance, ModuleInstanceId, ModuleKind, OperationId};
 use fedimint_core::db::{
@@ -1764,7 +1764,7 @@ impl MintClientModule {
                                 SendPaymentEvent {
                                     operation_id,
                                     amount: oob_notes.total_amount(),
-                                    oob_notes: oob_notes.to_string(),
+                                    oob_notes: encode_prefixed(FEDIMINT_PREFIX, &oob_notes),
                                 },
                             )
                             .await;
@@ -1963,7 +1963,7 @@ impl MintClientModule {
                 SendPaymentEvent {
                     operation_id,
                     amount: oob_notes.total_amount(),
-                    oob_notes: oob_notes.to_string(),
+                    oob_notes: encode_prefixed(FEDIMINT_PREFIX, &oob_notes),
                 },
             )
             .await;


### PR DESCRIPTION
Use new encoding for oob notes in mint send payment event.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
