### PR TITLE
fix(ci): publish fedimint-recurringdv2 image to Docker Hub

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -337,6 +337,8 @@ jobs:
             image: fedimint/gateway-cli
           - name: fedimint-recurringd
             image: fedimint/fedimint-recurringd
+          - name: fedimint-recurringdv2
+            image: fedimint/fedimint-recurringdv2
           - name: devtools
             image: fedimint/devtools
     runs-on: ${{ matrix.platform.runs-on }}
@@ -415,7 +417,7 @@ jobs:
       - name: Create and push multi-arch manifests
         run: |
           # hardcode container names since they're not available as outputs from the container job
-          containers="fedimintd fedimint-cli gatewayd gateway-cli fedimint-recurringd devtools"
+          containers="fedimintd fedimint-cli gatewayd gateway-cli fedimint-recurringd fedimint-recurringdv2 devtools"
 
           # Reference the following blog post for multi arch images with nix and docker manifest
           # https://tech.aufomm.com/how-to-build-multi-arch-docker-image-on-nixos


### PR DESCRIPTION
Working towards https://github.com/fedimint/fedimint/issues/8018

#8093 added `fedimint-recurringdv2` but didn't wire it up for Docker Hub publishing.

We need to add the image to the CI matrix and manifest list so it gets published alongside the other images on releases.