### PR TITLE
feat(ui): add checkbox for recovery when joining federation

### DIFF
--- a/gateway/fedimint-gateway-ui/src/connect_fed.rs
+++ b/gateway/fedimint-gateway-ui/src/connect_fed.rs
@@ -15,7 +15,12 @@ pub fn render() -> Markup {
         div class="card h-100" {
             div class="card-header dashboard-header" { "Connect a new Federation" }
             div class="card-body" {
-                form method="post" action=(CONNECT_FEDERATION_ROUTE) {
+                form method="post" action=(CONNECT_FEDERATION_ROUTE)
+                    onsubmit="var btn = this.querySelector('button[type=submit]'); \
+                              var isRecover = this.querySelector('#recover-checkbox').checked; \
+                              btn.disabled = true; \
+                              btn.innerHTML = '<span class=\"spinner-border spinner-border-sm\" role=\"status\"></span> ' + (isRecover ? 'Recovering...' : 'Connecting...');"
+                {
                     div class="mb-3" {
                         label class="form-label" { "Invite Code" }
                         input type="text" class="form-control" name="invite_code" required;


### PR DESCRIPTION
Builds on: https://github.com/fedimint/fedimint/pull/8174

Adds a checkbox to the form to join a federation. This allows users to recover after they've manually entered their mnemonic.

<img width="2689" height="310" alt="image" src="https://github.com/user-attachments/assets/f0325a0e-60ca-4afd-8e9c-51142b03d4e8" />
