### PR TITLE
feat(ui): filter payments events from payment log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3491,6 +3491,7 @@ dependencies = [
  "fedimint-core",
  "fedimint-eventlog",
  "fedimint-gateway-common",
+ "fedimint-gwv2-client",
  "fedimint-ln-common",
  "fedimint-logging",
  "fedimint-mint-client",

--- a/gateway/fedimint-gateway-ui/Cargo.toml
+++ b/gateway/fedimint-gateway-ui/Cargo.toml
@@ -24,6 +24,7 @@ fedimint-bitcoind = { workspace = true }
 fedimint-core = { workspace = true }
 fedimint-eventlog = { workspace = true }
 fedimint-gateway-common = { workspace = true }
+fedimint-gwv2-client = { workspace = true }
 fedimint-ln-common = { workspace = true }
 fedimint-logging = { workspace = true }
 fedimint-mint-client = { workspace = true }

--- a/gateway/fedimint-gateway-ui/src/payment_summary.rs
+++ b/gateway/fedimint-gateway-ui/src/payment_summary.rs
@@ -1,21 +1,63 @@
-use std::collections::HashMap;
 use std::time::{Duration, UNIX_EPOCH};
 
-use axum::extract::{Query, State};
+use axum::extract::{Query, RawQuery, State};
 use axum::response::Html;
 use fedimint_core::config::FederationId;
 use fedimint_core::module::serde_json;
 use fedimint_core::time::now;
-use fedimint_eventlog::EventLogId;
+use fedimint_eventlog::{Event, EventKind, EventLogId};
 use fedimint_gateway_common::{
     FederationInfo, PaymentLogPayload, PaymentLogResponse, PaymentStats, PaymentSummaryPayload,
     PaymentSummaryResponse,
 };
+use fedimint_gwv2_client::events::{
+    CompleteLightningPaymentSucceeded, IncomingPaymentFailed, IncomingPaymentStarted,
+    IncomingPaymentSucceeded, OutgoingPaymentFailed, OutgoingPaymentStarted,
+    OutgoingPaymentSucceeded,
+};
+use fedimint_mint_client::event::{OOBNotesReissued, OOBNotesSpent};
 use fedimint_ui_common::UiState;
 use fedimint_ui_common::auth::UserAuth;
-use maud::{Markup, html};
+use fedimint_wallet_client::events::{DepositConfirmed, WithdrawRequest};
+use maud::{Markup, PreEscaped, html};
+use serde::Deserialize;
 
 use crate::{DynGatewayApi, PAYMENT_LOG_ROUTE};
+
+/// Event categories for UI display - Lightning events
+const LIGHTNING_EVENTS: &[(&str, EventKind)] = &[
+    ("Outgoing Started", OutgoingPaymentStarted::KIND),
+    ("Outgoing Succeeded", OutgoingPaymentSucceeded::KIND),
+    ("Outgoing Failed", OutgoingPaymentFailed::KIND),
+    ("Incoming Started", IncomingPaymentStarted::KIND),
+    ("Incoming Succeeded", IncomingPaymentSucceeded::KIND),
+    ("Incoming Failed", IncomingPaymentFailed::KIND),
+    (
+        "Complete LN Payment",
+        CompleteLightningPaymentSucceeded::KIND,
+    ),
+];
+
+/// Event categories for UI display - Wallet events
+const WALLET_EVENTS: &[(&str, EventKind)] = &[
+    ("Withdraw Request", WithdrawRequest::KIND),
+    ("Deposit Confirmed", DepositConfirmed::KIND),
+];
+
+/// Event categories for UI display - E-cash events
+const ECASH_EVENTS: &[(&str, EventKind)] = &[
+    ("Notes Spent", OOBNotesSpent::KIND),
+    ("Notes Reissued", OOBNotesReissued::KIND),
+];
+
+/// Query parameters for the payment log handler
+/// Note: event_kinds is parsed separately from the raw query string
+/// because serde_urlencoded doesn't handle repeated params well
+#[derive(Debug, Deserialize)]
+pub struct PaymentLogQueryParams {
+    pub federation_id: Option<String>,
+    pub end_position: Option<EventLogId>,
+}
 
 pub async fn render<E>(api: &DynGatewayApi<E>, federations: &[FederationInfo]) -> Markup
 where
@@ -172,41 +214,83 @@ fn render_stats_table(title: &str, stats: &PaymentStats, title_class: &str) -> M
 fn render_payment_log_tab_initial(federations: &[FederationInfo]) -> Markup {
     html! {
         div {
-            form class="mb-3 d-flex gap-2 align-items-end" {
-                div class="flex-grow-1" {
-                    label class="form-label fw-bold" {
-                        "Federation"
-                    }
-
-                    select
-                        class="form-select form-select-sm"
-                        name="federation_id"
-                        hx-get=(PAYMENT_LOG_ROUTE)
-                        hx-trigger="change"
-                        hx-target="#payment-log-content"
-                        hx-include="this"
-                    {
-                        option value="" selected disabled {
-                            "Select a federation…"
+            form id="payment-log-form" class="mb-3" {
+                div class="d-flex gap-2 align-items-end mb-2" {
+                    div class="flex-grow-1" {
+                        label class="form-label fw-bold" {
+                            "Federation"
                         }
 
-                        @for fed in federations {
-                            option value=(fed.federation_id.to_string()) {
-                                (fed.federation_name.clone().unwrap_or_default())
+                        select
+                            class="form-select form-select-sm"
+                            name="federation_id"
+                            hx-get=(PAYMENT_LOG_ROUTE)
+                            hx-trigger="change"
+                            hx-target="#payment-log-content"
+                            hx-include="#payment-log-form"
+                        {
+                            option value="" selected disabled {
+                                "Select a federation…"
+                            }
+
+                            @for fed in federations {
+                                option value=(fed.federation_id.to_string()) {
+                                    (fed.federation_name.clone().unwrap_or_default())
+                                }
                             }
                         }
                     }
+
+                    button
+                        type="button"
+                        class="btn btn-outline-secondary btn-sm"
+                        title="Refresh payment log"
+                        hx-get=(PAYMENT_LOG_ROUTE)
+                        hx-target="#payment-log-content"
+                        hx-include="#payment-log-form"
+                    {
+                        "↻ Refresh"
+                    }
                 }
 
-                button
-                    type="button"
-                    class="btn btn-outline-secondary btn-sm"
-                    title="Refresh payment log"
-                    hx-get=(PAYMENT_LOG_ROUTE)
-                    hx-target="#payment-log-content"
-                    hx-include="closest form"
-                {
-                    "↻ Refresh"
+                // Collapsible filter section
+                div {
+                    button
+                        type="button"
+                        class="btn btn-sm btn-outline-secondary"
+                        data-bs-toggle="collapse"
+                        data-bs-target="#event-filter-collapse"
+                        aria-expanded="false"
+                        aria-controls="event-filter-collapse"
+                    {
+                        "▼ Filter by Event Type"
+                    }
+
+                    div class="collapse mt-2" id="event-filter-collapse" {
+                        div class="card card-body" {
+                            // Lightning Events
+                            (render_event_category("Lightning", "lightning", LIGHTNING_EVENTS))
+
+                            // Wallet Events
+                            (render_event_category("Wallet", "wallet", WALLET_EVENTS))
+
+                            // E-cash Events
+                            (render_event_category("E-cash", "ecash", ECASH_EVENTS))
+
+                            // Apply Filters button
+                            div class="mt-3" {
+                                button
+                                    type="button"
+                                    class="btn btn-primary btn-sm"
+                                    hx-get=(PAYMENT_LOG_ROUTE)
+                                    hx-target="#payment-log-content"
+                                    hx-include="#payment-log-form"
+                                {
+                                    "Apply Filters"
+                                }
+                            }
+                        }
+                    }
                 }
             }
 
@@ -218,6 +302,59 @@ fn render_payment_log_tab_initial(federations: &[FederationInfo]) -> Markup {
                     "Select a federation to view payment events."
                 }
             }
+
+            // JavaScript for toggle all/none functionality
+            script {
+                (PreEscaped(r#"
+                function toggleEventGroup(group, checked) {
+                    document.querySelectorAll('.' + group + '-event').forEach(function(cb) {
+                        cb.checked = checked;
+                    });
+                }
+                "#))
+            }
+        }
+    }
+}
+
+/// Renders a category of event checkboxes
+fn render_event_category(title: &str, css_class: &str, events: &[(&str, EventKind)]) -> Markup {
+    html! {
+        div class="mb-3" {
+            div class="d-flex align-items-center gap-2 mb-2" {
+                strong { (title) }
+                button
+                    type="button"
+                    class="btn btn-outline-secondary btn-sm py-0 px-1"
+                    onclick=(format!("toggleEventGroup('{}', true)", css_class))
+                {
+                    "All"
+                }
+                button
+                    type="button"
+                    class="btn btn-outline-secondary btn-sm py-0 px-1"
+                    onclick=(format!("toggleEventGroup('{}', false)", css_class))
+                {
+                    "None"
+                }
+            }
+            div class="row" {
+                @for (label, kind) in events {
+                    div class="col-6 col-md-4" {
+                        div class="form-check" {
+                            input
+                                type="checkbox"
+                                class=(format!("form-check-input {}-event", css_class))
+                                name="event_kinds"
+                                value=(kind.to_string())
+                                checked;
+                            label class="form-check-label small" {
+                                (label)
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 }
@@ -225,12 +362,13 @@ fn render_payment_log_tab_initial(federations: &[FederationInfo]) -> Markup {
 pub async fn payment_log_fragment_handler<E>(
     State(state): State<UiState<DynGatewayApi<E>>>,
     _auth: UserAuth,
-    Query(params): Query<HashMap<String, String>>,
+    RawQuery(raw_query): RawQuery,
+    Query(params): Query<PaymentLogQueryParams>,
 ) -> Html<String>
 where
     E: std::fmt::Display + std::fmt::Debug,
 {
-    let federation_id = match params.get("federation_id") {
+    let federation_id = match &params.federation_id {
         Some(v) => match v.parse::<FederationId>() {
             Ok(id) => id,
             Err(_) => {
@@ -254,31 +392,51 @@ where
 
     let pagination_size = 10;
 
-    // Use end_position query param if present
-    let end_position = params
-        .get("end_position")
-        .and_then(|v| v.parse::<EventLogId>().ok());
+    // Parse event_kinds from raw query string to handle repeated params
+    // serde_urlencoded doesn't properly deserialize repeated params into Vec
+    let event_kinds: Vec<EventKind> = parse_event_kinds_from_query(raw_query.as_deref());
 
     let result = state
         .api
         .handle_payment_log_msg(PaymentLogPayload {
-            end_position,
+            end_position: params.end_position,
             pagination_size,
             federation_id,
-            event_kinds: vec![],
+            event_kinds: event_kinds.clone(),
         })
         .await;
 
-    Html(render_payment_log_result(&result, federation_id).into_string())
+    Html(render_payment_log_result(&result, federation_id, &event_kinds).into_string())
+}
+
+/// Parse event_kinds from raw query string, handling repeated params
+fn parse_event_kinds_from_query(query: Option<&str>) -> Vec<EventKind> {
+    let Some(query) = query else {
+        return vec![];
+    };
+
+    url::form_urlencoded::parse(query.as_bytes())
+        .filter_map(|(key, value)| {
+            if key == "event_kinds" || key == "event_kinds[]" {
+                Some(EventKind::from(value.into_owned()))
+            } else {
+                None
+            }
+        })
+        .collect()
 }
 
 fn render_payment_log_result<E>(
     result: &Result<PaymentLogResponse, E>,
     federation_id: FederationId,
+    event_kinds: &[EventKind],
 ) -> Markup
 where
     E: std::fmt::Display,
 {
+    // Convert event kinds to strings for JSON serialization
+    let event_kinds_strings: Vec<String> = event_kinds.iter().map(ToString::to_string).collect();
+
     match result {
         Ok(PaymentLogResponse(entries)) if !entries.is_empty() => {
             // Compute next end_position as last entry position - 1
@@ -334,7 +492,8 @@ where
                                 hx-include="closest form"
                                 hx-vals=(serde_json::json!({
                                     "federation_id": federation_id.to_string(),
-                                    "end_position": next_pos
+                                    "end_position": next_pos,
+                                    "event_kinds": event_kinds_strings
                                 }))
                             {
                                 "Next"


### PR DESCRIPTION
Allows gateway operators to filter events based on their `KIND`.

<img width="1342" height="941" alt="image" src="https://github.com/user-attachments/assets/66f8c6f8-40d3-4727-abe2-31372483b079" />
