### PR TITLE
fix(ui): require password to reveal gateway mnemonic

### DIFF
--- a/gateway/fedimint-gateway-ui/src/lib.rs
+++ b/gateway/fedimint-gateway-ui/src/lib.rs
@@ -82,7 +82,6 @@ pub(crate) const PAYMENT_LOG_ROUTE: &str = "/ui/payment-log";
 pub(crate) const CREATE_WALLET_ROUTE: &str = "/ui/wallet/create";
 pub(crate) const RECOVER_WALLET_ROUTE: &str = "/ui/wallet/recover";
 pub(crate) const MNEMONIC_IFRAME_ROUTE: &str = "/ui/mnemonic/iframe";
-pub(crate) const MNEMONIC_REVEAL_ROUTE: &str = "/ui/mnemonic/reveal";
 
 #[derive(Default, Deserialize)]
 pub struct DashboardQuery {
@@ -420,8 +419,10 @@ pub fn router<E: Display + Send + Sync + std::fmt::Debug + 'static>(
             RECOVER_WALLET_ROUTE,
             get(recover_wallet_form).post(recover_wallet_handler),
         )
-        .route(MNEMONIC_IFRAME_ROUTE, get(mnemonic_iframe_handler))
-        .route(MNEMONIC_REVEAL_ROUTE, post(mnemonic_reveal_handler))
+        .route(
+            MNEMONIC_IFRAME_ROUTE,
+            get(mnemonic_iframe_handler).post(mnemonic_reveal_handler),
+        )
         .with_static_routes();
 
     app.with_state(UiState::new(api))

--- a/gateway/fedimint-gateway-ui/src/mnemonic.rs
+++ b/gateway/fedimint-gateway-ui/src/mnemonic.rs
@@ -7,7 +7,7 @@ use fedimint_ui_common::auth::UserAuth;
 use maud::{DOCTYPE, Markup, PreEscaped, html};
 use serde::Deserialize;
 
-use crate::{DynGatewayApi, MNEMONIC_IFRAME_ROUTE, MNEMONIC_REVEAL_ROUTE};
+use crate::{DynGatewayApi, MNEMONIC_IFRAME_ROUTE};
 
 /// Form data for revealing the mnemonic
 #[derive(Deserialize)]
@@ -31,7 +31,7 @@ pub fn render() -> Markup {
                 form
                     id="mnemonic-reveal-form"
                     method="post"
-                    action=(MNEMONIC_REVEAL_ROUTE)
+                    action=(MNEMONIC_IFRAME_ROUTE)
                     target="mnemonic-iframe"
                     class="mb-3"
                 {


### PR DESCRIPTION
This PR makes some changes to the gateway UI for how the mnemonic is displayed.

It now requires the user to re-enter their password in order for the mnemonic to be displayed.

<img width="1349" height="444" alt="image" src="https://github.com/user-attachments/assets/0984829e-dcaa-43f4-a8b7-ce7781f9cf00" />
