### PR TITLE
chore: bump version to v0.11.0-alpha

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2297,7 +2297,7 @@ dependencies = [
 
 [[package]]
 name = "devimint"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "axum 0.8.7",
@@ -2730,7 +2730,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fedimint-aead"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "argon2",
@@ -2762,7 +2762,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-api-client"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2787,7 +2787,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-bip39"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "bip39",
  "fedimint-client",
@@ -2798,7 +2798,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-bitcoind"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2812,14 +2812,14 @@ dependencies = [
 
 [[package]]
 name = "fedimint-build"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "fedimint-cli"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2859,7 +2859,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2889,7 +2889,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client-module"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -2919,7 +2919,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client-rpc"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2946,7 +2946,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client-uniffi"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "fedimint-build",
@@ -2964,7 +2964,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client-wasm"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2982,7 +2982,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-connectors"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "arti-client",
@@ -3016,7 +3016,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-core"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3081,7 +3081,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-cursed-redb"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3100,7 +3100,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-db-locked"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3112,7 +3112,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dbtool"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3147,7 +3147,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-derive"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
@@ -3157,7 +3157,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-derive-secret"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "bitcoin_hashes 0.14.0",
@@ -3169,11 +3169,11 @@ dependencies = [
 
 [[package]]
 name = "fedimint-docs"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 
 [[package]]
 name = "fedimint-dummy-client"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3193,7 +3193,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dummy-common"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -3203,7 +3203,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dummy-server"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3219,7 +3219,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dummy-tests"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "fedimint-client",
@@ -3240,7 +3240,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-empty-client"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3257,7 +3257,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-empty-common"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -3267,7 +3267,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-empty-server"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3283,7 +3283,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-eventlog"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3301,7 +3301,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-fountain"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3313,7 +3313,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-fuzz"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "fedimint-core",
  "fedimint-ln-common",
@@ -3326,7 +3326,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-client"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "bcrypt",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-common"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -3370,7 +3370,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-server"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3446,7 +3446,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-server-db"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -3474,7 +3474,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-ui"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "async-trait",
  "axum 0.8.7",
@@ -3501,7 +3501,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gw-client"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3531,7 +3531,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gwv2-client"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3558,7 +3558,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-hkdf"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "bitcoin_hashes 0.14.0",
 ]
@@ -3606,7 +3606,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lightning"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3632,7 +3632,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-client"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3666,7 +3666,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-common"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3689,7 +3689,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-server"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3714,7 +3714,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-tests"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3743,7 +3743,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-client"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3774,7 +3774,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-common"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3795,7 +3795,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-server"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3819,7 +3819,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-tests"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3853,7 +3853,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-load-test-tool"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "clap",
@@ -3881,7 +3881,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-logging"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "console-subscriber",
@@ -3894,7 +3894,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-client"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3915,7 +3915,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-common"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -3929,7 +3929,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-server"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3948,7 +3948,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-tests"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "clap",
@@ -3962,7 +3962,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-metrics"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "axum 0.8.7",
@@ -3974,7 +3974,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-client"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -4015,7 +4015,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-common"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "bitcoin_hashes 0.14.0",
@@ -4028,7 +4028,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-server"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4055,7 +4055,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-tests"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4089,7 +4089,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-portalloc"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "dirs",
@@ -4103,7 +4103,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-recoverytool"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -4126,7 +4126,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-recurringd"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "axum 0.8.7",
@@ -4159,7 +4159,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-recurringd-tests"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "devimint",
@@ -4172,7 +4172,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-recurringdv2"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "axum 0.8.7",
@@ -4194,7 +4194,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-rocksdb"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4211,7 +4211,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -4265,7 +4265,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server-bitcoin-rpc"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4280,7 +4280,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server-core"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4298,7 +4298,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server-tests"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "bitcoin",
  "fedimint-api-client",
@@ -4318,7 +4318,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server-ui"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4342,7 +4342,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-tbs"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "bls12_381",
  "criterion",
@@ -4357,7 +4357,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-testing"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4396,7 +4396,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-testing-core"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -4457,7 +4457,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-tpe"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "bitcoin_hashes 0.14.0",
  "bls12_381",
@@ -4471,7 +4471,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ui-common"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "axum 0.8.7",
  "axum-extra",
@@ -4482,7 +4482,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-unknown-common"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -4492,7 +4492,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-unknown-server"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4506,14 +4506,14 @@ dependencies = [
 
 [[package]]
 name = "fedimint-util-error"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "fedimint-wallet-client"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -4543,7 +4543,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-common"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-server"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4586,7 +4586,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-tests"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4619,7 +4619,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wasm-tests"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "fedimint-client",
@@ -4640,7 +4640,7 @@ dependencies = [
 
 [[package]]
 name = "fedimintd"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -4674,7 +4674,7 @@ dependencies = [
 
 [[package]]
 name = "fedimintd-envs"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 
 [[package]]
 name = "ff"
@@ -4991,7 +4991,7 @@ dependencies = [
 
 [[package]]
 name = "gateway-tests"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "clap",
@@ -6888,7 +6888,7 @@ dependencies = [
 
 [[package]]
 name = "lnurlp"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ keywords = ["bitcoin", "lightning", "chaumian", "e-cash", "federated"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/fedimint/fedimint"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 
 [workspace.metadata]
 authors = ["The Fedimint Developers"]
@@ -157,7 +157,7 @@ criterion = "0.5.1"
 # We need to pin this arti's `curve25519-dalek` dependency, due to `https://rustsec.org/advisories/RUSTSEC-2024-0344` vulnerability
 # It's been updated by https://gitlab.torproject.org/tpo/core/arti/-/merge_requests/2211, should be removed in next release.
 curve25519-dalek = ">=4.1.3"
-devimint = { path = "./devimint", version = "=0.10.0-alpha" }
+devimint = { path = "./devimint", version = "=0.11.0-alpha" }
 dirs = "6.0.0"
 erased-serde = "0.4"
 esplora-client = { version = "0.12.0", default-features = false, features = [
@@ -167,63 +167,63 @@ esplora-client = { version = "0.12.0", default-features = false, features = [
 ] }
 tor-rtcompat = { version = "0.33.0" }
 
-fedimint-aead = { path = "./crypto/aead", version = "=0.10.0-alpha" }
-fedimint-api-client = { path = "./fedimint-api-client", version = "=0.10.0-alpha" }
-fedimint-bip39 = { path = "./fedimint-bip39", version = "=0.10.0-alpha" }
-fedimint-bitcoind = { path = "./fedimint-bitcoind", version = "=0.10.0-alpha" }
-fedimint-build = { path = "./fedimint-build", version = "=0.10.0-alpha" }
-fedimint-client = { path = "./fedimint-client", version = "=0.10.0-alpha" }
-fedimint-client-module = { path = "./fedimint-client-module", version = "=0.10.0-alpha" }
-fedimint-client-rpc = { path = "./fedimint-client-rpc", version = "=0.10.0-alpha" }
-fedimint-connectors = { path = "./fedimint-connectors", version = "=0.10.0-alpha" }
-fedimint-core = { path = "./fedimint-core", version = "=0.10.0-alpha" }
-fedimint-cursed-redb = { path = "./fedimint-cursed-redb", version = "=0.10.0-alpha" }
-fedimint-db-locked = { path = "./fedimint-db-locked", version = "=0.10.0-alpha" }
-fedimint-derive = { path = "./fedimint-derive", version = "=0.10.0-alpha" }
-fedimint-derive-secret = { path = "./crypto/derive-secret", version = "=0.10.0-alpha" }
-fedimint-dummy-client = { path = "./modules/fedimint-dummy-client", version = "=0.10.0-alpha" }
-fedimint-dummy-common = { path = "./modules/fedimint-dummy-common", version = "=0.10.0-alpha" }
-fedimint-dummy-server = { path = "./modules/fedimint-dummy-server", version = "=0.10.0-alpha" }
-fedimint-empty-common = { path = "./modules/fedimint-empty-common", version = "=0.10.0-alpha" }
-fedimint-eventlog = { path = "./fedimint-eventlog", version = "=0.10.0-alpha" }
-fedimint-gateway-common = { package = "fedimint-gateway-common", path = "./gateway/fedimint-gateway-common", version = "=0.10.0-alpha" }
-fedimint-gateway-server = { package = "fedimint-gateway-server", path = "./gateway/fedimint-gateway-server", version = "=0.10.0-alpha" }
-fedimint-gateway-server-db = { package = "fedimint-gateway-server-db", path = "./gateway/fedimint-gateway-server-db", version = "=0.10.0-alpha" }
-fedimint-gateway-ui = { package = "fedimint-gateway-ui", path = "./gateway/fedimint-gateway-ui", version = "=0.10.0-alpha" }
-fedimint-gw-client = { path = "./modules/fedimint-gw-client", version = "=0.10.0-alpha" }
-fedimint-gwv2-client = { path = "./modules/fedimint-gwv2-client", version = "=0.10.0-alpha" }
-fedimint-lightning = { package = "fedimint-lightning", path = "./gateway/fedimint-lightning", version = "=0.10.0-alpha" }
-fedimint-ln-client = { path = "./modules/fedimint-ln-client", version = "=0.10.0-alpha" }
-fedimint-ln-common = { path = "./modules/fedimint-ln-common", version = "=0.10.0-alpha" }
-fedimint-ln-server = { path = "./modules/fedimint-ln-server", version = "=0.10.0-alpha" }
-fedimint-lnv2-client = { path = "./modules/fedimint-lnv2-client", version = "=0.10.0-alpha" }
-fedimint-lnv2-common = { path = "./modules/fedimint-lnv2-common", version = "=0.10.0-alpha" }
-fedimint-lnv2-server = { path = "./modules/fedimint-lnv2-server", version = "=0.10.0-alpha" }
-fedimint-logging = { path = "./fedimint-logging", version = "=0.10.0-alpha" }
-fedimint-meta-client = { path = "./modules/fedimint-meta-client", version = "=0.10.0-alpha" }
-fedimint-meta-common = { path = "./modules/fedimint-meta-common", version = "=0.10.0-alpha" }
-fedimint-meta-server = { path = "./modules/fedimint-meta-server", version = "=0.10.0-alpha" }
-fedimint-metrics = { path = "./fedimint-metrics", version = "=0.10.0-alpha" }
-fedimint-mint-client = { path = "./modules/fedimint-mint-client", version = "=0.10.0-alpha" }
-fedimint-mint-common = { path = "./modules/fedimint-mint-common", version = "=0.10.0-alpha" }
-fedimint-mint-server = { path = "./modules/fedimint-mint-server", version = "=0.10.0-alpha" }
-fedimint-portalloc = { path = "utils/portalloc", version = "=0.10.0-alpha" }
-fedimint-rocksdb = { path = "./fedimint-rocksdb", version = "=0.10.0-alpha" }
-fedimint-server = { path = "./fedimint-server", version = "=0.10.0-alpha" }
-fedimint-server-bitcoin-rpc = { path = "./fedimint-server-bitcoin-rpc", version = "=0.10.0-alpha" }
-fedimint-server-core = { path = "./fedimint-server-core", version = "=0.10.0-alpha" }
-fedimint-server-ui = { path = "./fedimint-server-ui", version = "=0.10.0-alpha" }
-fedimint-testing = { path = "./fedimint-testing", version = "=0.10.0-alpha" }
-fedimint-testing-core = { path = "./fedimint-testing-core", version = "=0.10.0-alpha" }
-fedimint-ui-common = { path = "./fedimint-ui-common", version = "=0.10.0-alpha" }
-fedimint-unknown-common = { path = "./modules/fedimint-unknown-common", version = "=0.10.0-alpha" }
-fedimint-unknown-server = { path = "./modules/fedimint-unknown-server", version = "=0.10.0-alpha" }
-fedimint-util-error = { path = "./fedimint-util-error", version = "=0.10.0-alpha" }
-fedimint-wallet-client = { path = "./modules/fedimint-wallet-client", version = "=0.10.0-alpha" }
-fedimint-wallet-common = { path = "./modules/fedimint-wallet-common", version = "=0.10.0-alpha" }
-fedimint-wallet-server = { path = "./modules/fedimint-wallet-server", version = "=0.10.0-alpha" }
-fedimintd = { path = "./fedimintd", version = "=0.10.0-alpha" }
-fedimintd-envs = { path = "./fedimintd-envs", version = "=0.10.0-alpha" }
+fedimint-aead = { path = "./crypto/aead", version = "=0.11.0-alpha" }
+fedimint-api-client = { path = "./fedimint-api-client", version = "=0.11.0-alpha" }
+fedimint-bip39 = { path = "./fedimint-bip39", version = "=0.11.0-alpha" }
+fedimint-bitcoind = { path = "./fedimint-bitcoind", version = "=0.11.0-alpha" }
+fedimint-build = { path = "./fedimint-build", version = "=0.11.0-alpha" }
+fedimint-client = { path = "./fedimint-client", version = "=0.11.0-alpha" }
+fedimint-client-module = { path = "./fedimint-client-module", version = "=0.11.0-alpha" }
+fedimint-client-rpc = { path = "./fedimint-client-rpc", version = "=0.11.0-alpha" }
+fedimint-connectors = { path = "./fedimint-connectors", version = "=0.11.0-alpha" }
+fedimint-core = { path = "./fedimint-core", version = "=0.11.0-alpha" }
+fedimint-cursed-redb = { path = "./fedimint-cursed-redb", version = "=0.11.0-alpha" }
+fedimint-db-locked = { path = "./fedimint-db-locked", version = "=0.11.0-alpha" }
+fedimint-derive = { path = "./fedimint-derive", version = "=0.11.0-alpha" }
+fedimint-derive-secret = { path = "./crypto/derive-secret", version = "=0.11.0-alpha" }
+fedimint-dummy-client = { path = "./modules/fedimint-dummy-client", version = "=0.11.0-alpha" }
+fedimint-dummy-common = { path = "./modules/fedimint-dummy-common", version = "=0.11.0-alpha" }
+fedimint-dummy-server = { path = "./modules/fedimint-dummy-server", version = "=0.11.0-alpha" }
+fedimint-empty-common = { path = "./modules/fedimint-empty-common", version = "=0.11.0-alpha" }
+fedimint-eventlog = { path = "./fedimint-eventlog", version = "=0.11.0-alpha" }
+fedimint-gateway-common = { package = "fedimint-gateway-common", path = "./gateway/fedimint-gateway-common", version = "=0.11.0-alpha" }
+fedimint-gateway-server = { package = "fedimint-gateway-server", path = "./gateway/fedimint-gateway-server", version = "=0.11.0-alpha" }
+fedimint-gateway-server-db = { package = "fedimint-gateway-server-db", path = "./gateway/fedimint-gateway-server-db", version = "=0.11.0-alpha" }
+fedimint-gateway-ui = { package = "fedimint-gateway-ui", path = "./gateway/fedimint-gateway-ui", version = "=0.11.0-alpha" }
+fedimint-gw-client = { path = "./modules/fedimint-gw-client", version = "=0.11.0-alpha" }
+fedimint-gwv2-client = { path = "./modules/fedimint-gwv2-client", version = "=0.11.0-alpha" }
+fedimint-lightning = { package = "fedimint-lightning", path = "./gateway/fedimint-lightning", version = "=0.11.0-alpha" }
+fedimint-ln-client = { path = "./modules/fedimint-ln-client", version = "=0.11.0-alpha" }
+fedimint-ln-common = { path = "./modules/fedimint-ln-common", version = "=0.11.0-alpha" }
+fedimint-ln-server = { path = "./modules/fedimint-ln-server", version = "=0.11.0-alpha" }
+fedimint-lnv2-client = { path = "./modules/fedimint-lnv2-client", version = "=0.11.0-alpha" }
+fedimint-lnv2-common = { path = "./modules/fedimint-lnv2-common", version = "=0.11.0-alpha" }
+fedimint-lnv2-server = { path = "./modules/fedimint-lnv2-server", version = "=0.11.0-alpha" }
+fedimint-logging = { path = "./fedimint-logging", version = "=0.11.0-alpha" }
+fedimint-meta-client = { path = "./modules/fedimint-meta-client", version = "=0.11.0-alpha" }
+fedimint-meta-common = { path = "./modules/fedimint-meta-common", version = "=0.11.0-alpha" }
+fedimint-meta-server = { path = "./modules/fedimint-meta-server", version = "=0.11.0-alpha" }
+fedimint-metrics = { path = "./fedimint-metrics", version = "=0.11.0-alpha" }
+fedimint-mint-client = { path = "./modules/fedimint-mint-client", version = "=0.11.0-alpha" }
+fedimint-mint-common = { path = "./modules/fedimint-mint-common", version = "=0.11.0-alpha" }
+fedimint-mint-server = { path = "./modules/fedimint-mint-server", version = "=0.11.0-alpha" }
+fedimint-portalloc = { path = "utils/portalloc", version = "=0.11.0-alpha" }
+fedimint-rocksdb = { path = "./fedimint-rocksdb", version = "=0.11.0-alpha" }
+fedimint-server = { path = "./fedimint-server", version = "=0.11.0-alpha" }
+fedimint-server-bitcoin-rpc = { path = "./fedimint-server-bitcoin-rpc", version = "=0.11.0-alpha" }
+fedimint-server-core = { path = "./fedimint-server-core", version = "=0.11.0-alpha" }
+fedimint-server-ui = { path = "./fedimint-server-ui", version = "=0.11.0-alpha" }
+fedimint-testing = { path = "./fedimint-testing", version = "=0.11.0-alpha" }
+fedimint-testing-core = { path = "./fedimint-testing-core", version = "=0.11.0-alpha" }
+fedimint-ui-common = { path = "./fedimint-ui-common", version = "=0.11.0-alpha" }
+fedimint-unknown-common = { path = "./modules/fedimint-unknown-common", version = "=0.11.0-alpha" }
+fedimint-unknown-server = { path = "./modules/fedimint-unknown-server", version = "=0.11.0-alpha" }
+fedimint-util-error = { path = "./fedimint-util-error", version = "=0.11.0-alpha" }
+fedimint-wallet-client = { path = "./modules/fedimint-wallet-client", version = "=0.11.0-alpha" }
+fedimint-wallet-common = { path = "./modules/fedimint-wallet-common", version = "=0.11.0-alpha" }
+fedimint-wallet-server = { path = "./modules/fedimint-wallet-server", version = "=0.11.0-alpha" }
+fedimintd = { path = "./fedimintd", version = "=0.11.0-alpha" }
+fedimintd-envs = { path = "./fedimintd-envs", version = "=0.11.0-alpha" }
 ff = "0.13.1"
 fs-lock = "=0.1.10"
 fs2 = "0.4.3"
@@ -235,7 +235,7 @@ gloo-timers = "0.3.0"
 group = "0.13.0"
 hex = "0.4.3"
 hex-conservative = "0.3.0"
-hkdf = { package = "fedimint-hkdf", path = "./crypto/hkdf", version = "=0.10.0-alpha" }
+hkdf = { package = "fedimint-hkdf", path = "./crypto/hkdf", version = "=0.11.0-alpha" }
 honggfuzz = { version = "=0.5.55", default-features = false } # needs to be pinned to the same version `cargo-fuzz` binary uses
 hyper = "1.6"
 imbl = "5.0.0"
@@ -308,7 +308,7 @@ substring = "1.4.5"
 subtle = "2.6.1"
 syn = "2.0"
 tar = "0.4.44"
-tbs = { package = "fedimint-tbs", path = "./crypto/tbs", version = "=0.10.0-alpha" }
+tbs = { package = "fedimint-tbs", path = "./crypto/tbs", version = "=0.11.0-alpha" }
 tempfile = "3.20.0"
 test-log = { version = "0.2", features = ["trace"], default-features = false }
 thiserror = "2.0.12"
@@ -327,7 +327,7 @@ tonic_lnd = { version = "0.3.0", package = "fedimint-tonic-lnd", features = [
 ] }
 tower = { version = "0.4.13", default-features = false }
 tower-http = { version = "0.6.6", features = ["cors"] }
-tpe = { package = "fedimint-tpe", path = "./crypto/tpe", version = "=0.10.0-alpha" }
+tpe = { package = "fedimint-tpe", path = "./crypto/tpe", version = "=0.11.0-alpha" }
 tracing = "0.1.41"
 tracing-opentelemetry = "0.29.0"
 tracing-subscriber = "0.3.20"


### PR DESCRIPTION
Working towards https://github.com/fedimint/fedimint/issues/8018

We started the `v0.10.0` release process so we can bump master to `v0.11.0-alpha`.