### PR TITLE
refactor: re-export common modules from server and client crates

### DIFF
--- a/modules/fedimint-dummy-server/src/lib.rs
+++ b/modules/fedimint-dummy-server/src/lib.rs
@@ -20,6 +20,7 @@ use fedimint_core::module::{
     ModuleConsensusVersion, ModuleInit, SupportedModuleApiVersions, TransactionItemAmounts,
 };
 use fedimint_core::{Amount, InPoint, OutPoint, PeerId, push_db_pair_items};
+pub use fedimint_dummy_common as common;
 use fedimint_dummy_common::config::{
     DummyClientConfig, DummyConfig, DummyConfigConsensus, DummyConfigPrivate,
 };

--- a/modules/fedimint-empty-server/src/lib.rs
+++ b/modules/fedimint-empty-server/src/lib.rs
@@ -18,6 +18,7 @@ use fedimint_core::module::{
     ModuleInit, SupportedModuleApiVersions, TransactionItemAmounts,
 };
 use fedimint_core::{InPoint, OutPoint, PeerId, push_db_pair_items};
+pub use fedimint_empty_common as common;
 use fedimint_empty_common::config::{
     EmptyClientConfig, EmptyConfig, EmptyConfigConsensus, EmptyConfigPrivate,
 };

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -6,6 +6,8 @@
 #![allow(clippy::must_use_candidate)]
 #![allow(clippy::too_many_lines)]
 
+pub use fedimint_ln_common as common;
+
 pub mod api;
 #[cfg(feature = "cli")]
 pub mod cli;

--- a/modules/fedimint-lnv2-client/src/lib.rs
+++ b/modules/fedimint-lnv2-client/src/lib.rs
@@ -4,6 +4,8 @@
 #![allow(clippy::module_name_repetitions)]
 #![allow(clippy::must_use_candidate)]
 
+pub use fedimint_lnv2_common as common;
+
 mod api;
 #[cfg(feature = "cli")]
 mod cli;

--- a/modules/fedimint-lnv2-server/src/lib.rs
+++ b/modules/fedimint-lnv2-server/src/lib.rs
@@ -2,6 +2,8 @@
 #![allow(clippy::cast_possible_wrap)]
 #![allow(clippy::module_name_repetitions)]
 
+pub use fedimint_lnv2_common as common;
+
 mod db;
 
 use std::collections::{BTreeMap, BTreeSet};

--- a/modules/fedimint-meta-server/src/lib.rs
+++ b/modules/fedimint-meta-server/src/lib.rs
@@ -3,6 +3,8 @@
 #![allow(clippy::missing_panics_doc)]
 #![allow(clippy::missing_errors_doc)]
 
+pub use fedimint_meta_common as common;
+
 pub mod db;
 
 use std::collections::BTreeMap;

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -64,6 +64,7 @@ use fedimint_core::{
 };
 use fedimint_derive_secret::{ChildId, DerivableSecret};
 use fedimint_logging::LOG_CLIENT_MODULE_WALLET;
+pub use fedimint_wallet_common as common;
 use fedimint_wallet_common::config::{FeeConsensus, WalletClientConfig};
 use fedimint_wallet_common::tweakable::Tweakable;
 pub use fedimint_wallet_common::*;


### PR DESCRIPTION
Server and client modules should re-export their common module publicly, so consumers don't need to depend on both server+common or client+common separately.

Added `pub use fedimint_*_common as common;` to:
- fedimint-dummy-server
- fedimint-empty-server
- fedimint-lnv2-server
- fedimint-meta-server
- fedimint-ln-client
- fedimint-lnv2-client
- fedimint-wallet-client (also kept the glob re-export)

Closes #4518

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
