### PR TITLE
recover wallet without downloading full history

### DIFF
--- a/fedimint-recoverytool/src/main.rs
+++ b/fedimint-recoverytool/src/main.rs
@@ -303,8 +303,8 @@ fn input_tweaks_and_peg_out_count(
                         .downcast_ref::<WalletInput>()
                         .expect("Instance id mapping incorrect")
                     {
-                        WalletInput::V0(input) => input.tweak_contract_key().serialize(),
-                        WalletInput::V1(input) => input.tweak_contract_key.serialize(),
+                        WalletInput::V0(input) => input.tweak_key().serialize(),
+                        WalletInput::V1(input) => input.tweak_key.serialize(),
                         WalletInput::Default { .. } => {
                             panic!("recoverytool only supports v0 wallet inputs")
                         }

--- a/modules/fedimint-wallet-client/src/backup.rs
+++ b/modules/fedimint-wallet-client/src/backup.rs
@@ -1,6 +1,6 @@
 mod recovery_history_tracker;
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::{Arc, Mutex};
 
 use fedimint_bitcoind::{DynBitcoindRpc, create_esplora_rpc};
@@ -107,6 +107,70 @@ pub enum WalletRecoveryState {
         variant: u64,
         bytes: Vec<u8>,
     },
+}
+
+/// Recovery state for slice-based recovery (V2)
+#[derive(Clone, Debug)]
+pub struct RecoveryStateV2 {
+    /// Scripts we're looking for → `TweakIdx`
+    pub pending_pubkey_scripts: BTreeMap<bitcoin::ScriptBuf, TweakIdx>,
+    /// Next `TweakIdx` to generate
+    pub next_pending_tweak_idx: TweakIdx,
+    /// `TweakIdx`es that were found in history
+    pub used_tweak_idxes: BTreeSet<TweakIdx>,
+    /// Claimed outpoints per `TweakIdx`
+    pub claimed_outpoints: BTreeMap<TweakIdx, Vec<bitcoin::OutPoint>>,
+}
+
+impl RecoveryStateV2 {
+    pub fn new() -> Self {
+        Self {
+            pending_pubkey_scripts: BTreeMap::new(),
+            next_pending_tweak_idx: TweakIdx(0),
+            used_tweak_idxes: BTreeSet::new(),
+            claimed_outpoints: BTreeMap::new(),
+        }
+    }
+
+    pub fn generate_next_pending_script(&mut self, data: &WalletClientModuleData) {
+        let script = data.derive_peg_in_script(self.next_pending_tweak_idx).0;
+
+        self.pending_pubkey_scripts
+            .insert(script, self.next_pending_tweak_idx);
+
+        self.next_pending_tweak_idx = self.next_pending_tweak_idx.next();
+    }
+
+    fn refill_pending_pool_up_to(&mut self, data: &WalletClientModuleData, tweak_idx: TweakIdx) {
+        while self.next_pending_tweak_idx < tweak_idx {
+            self.generate_next_pending_script(data);
+        }
+    }
+
+    pub fn handle_item(
+        &mut self,
+        outpoint: bitcoin::OutPoint,
+        script: &bitcoin::ScriptBuf,
+        data: &WalletClientModuleData,
+    ) {
+        if let Some(tweak_idx) = self.pending_pubkey_scripts.get(script).copied() {
+            self.used_tweak_idxes.insert(tweak_idx);
+            self.claimed_outpoints
+                .entry(tweak_idx)
+                .or_default()
+                .push(outpoint);
+
+            self.refill_pending_pool_up_to(data, tweak_idx.advance(FEDERATION_RECOVER_MAX_GAP));
+        }
+    }
+
+    pub fn new_start_idx(&self) -> TweakIdx {
+        self.used_tweak_idxes
+            .last()
+            .copied()
+            .unwrap_or(TweakIdx(0))
+            .advance(RECOVER_NUM_IDX_ADD_TO_LAST_USED)
+    }
 }
 
 /// Wallet client module recovery implementation

--- a/modules/fedimint-wallet-client/src/backup.rs
+++ b/modules/fedimint-wallet-client/src/backup.rs
@@ -141,7 +141,11 @@ impl RecoveryStateV2 {
         self.next_pending_tweak_idx = self.next_pending_tweak_idx.next();
     }
 
-    fn refill_pending_pool_up_to(&mut self, data: &WalletClientModuleData, tweak_idx: TweakIdx) {
+    pub fn refill_pending_pool_up_to(
+        &mut self,
+        data: &WalletClientModuleData,
+        tweak_idx: TweakIdx,
+    ) {
         while self.next_pending_tweak_idx < tweak_idx {
             self.generate_next_pending_script(data);
         }

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -174,9 +174,7 @@ impl WalletClientInit {
 
         let mut state = RecoveryStateV2::new();
 
-        for _ in 0..FEDERATION_RECOVER_MAX_GAP {
-            state.generate_next_pending_script(&data);
-        }
+        state.refill_pending_pool_up_to(&data, TweakIdx(FEDERATION_RECOVER_MAX_GAP));
 
         for start in (0..total_items).step_by(SLICE_SIZE as usize) {
             let end = std::cmp::min(start + SLICE_SIZE, total_items);

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -38,6 +38,7 @@ use fedimint_bitcoind::{DynBitcoindRpc, create_esplora_rpc};
 use fedimint_client_module::module::init::{
     ClientModuleInit, ClientModuleInitArgs, ClientModuleRecoverArgs,
 };
+use fedimint_client_module::module::recovery::RecoveryProgress;
 use fedimint_client_module::module::{ClientContext, ClientModule, IClientModule, OutPointRange};
 use fedimint_client_module::oplog::UpdateStreamOrOutcome;
 use fedimint_client_module::sm::{Context, DynState, ModuleNotifier, State, StateTransition};
@@ -77,10 +78,11 @@ use tokio::sync::watch;
 use tracing::{debug, instrument};
 
 use crate::api::WalletFederationApi;
-use crate::backup::WalletRecovery;
+use crate::backup::{FEDERATION_RECOVER_MAX_GAP, RecoveryStateV2, WalletRecovery};
 use crate::client_db::{
     ClaimedPegInData, ClaimedPegInKey, ClaimedPegInPrefix, NextPegInTweakIndexKey,
-    PegInTweakIndexData, PegInTweakIndexPrefix, RecoveryFinalizedKey, SupportsSafeDepositPrefix,
+    PegInTweakIndexData, PegInTweakIndexPrefix, RecoveryFinalizedKey, RecoveryStateKey,
+    SupportsSafeDepositPrefix,
 };
 use crate::deposit::DepositStateMachine;
 use crate::withdraw::{CreatedWithdrawState, WithdrawStateMachine, WithdrawStates};
@@ -152,9 +154,79 @@ where
 // TODO: should probably move to DB
 pub struct WalletClientInit(pub Option<DynBitcoindRpc>);
 
+const SLICE_SIZE: u64 = 10000;
+
 impl WalletClientInit {
     pub fn new(rpc: DynBitcoindRpc) -> Self {
         Self(Some(rpc))
+    }
+
+    async fn recover_from_slices(
+        &self,
+        args: &ClientModuleRecoverArgs<Self>,
+    ) -> anyhow::Result<()> {
+        let data = WalletClientModuleData {
+            cfg: args.cfg().clone(),
+            module_root_secret: args.module_root_secret().clone(),
+        };
+
+        let total_items = args.module_api().fetch_recovery_count().await?;
+
+        let mut state = RecoveryStateV2::new();
+
+        for _ in 0..FEDERATION_RECOVER_MAX_GAP {
+            state.generate_next_pending_script(&data);
+        }
+
+        for start in (0..total_items).step_by(SLICE_SIZE as usize) {
+            let end = std::cmp::min(start + SLICE_SIZE, total_items);
+
+            let items = args.module_api().fetch_recovery_slice(start, end).await?;
+
+            for item in &items {
+                match item {
+                    RecoveryItem::Input { outpoint, script } => {
+                        state.handle_item(*outpoint, script, &data);
+                    }
+                }
+            }
+
+            args.update_recovery_progress(RecoveryProgress {
+                complete: end.try_into().unwrap_or(u32::MAX),
+                total: total_items.try_into().unwrap_or(u32::MAX),
+            });
+        }
+
+        let mut dbtx = args.db().begin_transaction().await;
+
+        for tweak_idx in 0..state.new_start_idx().0 {
+            let operation_id = data.derive_peg_in_script(TweakIdx(tweak_idx)).3;
+
+            let claimed = state
+                .claimed_outpoints
+                .get(&TweakIdx(tweak_idx))
+                .cloned()
+                .unwrap_or_default();
+
+            dbtx.insert_new_entry(
+                &PegInTweakIndexKey(TweakIdx(tweak_idx)),
+                &PegInTweakIndexData {
+                    operation_id,
+                    creation_time: fedimint_core::time::now(),
+                    last_check_time: None,
+                    next_check_time: Some(fedimint_core::time::now()),
+                    claimed,
+                },
+            )
+            .await;
+        }
+
+        dbtx.insert_new_entry(&NextPegInTweakIndexKey, &state.new_start_idx())
+            .await;
+
+        dbtx.commit_tx().await;
+
+        Ok(())
     }
 }
 
@@ -270,18 +342,35 @@ impl ClientModuleInit for WalletClientInit {
 
     /// Wallet recovery
     ///
-    /// Query bitcoin rpc for history of addresses from last known used
-    /// addresses (or index 0) until `MAX_GAP` unused ones.
-    ///
-    /// Notably does not persist the progress of addresses being queried,
-    /// because it is not expected that it would take long enough to bother.
+    /// Uses slice-based recovery if supported by the federation, otherwise
+    /// falls back to session-based history recovery.
     async fn recover(
         &self,
         args: &ClientModuleRecoverArgs<Self>,
         snapshot: Option<&<Self::Module as ClientModule>::Backup>,
     ) -> anyhow::Result<()> {
-        args.recover_from_history::<WalletRecovery>(self, snapshot)
+        // Check if V1 (session-based) recovery state exists (resuming interrupted
+        // recovery)
+        if args
+            .db()
+            .begin_transaction_nc()
             .await
+            .get_value(&RecoveryStateKey)
+            .await
+            .is_some()
+        {
+            return args
+                .recover_from_history::<WalletRecovery>(self, snapshot)
+                .await;
+        }
+
+        // Determine which method to use based on endpoint availability
+        if args.module_api().fetch_recovery_count().await.is_ok() {
+            self.recover_from_slices(args).await
+        } else {
+            args.recover_from_history::<WalletRecovery>(self, snapshot)
+                .await
+        }
     }
 
     fn used_db_prefixes(&self) -> Option<BTreeSet<u8>> {

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -154,7 +154,7 @@ where
 // TODO: should probably move to DB
 pub struct WalletClientInit(pub Option<DynBitcoindRpc>);
 
-const SLICE_SIZE: u64 = 10000;
+const SLICE_SIZE: u64 = 1000;
 
 impl WalletClientInit {
     pub fn new(rpc: DynBitcoindRpc) -> Self {

--- a/modules/fedimint-wallet-common/src/endpoint_constants.rs
+++ b/modules/fedimint-wallet-common/src/endpoint_constants.rs
@@ -8,3 +8,5 @@ pub const SUPPORTED_MODULE_CONSENSUS_VERSION_ENDPOINT: &str = "supported_module_
 pub const ACTIVATE_CONSENSUS_VERSION_VOTING_ENDPOINT: &str = "activate_consensus_version_voting";
 pub const WALLET_SUMMARY_ENDPOINT: &str = "wallet_summary";
 pub const UTXO_CONFIRMED_ENDPOINT: &str = "utxo_confirmed";
+pub const RECOVERY_COUNT_ENDPOINT: &str = "recovery_count";
+pub const RECOVERY_SLICE_ENDPOINT: &str = "recovery_slice";

--- a/modules/fedimint-wallet-common/src/lib.rs
+++ b/modules/fedimint-wallet-common/src/lib.rs
@@ -220,6 +220,18 @@ impl WalletSummary {
     }
 }
 
+/// Recovery data for slice-based client recovery
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, Encodable, Decodable)]
+pub enum RecoveryItem {
+    /// A peg-in input was claimed
+    Input {
+        /// The Bitcoin outpoint that was claimed
+        outpoint: bitcoin::OutPoint,
+        /// The `script_pubkey` of the peg-in address (tweaked descriptor)
+        script: bitcoin::ScriptBuf,
+    },
+}
+
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, Encodable, Decodable)]
 pub struct PegOutFees {
     pub fee_rate: Feerate,
@@ -341,7 +353,7 @@ impl WalletInput {
     pub fn new_v1(peg_in_proof: &PegInProof) -> WalletInput {
         WalletInput::V1(WalletInputV1 {
             outpoint: peg_in_proof.outpoint(),
-            tweak_contract_key: *peg_in_proof.tweak_contract_key(),
+            tweak_key: peg_in_proof.tweak_key(),
             tx_out: peg_in_proof.tx_output(),
         })
     }
@@ -354,7 +366,7 @@ pub struct WalletInputV0(pub Box<PegInProof>);
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, Encodable, Decodable)]
 pub struct WalletInputV1 {
     pub outpoint: bitcoin::OutPoint,
-    pub tweak_contract_key: secp256k1::PublicKey,
+    pub tweak_key: secp256k1::PublicKey,
     pub tx_out: TxOut,
 }
 

--- a/modules/fedimint-wallet-common/src/txoproof.rs
+++ b/modules/fedimint-wallet-common/src/txoproof.rs
@@ -114,8 +114,8 @@ impl PegInProof {
         self.txout_proof.block()
     }
 
-    pub fn tweak_contract_key(&self) -> &PublicKey {
-        &self.tweak_contract_key
+    pub fn tweak_key(&self) -> PublicKey {
+        self.tweak_contract_key
     }
 
     pub fn identity(&self) -> (PublicKey, bitcoin::Txid) {

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -1606,6 +1606,9 @@ mod fedimint_migration_tests {
                         );
                         info!("Validated ConsensusVersionVotingActivation");
                     }
+                    DbKeyPrefix::RecoveryItem => {
+                        // Recovery items are new and won't be in old snapshots
+                    }
                 }
             }
             Ok(())


### PR DESCRIPTION
This PR https://github.com/fedimint/fedimint/pull/8110 changes the mint module such that it does not download the federation history in recovery anymore as we want to move away from the naive download of the federation history in general. Hence the modules need to implement their own custom way to recover.

 This PR adds slice-based recovery for the wallet module following the same pattern as https://github.com/fedimint/fedimint/pull/8110

  ## Server Side
  - Stores `RecoveryItem` (script + outpoint) for each peg-in input processed
  - Adds `recovery_count` and `recovery_slice` API endpoints
  - Includes migration to backfill recovery data from existing history

  ## Client Side
  - Downloads recovery items via `request_current_consensus`
  - Matches scripts against locally derived peg-in addresses using gap limit
  - Reconstructs `PegInTweakIndexData` entries with claimed outpoints
  - Falls back to session-based history recovery for older federations

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
