### PR TITLE
fix(tests): correct v0.8.0-v0.8.1 gateway fee handling

### DIFF
--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -37,7 +37,7 @@ use crate::cli::{CommonArgs, cleanup_on_exit, exec_user_command, setup};
 use crate::envs::{FM_DATA_DIR_ENV, FM_DEVIMINT_RUN_DEPRECATED_TESTS_ENV, FM_PASSWORD_ENV};
 use crate::federation::Client;
 use crate::util::{LoadTestTool, ProcessManager, almost_equal, poll};
-use crate::version_constants::{VERSION_0_8_0_ALPHA, VERSION_0_9_0_ALPHA, VERSION_0_10_0_ALPHA};
+use crate::version_constants::{VERSION_0_8_2, VERSION_0_9_0_ALPHA, VERSION_0_10_0_ALPHA};
 use crate::{DevFed, Gatewayd, LightningNode, Lnd, cmd, dev_fed};
 
 pub struct Stats {
@@ -787,10 +787,10 @@ pub async fn cli_tests(dev_fed: DevFed) -> Result<()> {
     info!("Testing LND gateway");
 
     let gatewayd_version = crate::util::Gatewayd::version_or_default().await;
-    // Gatewayd did not support default fees before v0.8.0
+    // Gatewayd did not support default fees before v0.8.2
     // In order for the amount tests to pass, we need to reliably set the fees to
     // 0,0.
-    if gatewayd_version < *VERSION_0_8_0_ALPHA {
+    if gatewayd_version < *VERSION_0_8_2 {
         gw_lnd
             .set_federation_routing_fee(fed_id.clone(), 0, 0)
             .await?;

--- a/devimint/src/version_constants.rs
+++ b/devimint/src/version_constants.rs
@@ -4,6 +4,8 @@ use semver::Version;
 
 pub static VERSION_0_8_0_ALPHA: LazyLock<Version> =
     LazyLock::new(|| Version::parse("0.8.0-alpha").expect("version is parsable"));
+pub static VERSION_0_8_2: LazyLock<Version> =
+    LazyLock::new(|| Version::parse("0.8.2").expect("version is parsable"));
 pub static VERSION_0_9_0_ALPHA: LazyLock<Version> =
     LazyLock::new(|| Version::parse("0.9.0-alpha").expect("version is parsable"));
 pub static VERSION_0_10_0_ALPHA: LazyLock<Version> =

--- a/gateway/integration_tests/src/main.rs
+++ b/gateway/integration_tests/src/main.rs
@@ -14,7 +14,7 @@ use devimint::envs::FM_DATA_DIR_ENV;
 use devimint::external::{Bitcoind, Esplora};
 use devimint::federation::Federation;
 use devimint::util::{ProcessManager, almost_equal, poll, poll_with_timeout};
-use devimint::version_constants::{VERSION_0_8_0_ALPHA, VERSION_0_10_0_ALPHA};
+use devimint::version_constants::{VERSION_0_8_0_ALPHA, VERSION_0_8_2, VERSION_0_10_0_ALPHA};
 use devimint::{Gatewayd, LightningNode, cli, cmd, util};
 use fedimint_core::config::FederationId;
 use fedimint_core::time::now;
@@ -363,9 +363,10 @@ async fn config_test(gw_type: LightningNodeType) -> anyhow::Result<()> {
                     .out_json()
                     .await?;
 
-
-                let (default_base, default_ppm) = if gatewayd_version >= *VERSION_0_8_0_ALPHA {
+                let (default_base, default_ppm) = if gatewayd_version >= *VERSION_0_8_2 {
                     (0, 0)
+                } else if gatewayd_version >= *VERSION_0_8_0_ALPHA {
+                    (2000, 3000)
                 } else {
                     (50000, 5000)
                 };


### PR DESCRIPTION
Fixes #8147

Backwards compatibility tests fail when testing `v0.10.0` with `v0.8.0` or `v0.8.1` gateways:

`devimint_cli_test`
```
Error: LND Gateway balance changed by 2007296 on LND outgoing payment, expected 2_000_000
```
https://github.com/fedimint/fedimint/actions/runs/20861671019/job/59942659276#step:6:16947

`gw_config_test_lnd`
```
assertion failed: Default Base msat for new federation was not correct
  left: 0
  right: 2000
```
https://github.com/fedimint/fedimint/actions/runs/20861671019/job/59942659276#step:6:9182

Both surface when running the full version matrix during release testing, not the partial matrix in regular CI.

Environment variable fee configuration was added in `v0.8.2` (#7758). In #7948, we added a version check assuming `v0.8.0-v0.8.2` support this, which is why this is showing up for the `v0.10.0` release process.

We need to handle the `v0.8.0` and `v0.8.1` cases specifically.