### PR TITLE
refactor: retire immutable meta and immutable federation name

### DIFF
--- a/fedimint-api-client/src/api/global_api/with_cache.rs
+++ b/fedimint-api-client/src/api/global_api/with_cache.rs
@@ -397,7 +397,7 @@ where
             SET_LOCAL_PARAMS_ENDPOINT,
             ApiRequestErased::new(SetLocalParamsRequest {
                 name,
-                federation_name,
+                _federation_name: federation_name,
                 disable_base_fees,
                 enabled_modules,
                 federation_size,

--- a/fedimint-core/src/admin_client.rs
+++ b/fedimint-core/src/admin_client.rs
@@ -45,8 +45,10 @@ pub enum SetupStatus {
 pub struct SetLocalParamsRequest {
     /// Name of the peer, used in TLS auth
     pub name: String,
-    /// Federation name set by the leader
-    pub federation_name: Option<String>,
+    /// Deprecated and ignored, kept for backward-compatible deserialization
+    #[serde(rename = "federation_name")]
+    #[allow(clippy::pub_underscore_fields)]
+    pub _federation_name: Option<String>,
     /// Whether to disable base fees, set by the leader
     pub disable_base_fees: Option<bool>,
     /// Modules enabled by the leader (if None, all available modules are

--- a/fedimint-core/src/setup_code.rs
+++ b/fedimint-core/src/setup_code.rs
@@ -13,8 +13,6 @@ pub struct PeerSetupCode {
     pub name: String,
     /// The peer's api and p2p endpoint
     pub endpoints: PeerEndpoints,
-    /// Federation name set by the leader
-    pub federation_name: Option<String>,
     /// Whether to disable base fees, set by the leader
     pub disable_base_fees: Option<bool>,
     /// Modules enabled by the leader (if None, all available modules are

--- a/fedimint-server-core/src/dashboard_ui.rs
+++ b/fedimint-server-core/src/dashboard_ui.rs
@@ -51,9 +51,6 @@ pub trait IDashboardApi {
     /// Get a map of peer IDs to guardian names
     async fn guardian_names(&self) -> BTreeMap<PeerId, String>;
 
-    /// Get the federation name
-    async fn federation_name(&self) -> String;
-
     /// Get the current active session count
     async fn session_count(&self) -> u64;
 

--- a/fedimint-server-core/src/setup_ui.rs
+++ b/fedimint-server-core/src/setup_ui.rs
@@ -37,7 +37,6 @@ pub trait ISetupApi {
         &self,
         auth: ApiAuth,
         name: String,
-        federation_name: Option<String>,
         disable_base_fees: Option<bool>,
         enabled_modules: Option<BTreeSet<ModuleKind>>,
         federation_size: Option<u32>,

--- a/fedimint-server-ui/src/dashboard/general.rs
+++ b/fedimint-server-ui/src/dashboard/general.rs
@@ -6,13 +6,19 @@ use maud::{Markup, html};
 /// Renders the Guardian info card with federation name, session count and
 /// guardian list
 pub fn render(
-    federation_name: &str,
+    federation_name: Option<&str>,
     session_count: u64,
     guardian_names: &BTreeMap<PeerId, String>,
 ) -> Markup {
     html! {
         div class="card h-100" {
-            div class="card-header dashboard-header" { (federation_name) }
+            div class="card-header dashboard-header" {
+                @if let Some(name) = federation_name {
+                    (name)
+                } @else {
+                    i { "Federation name not set" }
+                }
+            }
             div class="card-body" {
                 div id="session-count" class="alert alert-info" {
                     "Session Count: " strong { (session_count) }

--- a/fedimint-server-ui/src/dashboard/mod.rs
+++ b/fedimint-server-ui/src/dashboard/mod.rs
@@ -14,6 +14,7 @@ use axum::response::{Html, IntoResponse, Response};
 use axum::routing::{get, post};
 use axum_extra::extract::cookie::CookieJar;
 use consensus_explorer::consensus_explorer_view;
+use fedimint_core::config::META_FEDERATION_NAME_KEY;
 use fedimint_metrics::{Encoder, REGISTRY, TextEncoder};
 use fedimint_server_core::dashboard_ui::{DashboardApiModuleExt, DynDashboardApi};
 use fedimint_ui_common::assets::WithStaticRoutesExt;
@@ -175,7 +176,16 @@ async fn dashboard_view(
     _auth: UserAuth,
 ) -> impl IntoResponse {
     let guardian_names = state.api.guardian_names().await;
-    let federation_name = state.api.federation_name().await;
+    let federation_name =
+        if let Some(meta_module) = state.api.get_module::<fedimint_meta_server::Meta>() {
+            meta_module.get_consensus_json().await.and_then(|json| {
+                json.get(META_FEDERATION_NAME_KEY)
+                    .and_then(|v| v.as_str())
+                    .map(String::from)
+            })
+        } else {
+            None
+        };
     let session_count = state.api.session_count().await;
     let fedimintd_version = state.api.fedimintd_version().await;
     let consensus_ord_latency = state.api.consensus_ord_latency().await;
@@ -188,7 +198,7 @@ async fn dashboard_view(
     let content = html! {
         div class="row gy-4" {
             div class="col-md-6" {
-                (general::render(&federation_name, session_count, &guardian_names))
+                (general::render(federation_name.as_deref(), session_count, &guardian_names))
             }
 
             div class="col-md-6" {

--- a/fedimint-server-ui/src/setup.rs
+++ b/fedimint-server-ui/src/setup.rs
@@ -32,7 +32,6 @@ pub(crate) struct SetupInput {
     pub name: String,
     #[serde(default)]
     pub is_lead: bool,
-    pub federation_name: String,
     #[serde(default)]
     pub federation_size: String,
     #[serde(default)] // will not be sent if disabled
@@ -205,8 +204,6 @@ fn setup_form_content(
                 }
 
                 div class="toggle-content mt-3" {
-                    input type="text" class="form-control" id="federation_name" name="federation_name" placeholder="Federation Name";
-
                     div class="form-group mt-3" {
                         label class="form-label" for="federation_size" {
                             "Total number of guardians (including you)"
@@ -317,12 +314,6 @@ async fn setup_submit(
     let default_modules = state.api.default_modules();
 
     // Only use these settings if is_lead is true
-    let federation_name = if input.is_lead {
-        Some(input.federation_name)
-    } else {
-        None
-    };
-
     let disable_base_fees = if input.is_lead {
         Some(!input.enable_base_fees)
     } else {
@@ -370,7 +361,6 @@ async fn setup_submit(
         .set_local_parameters(
             ApiAuth::new(input.password),
             input.name,
-            federation_name,
             disable_base_fees,
             enabled_modules,
             federation_size,

--- a/fedimint-server/src/config/mod.rs
+++ b/fedimint-server/src/config/mod.rs
@@ -242,6 +242,7 @@ pub struct ConfigGenParams {
     pub api_auth: ApiAuth,
     /// Endpoints of all servers
     pub peers: BTreeMap<PeerId, PeerSetupCode>,
+    /// (Retired, see <https://github.com/fedimint/fedimint/issues/7889>)
     /// Guardian-defined key-value pairs that will be passed to the client
     pub meta: BTreeMap<String, String>,
     /// Whether to disable base fees for this federation

--- a/fedimint-server/src/config/setup.rs
+++ b/fedimint-server/src/config/setup.rs
@@ -59,8 +59,6 @@ pub struct LocalParams {
     endpoints: PeerEndpoints,
     /// Name of the peer, used in TLS auth
     name: String,
-    /// Federation name set by the leader
-    federation_name: Option<String>,
     /// Whether to disable base fees, set by the leader
     disable_base_fees: Option<bool>,
     /// Modules enabled by the leader (if None, all available modules are
@@ -76,7 +74,6 @@ impl LocalParams {
         PeerSetupCode {
             name: self.name.clone(),
             endpoints: self.endpoints.clone(),
-            federation_name: self.federation_name.clone(),
             disable_base_fees: self.disable_base_fees,
             enabled_modules: self.enabled_modules.clone(),
             federation_size: self.federation_size,
@@ -171,7 +168,6 @@ impl ISetupApi for SetupApi {
         &self,
         auth: ApiAuth,
         name: String,
-        federation_name: Option<String>,
         disable_base_fees: Option<bool>,
         enabled_modules: Option<BTreeSet<ModuleKind>>,
         federation_size: Option<u32>,
@@ -179,7 +175,6 @@ impl ISetupApi for SetupApi {
         if let Some(existing_local_parameters) = self.state.lock().await.local_params.clone()
             && existing_local_parameters.auth.as_str() == auth.as_str()
             && existing_local_parameters.name == name
-            && existing_local_parameters.federation_name == federation_name
             && existing_local_parameters.disable_base_fees == disable_base_fees
             && existing_local_parameters.enabled_modules == enabled_modules
             && existing_local_parameters.federation_size == federation_size
@@ -199,24 +194,12 @@ impl ISetupApi for SetupApi {
             "The password contains leading/trailing whitespace",
         );
 
-        if let Some(federation_name) = federation_name.as_ref() {
-            ensure!(!federation_name.is_empty(), "The federation name is empty");
-        }
-
-        if federation_name.is_some() {
-            ensure!(
-                federation_size.is_some(),
-                "The leader must set the federation size"
-            );
-        }
-
         if let Some(size) = federation_size {
             ensure!(
                 size == 1 || 4 <= size,
                 "Federation size must be 1 or at least 4"
             );
         }
-
         let mut state = self.state.lock().await;
 
         ensure!(
@@ -249,7 +232,6 @@ impl ISetupApi for SetupApi {
                     p2p_pk: iroh_p2p_sk.public(),
                 },
                 name,
-                federation_name,
                 disable_base_fees,
                 enabled_modules,
                 federation_size,
@@ -278,7 +260,6 @@ impl ISetupApi for SetupApi {
                     cert: tls_cert.as_ref().to_vec(),
                 },
                 name,
-                federation_name,
                 disable_base_fees,
                 enabled_modules,
                 federation_size,
@@ -313,18 +294,6 @@ impl ISetupApi for SetupApi {
             discriminant(&info.endpoints) == discriminant(&local_params.endpoints),
             "Guardian has different endpoint variant (TCP/Iroh) than us.",
         );
-
-        if let Some(federation_name) = state
-            .setup_codes
-            .iter()
-            .chain(once(&local_params.setup_code()))
-            .find_map(|info| info.federation_name.clone())
-        {
-            ensure!(
-                info.federation_name.is_none(),
-                "Federation name has already been set to {federation_name}"
-            );
-        }
 
         if let Some(disable_base_fees) = state
             .setup_codes
@@ -395,13 +364,6 @@ impl ISetupApi for SetupApi {
                 state.setup_codes.len()
             );
         }
-
-        state
-            .setup_codes
-            .iter()
-            .find_map(|info| info.federation_name.clone())
-            .context("We need one guardian to configure the federations name")?;
-
         let disable_base_fees = state
             .setup_codes
             .iter()
@@ -455,13 +417,7 @@ impl ISetupApi for SetupApi {
     }
 
     async fn cfg_federation_name(&self) -> Option<String> {
-        let state = self.state.lock().await;
-        let local_setup_code = state.local_params.as_ref().map(LocalParams::setup_code);
-        state
-            .setup_codes
-            .iter()
-            .chain(local_setup_code.iter())
-            .find_map(|info| info.federation_name.clone())
+        None
     }
 
     async fn cfg_base_fees_disabled(&self) -> Option<bool> {
@@ -527,7 +483,13 @@ pub fn server_endpoints() -> Vec<ApiEndpoint<SetupApi>> {
                     .request_auth()
                     .ok_or(ApiError::bad_request("Missing password".to_string()))?;
 
-                 config.set_local_parameters(auth, request.name, request.federation_name, request.disable_base_fees, request.enabled_modules, request.federation_size)
+                config.set_local_parameters(
+                    auth,
+                    request.name,
+                    request.disable_base_fees,
+                    request.enabled_modules,
+                    request.federation_size,
+                )
                     .await
                     .map_err(|e| ApiError::bad_request(e.to_string()))
             }

--- a/fedimint-server/src/config/setup.rs
+++ b/fedimint-server/src/config/setup.rs
@@ -8,7 +8,6 @@ use anyhow::{Context, ensure};
 use async_trait::async_trait;
 use fedimint_core::admin_client::{SetLocalParamsRequest, SetupStatus};
 use fedimint_core::base32::FEDIMINT_PREFIX;
-use fedimint_core::config::META_FEDERATION_NAME_KEY;
 use fedimint_core::core::{ModuleInstanceId, ModuleKind};
 use fedimint_core::db::Database;
 use fedimint_core::endpoint_constants::{
@@ -397,7 +396,7 @@ impl ISetupApi for SetupApi {
             );
         }
 
-        let federation_name = state
+        state
             .setup_codes
             .iter()
             .find_map(|info| info.federation_name.clone())
@@ -431,10 +430,7 @@ impl ISetupApi for SetupApi {
                 .map(|i| PeerId::from(i as u16))
                 .zip(state.setup_codes.clone())
                 .collect(),
-            meta: BTreeMap::from_iter(vec![(
-                META_FEDERATION_NAME_KEY.to_string(),
-                federation_name,
-            )]),
+            meta: BTreeMap::new(),
             disable_base_fees,
             enabled_modules,
             network: self.settings.network,

--- a/fedimint-server/src/consensus/api.rs
+++ b/fedimint-server/src/consensus/api.rs
@@ -15,7 +15,7 @@ use fedimint_core::admin_client::{GuardianConfigBackup, ServerStatusLegacy, Setu
 use fedimint_core::backup::{
     BackupStatistics, ClientBackupKey, ClientBackupKeyPrefix, ClientBackupSnapshot,
 };
-use fedimint_core::config::{ClientConfig, JsonClientConfig, META_FEDERATION_NAME_KEY};
+use fedimint_core::config::{ClientConfig, JsonClientConfig};
 use fedimint_core::core::backup::{BACKUP_REQUEST_MAX_PAYLOAD_SIZE_BYTES, SignedBackupRequest};
 use fedimint_core::core::{DynOutputOutcome, ModuleInstanceId, ModuleKind};
 use fedimint_core::db::{
@@ -723,15 +723,6 @@ impl IDashboardApi for ConsensusApi {
             .iter()
             .map(|(peer_id, endpoint)| (*peer_id, endpoint.name.clone()))
             .collect()
-    }
-
-    async fn federation_name(&self) -> String {
-        self.cfg
-            .consensus
-            .meta
-            .get(META_FEDERATION_NAME_KEY)
-            .cloned()
-            .expect("Federation name must be set")
     }
 
     async fn session_count(&self) -> u64 {

--- a/fedimint-testing-core/src/config.rs
+++ b/fedimint-testing-core/src/config.rs
@@ -57,7 +57,6 @@ pub fn local_config_gen_params(
                     p2p_url: p2p_url.parse().expect("Should parse"),
                     cert: tls_keys[peer].0.as_ref().to_vec(),
                 },
-                federation_name: None,
                 disable_base_fees: Some(!enable_mint_fees),
                 enabled_modules: None,
                 federation_size: None,

--- a/modules/fedimint-meta-server/src/lib.rs
+++ b/modules/fedimint-meta-server/src/lib.rs
@@ -611,4 +611,9 @@ impl Meta {
 
         Ok(submissions)
     }
+
+    /// Get the consensus data as JSON
+    pub async fn get_consensus_json(&self) -> Option<serde_json::Value> {
+        self.handle_get_consensus_request_ui().await.ok().flatten()
+    }
 }


### PR DESCRIPTION
Fix https://github.com/fedimint/fedimint/issues/7889

* `meta` in the config will not be used
* "Federation Name" will not be set during DKG

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
