### PR TITLE
feat: Revamp on-chain deposit client UX

### DIFF
--- a/modules/fedimint-wallet-client/src/events.rs
+++ b/modules/fedimint-wallet-client/src/events.rs
@@ -76,7 +76,10 @@ impl Event for SendPaymentStatusEvent {
 // Emitted when a deposit is confirmed
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct ReceivePaymentEvent {
+    /// The operation ID that created the address
     pub operation_id: OperationId,
+    /// The operation ID for this specific receive/claim operation
+    pub receive_operation_id: OperationId,
     pub amount: Amount,
     pub txid: Txid,
 }

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -138,6 +138,13 @@ pub enum WithdrawState {
     // RefundFailed(String),
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+pub enum ReceiveDepositState {
+    Claiming,
+    Claimed,
+    Failed(String),
+}
+
 async fn next_withdraw_state<S>(stream: &mut S) -> Option<WithdrawStates>
 where
     S: Stream<Item = WalletClientStates> + Unpin,
@@ -425,6 +432,16 @@ pub enum WalletOperationMetaVariant {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         expires_at: Option<SystemTime>,
     },
+    ReceiveDeposit {
+        /// The operation ID that created the address (parent operation)
+        address_operation_id: OperationId,
+        tweak_idx: TweakIdx,
+        btc_out_point: bitcoin::OutPoint,
+        #[serde(with = "bitcoin::amount::serde::as_sat")]
+        amount: bitcoin::Amount,
+        claim_txid: TransactionId,
+        change: Vec<OutPoint>,
+    },
     Withdraw {
         address: Address<NetworkUnchecked>,
         #[serde(with = "bitcoin::amount::serde::as_sat")]
@@ -648,6 +665,12 @@ impl ClientModule for WalletClientModule {
                         yield serde_json::to_value(state)?;
                     }
                 },
+                "subscribe_receive_deposit" => {
+                    let req: SubscribeReceiveDepositRequest = serde_json::from_value(request)?;
+                    for await state in self.subscribe_receive_deposit(req.operation_id).await?.into_stream() {
+                        yield serde_json::to_value(state)?;
+                    }
+                },
                 "subscribe_withdraw" => {
                     let req: SubscribeWithdrawRequest = serde_json::from_value(request)?;
                     for await state in self.subscribe_withdraw_updates(req.operation_id).await?.into_stream(){
@@ -689,6 +712,11 @@ pub struct PegInRequest {
 
 #[derive(Deserialize)]
 struct SubscribeDepositRequest {
+    operation_id: OperationId,
+}
+
+#[derive(Deserialize)]
+struct SubscribeReceiveDepositRequest {
     operation_id: OperationId,
 }
 
@@ -1151,6 +1179,50 @@ impl WalletClientModule {
                 }
             }
         }}))
+    }
+
+    pub async fn subscribe_receive_deposit(
+        &self,
+        operation_id: OperationId,
+    ) -> anyhow::Result<UpdateStreamOrOutcome<ReceiveDepositState>> {
+        let operation = self
+            .client_ctx
+            .get_operation(operation_id)
+            .await
+            .with_context(|| anyhow!("Operation not found: {}", operation_id.fmt_short()))?;
+
+        if operation.operation_module_kind() != WalletCommonInit::KIND.as_str() {
+            bail!("Operation is not a wallet operation");
+        }
+
+        let operation_meta = operation.meta::<WalletOperationMeta>();
+
+        let WalletOperationMetaVariant::ReceiveDeposit {
+            change,
+            address_operation_id,
+            ..
+        } = operation_meta.variant
+        else {
+            bail!("Operation is not a receive deposit operation");
+        };
+
+        let client_ctx = self.client_ctx.clone();
+
+        Ok(self
+            .client_ctx
+            .outcome_or_updates(operation, operation_id, move || {
+                stream! {
+                    yield ReceiveDepositState::Claiming;
+
+                    // Use address_operation_id for awaiting outputs since the
+                    // claim transaction is submitted under the address operation
+                    // ID for backward compatibility with await_num_deposits.
+                    match client_ctx.await_primary_module_outputs(address_operation_id, change.clone()).await {
+                        Ok(()) => yield ReceiveDepositState::Claimed,
+                        Err(e) => yield ReceiveDepositState::Failed(e.to_string())
+                    }
+                }
+            }))
     }
 
     pub async fn list_peg_in_tweak_idxes(&self) -> BTreeMap<TweakIdx, PegInTweakIndexData> {

--- a/modules/fedimint-wallet-client/src/pegin_monitor.rs
+++ b/modules/fedimint-wallet-client/src/pegin_monitor.rs
@@ -12,14 +12,14 @@ use fedimint_core::db::{
     AutocommitError, Database, DatabaseTransaction, IDatabaseTransactionOpsCoreTyped as _,
 };
 use fedimint_core::envs::is_running_in_test_env;
-use fedimint_core::module::Amounts;
+use fedimint_core::module::{Amounts, CommonModuleInit, serde_json};
 use fedimint_core::task::sleep;
 use fedimint_core::txoproof::TxOutProof;
 use fedimint_core::util::FmtCompactAnyhow as _;
 use fedimint_core::{BitcoinHash, TransactionId, secp256k1, time};
 use fedimint_logging::LOG_CLIENT_MODULE_WALLET;
-use fedimint_wallet_common::WalletInput;
 use fedimint_wallet_common::txoproof::PegInProof;
+use fedimint_wallet_common::{WalletCommonInit, WalletInput};
 use futures::StreamExt as _;
 use secp256k1::Keypair;
 use tokio::sync::watch;
@@ -31,7 +31,9 @@ use crate::client_db::{
     PegInTweakIndexPrefix, TweakIdx,
 };
 use crate::events::{DepositConfirmed, ReceivePaymentEvent};
-use crate::{WalletClientModule, WalletClientModuleData};
+use crate::{
+    WalletClientModule, WalletClientModuleData, WalletOperationMeta, WalletOperationMetaVariant,
+};
 
 /// A helper struct meant to combined data from all addresses/records
 /// into a single struct with all actionable data.
@@ -405,7 +407,7 @@ async fn claim_peg_in(
     tweak_idx: TweakIdx,
     tweak_key: Keypair,
     transaction: &bitcoin::Transaction,
-    operation_id: OperationId,
+    address_operation_id: OperationId,
     out_point: bitcoin::OutPoint,
     tx_out_proof: TxOutProof,
     federation_knows_utxo: bool,
@@ -419,9 +421,10 @@ async fn claim_peg_in(
         out_idx: u32,
         tweak_key: Keypair,
         txout_proof: TxOutProof,
-        operation_id: OperationId,
+        address_operation_id: OperationId,
+        receive_operation_id: OperationId,
         federation_knows_utxo: bool,
-    ) -> Option<OutPointRange> {
+    ) -> Option<(OutPointRange, bitcoin::Amount)> {
         let pegin_proof = PegInProof::new(
             txout_proof,
             btc_transaction.clone(),
@@ -431,6 +434,7 @@ async fn claim_peg_in(
         .expect("TODO: handle API returning faulty proofs");
 
         let amount = pegin_proof.tx_output().value.into();
+        let btc_amount = pegin_proof.tx_output().value;
         let wallet_input = if federation_knows_utxo {
             WalletInput::new_v1(&pegin_proof)
         } else {
@@ -465,57 +469,84 @@ async fn claim_peg_in(
             .log_event(
                 dbtx,
                 ReceivePaymentEvent {
-                    operation_id,
+                    operation_id: address_operation_id,
+                    receive_operation_id,
                     amount,
                     txid,
                 },
             )
             .await;
 
-        Some(
+        Some((
             client_ctx
                 .claim_inputs(
                     dbtx,
                     ClientInputBundle::new_no_sm(vec![client_input]),
-                    operation_id,
+                    address_operation_id,
                 )
                 .await
                 .expect("Cannot claim input, additional funding needed"),
-        )
+            btc_amount,
+        ))
     }
 
     let tx_out_proof = &tx_out_proof;
 
     debug!(target: LOG_CLIENT_MODULE_WALLET, %out_point, "Claiming a peg-in");
 
+    // Generate a new operation ID for this specific deposit claim
+    let receive_operation_id = OperationId::new_random();
+
     client_ctx
         .module_db()
         .autocommit(
             |dbtx, _| {
                 Box::pin(async {
-                    let maybe_change_range = claim_peg_in_inner(
+                    let maybe_claim_result = claim_peg_in_inner(
                         client_ctx,
                         dbtx,
                         transaction,
                         out_point.vout,
                         tweak_key,
                         tx_out_proof.clone(),
-                        operation_id,
+                        address_operation_id,
+                        receive_operation_id,
                         federation_knows_utxo,
                     )
                     .await;
 
-                    let claimed_pegin_data = if let Some(change_range) = maybe_change_range {
-                        ClaimedPegInData {
-                            claim_txid: change_range.txid(),
-                            change: change_range.into_iter().collect(),
-                        }
-                    } else {
-                        ClaimedPegInData {
-                            claim_txid: TransactionId::from_byte_array([0; 32]),
-                            change: vec![],
-                        }
-                    };
+                    let claimed_pegin_data =
+                        if let Some((change_range, btc_amount)) = maybe_claim_result {
+                            let claim_txid = change_range.txid();
+                            let change: Vec<_> = change_range.into_iter().collect();
+
+                            client_ctx
+                                .manual_operation_start_dbtx(
+                                    dbtx,
+                                    receive_operation_id,
+                                    WalletCommonInit::KIND.as_str(),
+                                    WalletOperationMeta {
+                                        variant: WalletOperationMetaVariant::ReceiveDeposit {
+                                            address_operation_id,
+                                            tweak_idx,
+                                            btc_out_point: out_point,
+                                            amount: btc_amount,
+                                            claim_txid,
+                                            change: change.clone(),
+                                        },
+                                        extra_meta: serde_json::Value::Null,
+                                    },
+                                    vec![],
+                                )
+                                .await?;
+
+                            ClaimedPegInData { claim_txid, change }
+                        } else {
+                            ClaimedPegInData {
+                                claim_txid: TransactionId::from_byte_array([0; 32]),
+                                change: vec![],
+                            }
+                        };
 
                     dbtx.insert_entry(
                         &ClaimedPegInKey {

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -12,7 +12,7 @@ use fedimint_client::secret::{PlainRootSecretStrategy, RootSecretStrategy};
 use fedimint_connectors::ConnectorRegistry;
 use fedimint_core::db::mem_impl::MemDatabase;
 use fedimint_core::db::{DatabaseTransaction, IRawDatabaseExt};
-use fedimint_core::module::{AmountUnit, serde_json};
+use fedimint_core::module::{AmountUnit, CommonModuleInit, serde_json};
 use fedimint_core::task::{TaskGroup, sleep_in_test};
 use fedimint_core::util::{BoxStream, NextOrPending, SafeUrl, retry};
 use fedimint_core::{Amount, BitcoinHash, Feerate, InPoint, PeerId, TransactionId, sats};
@@ -26,11 +26,14 @@ use fedimint_testing::federation::FederationTest;
 use fedimint_testing::fixtures::Fixtures;
 use fedimint_testing_core::config::API_AUTH;
 use fedimint_wallet_client::api::WalletFederationApi;
-use fedimint_wallet_client::{DepositStateV2, WalletClientInit, WalletClientModule, WithdrawState};
+use fedimint_wallet_client::{
+    DepositStateV2, WalletClientInit, WalletClientModule, WalletOperationMeta,
+    WalletOperationMetaVariant, WithdrawState,
+};
 use fedimint_wallet_common::config::WalletConfig;
 use fedimint_wallet_common::tweakable::Tweakable;
 use fedimint_wallet_common::txoproof::PegInProof;
-use fedimint_wallet_common::{PegOutFees, Rbf, TxOutputSummary};
+use fedimint_wallet_common::{PegOutFees, Rbf, TxOutputSummary, WalletCommonInit};
 use fedimint_wallet_server::WalletInit;
 use futures::stream::StreamExt;
 use secp256k1::rand::rngs::OsRng;
@@ -1662,6 +1665,204 @@ mod fedimint_migration_tests {
         )
         .await
     }
+}
+
+/// Tests that multiple deposits to the same address create separate operation
+/// log entries
+#[tokio::test(flavor = "multi_thread")]
+async fn multiple_deposits_create_separate_operations() -> anyhow::Result<()> {
+    let fixtures = fixtures();
+    let fed = fixtures.new_fed_degraded().await;
+    let client = fed.new_client().await;
+    let bitcoin = fixtures.bitcoin();
+    let bitcoin = bitcoin.lock_exclusive().await;
+    info!("Starting test multiple_deposits_create_separate_operations");
+
+    let finality_delay = 10;
+    bitcoin.mine_blocks(finality_delay).await;
+    await_consensus_to_catch_up(&client, 1).await?;
+    await_consensus_upgrade(&client, &fed).await?;
+
+    let wallet_module = client.get_first_module::<WalletClientModule>()?;
+
+    // Allocate a single deposit address
+    let (address_op_id, address, _) = wallet_module
+        .allocate_deposit_address_expert_only(())
+        .await?;
+    info!(?address, "Deposit address allocated");
+
+    // Verify the initial address allocation operation exists
+    let initial_ops = client
+        .operation_log()
+        .paginate_operations_rev(100, None)
+        .await;
+    let address_creation_op = initial_ops
+        .iter()
+        .find(|(key, _)| key.operation_id == address_op_id);
+    assert!(
+        address_creation_op.is_some(),
+        "Address creation operation should exist"
+    );
+
+    // Send first deposit to the address
+    let first_deposit_amount = bsats(PEG_IN_AMOUNT_SATS)
+        + bsats(wallet_module.get_fee_consensus().peg_in_abs.msats / 1000);
+    let (_proof, tx1) = bitcoin
+        .send_and_mine_block(&address, first_deposit_amount)
+        .await;
+    info!(?tx1, "First deposit transaction mined");
+
+    // Wait for finality and claim
+    bitcoin.mine_blocks(finality_delay).await;
+    wallet_module
+        .await_num_deposits_by_operation_id(address_op_id, 1)
+        .await?;
+    info!("First deposit claimed");
+
+    // Send second deposit to the same address
+    let second_deposit_amount = bsats(PEG_IN_AMOUNT_SATS + 5000)
+        + bsats(wallet_module.get_fee_consensus().peg_in_abs.msats / 1000);
+    let (_proof, tx2) = bitcoin
+        .send_and_mine_block(&address, second_deposit_amount)
+        .await;
+    info!(?tx2, "Second deposit transaction mined");
+
+    // Wait for finality and claim
+    bitcoin.mine_blocks(finality_delay).await;
+    wallet_module
+        .await_num_deposits_by_operation_id(address_op_id, 2)
+        .await?;
+    info!("Second deposit claimed");
+
+    // Verify the operation log structure
+    let all_ops = client
+        .operation_log()
+        .paginate_operations_rev(100, None)
+        .await;
+    info!("Total operations in log: {}", all_ops.len());
+
+    // Find all wallet operations
+    let wallet_ops: Vec<_> = all_ops
+        .iter()
+        .filter(|(_, entry)| entry.operation_module_kind() == WalletCommonInit::KIND.as_str())
+        .collect();
+
+    // Should have: 1 address allocation + 2 deposit claims = 3 operations
+    assert!(
+        wallet_ops.len() >= 3,
+        "Expected at least 3 wallet operations (1 address + 2 deposits), found {}",
+        wallet_ops.len()
+    );
+
+    // Verify address allocation operation
+    let address_ops: Vec<_> = wallet_ops
+        .iter()
+        .filter(|(_, entry)| {
+            let meta: WalletOperationMeta = entry.meta();
+            matches!(meta.variant, WalletOperationMetaVariant::Deposit { .. })
+        })
+        .collect();
+    assert_eq!(
+        address_ops.len(),
+        1,
+        "Expected exactly 1 address allocation operation, found {}",
+        address_ops.len()
+    );
+
+    // Verify deposit claim operations
+    let deposit_claim_ops: Vec<_> = wallet_ops
+        .iter()
+        .filter(|(_, entry)| {
+            let meta: WalletOperationMeta = entry.meta();
+            matches!(
+                meta.variant,
+                WalletOperationMetaVariant::ReceiveDeposit { .. }
+            )
+        })
+        .collect();
+
+    assert_eq!(
+        deposit_claim_ops.len(),
+        2,
+        "Expected exactly 2 ReceiveDeposit operations for the two deposits, found {}",
+        deposit_claim_ops.len()
+    );
+
+    // Validate each deposit operation contains correct data
+    let mut found_tx1 = false;
+    let mut found_tx2 = false;
+
+    for (_, entry) in deposit_claim_ops {
+        let meta: WalletOperationMeta = entry.meta();
+
+        if let WalletOperationMetaVariant::ReceiveDeposit {
+            address_operation_id,
+            btc_out_point,
+            amount,
+            claim_txid,
+            tweak_idx,
+            change,
+        } = meta.variant
+        {
+            // Verify address_operation_id matches the parent address allocation operation
+            assert_eq!(
+                address_operation_id, address_op_id,
+                "Deposit operation should reference the address allocation operation as parent"
+            );
+
+            // Verify each deposit has a unique outpoint
+            if btc_out_point.txid == tx1.compute_txid() {
+                found_tx1 = true;
+                info!(
+                    ?btc_out_point,
+                    ?amount,
+                    ?claim_txid,
+                    ?tweak_idx,
+                    change_len = change.len(),
+                    ?address_operation_id,
+                    "First deposit operation validated"
+                );
+            } else if btc_out_point.txid == tx2.compute_txid() {
+                found_tx2 = true;
+                info!(
+                    ?btc_out_point,
+                    ?amount,
+                    ?claim_txid,
+                    ?tweak_idx,
+                    change_len = change.len(),
+                    ?address_operation_id,
+                    "Second deposit operation validated"
+                );
+            }
+
+            // Verify operation has valid claim transaction ID
+            assert_ne!(
+                claim_txid,
+                TransactionId::from_byte_array([0; 32]),
+                "Claim transaction ID should be valid"
+            );
+        }
+    }
+
+    assert!(
+        found_tx1,
+        "Should find operation for first deposit transaction"
+    );
+    assert!(
+        found_tx2,
+        "Should find operation for second deposit transaction"
+    );
+
+    // Verify final balance reflects both deposits
+    let expected_balance = sats(PEG_IN_AMOUNT_SATS + PEG_IN_AMOUNT_SATS + 5000);
+    assert_eq!(
+        client.get_balance_for_btc().await?,
+        expected_balance,
+        "Final balance should reflect both deposits"
+    );
+
+    info!("Operation log validation complete - all checks passed");
+    Ok(())
 }
 
 // Verify the correct Bitcoin RPC is used


### PR DESCRIPTION
Closes #8123 

Previously, multiple deposits to the same address only showed one operation in the log (the address creation). Users couldn't see their individual deposits.

Now each deposit creates its own `ReceiveDeposit` operation, so users can track every incoming payment separately.

Changes made:
- Add `ReceiveDeposit` operation variant
- Create new operation when claiming each deposit in pegin_monitor
- Add `subscribe_receive_deposit()` for tracking claim progress
