### PR TITLE
chore: set RUST_LIB_BACKTRACE=1

### DIFF
--- a/devimint/src/util.rs
+++ b/devimint/src/util.rs
@@ -443,6 +443,7 @@ macro_rules! cmd {
                 $(.arg(&$arg))*
                 .kill_on_drop(true)
                 .env("RUST_BACKTRACE", "1")
+                .env("RUST_LIB_BACKTRACE", "0")
         }
     };
 }

--- a/nix/flakebox.nix
+++ b/nix/flakebox.nix
@@ -634,7 +634,7 @@ in
         ''
         + lib.concatStringsSep "\n" (
           lib.replicate times ''
-            env RUST_BACKTRACE=1 RUST_LOG=info cargo nextest run --locked --workspace --all-targets --cargo-profile $CARGO_PROFILE --profile nix-ccov --test-threads=$(($(nproc) * 2))
+            env RUST_BACKTRACE=1 RUST_LIB_BACKTRACE=0 RUST_LOG=info cargo nextest run --locked --workspace --all-targets --cargo-profile $CARGO_PROFILE --profile nix-ccov --test-threads=$(($(nproc) * 2))
           ''
         )
         + ''

--- a/nix/modules/fedimintd.nix
+++ b/nix/modules/fedimintd.nix
@@ -38,10 +38,12 @@ let
           description = "Extra Environment variables to pass to the fedimintd.";
           default = {
             RUST_BACKTRACE = "1";
+            RUST_LIB_BACKTRACE = "0";
           };
           example = {
             RUST_LOG = "info,fm=debug";
             RUST_BACKTRACE = "1";
+            RUST_LIB_BACKTRACE = "0";
           };
         };
 

--- a/scripts/dev/devimint-env.sh
+++ b/scripts/dev/devimint-env.sh
@@ -16,6 +16,7 @@ function devimint_env {
 
   export RUST_LOG=info
   export RUST_BACKTRACE=1
+  export RUST_LIB_BACKTRACE=0
 
   # For starship users, we can actually make the prompt distinct so there's
   # no confusion.

--- a/scripts/tests/backend-test.sh
+++ b/scripts/tests/backend-test.sh
@@ -16,6 +16,7 @@ function run_tests() {
 
   export FM_TEST_USE_REAL_DAEMONS=1
   export RUST_BACKTRACE=1
+  export RUST_LIB_BACKTRACE=0
   TEST_ARGS="${TEST_ARGS:-}"
   TEST_ARGS_SERIALIZED="${TEST_ARGS:-$TEST_ARGS --test-threads=1}"
   TEST_ARGS_THREADED="${TEST_ARGS:-$TEST_ARGS --test-threads=$(($(nproc) * 2))}"


### PR DESCRIPTION
I've been investigating huge memory usage in CI when running tests.

Turns out it is caused by anyhow capturing and caching backtrace resolution when RUST_BACKTRACE=1 .

<img width="3750" height="1906" alt="Screenshot From 2026-01-22 10-44-50" src="https://github.com/user-attachments/assets/83656308-02cd-4148-9d66-abe7b0c338c3" />

Related article going into the problem:

https://www.qovery.com/blog/rust-investigating-a-strange-out-of-memory-error

Setting RUST_LIB_BACKTRACE=1 along with RUST_BACKTRACE=1 will make only panics capture backtraces, which more or less what we actually want.

Now gatewayd's that I was able to observe at 1.6G are all under 200M.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
