### PR TITLE
chore: bump version to v0.10.0-rc.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2297,7 +2297,7 @@ dependencies = [
 
 [[package]]
 name = "devimint"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "axum 0.8.7",
@@ -2730,7 +2730,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fedimint-aead"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "argon2",
@@ -2762,7 +2762,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-api-client"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2787,7 +2787,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-bip39"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "bip39",
  "fedimint-client",
@@ -2798,7 +2798,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-bitcoind"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2812,14 +2812,14 @@ dependencies = [
 
 [[package]]
 name = "fedimint-build"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "fedimint-cli"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2859,7 +2859,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2889,7 +2889,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client-module"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -2919,7 +2919,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client-rpc"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2946,7 +2946,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client-uniffi"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "fedimint-build",
@@ -2964,7 +2964,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client-wasm"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2982,7 +2982,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-connectors"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "arti-client",
@@ -3016,7 +3016,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-core"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3081,7 +3081,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-cursed-redb"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3100,7 +3100,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-db-locked"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3112,7 +3112,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dbtool"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3147,7 +3147,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-derive"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
@@ -3157,7 +3157,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-derive-secret"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "bitcoin_hashes 0.14.0",
@@ -3169,11 +3169,11 @@ dependencies = [
 
 [[package]]
 name = "fedimint-docs"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 
 [[package]]
 name = "fedimint-dummy-client"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3193,7 +3193,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dummy-common"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -3203,7 +3203,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dummy-server"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3219,7 +3219,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dummy-tests"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "fedimint-client",
@@ -3240,7 +3240,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-empty-client"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3257,7 +3257,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-empty-common"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -3267,7 +3267,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-empty-server"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3283,7 +3283,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-eventlog"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3301,7 +3301,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-fountain"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3313,7 +3313,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-fuzz"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "fedimint-core",
  "fedimint-ln-common",
@@ -3326,7 +3326,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-client"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "bcrypt",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-common"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -3370,7 +3370,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-server"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3446,7 +3446,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-server-db"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -3474,7 +3474,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-ui"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "async-trait",
  "axum 0.8.7",
@@ -3501,7 +3501,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gw-client"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3531,7 +3531,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gwv2-client"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3558,7 +3558,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-hkdf"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "bitcoin_hashes 0.14.0",
 ]
@@ -3606,7 +3606,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lightning"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3632,7 +3632,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-client"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3666,7 +3666,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-common"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3689,7 +3689,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-server"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3714,7 +3714,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-tests"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3743,7 +3743,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-client"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3774,7 +3774,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-common"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3795,7 +3795,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-server"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3819,7 +3819,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-tests"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3853,7 +3853,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-load-test-tool"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3881,7 +3881,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-logging"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "console-subscriber",
@@ -3893,7 +3893,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-client"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3914,7 +3914,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-common"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -3928,7 +3928,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-server"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3947,7 +3947,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-tests"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3961,7 +3961,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-metrics"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "axum 0.8.7",
@@ -3973,7 +3973,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-client"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -4014,7 +4014,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-common"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "bitcoin_hashes 0.14.0",
@@ -4027,7 +4027,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-server"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4054,7 +4054,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-tests"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4088,7 +4088,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-portalloc"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -4102,7 +4102,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-recoverytool"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -4125,7 +4125,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-recurringd"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "axum 0.8.7",
@@ -4158,7 +4158,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-recurringd-tests"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "devimint",
@@ -4171,7 +4171,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-recurringdv2"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "axum 0.8.7",
@@ -4193,7 +4193,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-rocksdb"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4210,7 +4210,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -4264,7 +4264,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server-bitcoin-rpc"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4279,7 +4279,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server-core"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4297,7 +4297,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server-tests"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "bitcoin",
  "fedimint-api-client",
@@ -4317,7 +4317,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server-ui"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4341,7 +4341,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-tbs"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "bls12_381",
  "criterion",
@@ -4356,7 +4356,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-testing"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4395,7 +4395,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-testing-core"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -4456,7 +4456,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-tpe"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "bitcoin_hashes 0.14.0",
  "bls12_381",
@@ -4470,7 +4470,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ui-common"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "axum 0.8.7",
  "axum-extra",
@@ -4481,7 +4481,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-unknown-common"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -4491,7 +4491,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-unknown-server"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4505,14 +4505,14 @@ dependencies = [
 
 [[package]]
 name = "fedimint-util-error"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "fedimint-wallet-client"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -4542,7 +4542,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-common"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-server"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4585,7 +4585,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-tests"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4618,7 +4618,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wasm-tests"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "fedimint-client",
@@ -4639,7 +4639,7 @@ dependencies = [
 
 [[package]]
 name = "fedimintd"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -4673,7 +4673,7 @@ dependencies = [
 
 [[package]]
 name = "fedimintd-envs"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 
 [[package]]
 name = "ff"
@@ -4990,7 +4990,7 @@ dependencies = [
 
 [[package]]
 name = "gateway-tests"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -6893,7 +6893,7 @@ dependencies = [
 
 [[package]]
 name = "lnurlp"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ keywords = ["bitcoin", "lightning", "chaumian", "e-cash", "federated"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/fedimint/fedimint"
-version = "0.10.0-beta.4"
+version = "0.10.0-rc.0"
 
 [workspace.metadata]
 authors = ["The Fedimint Developers"]
@@ -157,7 +157,7 @@ criterion = "0.5.1"
 # We need to pin this arti's `curve25519-dalek` dependency, due to `https://rustsec.org/advisories/RUSTSEC-2024-0344` vulnerability
 # It's been updated by https://gitlab.torproject.org/tpo/core/arti/-/merge_requests/2211, should be removed in next release.
 curve25519-dalek = ">=4.1.3"
-devimint = { path = "./devimint", version = "=0.10.0-beta.4" }
+devimint = { path = "./devimint", version = "=0.10.0-rc.0" }
 dirs = "6.0.0"
 erased-serde = "0.4"
 esplora-client = { version = "0.12.0", default-features = false, features = [
@@ -167,63 +167,63 @@ esplora-client = { version = "0.12.0", default-features = false, features = [
 ] }
 tor-rtcompat = { version = "0.33.0" }
 
-fedimint-aead = { path = "./crypto/aead", version = "=0.10.0-beta.4" }
-fedimint-api-client = { path = "./fedimint-api-client", version = "=0.10.0-beta.4" }
-fedimint-bip39 = { path = "./fedimint-bip39", version = "=0.10.0-beta.4" }
-fedimint-bitcoind = { path = "./fedimint-bitcoind", version = "=0.10.0-beta.4" }
-fedimint-build = { path = "./fedimint-build", version = "=0.10.0-beta.4" }
-fedimint-client = { path = "./fedimint-client", version = "=0.10.0-beta.4" }
-fedimint-client-module = { path = "./fedimint-client-module", version = "=0.10.0-beta.4" }
-fedimint-client-rpc = { path = "./fedimint-client-rpc", version = "=0.10.0-beta.4" }
-fedimint-connectors = { path = "./fedimint-connectors", version = "=0.10.0-beta.4" }
-fedimint-core = { path = "./fedimint-core", version = "=0.10.0-beta.4" }
-fedimint-cursed-redb = { path = "./fedimint-cursed-redb", version = "=0.10.0-beta.4" }
-fedimint-db-locked = { path = "./fedimint-db-locked", version = "=0.10.0-beta.4" }
-fedimint-derive = { path = "./fedimint-derive", version = "=0.10.0-beta.4" }
-fedimint-derive-secret = { path = "./crypto/derive-secret", version = "=0.10.0-beta.4" }
-fedimint-dummy-client = { path = "./modules/fedimint-dummy-client", version = "=0.10.0-beta.4" }
-fedimint-dummy-common = { path = "./modules/fedimint-dummy-common", version = "=0.10.0-beta.4" }
-fedimint-dummy-server = { path = "./modules/fedimint-dummy-server", version = "=0.10.0-beta.4" }
-fedimint-empty-common = { path = "./modules/fedimint-empty-common", version = "=0.10.0-beta.4" }
-fedimint-eventlog = { path = "./fedimint-eventlog", version = "=0.10.0-beta.4" }
-fedimint-gateway-common = { package = "fedimint-gateway-common", path = "./gateway/fedimint-gateway-common", version = "=0.10.0-beta.4" }
-fedimint-gateway-server = { package = "fedimint-gateway-server", path = "./gateway/fedimint-gateway-server", version = "=0.10.0-beta.4" }
-fedimint-gateway-server-db = { package = "fedimint-gateway-server-db", path = "./gateway/fedimint-gateway-server-db", version = "=0.10.0-beta.4" }
-fedimint-gateway-ui = { package = "fedimint-gateway-ui", path = "./gateway/fedimint-gateway-ui", version = "=0.10.0-beta.4" }
-fedimint-gw-client = { path = "./modules/fedimint-gw-client", version = "=0.10.0-beta.4" }
-fedimint-gwv2-client = { path = "./modules/fedimint-gwv2-client", version = "=0.10.0-beta.4" }
-fedimint-lightning = { package = "fedimint-lightning", path = "./gateway/fedimint-lightning", version = "=0.10.0-beta.4" }
-fedimint-ln-client = { path = "./modules/fedimint-ln-client", version = "=0.10.0-beta.4" }
-fedimint-ln-common = { path = "./modules/fedimint-ln-common", version = "=0.10.0-beta.4" }
-fedimint-ln-server = { path = "./modules/fedimint-ln-server", version = "=0.10.0-beta.4" }
-fedimint-lnv2-client = { path = "./modules/fedimint-lnv2-client", version = "=0.10.0-beta.4" }
-fedimint-lnv2-common = { path = "./modules/fedimint-lnv2-common", version = "=0.10.0-beta.4" }
-fedimint-lnv2-server = { path = "./modules/fedimint-lnv2-server", version = "=0.10.0-beta.4" }
-fedimint-logging = { path = "./fedimint-logging", version = "=0.10.0-beta.4" }
-fedimint-meta-client = { path = "./modules/fedimint-meta-client", version = "=0.10.0-beta.4" }
-fedimint-meta-common = { path = "./modules/fedimint-meta-common", version = "=0.10.0-beta.4" }
-fedimint-meta-server = { path = "./modules/fedimint-meta-server", version = "=0.10.0-beta.4" }
-fedimint-metrics = { path = "./fedimint-metrics", version = "=0.10.0-beta.4" }
-fedimint-mint-client = { path = "./modules/fedimint-mint-client", version = "=0.10.0-beta.4" }
-fedimint-mint-common = { path = "./modules/fedimint-mint-common", version = "=0.10.0-beta.4" }
-fedimint-mint-server = { path = "./modules/fedimint-mint-server", version = "=0.10.0-beta.4" }
-fedimint-portalloc = { path = "utils/portalloc", version = "=0.10.0-beta.4" }
-fedimint-rocksdb = { path = "./fedimint-rocksdb", version = "=0.10.0-beta.4" }
-fedimint-server = { path = "./fedimint-server", version = "=0.10.0-beta.4" }
-fedimint-server-bitcoin-rpc = { path = "./fedimint-server-bitcoin-rpc", version = "=0.10.0-beta.4" }
-fedimint-server-core = { path = "./fedimint-server-core", version = "=0.10.0-beta.4" }
-fedimint-server-ui = { path = "./fedimint-server-ui", version = "=0.10.0-beta.4" }
-fedimint-testing = { path = "./fedimint-testing", version = "=0.10.0-beta.4" }
-fedimint-testing-core = { path = "./fedimint-testing-core", version = "=0.10.0-beta.4" }
-fedimint-ui-common = { path = "./fedimint-ui-common", version = "=0.10.0-beta.4" }
-fedimint-unknown-common = { path = "./modules/fedimint-unknown-common", version = "=0.10.0-beta.4" }
-fedimint-unknown-server = { path = "./modules/fedimint-unknown-server", version = "=0.10.0-beta.4" }
-fedimint-util-error = { path = "./fedimint-util-error", version = "=0.10.0-beta.4" }
-fedimint-wallet-client = { path = "./modules/fedimint-wallet-client", version = "=0.10.0-beta.4" }
-fedimint-wallet-common = { path = "./modules/fedimint-wallet-common", version = "=0.10.0-beta.4" }
-fedimint-wallet-server = { path = "./modules/fedimint-wallet-server", version = "=0.10.0-beta.4" }
-fedimintd = { path = "./fedimintd", version = "=0.10.0-beta.4" }
-fedimintd-envs = { path = "./fedimintd-envs", version = "=0.10.0-beta.4" }
+fedimint-aead = { path = "./crypto/aead", version = "=0.10.0-rc.0" }
+fedimint-api-client = { path = "./fedimint-api-client", version = "=0.10.0-rc.0" }
+fedimint-bip39 = { path = "./fedimint-bip39", version = "=0.10.0-rc.0" }
+fedimint-bitcoind = { path = "./fedimint-bitcoind", version = "=0.10.0-rc.0" }
+fedimint-build = { path = "./fedimint-build", version = "=0.10.0-rc.0" }
+fedimint-client = { path = "./fedimint-client", version = "=0.10.0-rc.0" }
+fedimint-client-module = { path = "./fedimint-client-module", version = "=0.10.0-rc.0" }
+fedimint-client-rpc = { path = "./fedimint-client-rpc", version = "=0.10.0-rc.0" }
+fedimint-connectors = { path = "./fedimint-connectors", version = "=0.10.0-rc.0" }
+fedimint-core = { path = "./fedimint-core", version = "=0.10.0-rc.0" }
+fedimint-cursed-redb = { path = "./fedimint-cursed-redb", version = "=0.10.0-rc.0" }
+fedimint-db-locked = { path = "./fedimint-db-locked", version = "=0.10.0-rc.0" }
+fedimint-derive = { path = "./fedimint-derive", version = "=0.10.0-rc.0" }
+fedimint-derive-secret = { path = "./crypto/derive-secret", version = "=0.10.0-rc.0" }
+fedimint-dummy-client = { path = "./modules/fedimint-dummy-client", version = "=0.10.0-rc.0" }
+fedimint-dummy-common = { path = "./modules/fedimint-dummy-common", version = "=0.10.0-rc.0" }
+fedimint-dummy-server = { path = "./modules/fedimint-dummy-server", version = "=0.10.0-rc.0" }
+fedimint-empty-common = { path = "./modules/fedimint-empty-common", version = "=0.10.0-rc.0" }
+fedimint-eventlog = { path = "./fedimint-eventlog", version = "=0.10.0-rc.0" }
+fedimint-gateway-common = { package = "fedimint-gateway-common", path = "./gateway/fedimint-gateway-common", version = "=0.10.0-rc.0" }
+fedimint-gateway-server = { package = "fedimint-gateway-server", path = "./gateway/fedimint-gateway-server", version = "=0.10.0-rc.0" }
+fedimint-gateway-server-db = { package = "fedimint-gateway-server-db", path = "./gateway/fedimint-gateway-server-db", version = "=0.10.0-rc.0" }
+fedimint-gateway-ui = { package = "fedimint-gateway-ui", path = "./gateway/fedimint-gateway-ui", version = "=0.10.0-rc.0" }
+fedimint-gw-client = { path = "./modules/fedimint-gw-client", version = "=0.10.0-rc.0" }
+fedimint-gwv2-client = { path = "./modules/fedimint-gwv2-client", version = "=0.10.0-rc.0" }
+fedimint-lightning = { package = "fedimint-lightning", path = "./gateway/fedimint-lightning", version = "=0.10.0-rc.0" }
+fedimint-ln-client = { path = "./modules/fedimint-ln-client", version = "=0.10.0-rc.0" }
+fedimint-ln-common = { path = "./modules/fedimint-ln-common", version = "=0.10.0-rc.0" }
+fedimint-ln-server = { path = "./modules/fedimint-ln-server", version = "=0.10.0-rc.0" }
+fedimint-lnv2-client = { path = "./modules/fedimint-lnv2-client", version = "=0.10.0-rc.0" }
+fedimint-lnv2-common = { path = "./modules/fedimint-lnv2-common", version = "=0.10.0-rc.0" }
+fedimint-lnv2-server = { path = "./modules/fedimint-lnv2-server", version = "=0.10.0-rc.0" }
+fedimint-logging = { path = "./fedimint-logging", version = "=0.10.0-rc.0" }
+fedimint-meta-client = { path = "./modules/fedimint-meta-client", version = "=0.10.0-rc.0" }
+fedimint-meta-common = { path = "./modules/fedimint-meta-common", version = "=0.10.0-rc.0" }
+fedimint-meta-server = { path = "./modules/fedimint-meta-server", version = "=0.10.0-rc.0" }
+fedimint-metrics = { path = "./fedimint-metrics", version = "=0.10.0-rc.0" }
+fedimint-mint-client = { path = "./modules/fedimint-mint-client", version = "=0.10.0-rc.0" }
+fedimint-mint-common = { path = "./modules/fedimint-mint-common", version = "=0.10.0-rc.0" }
+fedimint-mint-server = { path = "./modules/fedimint-mint-server", version = "=0.10.0-rc.0" }
+fedimint-portalloc = { path = "utils/portalloc", version = "=0.10.0-rc.0" }
+fedimint-rocksdb = { path = "./fedimint-rocksdb", version = "=0.10.0-rc.0" }
+fedimint-server = { path = "./fedimint-server", version = "=0.10.0-rc.0" }
+fedimint-server-bitcoin-rpc = { path = "./fedimint-server-bitcoin-rpc", version = "=0.10.0-rc.0" }
+fedimint-server-core = { path = "./fedimint-server-core", version = "=0.10.0-rc.0" }
+fedimint-server-ui = { path = "./fedimint-server-ui", version = "=0.10.0-rc.0" }
+fedimint-testing = { path = "./fedimint-testing", version = "=0.10.0-rc.0" }
+fedimint-testing-core = { path = "./fedimint-testing-core", version = "=0.10.0-rc.0" }
+fedimint-ui-common = { path = "./fedimint-ui-common", version = "=0.10.0-rc.0" }
+fedimint-unknown-common = { path = "./modules/fedimint-unknown-common", version = "=0.10.0-rc.0" }
+fedimint-unknown-server = { path = "./modules/fedimint-unknown-server", version = "=0.10.0-rc.0" }
+fedimint-util-error = { path = "./fedimint-util-error", version = "=0.10.0-rc.0" }
+fedimint-wallet-client = { path = "./modules/fedimint-wallet-client", version = "=0.10.0-rc.0" }
+fedimint-wallet-common = { path = "./modules/fedimint-wallet-common", version = "=0.10.0-rc.0" }
+fedimint-wallet-server = { path = "./modules/fedimint-wallet-server", version = "=0.10.0-rc.0" }
+fedimintd = { path = "./fedimintd", version = "=0.10.0-rc.0" }
+fedimintd-envs = { path = "./fedimintd-envs", version = "=0.10.0-rc.0" }
 ff = "0.13.1"
 fs-lock = "=0.1.10"
 fs2 = "0.4.3"
@@ -235,7 +235,7 @@ gloo-timers = "0.3.0"
 group = "0.13.0"
 hex = "0.4.3"
 hex-conservative = "0.3.0"
-hkdf = { package = "fedimint-hkdf", path = "./crypto/hkdf", version = "=0.10.0-beta.4" }
+hkdf = { package = "fedimint-hkdf", path = "./crypto/hkdf", version = "=0.10.0-rc.0" }
 honggfuzz = { version = "=0.5.55", default-features = false } # needs to be pinned to the same version `cargo-fuzz` binary uses
 hyper = "1.6"
 imbl = "5.0.0"
@@ -307,7 +307,7 @@ substring = "1.4.5"
 subtle = "2.6.1"
 syn = "2.0"
 tar = "0.4.44"
-tbs = { package = "fedimint-tbs", path = "./crypto/tbs", version = "=0.10.0-beta.4" }
+tbs = { package = "fedimint-tbs", path = "./crypto/tbs", version = "=0.10.0-rc.0" }
 tempfile = "3.20.0"
 test-log = { version = "0.2", features = ["trace"], default-features = false }
 thiserror = "2.0.12"
@@ -326,7 +326,7 @@ tonic_lnd = { version = "0.3.0", package = "fedimint-tonic-lnd", features = [
 ] }
 tower = { version = "0.4.13", default-features = false }
 tower-http = { version = "0.6.6", features = ["cors"] }
-tpe = { package = "fedimint-tpe", path = "./crypto/tpe", version = "=0.10.0-beta.4" }
+tpe = { package = "fedimint-tpe", path = "./crypto/tpe", version = "=0.10.0-rc.0" }
 tracing = "0.1.41"
 tracing-opentelemetry = "0.24.0"
 tracing-subscriber = "0.3.20"


### PR DESCRIPTION
Working towards https://github.com/fedimint/fedimint/issues/8018

The recurringdv2 image successfully published to docker hub
https://github.com/fedimint/fedimint/actions/runs/21004049712

We'll spend more time on the gateway ui in the release candidates, but nothing blocks us from moving forward and making backwards-compatibility guarantees.