### PR TITLE
chore: remove database savepoints

### DIFF
--- a/fedimint-core/src/db/mem_impl/tests.rs
+++ b/fedimint-core/src/db/mem_impl/tests.rs
@@ -57,11 +57,6 @@ async fn test_dbtx_prevent_nonrepeatable_reads() {
 }
 
 #[test_log::test(tokio::test)]
-async fn test_dbtx_rollback_to_savepoint() {
-    fedimint_core::db::verify_rollback_to_savepoint(database()).await;
-}
-
-#[test_log::test(tokio::test)]
 async fn test_dbtx_phantom_entry() {
     fedimint_core::db::verify_phantom_entry(database()).await;
 }

--- a/fedimint-cursed-redb/src/lib.rs
+++ b/fedimint-cursed-redb/src/lib.rs
@@ -194,16 +194,7 @@ impl<'a> IDatabaseTransactionOpsCore for MemAndRedbTransaction<'a> {
     }
 }
 
-#[apply(async_trait_maybe_send!)]
-impl<'a> IDatabaseTransactionOps for MemAndRedbTransaction<'a> {
-    async fn rollback_tx_to_savepoint(&mut self) -> DatabaseResult<()> {
-        unimplemented!()
-    }
-
-    async fn set_tx_savepoint(&mut self) -> DatabaseResult<()> {
-        unimplemented!()
-    }
-}
+impl<'a> IDatabaseTransactionOps for MemAndRedbTransaction<'a> {}
 
 // In-memory database transaction should only be used for test code and never
 // for production as it doesn't properly implement MVCC


### PR DESCRIPTION
## Summary
- Remove unused savepoint functionality from the database layer
- Savepoints were not being used anywhere in the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)