### PR TITLE
chore(client): deprecate backup-related public methods

### DIFF
--- a/fedimint-cli/src/client.rs
+++ b/fedimint-cli/src/client.rs
@@ -474,6 +474,7 @@ pub async fn handle_command(
         ClientCmd::Backup { metadata } => {
             let metadata = metadata_from_clap_cli(metadata)?;
 
+            #[allow(deprecated)]
             client
                 .backup_to_federation(Metadata::from_json_serialized(metadata))
                 .await?;

--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -828,6 +828,7 @@ impl FedimintCli {
             .await
             .map_err_cli()?;
 
+        #[allow(deprecated)]
         let backup = preview
             .download_backup_from_federation(root_secret.clone())
             .await

--- a/fedimint-client-rpc/src/lib.rs
+++ b/fedimint-client-rpc/src/lib.rs
@@ -235,6 +235,7 @@ impl RpcGlobalState {
         };
 
         // Check if backup exists
+        #[allow(deprecated)]
         let backup = preview
             .download_backup_from_federation(RootSecret::StandardDoubleDerive(
                 federation_secret.clone(),

--- a/fedimint-client/src/backup.rs
+++ b/fedimint-client/src/backup.rs
@@ -271,6 +271,9 @@ impl Event for EventBackupDone {
 
 impl Client {
     /// Create a backup, include provided `metadata`
+    #[deprecated(
+        note = "Recovery is now efficient enough that backups are no longer necessary. Backups will be removed in v0.13.0 due to backups being inherently complicated and brittle."
+    )]
     pub async fn create_backup(&self, metadata: Metadata) -> anyhow::Result<ClientBackup> {
         let session_count = self.api.session_count().await?;
         let mut modules = BTreeMap::new();
@@ -305,6 +308,10 @@ impl Client {
     }
 
     /// Prepare an encrypted backup and send it to federation for storing
+    #[deprecated(
+        note = "Recovery is now efficient enough that backups are no longer necessary. Backups will be removed in v0.13.0 due to backups being inherently complicated and brittle."
+    )]
+    #[allow(deprecated)]
     pub async fn backup_to_federation(&self, metadata: Metadata) -> Result<()> {
         ensure!(
             !self.has_pending_recoveries(),
@@ -330,6 +337,9 @@ impl Client {
     }
 
     /// Validate backup before sending it to federation
+    #[deprecated(
+        note = "Recovery is now efficient enough that backups are no longer necessary. Backups will be removed in v0.13.0 due to backups being inherently complicated and brittle."
+    )]
     pub fn validate_backup(&self, backup: &EncryptedClientBackup) -> Result<()> {
         if BACKUP_REQUEST_MAX_PAYLOAD_SIZE_BYTES < backup.len() {
             bail!("Backup payload too large");
@@ -338,6 +348,10 @@ impl Client {
     }
 
     /// Upload `backup` to federation
+    #[deprecated(
+        note = "Recovery is now efficient enough that backups are no longer necessary. Backups will be removed in v0.13.0 due to backups being inherently complicated and brittle."
+    )]
+    #[allow(deprecated)]
     pub async fn upload_backup(&self, backup: &EncryptedClientBackup) -> Result<()> {
         self.validate_backup(backup)?;
         let size = backup.len();
@@ -356,6 +370,10 @@ impl Client {
         Ok(())
     }
 
+    #[deprecated(
+        note = "Recovery is now efficient enough that backups are no longer necessary. Backups will be removed in v0.13.0 due to backups being inherently complicated and brittle."
+    )]
+    #[allow(deprecated)]
     pub async fn download_backup_from_federation(&self) -> Result<Option<ClientBackup>> {
         Self::download_backup_from_federation_static(
             &self.api,
@@ -366,6 +384,10 @@ impl Client {
     }
 
     /// Download most recent valid backup found from the Federation
+    #[deprecated(
+        note = "Recovery is now efficient enough that backups are no longer necessary. Backups will be removed in v0.13.0 due to backups being inherently complicated and brittle."
+    )]
+    #[allow(deprecated)]
     pub async fn download_backup_from_federation_static(
         api: &DynGlobalApi,
         root_secret: &DerivableSecret,
@@ -406,10 +428,16 @@ impl Client {
 
     /// Backup id derived from the root secret key (public key used to self-sign
     /// backup requests)
+    #[deprecated(
+        note = "Recovery is now efficient enough that backups are no longer necessary. Backups will be removed in v0.13.0 due to backups being inherently complicated and brittle."
+    )]
     pub fn get_backup_id(&self) -> PublicKey {
         self.get_derived_backup_signing_key().public_key()
     }
 
+    #[deprecated(
+        note = "Recovery is now efficient enough that backups are no longer necessary. Backups will be removed in v0.13.0 due to backups being inherently complicated and brittle."
+    )]
     pub fn get_backup_id_static(root_secret: &DerivableSecret) -> PublicKey {
         Self::get_derived_backup_signing_key_static(root_secret).public_key()
     }

--- a/fedimint-client/src/client.rs
+++ b/fedimint-client/src/client.rs
@@ -1767,6 +1767,7 @@ impl Client {
                         });
                     }
                 }
+                #[allow(deprecated)]
                 "backup_to_federation" => {
                     let metadata = if params.is_null() {
                         Metadata::from_json_serialized(serde_json::json!({}))

--- a/fedimint-client/src/client/builder.rs
+++ b/fedimint-client/src/client/builder.rs
@@ -1287,6 +1287,10 @@ impl ClientPreview {
     }
 
     /// Download most recent valid backup found from the Federation
+    #[deprecated(
+        note = "Recovery is now efficient enough that backups are no longer necessary. Backups will be removed in v0.13.0 due to backups being inherently complicated and brittle."
+    )]
+    #[allow(deprecated)]
     pub async fn download_backup_from_federation(
         &self,
         pre_root_secret: RootSecret,

--- a/gateway/fedimint-gateway-server/src/federation_manager.rs
+++ b/gateway/fedimint-gateway-server/src/federation_manager.rs
@@ -315,6 +315,7 @@ impl FederationManager {
     ) {
         if let Some(client) = self.client(federation_id) {
             let metadata: BTreeMap<String, String> = BTreeMap::new();
+            #[allow(deprecated)]
             if client
                 .value()
                 .backup_to_federation(fedimint_client::backup::Metadata::from_json_serialized(

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -1179,6 +1179,7 @@ impl Gateway {
             )))?
             .value();
         let metadata: BTreeMap<String, String> = BTreeMap::new();
+        #[allow(deprecated)]
         client
             .backup_to_federation(fedimint_client::backup::Metadata::from_json_serialized(
                 metadata,

--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -287,6 +287,7 @@ async fn sends_ecash_oob_highly_parallel() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[allow(deprecated)]
 #[tokio::test(flavor = "multi_thread")]
 async fn backup_encode_decode_roundtrip() -> anyhow::Result<()> {
     // Print notes for client
@@ -315,6 +316,7 @@ async fn backup_encode_decode_roundtrip() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[allow(deprecated)]
 #[tokio::test(flavor = "multi_thread")]
 async fn ecash_backup_can_recover_metadata() -> anyhow::Result<()> {
     // Print notes for client


### PR DESCRIPTION
## Summary
- Mark all public backup methods in fedimint-client as deprecated (to be removed in v0.13.0)
- Add `#[allow(deprecated)]` to internal callers to suppress warnings

**Deprecated methods:**
- `Client::create_backup`, `backup_to_federation`, `validate_backup`, `upload_backup`
- `Client::download_backup_from_federation`, `download_backup_from_federation_static`
- `Client::get_backup_id`, `get_backup_id_static`
- `ClientBuilder::download_backup_from_federation`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)