### PR TITLE
fix(ci): run cross vs release branches

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -261,9 +261,13 @@ jobs:
           nix build -L .#ci.cargoDeny
 
   cross:
-    # we run it in the MQ, not in PR itself, because other than Nix/nixpkgs/toolchain
-    # changes, it is unlikely to be broken by normal dev work
-    if: github.repository == 'fedimint/fedimint' && (github.event_name == 'merge_group')
+    # we run it in the MQ for master, not in PR itself, because other than Nix/nixpkgs/toolchain
+    # changes, it is unlikely to be broken by normal dev work. for release branches we run on PR
+    # since there's no merge queue
+    if: >-
+      github.repository == 'fedimint/fedimint' &&
+      (github.event_name == 'merge_group' ||
+       (github.event_name == 'pull_request' && startsWith(github.base_ref, 'releases/')))
     name: "Cross-compile on ${{ matrix.host }} to ${{ matrix.toolchain }}"
     needs: [lint, shell]
 


### PR DESCRIPTION
In https://github.com/fedimint/fedimint/pull/8051 we improved the load of our self-hosted runners by only running the cross job in the merge queue. This causes our required jobs vs `releases/v0.10` to hang indefinitely since the job won't run on PR push.

See: https://github.com/fedimint/fedimint/pull/8136
<img width="870" height="171" alt="image" src="https://github.com/user-attachments/assets/fa4c2e4c-0448-4781-996e-a84ab76eaf74" />
