### PR TITLE
fix(gateway-ui): remove sync badge and block height from bitcoin card

### DIFF
--- a/fedimint-testing/src/fixtures.rs
+++ b/fedimint-testing/src/fixtures.rs
@@ -254,9 +254,6 @@ impl Fixtures {
             env::var(FM_PORT_ESPLORA_ENV).unwrap_or(String::from("50002"))
         ))
         .expect("Failed to parse default esplora server");
-        let bitcoin_rpc = fedimint_bitcoind::EsploraClient::new(&esplora_server_url)
-            .expect("Could not create EsploraClient")
-            .into_dyn();
         let esplora_chain_source = ChainSource::Esplora {
             server_url: esplora_server_url,
         };
@@ -285,7 +282,6 @@ impl Fixtures {
             fedimint_gateway_server::GatewayState::Running { lightning_context },
             esplora_chain_source,
             None,
-            bitcoin_rpc,
         )
         .await
         .expect("Failed to create gateway")

--- a/gateway/fedimint-gateway-ui/src/bitcoin.rs
+++ b/gateway/fedimint-gateway-ui/src/bitcoin.rs
@@ -10,23 +10,7 @@ where
     E: std::fmt::Display,
 {
     debug!(target: LOG_GATEWAY_UI, "Getting bitcoin chain source...");
-    let (blockchain_info, chain_source, network) = api.get_chain_source().await;
-
-    // Determine block height and synced status
-    let (block_height, status_badge) = match blockchain_info {
-        Some(info) => {
-            let badge = if info.synced {
-                html! { span class="badge bg-success" { "🟢 Synced" } }
-            } else {
-                html! { span class="badge bg-warning" { "🟡 Syncing" } }
-            };
-            (info.block_height, badge)
-        }
-        None => (
-            0,
-            html! { span class="badge bg-danger" { "❌ Not Connected" } },
-        ),
-    };
+    let (chain_source, network) = api.get_chain_source().await;
 
     html! {
         div class="card h-100" {
@@ -51,14 +35,6 @@ where
                         tr {
                             th { "Network" }
                             td { (network) }
-                        }
-                        tr {
-                            th { "Block Height" }
-                            td { (block_height) }
-                        }
-                        tr {
-                            th { "Status" }
-                            td { (status_badge) }
                         }
 
                         @match &chain_source {

--- a/gateway/fedimint-gateway-ui/src/lib.rs
+++ b/gateway/fedimint-gateway-ui/src/lib.rs
@@ -17,7 +17,6 @@ use axum::routing::{get, post};
 use axum::{Form, Router};
 use axum_extra::extract::CookieJar;
 use axum_extra::extract::cookie::{Cookie, SameSite};
-use fedimint_bitcoind::BlockchainInfo;
 use fedimint_core::bitcoin::Network;
 use fedimint_core::secp256k1::serde::Deserialize;
 use fedimint_core::task::TaskGroup;
@@ -198,7 +197,7 @@ pub trait IAdminGateway {
 
     fn gatewayd_version(&self) -> String;
 
-    async fn get_chain_source(&self) -> (Option<BlockchainInfo>, ChainSource, Network);
+    async fn get_chain_source(&self) -> (ChainSource, Network);
 
     fn lightning_mode(&self) -> LightningMode;
 }


### PR DESCRIPTION
It turns out it is very common for the `get_height` RPC to an esplora server to get rate limited. And using the esplora client dependency that we have, when it doesn't succeed, it ends up hanging because it is retrying.

This isn't ideal for the UI, because it looks like it won't load. Ultimately this information isn't that relevant (the more interesting sync status is the Lightning node). So I think the best course of action is just to remove.

This way, the UI doesn't ever hang. Refreshing the UI is always fast.

<img width="1338" height="329" alt="image" src="https://github.com/user-attachments/assets/ea716b0e-7793-4b77-a559-bc4dca4c859d" />
