### PR TITLE
chore: assert_matches! instead of assert!(matches!)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2765,6 +2765,7 @@ name = "fedimint-api-client"
 version = "0.10.0-alpha"
 dependencies = [
  "anyhow",
+ "assert_matches",
  "async-channel",
  "async-trait",
  "bitcoin",
@@ -2861,6 +2862,7 @@ name = "fedimint-client"
 version = "0.10.0-alpha"
 dependencies = [
  "anyhow",
+ "assert_matches",
  "async-stream",
  "async-trait",
  "bitcoin",
@@ -3017,6 +3019,7 @@ name = "fedimint-core"
 version = "0.10.0-alpha"
 dependencies = [
  "anyhow",
+ "assert_matches",
  "async-channel",
  "async-lock",
  "async-recursion",
@@ -3301,6 +3304,7 @@ name = "fedimint-fountain"
 version = "0.10.0-alpha"
 dependencies = [
  "anyhow",
+ "assert_matches",
  "bitcoin_hashes 0.14.0",
  "fedimint-core",
  "rand 0.8.5",
@@ -3630,6 +3634,7 @@ version = "0.10.0-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
+ "assert_matches",
  "async-stream",
  "async-trait",
  "bitcoin",
@@ -3970,6 +3975,7 @@ version = "0.10.0-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
+ "assert_matches",
  "async-stream",
  "async-trait",
  "base64 0.22.1",
@@ -4049,6 +4055,7 @@ name = "fedimint-mint-tests"
 version = "0.10.0-alpha"
 dependencies = [
  "anyhow",
+ "assert_matches",
  "bitcoin_hashes 0.14.0",
  "bls12_381",
  "clap",
@@ -4506,6 +4513,7 @@ version = "0.10.0-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
+ "assert_matches",
  "async-stream",
  "async-trait",
  "bitcoin",

--- a/fedimint-api-client/Cargo.toml
+++ b/fedimint-api-client/Cargo.toml
@@ -38,5 +38,8 @@ tokio = { workspace = true }
 tokio-stream = { workspace = true }
 tracing = { workspace = true }
 
+[dev-dependencies]
+assert_matches = { workspace = true }
+
 [lints]
 workspace = true

--- a/fedimint-api-client/src/query.rs
+++ b/fedimint-api-client/src/query.rs
@@ -137,31 +137,15 @@ impl<R: Eq + Clone> QueryStrategy<R> for ThresholdConsensus<R> {
 
 #[test]
 fn test_threshold_consensus() {
+    use assert_matches::assert_matches;
+
     let mut consensus = ThresholdConsensus::<u64>::new(NumPeers::from(4));
 
-    assert!(matches!(
-        consensus.process(PeerId::from(0), 1),
-        QueryStep::Continue
-    ));
-    assert!(matches!(
-        consensus.process(PeerId::from(1), 1),
-        QueryStep::Continue
-    ));
-    assert!(matches!(
-        consensus.process(PeerId::from(2), 0),
-        QueryStep::Retry(..)
-    ));
+    assert_matches!(consensus.process(PeerId::from(0), 1), QueryStep::Continue);
+    assert_matches!(consensus.process(PeerId::from(1), 1), QueryStep::Continue);
+    assert_matches!(consensus.process(PeerId::from(2), 0), QueryStep::Retry(..));
 
-    assert!(matches!(
-        consensus.process(PeerId::from(0), 1),
-        QueryStep::Continue
-    ));
-    assert!(matches!(
-        consensus.process(PeerId::from(1), 1),
-        QueryStep::Continue
-    ));
-    assert!(matches!(
-        consensus.process(PeerId::from(2), 1),
-        QueryStep::Success(1)
-    ));
+    assert_matches!(consensus.process(PeerId::from(0), 1), QueryStep::Continue);
+    assert_matches!(consensus.process(PeerId::from(1), 1), QueryStep::Continue);
+    assert_matches!(consensus.process(PeerId::from(2), 1), QueryStep::Success(1));
 }

--- a/fedimint-client-module/src/oplog.rs
+++ b/fedimint-client-module/src/oplog.rs
@@ -182,6 +182,15 @@ pub enum UpdateStreamOrOutcome<U> {
     Outcome(U),
 }
 
+impl<U: Debug> Debug for UpdateStreamOrOutcome<U> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            UpdateStreamOrOutcome::UpdateStream(_) => write!(f, "UpdateStream"),
+            UpdateStreamOrOutcome::Outcome(o) => f.debug_tuple("Outcome").field(o).finish(),
+        }
+    }
+}
+
 impl<U> UpdateStreamOrOutcome<U>
 where
     U: MaybeSend + MaybeSync + 'static,

--- a/fedimint-client/Cargo.toml
+++ b/fedimint-client/Cargo.toml
@@ -47,6 +47,7 @@ tokio-stream = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
+assert_matches = { workspace = true }
 tracing-test = { workspace = true }
 
 [build-dependencies]

--- a/fedimint-client/src/oplog/tests.rs
+++ b/fedimint-client/src/oplog/tests.rs
@@ -1,5 +1,6 @@
 use std::time::{Duration, SystemTime};
 
+use assert_matches::assert_matches;
 use fedimint_client_module::oplog::{JsonStringed, OperationOutcome, UpdateStreamOrOutcome};
 use fedimint_core::core::OperationId;
 use fedimint_core::db::mem_impl::MemDatabase;
@@ -77,10 +78,10 @@ async fn test_operation_log_update() {
     let update_stream_or_outcome =
         OperationLog::outcome_or_updates::<String, _>(&db, op_id, op, futures::stream::empty);
 
-    assert!(matches!(
+    assert_matches!(
         &update_stream_or_outcome,
         UpdateStreamOrOutcome::Outcome(s) if s == "baz"
-    ));
+    );
 
     let updates = update_stream_or_outcome
         .into_stream()

--- a/fedimint-core/Cargo.toml
+++ b/fedimint-core/Cargo.toml
@@ -89,6 +89,7 @@ tokio = { workspace = true, features = ["io-util"] }
 wasm-bindgen-futures = { workspace = true }
 
 [dev-dependencies]
+assert_matches = { workspace = true }
 test-log = { workspace = true }
 tokio-test = { workspace = true }
 

--- a/fedimint-core/src/util/tests.rs
+++ b/fedimint-core/src/util/tests.rs
@@ -2,6 +2,7 @@ use std::sync::atomic::{AtomicU8, Ordering};
 use std::time::Duration;
 
 use anyhow::anyhow;
+use assert_matches::assert_matches;
 use fedimint_core::runtime::Elapsed;
 use futures::FutureExt;
 
@@ -75,10 +76,10 @@ async fn test_next_or_pending() {
     let mut stream = futures::stream::iter(vec![1, 2]);
     assert_eq!(stream.next_or_pending().now_or_never(), Some(1));
     assert_eq!(stream.next_or_pending().now_or_never(), Some(2));
-    assert!(matches!(
+    assert_matches!(
         timeout(Duration::from_millis(100), stream.next_or_pending()).await,
         Err(Elapsed { .. })
-    ));
+    );
 }
 
 #[tokio::test]

--- a/fedimint-fountain/Cargo.toml
+++ b/fedimint-fountain/Cargo.toml
@@ -19,5 +19,8 @@ fedimint-core = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
 
+[dev-dependencies]
+assert_matches = { workspace = true }
+
 [lints]
 workspace = true

--- a/fedimint-fountain/src/fountain.rs
+++ b/fedimint-fountain/src/fountain.rs
@@ -293,6 +293,8 @@ impl Decoder {
 
 #[cfg(test)]
 mod tests {
+    use assert_matches::assert_matches;
+
     use super::*;
 
     #[test]
@@ -328,10 +330,10 @@ mod tests {
         assert_eq!(decoder.receive(encoder1.next_fragment()).unwrap(), None);
 
         // Try to receive fragment from encoder2 with different metadata - should reject
-        assert!(matches!(
+        assert_matches!(
             decoder.receive(encoder2.next_fragment()),
             Err(Error::InconsistentFragment)
-        ));
+        );
 
         // Receiving another fragment from encoder1 should work and complete
         assert_eq!(
@@ -351,25 +353,25 @@ mod tests {
 
         // Check simple_fragments.
         fragment.meta.simple_fragments = 0;
-        assert!(matches!(
+        assert_matches!(
             decoder.receive(fragment.clone()),
             Err(Error::InvalidFragment)
-        ));
+        );
         fragment.meta.simple_fragments = 8;
 
         // Check message_length.
         fragment.meta.message_length = 0;
-        assert!(matches!(
+        assert_matches!(
             decoder.receive(fragment.clone()),
             Err(Error::InvalidFragment)
-        ));
+        );
         fragment.meta.message_length = 100;
 
         // Check data.
         fragment.data = vec![];
-        assert!(matches!(
+        assert_matches!(
             decoder.receive(fragment.clone()),
             Err(Error::InvalidFragment)
-        ));
+        );
     }
 }

--- a/modules/fedimint-ln-client/Cargo.toml
+++ b/modules/fedimint-ln-client/Cargo.toml
@@ -26,6 +26,7 @@ path = "src/lib.rs"
 [dependencies]
 anyhow = { workspace = true }
 aquamarine = { workspace = true }
+assert_matches = { workspace = true }
 async-stream = { workspace = true }
 async-trait = { workspace = true }
 bitcoin = { workspace = true }

--- a/modules/fedimint-ln-client/src/incoming.rs
+++ b/modules/fedimint-ln-client/src/incoming.rs
@@ -10,6 +10,7 @@
 use core::fmt;
 use std::time::Duration;
 
+use assert_matches::assert_matches;
 use bitcoin::hashes::sha256;
 use fedimint_client_module::DynGlobalClientContext;
 use fedimint_client_module::sm::{ClientSMDatabaseTransaction, State, StateTransition};
@@ -273,10 +274,7 @@ impl DecryptingPreimageState {
         global_context: DynGlobalClientContext,
         context: LightningClientContext,
     ) -> IncomingStateMachine {
-        assert!(matches!(
-            old_state.state,
-            IncomingSmStates::DecryptingPreimage(_)
-        ));
+        assert_matches!(old_state.state, IncomingSmStates::DecryptingPreimage(_));
 
         match result {
             Ok(preimage) => {

--- a/modules/fedimint-ln-client/src/pay.rs
+++ b/modules/fedimint-ln-client/src/pay.rs
@@ -1,5 +1,6 @@
 use std::time::{Duration, SystemTime};
 
+use assert_matches::assert_matches;
 use bitcoin::hashes::sha256;
 use fedimint_client_module::DynGlobalClientContext;
 use fedimint_client_module::sm::{ClientSMDatabaseTransaction, State, StateTransition};
@@ -192,10 +193,10 @@ impl LightningPayCreatedOutgoingLnContract {
         old_state: LightningPayStateMachine,
         gateway: LightningGateway,
     ) -> LightningPayStateMachine {
-        assert!(matches!(
+        assert_matches!(
             old_state.state,
             LightningPayStates::CreatedOutgoingLnContract(_)
-        ));
+        );
 
         match result {
             Ok(timelock) => {

--- a/modules/fedimint-ln-tests/Cargo.toml
+++ b/modules/fedimint-ln-tests/Cargo.toml
@@ -13,7 +13,6 @@ path = "tests/tests.rs"
 
 [dependencies]
 anyhow = { workspace = true }
-assert_matches = { workspace = true }
 bitcoin_hashes = { workspace = true }
 fedimint-client = { workspace = true }
 fedimint-client-module = { workspace = true }
@@ -35,6 +34,9 @@ strum = { workspace = true }
 threshold_crypto = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+
+[dev-dependencies]
+assert_matches = { workspace = true }
 
 [lints]
 workspace = true

--- a/modules/fedimint-mint-client/Cargo.toml
+++ b/modules/fedimint-mint-client/Cargo.toml
@@ -31,6 +31,7 @@ path = "benches/notes.rs"
 [dependencies]
 anyhow = { workspace = true }
 aquamarine = { workspace = true }
+assert_matches = { workspace = true }
 async-stream = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }

--- a/modules/fedimint-mint-client/src/input.rs
+++ b/modules/fedimint-mint-client/src/input.rs
@@ -1,3 +1,4 @@
+use assert_matches::assert_matches;
 use fedimint_client_module::DynGlobalClientContext;
 use fedimint_client_module::module::OutPointRange;
 use fedimint_client_module::sm::{ClientSMDatabaseTransaction, State, StateTransition};
@@ -148,7 +149,7 @@ impl MintInputStateCreated {
         dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
         global_context: DynGlobalClientContext,
     ) -> MintInputStateMachine {
-        assert!(matches!(old_state.state, MintInputStates::Created(_)));
+        assert_matches!(old_state.state, MintInputStates::Created(_));
 
         match result {
             Ok(()) => {
@@ -241,7 +242,7 @@ impl MintInputStateCreatedBundle {
         dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
         global_context: DynGlobalClientContext,
     ) -> MintInputStateMachine {
-        assert!(matches!(old_state.state, MintInputStates::CreatedBundle(_)));
+        assert_matches!(old_state.state, MintInputStates::CreatedBundle(_));
 
         match result {
             Ok(()) => {
@@ -346,10 +347,7 @@ impl MintInputStateRefundedBundle {
         dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
         global_context: DynGlobalClientContext,
     ) -> MintInputStateMachine {
-        assert!(matches!(
-            old_state.state,
-            MintInputStates::RefundedBundle(_)
-        ));
+        assert_matches!(old_state.state, MintInputStates::RefundedBundle(_));
 
         match result {
             Ok(()) => {

--- a/modules/fedimint-mint-client/src/output.rs
+++ b/modules/fedimint-mint-client/src/output.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 use std::hash;
 
 use anyhow::{anyhow, bail};
+use assert_matches::assert_matches;
 use fedimint_api_client::api::{
     FederationApiExt, SerdeOutputOutcome, ServerError,
     VERSION_THAT_INTRODUCED_AWAIT_OUTPUTS_OUTCOMES, deserialize_outcome,
@@ -193,7 +194,7 @@ impl MintOutputStatesCreated {
     }
 
     fn transition_tx_rejected(old_state: &MintOutputStateMachine) -> MintOutputStateMachine {
-        assert!(matches!(old_state.state, MintOutputStates::Created(_)));
+        assert_matches!(old_state.state, MintOutputStates::Created(_));
 
         MintOutputStateMachine {
             common: old_state.common,
@@ -386,7 +387,7 @@ impl MintOutputStatesCreatedMulti {
         dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
         old_state: MintOutputStateMachine,
     ) -> MintOutputStateMachine {
-        assert!(matches!(old_state.state, MintOutputStates::CreatedMulti(_)));
+        assert_matches!(old_state.state, MintOutputStates::CreatedMulti(_));
 
         client_ctx
             .log_event(

--- a/modules/fedimint-mint-tests/Cargo.toml
+++ b/modules/fedimint-mint-tests/Cargo.toml
@@ -38,6 +38,7 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
+assert_matches = { workspace = true }
 fedimint-dummy-client = { workspace = true }
 fedimint-dummy-common = { workspace = true }
 fedimint-dummy-server = { workspace = true }

--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use assert_matches::assert_matches;
 use bls12_381::G1Affine;
 use fedimint_client::backup::{ClientBackup, Metadata};
 use fedimint_client::transaction::{ClientInput, ClientInputBundle, TransactionBuilder};
@@ -713,14 +714,14 @@ async fn repair_wallet() -> anyhow::Result<()> {
             )
             .await?;
         let op_id = client_mint.reissue_external_notes(reissue_note, ()).await?;
-        assert!(matches!(
+        assert_matches!(
             client_mint
                 .subscribe_reissue_external_notes(op_id)
                 .await?
                 .await_outcome()
                 .await,
             Some(ReissueExternalNotesState::Done)
-        ));
+        );
 
         let mut dbtx = client_mint.db.begin_transaction().await;
         dbtx.insert_entry(&TEST_NOTE_INDEX_KEY, &(old_nonce_index - 1))

--- a/modules/fedimint-wallet-client/Cargo.toml
+++ b/modules/fedimint-wallet-client/Cargo.toml
@@ -22,6 +22,7 @@ path = "src/lib.rs"
 [dependencies]
 anyhow = { workspace = true }
 aquamarine = { workspace = true }
+assert_matches = { workspace = true }
 async-stream = { workspace = true }
 async-trait = { workspace = true }
 bitcoin = { workspace = true }

--- a/modules/fedimint-wallet-client/src/deposit.rs
+++ b/modules/fedimint-wallet-client/src/deposit.rs
@@ -1,6 +1,7 @@
 use std::cmp;
 use std::time::{Duration, SystemTime};
 
+use assert_matches::assert_matches;
 use fedimint_client_module::DynGlobalClientContext;
 use fedimint_client_module::sm::{ClientSMDatabaseTransaction, State, StateTransition};
 use fedimint_client_module::transaction::{ClientInput, ClientInputBundle};
@@ -178,8 +179,9 @@ async fn await_deposit_address_timeout(timeout_at: SystemTime) {
 }
 
 fn transition_deposit_timeout(old_state: &DepositStateMachine) -> DepositStateMachine {
-    assert!(
-        matches!(old_state.state, DepositStates::Created(_)),
+    assert_matches!(
+        old_state.state,
+        DepositStates::Created(_),
         "Invalid previous state"
     );
 

--- a/modules/fedimint-wallet-client/src/withdraw.rs
+++ b/modules/fedimint-wallet-client/src/withdraw.rs
@@ -1,3 +1,4 @@
+use assert_matches::assert_matches;
 use bitcoin::Txid;
 use fedimint_api_client::api::{FederationApiExt, deserialize_outcome};
 use fedimint_client_module::DynGlobalClientContext;
@@ -105,8 +106,9 @@ async fn transition_withdraw_processed(
     client_ctx: WalletClientContext,
     dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
 ) -> WithdrawStateMachine {
-    assert!(
-        matches!(old_state.state, WithdrawStates::Created(_)),
+    assert_matches!(
+        old_state.state,
+        WithdrawStates::Created(_),
         "Unexpected old state: got {:?}, expected Created",
         old_state.state
     );

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -281,10 +281,10 @@ async fn on_chain_peg_in_and_peg_out_happy_case() -> anyhow::Result<()> {
         .await;
 
     info!("Waiting for confirmation");
-    assert!(matches!(
+    assert_matches!(
         deposit_updates.next().await.unwrap(),
         DepositStateV2::WaitingForConfirmation { btc_out_point, .. } if btc_out_point.txid == tx.compute_txid()
-    ));
+    );
 
     bitcoin.mine_blocks(finality_delay).await;
 
@@ -306,16 +306,16 @@ async fn on_chain_peg_in_and_peg_out_happy_case() -> anyhow::Result<()> {
     };
 
     info!("Waiting for claim tx");
-    assert!(matches!(
+    assert_matches!(
         await_update_while_rechecking.await.unwrap(),
         DepositStateV2::Confirmed { btc_out_point, .. } if btc_out_point.txid == tx.compute_txid()
-    ));
+    );
 
     info!("Waiting for e-cash");
-    assert!(matches!(
+    assert_matches!(
         deposit_updates.next().await.unwrap(),
         DepositStateV2::Claimed { btc_out_point, .. } if btc_out_point.txid == tx.compute_txid()
-    ));
+    );
 
     info!("Checking balance after deposit");
     let mut balance_sub = client.subscribe_balance_changes(AmountUnit::BITCOIN).await;
@@ -478,7 +478,7 @@ async fn peg_out_fail_refund() -> anyhow::Result<()> {
     let sub = wallet_module.subscribe_withdraw_updates(op).await?;
     let mut sub = sub.into_stream();
     assert_eq!(sub.ok().await?, WithdrawState::Created);
-    assert!(matches!(sub.ok().await?, WithdrawState::Failed(_)));
+    assert_matches!(sub.ok().await?, WithdrawState::Failed(_));
 
     // Check that we get our money back if the peg-out fails
     assert_eq!(balance_sub.next().await.unwrap(), sats(PEG_IN_AMOUNT_SATS));
@@ -849,15 +849,15 @@ async fn dust_deposits_are_ignored() -> anyhow::Result<()> {
 
     let mut deposit_updates = wallet_module.subscribe_deposit(op).await?.into_stream();
     info!("Waiting for transaction");
-    assert!(matches!(
+    assert_matches!(
         deposit_updates.next().await.unwrap(),
         DepositStateV2::WaitingForTransaction
-    ));
+    );
     info!("Waiting for confirmation");
-    assert!(matches!(
+    assert_matches!(
         deposit_updates.next().await.unwrap(),
         DepositStateV2::WaitingForConfirmation { btc_out_point, .. } if btc_out_point.txid == tx.compute_txid()
-    ));
+    );
 
     bitcoin.mine_blocks(finality_delay).await;
 
@@ -879,16 +879,16 @@ async fn dust_deposits_are_ignored() -> anyhow::Result<()> {
     };
 
     info!("Waiting for claim tx");
-    assert!(matches!(
+    assert_matches!(
         await_update_while_rechecking.await.unwrap(),
         DepositStateV2::Confirmed { btc_out_point, .. } if btc_out_point.txid == tx.compute_txid()
-    ));
+    );
 
     info!("Waiting for e-cash");
-    assert!(matches!(
+    assert_matches!(
         deposit_updates.next().await.unwrap(),
         DepositStateV2::Claimed { btc_out_point, .. } if btc_out_point.txid == tx.compute_txid()
-    ));
+    );
 
     info!("Checking balance after deposit");
     assert_eq!(client.get_balance_for_btc().await?, Amount::ZERO);


### PR DESCRIPTION
gives better failure messages

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
