### PR TITLE
chore(client): deprecate client-side backup functionality

### DIFF
--- a/fedimint-cli/src/client.rs
+++ b/fedimint-cli/src/client.rs
@@ -165,6 +165,9 @@ pub enum ClientCmd {
         address: bitcoin::Address<NetworkUnchecked>,
     },
     /// Upload the (encrypted) snapshot of mint notes to federation
+    ///
+    /// DEPRECATED: Backups are no longer used. TODO: Remove in 0.13.0
+    #[clap(hide = true)]
     Backup {
         #[clap(long = "metadata")]
         /// Backup metadata, encoded as `key=value` (use `--metadata=key=value`,

--- a/fedimint-client-module/src/module/mod.rs
+++ b/fedimint-client-module/src/module/mod.rs
@@ -748,6 +748,9 @@ pub trait ClientModule: Debug + MaybeSend + MaybeSync + 'static {
 
     /// Data stored in regular backups so that restoring doesn't have to start
     /// from epoch 0
+    ///
+    /// TODO: Remove in 0.13.0
+    #[deprecated(since = "0.11.0", note = "Will be removed in 0.13.0")]
     type Backup: ModuleBackup;
 
     /// Data and API clients available to state machine transitions of this
@@ -825,10 +828,14 @@ pub trait ClientModule: Debug + MaybeSend + MaybeSync + 'static {
         output: &<Self::Common as ModuleCommon>::Output,
     ) -> Option<Amounts>;
 
+    /// TODO: Remove in 0.13.0
+    #[deprecated(since = "0.11.0", note = "Will be removed in 0.13.0")]
     fn supports_backup(&self) -> bool {
         false
     }
 
+    /// TODO: Remove in 0.13.0
+    #[deprecated(since = "0.11.0", note = "Will be removed in 0.13.0")]
     async fn backup(&self) -> anyhow::Result<Self::Backup> {
         anyhow::bail!("Backup not supported");
     }

--- a/fedimint-client-module/src/module/recovery.rs
+++ b/fedimint-client-module/src/module/recovery.rs
@@ -11,6 +11,8 @@ use fedimint_core::{
 };
 use serde::{Deserialize, Serialize};
 
+/// TODO: Remove in 0.13.0
+#[deprecated(since = "0.11.0", note = "Will be removed in 0.13.0")]
 pub trait IModuleBackup: Debug + DynEncodable {
     fn as_any(&self) -> &(maybe_add_send_sync!(dyn Any));
     fn module_kind(&self) -> Option<ModuleKind>;
@@ -18,6 +20,8 @@ pub trait IModuleBackup: Debug + DynEncodable {
     fn erased_eq_no_instance_id(&self, other: &DynModuleBackup) -> bool;
 }
 
+/// TODO: Remove in 0.13.0
+#[deprecated(since = "0.11.0", note = "Will be removed in 0.13.0")]
 pub trait ModuleBackup:
     std::fmt::Debug
     + IntoDynInstance<DynType = DynModuleBackup>
@@ -32,6 +36,8 @@ pub trait ModuleBackup:
     const KIND: Option<ModuleKind>;
 }
 
+// TODO: Remove in 0.13.0
+#[allow(deprecated)]
 impl IModuleBackup for ::fedimint_core::core::DynUnknown {
     fn as_any(&self) -> &(maybe_add_send_sync!(dyn Any)) {
         self
@@ -55,6 +61,8 @@ impl IModuleBackup for ::fedimint_core::core::DynUnknown {
     }
 }
 
+// TODO: Remove in 0.13.0
+#[allow(deprecated)]
 impl<T> IModuleBackup for T
 where
     T: ModuleBackup,
@@ -81,19 +89,26 @@ where
     }
 }
 
+// TODO: Remove in 0.13.0
 module_plugin_dyn_newtype_define! {
     pub DynModuleBackup(Box<IModuleBackup>)
 }
 
+// TODO: Remove in 0.13.0
 module_plugin_dyn_newtype_encode_decode!(DynModuleBackup);
 
+// TODO: Remove in 0.13.0
 module_plugin_dyn_newtype_clone_passthrough!(DynModuleBackup);
 
+// TODO: Remove in 0.13.0
 module_plugin_dyn_newtype_eq_passthrough!(DynModuleBackup);
 
 /// A backup type for modules without a backup implementation. The default
 /// variant allows implementing a backup strategy for the module later on by
 /// copying this enum into the module and adding a second variant to it.
+///
+/// TODO: Remove in 0.13.0
+#[deprecated(since = "0.11.0", note = "Will be removed in 0.13.0")]
 #[derive(Clone, PartialEq, Eq, Debug, Encodable, Decodable)]
 pub enum NoModuleBackup {
     NoModuleBackup,
@@ -104,10 +119,14 @@ pub enum NoModuleBackup {
     },
 }
 
+// TODO: Remove in 0.13.0
+#[allow(deprecated)]
 impl ModuleBackup for NoModuleBackup {
     const KIND: Option<ModuleKind> = None;
 }
 
+// TODO: Remove in 0.13.0
+#[allow(deprecated)]
 impl IntoDynInstance for NoModuleBackup {
     type DynType = DynModuleBackup;
 

--- a/fedimint-client/src/backup.rs
+++ b/fedimint-client/src/backup.rs
@@ -29,6 +29,9 @@ use crate::secret::DeriveableSecretClientExt;
 ///
 /// A backup can have a blob of extra data encoded in it. We provide methods to
 /// use json encoding, but clients are free to use their own encoding.
+///
+/// TODO: Remove in 0.13.0
+#[deprecated(since = "0.11.0", note = "Will be removed in 0.13.0")]
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Encodable, Decodable, Clone)]
 pub struct Metadata(Vec<u8>);
 
@@ -68,6 +71,9 @@ impl Metadata {
 }
 
 /// Client state backup
+///
+/// TODO: Remove in 0.13.0
+#[deprecated(since = "0.11.0", note = "Will be removed in 0.13.0")]
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ClientBackup {
     /// Session count taken right before taking the backup
@@ -217,6 +223,9 @@ impl ClientBackup {
 }
 
 /// Encrypted version of [`ClientBackup`].
+///
+/// TODO: Remove in 0.13.0
+#[deprecated(since = "0.11.0", note = "Will be removed in 0.13.0")]
 #[derive(Clone)]
 pub struct EncryptedClientBackup(Vec<u8>);
 
@@ -269,8 +278,13 @@ impl Event for EventBackupDone {
     const PERSISTENCE: EventPersistence = EventPersistence::Persistent;
 }
 
+/// TODO: Remove in 0.13.0
+#[allow(deprecated)]
 impl Client {
     /// Create a backup, include provided `metadata`
+    ///
+    /// TODO: Remove in 0.13.0
+    #[deprecated(since = "0.11.0", note = "Will be removed in 0.13.0")]
     pub async fn create_backup(&self, metadata: Metadata) -> anyhow::Result<ClientBackup> {
         let session_count = self.api.session_count().await?;
         let mut modules = BTreeMap::new();
@@ -305,6 +319,9 @@ impl Client {
     }
 
     /// Prepare an encrypted backup and send it to federation for storing
+    ///
+    /// TODO: Remove in 0.13.0
+    #[deprecated(since = "0.11.0", note = "Will be removed in 0.13.0")]
     pub async fn backup_to_federation(&self, metadata: Metadata) -> Result<()> {
         ensure!(
             !self.has_pending_recoveries(),
@@ -330,6 +347,9 @@ impl Client {
     }
 
     /// Validate backup before sending it to federation
+    ///
+    /// TODO: Remove in 0.13.0
+    #[deprecated(since = "0.11.0", note = "Will be removed in 0.13.0")]
     pub fn validate_backup(&self, backup: &EncryptedClientBackup) -> Result<()> {
         if BACKUP_REQUEST_MAX_PAYLOAD_SIZE_BYTES < backup.len() {
             bail!("Backup payload too large");
@@ -338,6 +358,9 @@ impl Client {
     }
 
     /// Upload `backup` to federation
+    ///
+    /// TODO: Remove in 0.13.0
+    #[deprecated(since = "0.11.0", note = "Will be removed in 0.13.0")]
     pub async fn upload_backup(&self, backup: &EncryptedClientBackup) -> Result<()> {
         self.validate_backup(backup)?;
         let size = backup.len();
@@ -356,6 +379,8 @@ impl Client {
         Ok(())
     }
 
+    /// TODO: Remove in 0.13.0
+    #[deprecated(since = "0.11.0", note = "Will be removed in 0.13.0")]
     pub async fn download_backup_from_federation(&self) -> Result<Option<ClientBackup>> {
         Self::download_backup_from_federation_static(
             &self.api,
@@ -366,6 +391,9 @@ impl Client {
     }
 
     /// Download most recent valid backup found from the Federation
+    ///
+    /// TODO: Remove in 0.13.0
+    #[deprecated(since = "0.11.0", note = "Will be removed in 0.13.0")]
     pub async fn download_backup_from_federation_static(
         api: &DynGlobalApi,
         root_secret: &DerivableSecret,
@@ -406,10 +434,15 @@ impl Client {
 
     /// Backup id derived from the root secret key (public key used to self-sign
     /// backup requests)
+    ///
+    /// TODO: Remove in 0.13.0
+    #[deprecated(since = "0.11.0", note = "Will be removed in 0.13.0")]
     pub fn get_backup_id(&self) -> PublicKey {
         self.get_derived_backup_signing_key().public_key()
     }
 
+    /// TODO: Remove in 0.13.0
+    #[deprecated(since = "0.11.0", note = "Will be removed in 0.13.0")]
     pub fn get_backup_id_static(root_secret: &DerivableSecret) -> PublicKey {
         Self::get_derived_backup_signing_key_static(root_secret).public_key()
     }

--- a/gateway/fedimint-gateway-common/src/lib.rs
+++ b/gateway/fedimint-gateway-common/src/lib.rs
@@ -29,6 +29,8 @@ pub const V1_API_ENDPOINT: &str = "v1";
 
 pub const ADDRESS_ENDPOINT: &str = "/address";
 pub const ADDRESS_RECHECK_ENDPOINT: &str = "/address_recheck";
+/// TODO: Remove in 0.13.0
+#[deprecated(since = "0.11.0", note = "Will be removed in 0.13.0")]
 pub const BACKUP_ENDPOINT: &str = "/backup";
 pub const CONFIGURATION_ENDPOINT: &str = "/config";
 pub const CONNECT_FED_ENDPOINT: &str = "/connect_fed";
@@ -70,6 +72,8 @@ pub struct LeaveFedPayload {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct InfoPayload;
 
+/// TODO: Remove in 0.13.0
+#[deprecated(since = "0.11.0", note = "Will be removed in 0.13.0")]
 #[derive(Debug, Serialize, Deserialize)]
 pub struct BackupPayload {
     pub federation_id: FederationId,
@@ -156,6 +160,8 @@ pub struct FederationInfo {
     pub federation_name: Option<String>,
     pub balance_msat: Amount,
     pub config: FederationConfig,
+    /// TODO: Remove in 0.13.0
+    #[deprecated(since = "0.11.0", note = "Will be removed in 0.13.0")]
     pub last_backup_time: Option<SystemTime>,
 }
 

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -650,6 +650,10 @@ impl Gateway {
 
     /// Spawns a background task that checks every `BACKUP_UPDATE_INTERVAL` to
     /// see if any federations need to be backed up.
+    ///
+    /// TODO: Remove in 0.13.0
+    #[deprecated(since = "0.11.0", note = "Will be removed in 0.13.0")]
+    #[allow(deprecated)]
     fn spawn_backup_task(&self) {
         let self_copy = self.clone();
         self.task_group
@@ -671,6 +675,10 @@ impl Gateway {
     /// Loops through all federations and checks their last save backup time. If
     /// the last saved backup time is past the threshold time, backup the
     /// federation.
+    ///
+    /// TODO: Remove in 0.13.0
+    #[deprecated(since = "0.11.0", note = "Will be removed in 0.13.0")]
+    #[allow(deprecated)]
     pub async fn backup_all_federations(&self, dbtx: &mut DatabaseTransaction<'_, Committable>) {
         /// How long the federation manager should wait to backup the ecash for
         /// each federation
@@ -1155,6 +1163,10 @@ impl Gateway {
 
     /// Handles a request for the gateway to backup a connected federation's
     /// ecash.
+    ///
+    /// TODO: Remove in 0.13.0
+    #[deprecated(since = "0.11.0", note = "Will be removed in 0.13.0")]
+    #[allow(deprecated)]
     pub async fn handle_backup_msg(
         &self,
         BackupPayload { federation_id }: BackupPayload,

--- a/modules/fedimint-mint-client/src/backup.rs
+++ b/modules/fedimint-mint-client/src/backup.rs
@@ -1,3 +1,5 @@
+// TODO: Remove entire backup module in 0.13.0
+#[allow(deprecated)]
 use fedimint_client_module::module::recovery::{DynModuleBackup, ModuleBackup};
 use fedimint_core::core::{IntoDynInstance, ModuleInstanceId, ModuleKind};
 use fedimint_core::db::DatabaseTransaction;
@@ -12,6 +14,8 @@ use crate::{MintClientStateMachines, NoteIndex, SpendableNote};
 
 pub mod recovery;
 
+/// TODO: Remove in 0.13.0
+#[deprecated(since = "0.11.0", note = "Will be removed in 0.13.0")]
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Debug, Encodable, Decodable)]
 pub enum EcashBackup {
     V0(EcashBackupV0),
@@ -42,6 +46,9 @@ impl EcashBackup {
 ///
 /// Used to speed up and improve privacy of ecash recovery,
 /// by avoiding scanning the whole history.
+///
+/// TODO: Remove in 0.13.0
+#[deprecated(since = "0.11.0", note = "Will be removed in 0.13.0")]
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Debug, Encodable, Decodable)]
 pub struct EcashBackupV0 {
     spendable_notes: TieredMulti<SpendableNote>,
@@ -75,6 +82,8 @@ impl IntoDynInstance for EcashBackup {
 }
 
 impl MintClientModule {
+    /// TODO: Remove in 0.13.0
+    #[deprecated(since = "0.11.0", note = "Will be removed in 0.13.0")]
     pub async fn prepare_plaintext_ecash_backup(
         &self,
         dbtx: &mut DatabaseTransaction<'_>,

--- a/modules/fedimint-wallet-client/src/backup.rs
+++ b/modules/fedimint-wallet-client/src/backup.rs
@@ -1,3 +1,5 @@
+// TODO: Remove backup types in 0.13.0
+#[allow(deprecated)]
 mod recovery_history_tracker;
 
 use std::collections::{BTreeMap, BTreeSet};
@@ -27,6 +29,8 @@ use crate::client_db::{
 };
 use crate::{WalletClientInit, WalletClientModule, WalletClientModuleData};
 
+/// TODO: Remove in 0.13.0
+#[deprecated(since = "0.11.0", note = "Will be removed in 0.13.0")]
 #[derive(Clone, PartialEq, Eq, Debug, Encodable, Decodable)]
 pub enum WalletModuleBackup {
     V0(WalletModuleBackupV0),
@@ -51,6 +55,8 @@ impl ModuleBackup for WalletModuleBackup {
 }
 
 impl WalletModuleBackup {
+    /// TODO: Remove in 0.13.0
+    #[deprecated(since = "0.11.0", note = "Will be removed in 0.13.0")]
     pub fn new_v1(
         session_count: u64,
         next_tweak_idx: TweakIdx,
@@ -64,12 +70,16 @@ impl WalletModuleBackup {
     }
 }
 
+/// TODO: Remove in 0.13.0
+#[deprecated(since = "0.11.0", note = "Will be removed in 0.13.0")]
 #[derive(Clone, PartialEq, Eq, Debug, Encodable, Decodable)]
 pub struct WalletModuleBackupV0 {
     pub session_count: u64,
     pub next_tweak_idx: TweakIdx,
 }
 
+/// TODO: Remove in 0.13.0
+#[deprecated(since = "0.11.0", note = "Will be removed in 0.13.0")]
 #[derive(Clone, PartialEq, Eq, Debug, Encodable, Decodable)]
 pub struct WalletModuleBackupV1 {
     pub session_count: u64,


### PR DESCRIPTION
## Summary
- Deprecate client-side backup functionality (to be removed in 0.13.0)
- Mark all backup-related types and methods with `#[deprecated]` attributes
- Hide CLI backup command

Since both mint and wallet modules now use slice-based recovery and no longer need backup snapshots, the backup functionality is deprecated but kept for backwards compatibility.

### Deprecated items:
- `ClientBackup`, `Metadata`, `EncryptedClientBackup` types
- `backup_to_federation()`, `create_backup()`, `upload_backup()` methods
- `download_backup_from_federation()` methods
- `ModuleBackup` trait and associated types (`IModuleBackup`, `DynModuleBackup`, `NoModuleBackup`)
- `EcashBackup`, `EcashBackupV0` types
- `WalletModuleBackup` types and `new_v1()` method
- `ClientModule::Backup` associated type
- `ClientModule::supports_backup()` and `backup()` methods
- Gateway backup endpoints and methods
- CLI backup command (hidden)

Depends on #8113

🤖 Generated with [Claude Code](https://claude.com/claude-code)