### PR TITLE
feat: enable guardians to announce expiration

### DIFF
--- a/fedimint-api-client/src/api/global_api/with_cache.rs
+++ b/fedimint-api-client/src/api/global_api/with_cache.rs
@@ -6,7 +6,9 @@ use std::sync::Arc;
 use anyhow::{anyhow, format_err};
 use bitcoin::secp256k1;
 use fedimint_connectors::ServerResult;
-use fedimint_core::admin_client::{GuardianConfigBackup, SetLocalParamsRequest, SetupStatus};
+use fedimint_core::admin_client::{
+    ExpirationStatus, GuardianConfigBackup, SetLocalParamsRequest, SetupStatus,
+};
 use fedimint_core::backup::{BackupStatistics, ClientBackupSnapshot};
 use fedimint_core::core::backup::SignedBackupRequest;
 use fedimint_core::core::{ModuleInstanceId, ModuleKind};
@@ -14,11 +16,11 @@ use fedimint_core::endpoint_constants::{
     ADD_PEER_SETUP_CODE_ENDPOINT, API_ANNOUNCEMENTS_ENDPOINT, AUDIT_ENDPOINT, AUTH_ENDPOINT,
     AWAIT_SESSION_OUTCOME_ENDPOINT, AWAIT_TRANSACTION_ENDPOINT, BACKUP_ENDPOINT,
     BACKUP_STATISTICS_ENDPOINT, CHAIN_ID_ENDPOINT, CHANGE_PASSWORD_ENDPOINT,
-    FEDIMINTD_VERSION_ENDPOINT, GET_SETUP_CODE_ENDPOINT, GUARDIAN_CONFIG_BACKUP_ENDPOINT,
-    GUARDIAN_METADATA_ENDPOINT, INVITE_CODE_ENDPOINT, RECOVER_ENDPOINT,
-    RESET_PEER_SETUP_CODES_ENDPOINT, RESTART_FEDERATION_SETUP_ENDPOINT, SESSION_COUNT_ENDPOINT,
-    SESSION_STATUS_ENDPOINT, SESSION_STATUS_V2_ENDPOINT, SET_LOCAL_PARAMS_ENDPOINT,
-    SET_PASSWORD_ENDPOINT, SETUP_STATUS_ENDPOINT, SHUTDOWN_ENDPOINT,
+    EXPIRATION_STATUS_ENDPOINT, FEDIMINTD_VERSION_ENDPOINT, GET_SETUP_CODE_ENDPOINT,
+    GUARDIAN_CONFIG_BACKUP_ENDPOINT, GUARDIAN_METADATA_ENDPOINT, INVITE_CODE_ENDPOINT,
+    RECOVER_ENDPOINT, RESET_PEER_SETUP_CODES_ENDPOINT, RESTART_FEDERATION_SETUP_ENDPOINT,
+    SESSION_COUNT_ENDPOINT, SESSION_STATUS_ENDPOINT, SESSION_STATUS_V2_ENDPOINT,
+    SET_LOCAL_PARAMS_ENDPOINT, SET_PASSWORD_ENDPOINT, SETUP_STATUS_ENDPOINT, SHUTDOWN_ENDPOINT,
     SIGN_API_ANNOUNCEMENT_ENDPOINT, SIGN_GUARDIAN_METADATA_ENDPOINT, START_DKG_ENDPOINT,
     STATUS_ENDPOINT, SUBMIT_API_ANNOUNCEMENT_ENDPOINT, SUBMIT_GUARDIAN_METADATA_ENDPOINT,
     SUBMIT_TRANSACTION_ENDPOINT,
@@ -648,5 +650,13 @@ where
     async fn chain_id(&self) -> FederationResult<ChainId> {
         self.request_current_consensus(CHAIN_ID_ENDPOINT.to_owned(), ApiRequestErased::default())
             .await
+    }
+
+    async fn expiration_status(&self) -> FederationResult<Option<ExpirationStatus>> {
+        self.request_current_consensus(
+            EXPIRATION_STATUS_ENDPOINT.to_owned(),
+            ApiRequestErased::default(),
+        )
+        .await
     }
 }

--- a/fedimint-api-client/src/api/mod.rs
+++ b/fedimint-api-client/src/api/mod.rs
@@ -16,7 +16,9 @@ pub use fedimint_connectors::error::ServerError;
 use fedimint_connectors::{
     ConnectionPool, ConnectorRegistry, DynGuaridianConnection, IGuardianConnection,
 };
-use fedimint_core::admin_client::{GuardianConfigBackup, ServerStatusLegacy, SetupStatus};
+use fedimint_core::admin_client::{
+    ExpirationStatus, GuardianConfigBackup, ServerStatusLegacy, SetupStatus,
+};
 use fedimint_core::backup::{BackupStatistics, ClientBackupSnapshot};
 use fedimint_core::core::backup::SignedBackupRequest;
 use fedimint_core::core::{Decoder, DynOutputOutcome, ModuleInstanceId, ModuleKind, OutputOutcome};
@@ -589,6 +591,14 @@ pub trait IGlobalFederationApi: IRawFederationApi {
     /// Returns the chain ID (bitcoin block hash at height 1) from the
     /// federation
     async fn chain_id(&self) -> FederationResult<ChainId>;
+
+    /// Fetch the federation's expiration status with threshold
+    /// consensus verification.
+    ///
+    /// Returns `Some(announcement)` if the federation has announced
+    /// expiration and a threshold of guardians agree. Returns `None` if
+    /// no expiration has been announced.
+    async fn expiration_status(&self) -> FederationResult<Option<ExpirationStatus>>;
 }
 
 pub fn deserialize_outcome<R>(

--- a/fedimint-client/src/client.rs
+++ b/fedimint-client/src/client.rs
@@ -34,6 +34,7 @@ use fedimint_client_module::{
     ModuleRecoveryCompleted, TransactionUpdates, TxCreatedEvent,
 };
 use fedimint_connectors::ConnectorRegistry;
+use fedimint_core::admin_client::ExpirationStatus;
 use fedimint_core::config::{
     ClientConfig, FederationId, GlobalClientConfig, JsonClientConfig, ModuleInitRegistry,
 };
@@ -207,6 +208,19 @@ impl Client {
 
     pub fn api_clone(&self) -> DynGlobalApi {
         self.api.clone()
+    }
+
+    /// Get the expiration status from local DB cache.
+    ///
+    /// This is a fast, non-blocking read from the local database. The value
+    /// is refreshed daily by a background task. Returns `None` if no
+    /// expiration has been set or if the cache hasn't been populated yet.
+    pub async fn expiration_status(&self) -> Option<ExpirationStatus> {
+        self.db()
+            .begin_transaction_nc()
+            .await
+            .get_value(&crate::db::ExpirationStatusKey)
+            .await
     }
 
     /// Returns a stream that emits the current connection status of all peers

--- a/fedimint-client/src/client/builder.rs
+++ b/fedimint-client/src/client/builder.rs
@@ -63,6 +63,7 @@ use crate::db::{
     ClientModuleRecoveryState, ClientPreRootSecretHashKey, InitMode, InitState,
     PendingClientConfigKey, apply_migrations_client_module_dbtx,
 };
+use crate::expiration::run_expiration_status_task;
 use crate::guardian_metadata::run_guardian_metadata_refresh_task;
 use crate::meta::MetaService;
 use crate::module_init::ClientModuleInitRegistry;
@@ -1048,6 +1049,19 @@ impl ClientBuilder {
                         .wait_for_initialized_connections()
                         .await;
                     run_guardian_metadata_refresh_task(client_inner.clone()).await
+                }
+            });
+
+        client_inner
+            .task_group
+            .spawn_cancellable("update-expiration-status", {
+                let client_inner = client_inner.clone();
+                async move {
+                    client_inner
+                        .connectors
+                        .wait_for_initialized_connections()
+                        .await;
+                    run_expiration_status_task(client_inner.clone()).await
                 }
             });
 

--- a/fedimint-client/src/db.rs
+++ b/fedimint-client/src/db.rs
@@ -61,6 +61,7 @@ pub enum DbKeyPrefix {
     ChainId = 0x3c,
     ClientModuleRecovery = 0x40,
     GuardianMetadata = 0x42,
+    ExpirationStatus = 0x43,
 
     DatabaseVersion = fedimint_core::db::DbKeyPrefix::DatabaseVersion as u8,
     ClientBackup = fedimint_core::db::DbKeyPrefix::ClientBackup as u8,
@@ -468,6 +469,15 @@ impl_db_record!(
 );
 
 impl_db_lookup!(key = MetaFieldKey, query_prefix = MetaFieldPrefix);
+
+#[derive(Clone, Debug, Encodable, Decodable)]
+pub struct ExpirationStatusKey;
+
+impl_db_record!(
+    key = ExpirationStatusKey,
+    value = fedimint_core::admin_client::ExpirationStatus,
+    db_prefix = DbKeyPrefix::ExpirationStatus,
+);
 
 pub fn get_core_client_database_migrations()
 -> BTreeMap<DatabaseVersion, fedimint_core::db::ClientCoreDbMigrationFn> {

--- a/fedimint-client/src/expiration.rs
+++ b/fedimint-client/src/expiration.rs
@@ -1,0 +1,41 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use fedimint_core::db::IDatabaseTransactionOpsCoreTyped;
+use fedimint_core::runtime::sleep;
+use fedimint_core::util::FmtCompact as _;
+use fedimint_logging::LOG_CLIENT;
+use tracing::debug;
+
+use crate::Client;
+use crate::db::ExpirationStatusKey;
+
+pub(crate) async fn run_expiration_status_task(client: Arc<Client>) {
+    loop {
+        match client.api.expiration_status().await {
+            Ok(status) => {
+                let mut dbtx = client.db().begin_transaction().await;
+
+                match status {
+                    Some(s) => {
+                        dbtx.insert_entry(&ExpirationStatusKey, &s).await;
+                    }
+                    None => {
+                        dbtx.remove_entry(&ExpirationStatusKey).await;
+                    }
+                }
+
+                dbtx.commit_tx().await;
+            }
+            Err(err) => {
+                debug!(
+                    target: LOG_CLIENT,
+                    err = %err.fmt_compact(),
+                    "Failed to fetch expiration status"
+                );
+            }
+        }
+
+        sleep(Duration::from_secs(86400)).await; // Check once a day
+    }
+}

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -81,6 +81,9 @@ mod api_announcements;
 /// Guardian metadata handling
 mod guardian_metadata;
 
+/// Expiration status handling
+mod expiration;
+
 /// Core [`Client`]
 mod client;
 

--- a/fedimint-core/src/admin_client.rs
+++ b/fedimint-core/src/admin_client.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::core::ModuleKind;
 use crate::encoding::{Decodable, Encodable};
+use crate::invite_code::InviteCode;
 
 /// The state of the server returned via APIs
 #[derive(Debug, Clone, Default, Serialize, Deserialize, Eq, PartialEq, Encodable, Decodable)]
@@ -60,4 +61,14 @@ pub struct SetLocalParamsRequest {
 pub struct GuardianConfigBackup {
     #[serde(with = "crate::hex::serde")]
     pub tar_archive_bytes: Vec<u8>,
+}
+
+/// Status indicating that a federation is expiring, with a target date
+/// and optional successor federation invite code for users to migrate to.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Encodable, Decodable)]
+pub struct ExpirationStatus {
+    /// Expiration date as a unix timestamp (midnight UTC)
+    pub date: u64,
+    /// Optional invite code for the successor federation
+    pub successor: Option<InviteCode>,
 }

--- a/fedimint-core/src/endpoint_constants.rs
+++ b/fedimint-core/src/endpoint_constants.rs
@@ -42,3 +42,4 @@ pub const SIGN_GUARDIAN_METADATA_ENDPOINT: &str = "sign_guardian_metadata";
 pub const FEDIMINTD_VERSION_ENDPOINT: &str = "fedimintd_version";
 pub const CHANGE_PASSWORD_ENDPOINT: &str = "change_password";
 pub const CHAIN_ID_ENDPOINT: &str = "chain_id";
+pub const EXPIRATION_STATUS_ENDPOINT: &str = "expiration_status";

--- a/fedimint-dbtool/src/dump.rs
+++ b/fedimint-dbtool/src/dump.rs
@@ -320,7 +320,8 @@ impl DatabaseDump {
             server_db::DbKeyPrefix::Module
             | server_db::DbKeyPrefix::ServerInfo
             | server_db::DbKeyPrefix::DatabaseVersion
-            | server_db::DbKeyPrefix::ClientBackup => {}
+            | server_db::DbKeyPrefix::ClientBackup
+            | server_db::DbKeyPrefix::ExpirationStatus => {}
             server_db::DbKeyPrefix::ApiAnnouncements => {
                 push_db_pair_items_no_serde!(
                     dbtx,

--- a/fedimint-server-core/src/dashboard_ui.rs
+++ b/fedimint-server-core/src/dashboard_ui.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use fedimint_core::admin_client::GuardianConfigBackup;
+use fedimint_core::admin_client::{ExpirationStatus, GuardianConfigBackup};
 use fedimint_core::bitcoin::Network;
 use fedimint_core::core::ModuleKind;
 use fedimint_core::module::ApiAuth;
@@ -98,6 +98,12 @@ pub trait IDashboardApi {
         current_password: &str,
         guardian_auth: &GuardianAuthToken,
     ) -> Result<(), String>;
+
+    /// Get the current expiration status, if set
+    async fn expiration_status(&self) -> Option<ExpirationStatus>;
+
+    /// Set or clear the expiration status
+    async fn set_expiration_status(&self, status: Option<ExpirationStatus>);
 
     /// Create a trait object
     fn into_dyn(self) -> DynDashboardApi

--- a/fedimint-server-tests/tests/migration.rs
+++ b/fedimint-server-tests/tests/migration.rs
@@ -210,7 +210,8 @@ async fn test_server_db_migrations() -> anyhow::Result<()> {
                     DbKeyPrefix::Module
                     | DbKeyPrefix::ServerInfo
                     | DbKeyPrefix::DatabaseVersion
-                    | DbKeyPrefix::ClientBackup => {}
+                    | DbKeyPrefix::ClientBackup
+                    | DbKeyPrefix::ExpirationStatus => {}
                     DbKeyPrefix::ApiAnnouncements => {
                         let announcements = dbtx
                             .find_by_prefix(&ApiAnnouncementPrefix)

--- a/fedimint-server-ui/src/dashboard/backup.rs
+++ b/fedimint-server-ui/src/dashboard/backup.rs
@@ -1,0 +1,49 @@
+use axum::body::Body;
+use axum::extract::State;
+use axum::http::header;
+use axum::response::{IntoResponse, Response};
+use fedimint_server_core::dashboard_ui::DynDashboardApi;
+use fedimint_ui_common::UiState;
+use fedimint_ui_common::auth::UserAuth;
+use maud::{Markup, html};
+
+use crate::DOWNLOAD_BACKUP_ROUTE;
+
+pub fn render() -> Markup {
+    html! {
+        div class="card h-100" {
+            div class="card-header dashboard-header" { "Guardian Configuration Backup" }
+            div class="card-body" {
+                div class="alert alert-warning" {
+                    "This is a static backup, you only need to download it once. You can use it to restore your guardian if your server fails. Store this file securely since anyone with it and your password can run your guardian node."
+                }
+                a href=(DOWNLOAD_BACKUP_ROUTE) class="btn btn-primary" {
+                    "Download Guardian Backup"
+                }
+            }
+        }
+    }
+}
+
+pub async fn download(
+    State(state): State<UiState<DynDashboardApi>>,
+    user_auth: UserAuth,
+) -> impl IntoResponse {
+    let api_auth = state.api.auth().await;
+
+    let backup = state
+        .api
+        .download_guardian_config_backup(&api_auth.0, &user_auth.guardian_auth_token)
+        .await;
+
+    let filename = "guardian-backup.tar";
+
+    Response::builder()
+        .header(header::CONTENT_TYPE, "application/x-tar")
+        .header(
+            header::CONTENT_DISPOSITION,
+            format!("attachment; filename=\"{filename}\""),
+        )
+        .body(Body::from(backup.tar_archive_bytes))
+        .expect("Failed to build response")
+}

--- a/fedimint-server-ui/src/dashboard/expiration.rs
+++ b/fedimint-server-ui/src/dashboard/expiration.rs
@@ -1,0 +1,128 @@
+use axum::extract::{Form, State};
+use axum::response::{Html, IntoResponse, Redirect};
+use chrono::{Datelike, Months, Utc};
+use fedimint_core::admin_client::ExpirationStatus;
+use fedimint_core::invite_code::InviteCode;
+use fedimint_server_core::dashboard_ui::DynDashboardApi;
+use fedimint_ui_common::auth::UserAuth;
+use fedimint_ui_common::{ROOT_ROUTE, UiState, dashboard_layout};
+use maud::{Markup, html};
+use serde::Deserialize;
+
+use crate::{CLEAR_EXPIRATION_ROUTE, SET_EXPIRATION_ROUTE};
+
+#[derive(Debug, Deserialize)]
+pub struct ExpirationForm {
+    pub expiration_date: String,
+    pub successor_invite_code: Option<String>,
+}
+
+pub fn render(status: Option<&ExpirationStatus>) -> Markup {
+    html! {
+        div class="card h-100" {
+            div class="card-header dashboard-header" { "Federation Expiration" }
+            div class="card-body" {
+                @if let Some(status) = status {
+                    div class="alert alert-info" {
+                        strong { "Expiration Announced" }
+                        @if let Some(date) = chrono::DateTime::from_timestamp(status.date as i64, 0) {
+                            strong { " - " (date.format("%B %-d, %Y")) }
+                        }
+                        @if let Some(ref successor) = status.successor {
+                            p class="mb-0 mt-2" { (successor.to_string()) }
+                        }
+                    }
+                    form method="post" action=(CLEAR_EXPIRATION_ROUTE) {
+                        button type="submit" class="btn btn-primary" {
+                            "Clear Expiration Announcement"
+                        }
+                    }
+                } @else {
+                    div class="alert alert-warning" {
+                        "All guardians have to enter the exact same values for an expiration status."
+                    }
+                    form method="post" action=(SET_EXPIRATION_ROUTE) {
+                        div class="form-group mb-3" {
+                            select class="form-select" id="expiration_date" name="expiration_date" required {
+                                option value="" selected disabled { "Select Expiration Date" }
+                                @let now = Utc::now();
+                                @for i in 1..=12u32 {
+                                    @let last_day = now.date_naive()
+                                        .with_day(1).expect("day 1 is always valid")
+                                        .checked_add_months(Months::new(i + 1))
+                                        .expect("adding months to current date can't overflow")
+                                        .pred_opt()
+                                        .expect("predecessor of first of month is always valid");
+                                    @let timestamp = last_day
+                                        .and_hms_opt(0, 0, 0).expect("midnight is always valid")
+                                        .and_utc()
+                                        .timestamp();
+                                    option value=(timestamp) {
+                                        (last_day.format("%B %-d, %Y"))
+                                    }
+                                }
+                            }
+                        }
+                        div class="form-group mb-3" {
+                            input
+                                type="text"
+                                class="form-control"
+                                id="successor_invite_code"
+                                name="successor_invite_code"
+                                placeholder="Enter Optional Invite Code";
+                        }
+                        button type="submit" class="btn btn-primary" {
+                            "Announce Expiration"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+pub async fn post_set_expiration(
+    State(state): State<UiState<DynDashboardApi>>,
+    _auth: UserAuth,
+    Form(form): Form<ExpirationForm>,
+) -> impl IntoResponse {
+    let date = form
+        .expiration_date
+        .parse::<u64>()
+        .expect("date values are generated server-side");
+
+    let invite_input = form.successor_invite_code.filter(|s| !s.trim().is_empty());
+
+    let successor = match &invite_input {
+        Some(s) => match s.parse::<InviteCode>() {
+            Ok(code) => Some(code),
+            Err(_) => {
+                let content = html! {
+                    div class="alert alert-danger" { "Invalid invite code format" }
+                    div class="button-container" {
+                        a href="/" class="btn btn-primary" { "Return to Dashboard" }
+                    }
+                };
+                return Html(dashboard_layout(content, "Invalid Invite Code", None).into_string())
+                    .into_response();
+            }
+        },
+        None => None,
+    };
+
+    state
+        .api
+        .set_expiration_status(Some(ExpirationStatus { date, successor }))
+        .await;
+
+    Redirect::to(ROOT_ROUTE).into_response()
+}
+
+pub async fn post_clear_expiration(
+    State(state): State<UiState<DynDashboardApi>>,
+    _auth: UserAuth,
+) -> impl IntoResponse {
+    state.api.set_expiration_status(None).await;
+
+    Redirect::to(ROOT_ROUTE)
+}

--- a/fedimint-server-ui/src/lib.rs
+++ b/fedimint-server-ui/src/lib.rs
@@ -16,6 +16,8 @@ pub const EXPLORER_ROUTE: &str = "/explorer/{session_idx}";
 pub const DOWNLOAD_BACKUP_ROUTE: &str = "/download-backup";
 pub const CHANGE_PASSWORD_ROUTE: &str = "/change-password";
 pub const METRICS_ROUTE: &str = "/metrics";
+pub const SET_EXPIRATION_ROUTE: &str = "/set-expiration";
+pub const CLEAR_EXPIRATION_ROUTE: &str = "/clear-expiration";
 
 #[derive(Debug, Deserialize)]
 pub struct PasswordChangeInput {

--- a/fedimint-server/src/consensus/api.rs
+++ b/fedimint-server/src/consensus/api.rs
@@ -11,7 +11,9 @@ use fedimint_aead::{encrypt, get_encryption_key, random_salt};
 use fedimint_api_client::api::{
     LegacyFederationStatus, LegacyP2PConnectionStatus, LegacyPeerStatus, StatusResponse,
 };
-use fedimint_core::admin_client::{GuardianConfigBackup, ServerStatusLegacy, SetupStatus};
+use fedimint_core::admin_client::{
+    ExpirationStatus, GuardianConfigBackup, ServerStatusLegacy, SetupStatus,
+};
 use fedimint_core::backup::{
     BackupStatistics, ClientBackupKey, ClientBackupKeyPrefix, ClientBackupSnapshot,
 };
@@ -28,13 +30,14 @@ use fedimint_core::endpoint_constants::{
     AWAIT_SESSION_OUTCOME_ENDPOINT, AWAIT_SIGNED_SESSION_OUTCOME_ENDPOINT,
     AWAIT_TRANSACTION_ENDPOINT, BACKUP_ENDPOINT, BACKUP_STATISTICS_ENDPOINT, CHAIN_ID_ENDPOINT,
     CHANGE_PASSWORD_ENDPOINT, CLIENT_CONFIG_ENDPOINT, CLIENT_CONFIG_JSON_ENDPOINT,
-    CONSENSUS_ORD_LATENCY_ENDPOINT, FEDERATION_ID_ENDPOINT, FEDIMINTD_VERSION_ENDPOINT,
-    GUARDIAN_CONFIG_BACKUP_ENDPOINT, GUARDIAN_METADATA_ENDPOINT, INVITE_CODE_ENDPOINT,
-    P2P_CONNECTION_STATUS_ENDPOINT, RECOVER_ENDPOINT, SERVER_CONFIG_CONSENSUS_HASH_ENDPOINT,
-    SESSION_COUNT_ENDPOINT, SESSION_STATUS_ENDPOINT, SESSION_STATUS_V2_ENDPOINT,
-    SETUP_STATUS_ENDPOINT, SHUTDOWN_ENDPOINT, SIGN_API_ANNOUNCEMENT_ENDPOINT,
-    SIGN_GUARDIAN_METADATA_ENDPOINT, STATUS_ENDPOINT, SUBMIT_API_ANNOUNCEMENT_ENDPOINT,
-    SUBMIT_GUARDIAN_METADATA_ENDPOINT, SUBMIT_TRANSACTION_ENDPOINT, VERSION_ENDPOINT,
+    CONSENSUS_ORD_LATENCY_ENDPOINT, EXPIRATION_STATUS_ENDPOINT, FEDERATION_ID_ENDPOINT,
+    FEDIMINTD_VERSION_ENDPOINT, GUARDIAN_CONFIG_BACKUP_ENDPOINT, GUARDIAN_METADATA_ENDPOINT,
+    INVITE_CODE_ENDPOINT, P2P_CONNECTION_STATUS_ENDPOINT, RECOVER_ENDPOINT,
+    SERVER_CONFIG_CONSENSUS_HASH_ENDPOINT, SESSION_COUNT_ENDPOINT, SESSION_STATUS_ENDPOINT,
+    SESSION_STATUS_V2_ENDPOINT, SETUP_STATUS_ENDPOINT, SHUTDOWN_ENDPOINT,
+    SIGN_API_ANNOUNCEMENT_ENDPOINT, SIGN_GUARDIAN_METADATA_ENDPOINT, STATUS_ENDPOINT,
+    SUBMIT_API_ANNOUNCEMENT_ENDPOINT, SUBMIT_GUARDIAN_METADATA_ENDPOINT,
+    SUBMIT_TRANSACTION_ENDPOINT, VERSION_ENDPOINT,
 };
 use fedimint_core::epoch::ConsensusItem;
 use fedimint_core::module::audit::{Audit, AuditSummary};
@@ -74,6 +77,7 @@ use crate::config::{ServerConfig, legacy_consensus_config_hash};
 use crate::consensus::db::{AcceptedItemPrefix, AcceptedTransactionKey, SignedSessionOutcomeKey};
 use crate::consensus::engine::get_finished_session_count_static;
 use crate::consensus::transaction::{TxProcessingMode, process_transaction_with_dbtx};
+use crate::db::ExpirationStatusKey;
 use crate::metrics::{BACKUP_WRITE_SIZE_BYTES, STORED_BACKUPS_COUNT};
 use crate::net::api::HasApiContext;
 use crate::net::api::announcement::{ApiAnnouncementKey, ApiAnnouncementPrefix};
@@ -805,6 +809,29 @@ impl IDashboardApi for ConsensusApi {
         self.change_guardian_password(new_password, guardian_auth)
             .map_err(|e| e.to_string())
     }
+
+    async fn expiration_status(&self) -> Option<ExpirationStatus> {
+        self.db
+            .begin_transaction_nc()
+            .await
+            .get_value(&ExpirationStatusKey)
+            .await
+    }
+
+    async fn set_expiration_status(&self, status: Option<ExpirationStatus>) {
+        let mut dbtx = self.db.begin_transaction().await;
+
+        match status {
+            Some(a) => {
+                dbtx.insert_entry(&ExpirationStatusKey, &a).await;
+            }
+            None => {
+                dbtx.remove_entry(&ExpirationStatusKey).await;
+            }
+        }
+
+        dbtx.commit_tx().await;
+    }
 }
 
 pub fn server_endpoints() -> Vec<ApiEndpoint<ConsensusApi>> {
@@ -1108,6 +1135,13 @@ pub fn server_endpoints() -> Vec<ApiEndpoint<ConsensusApi>> {
                     .get_chain_id()
                     .await
                     .map_err(|e| ApiError::server_error(e.to_string()))
+            }
+        },
+        api_endpoint! {
+            EXPIRATION_STATUS_ENDPOINT,
+            ApiVersion::new(0, 7),
+            async |fedimint: &ConsensusApi, _context, _v: ()| -> Option<ExpirationStatus> {
+                Ok(fedimint.expiration_status().await)
             }
         },
     ]

--- a/fedimint-server/src/db.rs
+++ b/fedimint-server/src/db.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeSet;
 
 use bitcoin::hex::DisplayHex as _;
+use fedimint_core::admin_client::ExpirationStatus;
 use fedimint_core::db::{
     DatabaseTransaction, IDatabaseTransactionOpsCore as _, MODULE_GLOBAL_PREFIX,
 };
@@ -20,6 +21,7 @@ pub enum DbKeyPrefix {
     ApiAnnouncements = 0x06,
     ServerInfo = 0x07,
     GuardianMetadata = 0x08,
+    ExpirationStatus = 0x09,
 
     DatabaseVersion = fedimint_core::db::DbKeyPrefix::DatabaseVersion as u8,
     ClientBackup = fedimint_core::db::DbKeyPrefix::ClientBackup as u8,
@@ -66,5 +68,15 @@ impl_db_record!(
     key = ServerInfoKey,
     value = ServerInfo,
     db_prefix = DbKeyPrefix::ServerInfo,
+    notify_on_modify = false,
+);
+
+#[derive(Clone, Debug, Encodable, Decodable)]
+pub struct ExpirationStatusKey;
+
+impl_db_record!(
+    key = ExpirationStatusKey,
+    value = ExpirationStatus,
+    db_prefix = DbKeyPrefix::ExpirationStatus,
     notify_on_modify = false,
 );


### PR DESCRIPTION
## Summary

I consider this to be a reasonable good UX for the guardians even though there is no internal voting. Having a feature specific UI here is important in my opinion. This is the only feature I really need from the meta module and it is reasonable simple to implement on its own. Conduit does not load the meta module at all at the moment and I dont want to be forced to use it just for this. 

- Add `ExpirationAnnouncement` type with optional expiration date and successor federation invite code
- Add server API endpoint and database storage for expiration announcements
- Add client-side background task that fetches and caches the announcement daily
- Add dashboard UI for guardians to set/clear expiration announcements
- Extract guardian backup card into its own `backup.rs` module for consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1089" height="419" alt="Bildschirmfoto 2026-02-07 um 16 31 20" src="https://github.com/user-attachments/assets/f9e5ad2e-f59d-4020-bd4e-3ff9a2be84d0" />

<img width="1089" height="419" alt="Bildschirmfoto 2026-02-07 um 16 31 42" src="https://github.com/user-attachments/assets/8d0006f6-6411-463d-8995-d95136ba4f25" />

<img width="1089" height="419" alt="Bildschirmfoto 2026-02-07 um 16 32 14" src="https://github.com/user-attachments/assets/b86609c3-0cbc-4791-8f78-bc820fc7df21" />


