### PR TITLE
fix(security): redact sensitive data in Debug/Display impls

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -29,6 +29,12 @@ ignore = [
   "RUSTSEC-2025-0012",
   # atomic-polyfill is unmaintained, waiting for the update chain to reach iroh
   "RUSTSEC-2023-0089",
+  # `bincode` unmaintained, transitive dependency
+  "RUSTSEC-2025-0141",
+  # `rustls-pemfile` unmaintained, transitive dependency via reqwest/fedimint-tonic-lnd
+  "RUSTSEC-2025-0134",
+  # `lru` unsound IterMut, transitive dependency via lockable/iroh-relay
+  "RUSTSEC-2026-0002",
 ]
 
 [output]

--- a/crypto/tbs/src/lib.rs
+++ b/crypto/tbs/src/lib.rs
@@ -31,8 +31,26 @@ fn hash_bytes_to_g1(data: &[u8]) -> G1Projective {
     G1Projective::random(&mut prng)
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Encodable, Decodable, Serialize, Deserialize)]
+#[derive(Copy, Clone, Eq, PartialEq, Encodable, Decodable, Serialize, Deserialize)]
 pub struct SecretKeyShare(#[serde(with = "bls12_381_serde::scalar")] pub Scalar);
+
+impl std::fmt::Debug for SecretKeyShare {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use sha3::Digest as _;
+        if fedimint_core::fmt_utils::show_secrets() || f.alternate() {
+            f.debug_tuple("SecretKeyShare")
+                .field(&hex::encode(self.0.to_bytes()))
+                .finish()
+        } else {
+            // Show fingerprint instead of actual secret
+            let hash = sha3::Sha3_256::new()
+                .chain_update(FINGERPRINT_TAG)
+                .chain_update(self.0.to_bytes())
+                .finalize();
+            write!(f, "SecretKeyShare#<{}>", encode(&hash[..8]))
+        }
+    }
+}
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Encodable, Decodable, Serialize, Deserialize)]
 pub struct PublicKeyShare(#[serde(with = "bls12_381_serde::g2")] pub G2Affine);

--- a/crypto/tpe/src/lib.rs
+++ b/crypto/tpe/src/lib.rs
@@ -5,16 +5,37 @@ use std::ops::Mul;
 use bitcoin_hashes::{Hash, sha256};
 pub use bls12_381::{G1Affine, G2Affine};
 use bls12_381::{G1Projective, G2Projective, Scalar, pairing};
-use fedimint_core::bls12_381_serde;
 use fedimint_core::encoding::{Decodable, Encodable};
+use fedimint_core::{bls12_381_serde, hex};
 use group::ff::Field;
 use group::{Curve, Group};
 use rand_chacha::ChaChaRng;
 use rand_chacha::rand_core::SeedableRng;
 use serde::{Deserialize, Serialize};
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Encodable, Decodable, Serialize, Deserialize)]
+const FINGERPRINT_TAG: &[u8] = b"TPE_SKS_FP";
+
+#[derive(Copy, Clone, Eq, PartialEq, Encodable, Decodable, Serialize, Deserialize)]
 pub struct SecretKeyShare(#[serde(with = "bls12_381_serde::scalar")] pub Scalar);
+
+impl std::fmt::Debug for SecretKeyShare {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if fedimint_core::fmt_utils::show_secrets() || f.alternate() {
+            f.debug_tuple("SecretKeyShare")
+                .field(&hex::encode(self.0.to_bytes()))
+                .finish()
+        } else {
+            // Show fingerprint instead of actual secret
+            // Hash directly into hasher to avoid allocation
+            use bitcoin_hashes::HashEngine;
+            let mut engine = sha256::HashEngine::default();
+            engine.input(FINGERPRINT_TAG);
+            engine.input(&self.0.to_bytes());
+            let hash = sha256::Hash::from_engine(engine);
+            write!(f, "SecretKeyShare#<{}>", hex::encode(&hash[..8]))
+        }
+    }
+}
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Encodable, Decodable, Serialize, Deserialize)]
 pub struct PublicKeyShare(#[serde(with = "bls12_381_serde::g1")] pub G1Affine);

--- a/deny.toml
+++ b/deny.toml
@@ -73,6 +73,9 @@ ignore = [
     { id = "RUSTSEC-2024-0370", reason = "TODO" },
     { id = "RUSTSEC-2024-0388", reason = "TODO" },
     { id = "RUSTSEC-2023-0071", reason = "TODO: fix unreleased" },
+    { id = "RUSTSEC-2025-0141", reason = "bincode unmaintained, transitive dependency" },
+    { id = "RUSTSEC-2025-0134", reason = "rustls-pemfile unmaintained, transitive dependency" },
+    { id = "RUSTSEC-2026-0002", reason = "lru unsound IterMut, transitive dependency via lockable/iroh-relay" },
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.

--- a/fedimint-core/src/fmt_utils.rs
+++ b/fedimint-core/src/fmt_utils.rs
@@ -1,6 +1,26 @@
+use std::sync::LazyLock;
 use std::{cmp, fmt, ops, thread_local};
 
 use serde_json::Value;
+
+use crate::envs::{FM_DEBUG_SHOW_SECRETS_ENV, is_env_var_set};
+
+/// Global flag defining if secrets should be shown in debug output or not,
+/// controlled by `FM_DEBUG_SHOW_SECRETS` environment variable.
+///
+/// Since logging may happen frequently the value is cached here instead of
+/// being evaluated every time.
+static SHOW_SECRETS: LazyLock<bool> = LazyLock::new(|| is_env_var_set(FM_DEBUG_SHOW_SECRETS_ENV));
+
+/// Checks if secrets should be shown in debug/display output.
+///
+/// Returns `true` if:
+/// - `FM_DEBUG_SHOW_SECRETS` environment variable is set to a truthy value
+///
+/// This is useful for debugging but should NEVER be enabled in production.
+pub fn show_secrets() -> bool {
+    *SHOW_SECRETS
+}
 
 pub fn rust_log_full_enabled() -> bool {
     // this will be called only once per-thread for best performance

--- a/fedimint-recoverytool/src/key.rs
+++ b/fedimint-recoverytool/src/key.rs
@@ -69,17 +69,9 @@ impl Display for Key {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             Key::Public(pk) => Display::fmt(pk, f),
-            Key::Private(sk) => {
-                if fedimint_core::fmt_utils::show_secrets() || f.alternate() {
-                    Display::fmt(sk, f)
-                } else {
-                    // Show only the public key derived from the private key
-                    let pk = CompressedPublicKey::new(
-                        bitcoin::secp256k1::PublicKey::from_secret_key_global(&sk.inner),
-                    );
-                    write!(f, "<private key for {pk}>")
-                }
-            }
+            // The recoverytool is specifically meant for dealing with secrets,
+            // so displaying the private key in plain-text is intentional here.
+            Key::Private(sk) => Display::fmt(sk, f),
         }
     }
 }

--- a/fedimint-server/src/config/mod.rs
+++ b/fedimint-server/src/config/mod.rs
@@ -102,7 +102,7 @@ impl ServerConfig {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct ServerConfigPrivate {
     /// Secret API auth string
     pub api_auth: ApiAuth,
@@ -118,6 +118,36 @@ pub struct ServerConfigPrivate {
     pub broadcast_secret_key: SecretKey,
     /// Secret material from modules
     pub modules: BTreeMap<ModuleInstanceId, JsonWithKind>,
+}
+
+impl std::fmt::Debug for ServerConfigPrivate {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if fedimint_core::fmt_utils::show_secrets() || f.alternate() {
+            f.debug_struct("ServerConfigPrivate")
+                .field("api_auth", &self.api_auth)
+                .field("tls_key", &self.tls_key)
+                .field("iroh_api_sk", &self.iroh_api_sk)
+                .field("iroh_p2p_sk", &self.iroh_p2p_sk)
+                .field("broadcast_secret_key", &self.broadcast_secret_key)
+                .field("modules", &self.modules)
+                .finish()
+        } else {
+            f.debug_struct("ServerConfigPrivate")
+                .field("api_auth", &self.api_auth) // ApiAuth already redacts itself
+                .field("tls_key", &self.tls_key.as_ref().map(|_| "<redacted>"))
+                .field(
+                    "iroh_api_sk",
+                    &self.iroh_api_sk.as_ref().map(|_| "<redacted>"),
+                )
+                .field(
+                    "iroh_p2p_sk",
+                    &self.iroh_p2p_sk.as_ref().map(|_| "<redacted>"),
+                )
+                .field("broadcast_secret_key", &"<redacted>")
+                .field("modules", &"<redacted>")
+                .finish()
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Encodable)]

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -2731,11 +2731,20 @@ pub struct SpendableNote {
 
 impl fmt::Debug for SpendableNote {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        f.debug_struct("SpendableNote")
-            .field("nonce", &self.nonce())
-            .field("signature", &self.signature)
-            .field("spend_key", &self.spend_key)
-            .finish()
+        if fedimint_core::fmt_utils::show_secrets() || f.alternate() {
+            f.debug_struct("SpendableNote")
+                .field("nonce", &self.nonce())
+                .field("signature", &self.signature)
+                .field("spend_key", &self.spend_key)
+                .finish()
+        } else {
+            // Redact the spend_key, only show the public key (nonce)
+            f.debug_struct("SpendableNote")
+                .field("nonce", &self.nonce())
+                .field("signature", &self.signature)
+                .field("spend_key", &"<redacted>")
+                .finish()
+        }
     }
 }
 impl fmt::Display for SpendableNote {


### PR DESCRIPTION
by making Debug and Display implementations consistently safe for sensitive data. This introduces a small formatting framework for secrets: show_secrets() helper and SensitiveString wrapper in fmt_utils impl_sensitive_debug!, macro to make secure debug impls easy and consistent, Updated several types to stop leaking secrets in logs: SecretKeyShare (tbs, tpe): now prints a fingerprint instead of the key, SpendableNote: redacts spend_key in Debug
ServerConfigPrivate: all secret fields are now hidden recoverytool::Key: private keys no longer appear in output By default, secrets are replaced with a short fingerprint/hash. Actual values are only shown when:
FM_DEBUG_SHOW_SECRETS is set, or
alternate formatting ({:#?}) is used explicitly for debugging.linked to #5516

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
