### PR TITLE
Fix honggfuzz overlay typo

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -386,7 +386,7 @@
                   with pkgs;
                   commonShellArgs.nativeBuildInputs
                   ++ [
-                    cargo-hongfuzz
+                    cargo-honggfuzz
                     lldb
                     clang
                   ];

--- a/nix/overlays/cargo-honggfuzz.nix
+++ b/nix/overlays/cargo-honggfuzz.nix
@@ -1,3 +1,3 @@
 final: prev: {
-  cargo-hongfuzz = prev.callPackage ../pkgs/cargo-honggfuzz.nix { };
+  cargo-honggfuzz = prev.callPackage ../pkgs/cargo-honggfuzz.nix { };
 }


### PR DESCRIPTION
I'm not totally sure if this is the root of any of the honggfuzz errors on fuzzing with honggfuzz in nix but this is a bit confusing even if it doesn't cause errors.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
