### PR TITLE
chore: update flakebox to include a fix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -436,17 +436,17 @@
         "wild": "wild"
       },
       "locked": {
-        "lastModified": 1762577276,
-        "narHash": "sha256-4hDlMtyHITW9boM6zdJIaDp/mvSiUwO/BdCCLQjxEw4=",
+        "lastModified": 1768010000,
+        "narHash": "sha256-/oUVHAj020wdMzgmBtojT58hwHkS9/CoHp/2x1k6dEE=",
         "owner": "dpc",
         "repo": "flakebox",
-        "rev": "9a22c690bc3c15291c3c70f662c855b5bdaffc0e",
+        "rev": "3e20ed1239ea83da3790ae2f2d207b508b429c2b",
         "type": "github"
       },
       "original": {
         "owner": "dpc",
         "repo": "flakebox",
-        "rev": "9a22c690bc3c15291c3c70f662c855b5bdaffc0e",
+        "rev": "3e20ed1239ea83da3790ae2f2d207b508b429c2b",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     flakebox = {
-      url = "github:dpc/flakebox?rev=9a22c690bc3c15291c3c70f662c855b5bdaffc0e";
+      url = "github:dpc/flakebox?rev=3e20ed1239ea83da3790ae2f2d207b508b429c2b";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.fenix.follows = "fenix";
     };
@@ -139,7 +139,6 @@
             just.importPaths = [ "justfile.fedimint.just" ];
             # we have a custom final check
             just.rules.final-check.enable = false;
-            rust.pre-commit.leftover-dbg.enable = false;
             git.pre-commit.trailing_newline = false;
             git.pre-commit.hooks = {
               check_forbidden_dependencies = builtins.readFile ./nix/check-forbidden-deps.sh;
@@ -155,7 +154,7 @@
           # the newer (clang 18, clang 19) toolchains, which causes
           # fedimint-cli segfault randomly, but only in Nix sandbox (?!).
           # Supper weird.
-          stdenv = p: p.clang_20.stdenv;
+          stdenv = p: p.llvmPackages_20.stdenv;
           clang = pkgs.llvmPackages_20.clang;
           libclang = pkgs.llvmPackages_20.libclang.lib;
           clang-unwrapped = pkgs.llvmPackages_20.clang-unwrapped;


### PR DESCRIPTION
https://github.com/rustshop/flakebox/pull/213
https://github.com/rustshop/flakebox/pull/214

The core of the fix is that now this is not empty:

```
> echo $NIX_LDFLAGS
-rpath /home/dpc/lab/fedimint/fedimint/outputs/out/lib  -L/nix/store/g6a7jlc1ca082nskhym3qq9sxw35dc38-rust-mixed/lib -L/nix/store/jj6jldlw37r8yy9kc1smrax9dhnjm2x4-python3-3.13.9/lib ... 
```

Fix #8146

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
