### PR TITLE
fix: Only sync wallets in devimint

### DIFF
--- a/gateway/fedimint-lightning/src/ldk.rs
+++ b/gateway/fedimint-lightning/src/ldk.rs
@@ -16,7 +16,6 @@ use fedimint_gateway_common::{
 };
 use fedimint_ln_common::contracts::Preimage;
 use fedimint_logging::LOG_LIGHTNING;
-use ldk_node::config::{BackgroundSyncConfig, EsploraSyncConfig};
 use ldk_node::lightning::ln::msgs::SocketAddress;
 use ldk_node::lightning::routing::gossip::NodeAlias;
 use ldk_node::payment::{PaymentDirection, PaymentKind, PaymentStatus, SendingParameters};
@@ -129,16 +128,7 @@ impl GatewayLdkClient {
                 );
             }
             ChainSource::Esplora { server_url } => {
-                node_builder.set_chain_source_esplora(
-                    get_esplora_url(server_url)?,
-                    Some(EsploraSyncConfig {
-                        background_sync_config: Some(BackgroundSyncConfig {
-                            onchain_wallet_sync_interval_secs: 30,
-                            lightning_wallet_sync_interval_secs: 30,
-                            fee_rate_cache_update_interval_secs: 30,
-                        }),
-                    }),
-                );
+                node_builder.set_chain_source_esplora(get_esplora_url(server_url)?, None);
             }
         };
         let Some(data_dir_str) = data_dir.to_str() else {


### PR DESCRIPTION
https://github.com/fedimint/fedimint/pull/8083 introduced an explicit RPC call to sync the wallet (only relevant for LDK). It turns on that we're not setting the background sync config for Esplora in LDK, so this `sync_wallet` call was required. But bitcoind does background syncing automatically, so its not required when running in bitcoind mode: https://docs.rs/ldk-node/0.7.0/ldk_node/struct.Node.html#method.sync_wallets

I think the best configuration is to call `sync_wallet` when in devimint (which is what we did before https://github.com/fedimint/fedimint/pull/8083) so that the sync doesn't need to wait for the background process in devimint. But it should be fine to rely on it in production.