### PR TITLE
chore: add more efficient recovery for the mint module without a backup

### DIFF
--- a/fedimint-core/src/encoding/btc.rs
+++ b/fedimint-core/src/encoding/btc.rs
@@ -248,6 +248,23 @@ impl Decodable for bitcoin::hashes::sha256::Hash {
     }
 }
 
+impl Encodable for bitcoin::hashes::hash160::Hash {
+    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<(), Error> {
+        self.to_byte_array().consensus_encode(writer)
+    }
+}
+
+impl Decodable for bitcoin::hashes::hash160::Hash {
+    fn consensus_decode_partial<D: std::io::Read>(
+        d: &mut D,
+        modules: &ModuleDecoderRegistry,
+    ) -> Result<Self, DecodeError> {
+        Ok(Self::from_byte_array(Decodable::consensus_decode_partial(
+            d, modules,
+        )?))
+    }
+}
+
 impl Encodable for lightning_invoice::Bolt11Invoice {
     fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<(), Error> {
         self.to_string().consensus_encode(writer)

--- a/modules/fedimint-mint-client/src/api.rs
+++ b/modules/fedimint-mint-client/src/api.rs
@@ -1,17 +1,41 @@
 use fedimint_api_client::api::{FederationApiExt, FederationResult, IModuleFederationApi};
-use fedimint_core::module::ApiRequestErased;
+use fedimint_core::bitcoin::hashes::sha256;
+use fedimint_core::module::registry::ModuleRegistry;
+use fedimint_core::module::{ApiRequestErased, SerdeModuleEncodingBase64};
 use fedimint_core::task::{MaybeSend, MaybeSync};
-use fedimint_core::{apply, async_trait_maybe_send};
-use fedimint_mint_common::endpoint_constants::{BLIND_NONCE_USED_ENDPOINT, NOTE_SPENT_ENDPOINT};
-use fedimint_mint_common::{BlindNonce, Nonce};
+use fedimint_core::{OutPoint, PeerId, apply, async_trait_maybe_send};
+use fedimint_mint_common::endpoint_constants::{
+    BLIND_NONCE_USED_ENDPOINT, NOTE_SPENT_ENDPOINT, RECOVERY_BLIND_NONCE_OUTPOINTS_ENDPOINT,
+    RECOVERY_COUNT_ENDPOINT, RECOVERY_SLICE_ENDPOINT, RECOVERY_SLICE_HASH_ENDPOINT,
+};
+use fedimint_mint_common::{BlindNonce, Nonce, RecoveryItem};
 
 #[apply(async_trait_maybe_send!)]
 pub trait MintFederationApi {
-    /// Check if an e-cash  note was already issued for the given blind nonce.
     async fn check_blind_nonce_used(&self, blind_nonce: BlindNonce) -> FederationResult<bool>;
 
-    /// Check if an e-cash note was already spent.
     async fn check_note_spent(&self, nonce: Nonce) -> FederationResult<bool>;
+
+    /// Returns the total number of recovery items stored on the federation.
+    async fn fetch_recovery_count(&self) -> anyhow::Result<u64>;
+
+    /// Returns the consensus hash of recovery items in the range `[start,
+    /// end)`.
+    async fn fetch_recovery_slice_hash(&self, start: u64, end: u64) -> sha256::Hash;
+
+    /// Fetches recovery items in the range `[start, end)` from a specific peer.
+    async fn fetch_recovery_slice(
+        &self,
+        peer: PeerId,
+        start: u64,
+        end: u64,
+    ) -> anyhow::Result<Vec<RecoveryItem>>;
+
+    /// Returns the outpoints where the given blind nonces were used.
+    async fn fetch_blind_nonce_outpoints(
+        &self,
+        blind_nonces: Vec<BlindNonce>,
+    ) -> anyhow::Result<Vec<OutPoint>>;
 }
 
 #[apply(async_trait_maybe_send!)]
@@ -33,5 +57,51 @@ where
             ApiRequestErased::new(nonce),
         )
         .await
+    }
+
+    async fn fetch_recovery_count(&self) -> anyhow::Result<u64> {
+        self.request_current_consensus::<u64>(
+            RECOVERY_COUNT_ENDPOINT.to_string(),
+            ApiRequestErased::default(),
+        )
+        .await
+        .map_err(|e| anyhow::anyhow!("{e}"))
+    }
+
+    async fn fetch_recovery_slice_hash(&self, start: u64, end: u64) -> sha256::Hash {
+        self.request_current_consensus_retry(
+            RECOVERY_SLICE_HASH_ENDPOINT.to_owned(),
+            ApiRequestErased::new((start, end)),
+        )
+        .await
+    }
+
+    async fn fetch_recovery_slice(
+        &self,
+        peer: PeerId,
+        start: u64,
+        end: u64,
+    ) -> anyhow::Result<Vec<RecoveryItem>> {
+        let result = self
+            .request_single_peer::<SerdeModuleEncodingBase64<Vec<RecoveryItem>>>(
+                RECOVERY_SLICE_ENDPOINT.to_owned(),
+                ApiRequestErased::new((start, end)),
+                peer,
+            )
+            .await?;
+
+        Ok(result.try_into_inner(&ModuleRegistry::default())?)
+    }
+
+    async fn fetch_blind_nonce_outpoints(
+        &self,
+        blind_nonces: Vec<BlindNonce>,
+    ) -> anyhow::Result<Vec<OutPoint>> {
+        self.request_current_consensus::<Vec<OutPoint>>(
+            RECOVERY_BLIND_NONCE_OUTPOINTS_ENDPOINT.to_string(),
+            ApiRequestErased::new(blind_nonces),
+        )
+        .await
+        .map_err(|e| anyhow::anyhow!("{e}"))
     }
 }

--- a/modules/fedimint-mint-client/src/client_db.rs
+++ b/modules/fedimint-mint-client/src/client_db.rs
@@ -28,6 +28,7 @@ pub enum DbKeyPrefix {
     RecoveryState = 0x2c,
     RecoveryFinalized = 0x2d,
     ReusedNoteIndices = 0x2e,
+    RecoveryStateV2 = 0x2f,
     /// Prefixes between 0xb0..=0xcf shall all be considered allocated for
     /// historical and future external use
     ExternalReservedStart = 0xb0,
@@ -124,6 +125,15 @@ impl_db_record!(
 impl_db_lookup!(
     key = CancelledOOBSpendKey,
     query_prefix = CancelledOOBSpendKeyPrefix,
+);
+
+#[derive(Debug, Clone, Encodable, Decodable, Serialize)]
+pub struct RecoveryStateV2Key;
+
+impl_db_record!(
+    key = RecoveryStateV2Key,
+    value = crate::backup::recovery::RecoveryStateV2,
+    db_prefix = DbKeyPrefix::RecoveryStateV2,
 );
 
 pub async fn migrate_to_v1(

--- a/modules/fedimint-mint-common/src/endpoint_constants.rs
+++ b/modules/fedimint-mint-common/src/endpoint_constants.rs
@@ -1,3 +1,7 @@
 pub const AWAIT_OUTPUT_OUTCOME_ENDPOINT: &str = "await_output_outcome";
 pub const NOTE_SPENT_ENDPOINT: &str = "note_spent";
 pub const BLIND_NONCE_USED_ENDPOINT: &str = "blind_nonce_used";
+pub const RECOVERY_COUNT_ENDPOINT: &str = "recovery_count";
+pub const RECOVERY_SLICE_ENDPOINT: &str = "recovery_slice";
+pub const RECOVERY_SLICE_HASH_ENDPOINT: &str = "recovery_slice_hash";
+pub const RECOVERY_BLIND_NONCE_OUTPOINTS_ENDPOINT: &str = "recovery_blind_nonce_outpoints";

--- a/modules/fedimint-mint-common/src/lib.rs
+++ b/modules/fedimint-mint-common/src/lib.rs
@@ -240,6 +240,19 @@ plugin_types_trait_impl_common!(
     MintOutputError
 );
 
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, Encodable, Decodable)]
+pub enum RecoveryItem {
+    /// A mint output was created (note issuance)
+    Output {
+        amount: Amount,
+        nonce: bitcoin_hashes::hash160::Hash,
+    },
+    /// A mint input was spent (note redemption)
+    Input {
+        nonce: bitcoin_hashes::hash160::Hash,
+    },
+}
+
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Error, Encodable, Decodable)]
 pub enum MintInputError {
     #[error("The note is already spent")]

--- a/modules/fedimint-mint-server/src/db.rs
+++ b/modules/fedimint-mint-server/src/db.rs
@@ -1,6 +1,6 @@
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::{Amount, OutPoint, impl_db_lookup, impl_db_record};
-use fedimint_mint_common::{BlindNonce, MintOutputOutcome, Nonce};
+use fedimint_mint_common::{BlindNonce, MintOutputOutcome, Nonce, RecoveryItem};
 use serde::Serialize;
 use strum_macros::EnumIter;
 
@@ -12,6 +12,8 @@ pub enum DbKeyPrefix {
     MintAuditItem = 0x14,
     // 0x15 was previously used for e-cash backups, but removed in DB migration 1
     BlindNonce = 0x16,
+    RecoveryItem = 0x17,
+    RecoveryBlindNonceOutpoint = 0x18,
 }
 
 impl std::fmt::Display for DbKeyPrefix {
@@ -88,4 +90,34 @@ impl_db_record!(
 impl_db_lookup!(
     key = MintAuditItemKey,
     query_prefix = MintAuditItemKeyPrefix
+);
+
+#[derive(Debug, Clone, Copy, Encodable, Decodable, Serialize)]
+pub struct RecoveryItemKey(pub u64);
+
+#[derive(Debug, Encodable, Decodable)]
+pub struct RecoveryItemKeyPrefix;
+
+impl_db_record!(
+    key = RecoveryItemKey,
+    value = RecoveryItem,
+    db_prefix = DbKeyPrefix::RecoveryItem,
+);
+impl_db_lookup!(key = RecoveryItemKey, query_prefix = RecoveryItemKeyPrefix);
+
+/// Maps blind nonce to outpoint for recovery
+#[derive(Debug, Encodable, Decodable, Serialize)]
+pub struct RecoveryBlindNonceOutpointKey(pub BlindNonce);
+
+#[derive(Debug, Encodable, Decodable)]
+pub struct RecoveryBlindNonceOutpointKeyPrefix;
+
+impl_db_record!(
+    key = RecoveryBlindNonceOutpointKey,
+    value = OutPoint,
+    db_prefix = DbKeyPrefix::RecoveryBlindNonceOutpoint,
+);
+impl_db_lookup!(
+    key = RecoveryBlindNonceOutpointKey,
+    query_prefix = RecoveryBlindNonceOutpointKeyPrefix
 );

--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -1027,6 +1027,14 @@ mod fedimint_migration_tests {
                         // Would require an entire re-design of the way we test
                         // here, manually testing instead for now
                     }
+                    DbKeyPrefix::RecoveryItem => {
+                        // New prefix for slice-based recovery, no migration
+                        // needed
+                    }
+                    DbKeyPrefix::RecoveryBlindNonceOutpoint => {
+                        // New prefix for slice-based recovery, no migration
+                        // needed
+                    }
                 }
             }
 

--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -1122,6 +1122,10 @@ mod fedimint_migration_tests {
                             info!("Validated RecoveryFinalized");
                         }
                         fedimint_mint_client::client_db::DbKeyPrefix::ReusedNoteIndices => {}
+                        fedimint_mint_client::client_db::DbKeyPrefix::RecoveryStateV2 => {
+                            // New prefix for slice-based recovery, no migration
+                            // needed
+                        }
                         fedimint_mint_client::client_db::DbKeyPrefix::ExternalReservedStart
                         | fedimint_mint_client::client_db::DbKeyPrefix::CoreInternalReservedEnd
                         | fedimint_mint_client::client_db::DbKeyPrefix::CoreInternalReservedStart =>


### PR DESCRIPTION
The current recovery, loading the entire transaction history still leaves quite a bit of efficiency on the table. By defining module specific endpoints we can significantly reduce the number of bytes we have do download per mint input / output

* Input: 64 + 32 = 96 -> 20
* Ouput: 48 -> 20

So in total about 73% less bytes to download. Furthermore we don't have to download potentially empty or almost empty signed session outcomes. Instead we can download exactly 10k recovery items per request in the current configuration, or about 210 kilobyte per request making recovery performance more predictable.

I have currently still two test scripts in this pr I used to setup a remote federation on a Hetzner machine and performance test the recovery from my local machine, even on my crappy South African mobile connection I hit about 30k recovery items per second or about 1500 tx/s. This would be about 900k transactions per 10 minutes of recovery.

Off course to actually harvest efficiency improvements here we would have stop downloading the history in the wallet module and purely recovery from esplora like done here https://github.com/fedimint/fedimint/pull/8111 or from custom endpoints as well.

The current implementation is not using a backup either, as the assumption would be that the performance above should be sufficient. This reduces the number of moving parts. Especially backing up in flight state machines seems brittle here.
Hence, in combination with https://github.com/fedimint/fedimint/pull/8111, this pr would allow us to rip the existing backup, storage, and history download resulting in an overall much simpler system.

This pr is result / part of a larger consideration. After giving quite a bit of thought to the recovery options one of my conclusions is the following: it is possible to make seed phrase reuse safe in a sense that you won't loose money when you use the same seed phrase on two active devices or when you mistakenly join instead of recovering a federation that you have previously used before with the same seed phrase. Whatever happens as long as  you have the 12 words you will recover all funds, no edge cases. This would actually allow that if you are migrating between phones and not recovering after loss, you can enter the new seed phrase in the new phone, join instead of recovery, and then transfer the balance via an ecash payment between the phones. To achieve this recovery requires to things:

* Do not use an index to derive nonces but instead store random bytes with every nonce. This in turn requires to scan the history and makes a cashu style recovery where you only request your own nonces impossible as you can't predict them anymore.
* No backup as they might conflict when reusing keys.

Hence the recovery in this pr would be very close to what be required to achieve this, the only difference is the derivation scheme.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
