### PR TITLE
chore(startos): bump to v0.10.0

### DIFF
--- a/fedimint-startos/Dockerfile
+++ b/fedimint-startos/Dockerfile
@@ -11,7 +11,7 @@ RUN case "$TARGETARCH" in \
     chmod +x /tmp/yq
 
 # Stage 2: Main image
-FROM fedimint/fedimintd:v0.9.1
+FROM fedimint/fedimintd:v0.10.0
 
 # Copy yq from downloader stage
 COPY --from=downloader /tmp/yq /usr/local/bin/yq

--- a/fedimint-startos/manifest.yaml
+++ b/fedimint-startos/manifest.yaml
@@ -1,8 +1,8 @@
 id: fedimintd
 title: "Fedimint"
-version: 0.9.1
+version: 0.10.0
 release-notes: |
-  Read more about the release [here](https://github.com/fedimint/fedimint/releases/tag/v0.9.1)
+  Read more about the release [here](https://github.com/fedimint/fedimint/releases/tag/v0.10.0)
 license: MIT
 wrapper-repo: "https://github.com/fedimint/fedimint/tree/master/fedimint-startos"
 upstream-repo: "https://github.com/fedimint/fedimint"

--- a/fedimint-startos/scripts/procedures/migrations.ts
+++ b/fedimint-startos/scripts/procedures/migrations.ts
@@ -24,5 +24,5 @@ export const migration: T.ExpectedExports.migration = compat.migrations.fromMapp
       ),
     },
   },
-  "0.9.1"
+  "0.10.0"
 );


### PR DESCRIPTION
Followup to https://github.com/fedimint/fedimint/issues/8018

`v0.10.0` is released so we can upgrade the Start9 package.