### PR TITLE
fix: retire config meta fields

### DIFF
--- a/devimint/src/util.rs
+++ b/devimint/src/util.rs
@@ -747,9 +747,7 @@ impl FedimintCli {
             "setup",
             endpoint,
             "set-local-params",
-            format!("Devimint Guardian {peer}"),
-            "--federation-name",
-            "Devimint Federation"
+            format!("Devimint Guardian {peer}")
         )
         .out_json()
         .await?;

--- a/fedimint-server/src/config/setup.rs
+++ b/fedimint-server/src/config/setup.rs
@@ -8,7 +8,6 @@ use anyhow::{Context, ensure};
 use async_trait::async_trait;
 use fedimint_core::admin_client::{SetLocalParamsRequest, SetupStatus};
 use fedimint_core::base32::FEDIMINT_PREFIX;
-use fedimint_core::config::META_FEDERATION_NAME_KEY;
 use fedimint_core::core::{ModuleInstanceId, ModuleKind};
 use fedimint_core::db::Database;
 use fedimint_core::endpoint_constants::{
@@ -338,12 +337,6 @@ impl ISetupApi for SetupApi {
             "The number of guardians is invalid"
         );
 
-        let federation_name = state
-            .setup_codes
-            .iter()
-            .find_map(|info| info.federation_name.clone())
-            .context("We need one guardian to configure the federations name")?;
-
         let disable_base_fees = state
             .setup_codes
             .iter()
@@ -372,10 +365,7 @@ impl ISetupApi for SetupApi {
                 .map(|i| PeerId::from(i as u16))
                 .zip(state.setup_codes.clone().into_iter())
                 .collect(),
-            meta: BTreeMap::from_iter(vec![(
-                META_FEDERATION_NAME_KEY.to_string(),
-                federation_name,
-            )]),
+            meta: BTreeMap::new(),
             disable_base_fees,
             enabled_modules,
             network: self.settings.network,

--- a/fedimint-server/src/consensus/api.rs
+++ b/fedimint-server/src/consensus/api.rs
@@ -617,7 +617,7 @@ impl IDashboardApi for ConsensusApi {
             .meta
             .get(META_FEDERATION_NAME_KEY)
             .cloned()
-            .expect("Federation name must be set")
+            .unwrap_or_default()
     }
 
     async fn session_count(&self) -> u64 {


### PR DESCRIPTION
Fixes #7889. Retire config meta by:

Making federation_name optional during DKG setup
Defaulting consensus config meta to empty map instead of populating with federation_name
Returning empty string from federation_name() API when not set instead of panicking<!--

