### PR TITLE
fix(lnv1): `subscribe_ln_receive` waits until notes are claimed

### DIFF
--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -1923,11 +1923,6 @@ impl LightningClientModule {
                 yield LnReceiveState::WaitingForPayment { invoice: invoice.to_string(), timeout: invoice.expiry_time() };
 
                 match self_ref.await_receive_success(operation_id).await {
-                    Ok(is_external) if is_external => {
-                        // If the payment was external, we can consider it claimed
-                        yield LnReceiveState::Claimed;
-                        return;
-                    }
                     Ok(_) => {
 
                         yield LnReceiveState::Funded;

--- a/modules/fedimint-ln-tests/tests/tests.rs
+++ b/modules/fedimint-ln-tests/tests/tests.rs
@@ -508,8 +508,8 @@ async fn can_receive_for_other_user() -> anyhow::Result<()> {
                 .into_stream();
             assert_eq!(sub2.ok().await?, InternalPayState::Funding);
             assert_matches!(sub2.ok().await?, InternalPayState::Preimage { .. });
-            // goes from preimage to immediate claim because it is for another user
-            assert_eq!(sub1.ok().await?, LnReceiveState::Claimed);
+            // goes from preimage to `Funded` because it is for another user
+            assert_eq!(sub1.ok().await?, LnReceiveState::Funded);
         }
         _ => panic!("Expected internal payment!"),
     }
@@ -567,8 +567,8 @@ async fn can_receive_for_other_user() -> anyhow::Result<()> {
                 .into_stream();
             assert_eq!(sub2.ok().await?, InternalPayState::Funding);
             assert_matches!(sub2.ok().await?, InternalPayState::Preimage { .. });
-            // goes from preimage to immediate claim because it is for another user
-            assert_eq!(sub1.ok().await?, LnReceiveState::Claimed);
+            // goes from preimage to `Funded` because it is for another user
+            assert_eq!(sub1.ok().await?, LnReceiveState::Funded);
         }
         _ => panic!("Expected internal payment!"),
     }
@@ -642,8 +642,8 @@ async fn can_receive_for_other_user_tweaked() -> anyhow::Result<()> {
                 .into_stream();
             assert_eq!(sub2.ok().await?, InternalPayState::Funding);
             assert_matches!(sub2.ok().await?, InternalPayState::Preimage { .. });
-            // goes from preimage to immediate claim because it is for another user
-            assert_eq!(sub1.ok().await?, LnReceiveState::Claimed);
+            // goes from preimage to `Funded` because it is for another user
+            assert_eq!(sub1.ok().await?, LnReceiveState::Funded);
         }
         _ => panic!("Expected internal payment!"),
     }


### PR DESCRIPTION
Fixes: https://github.com/fedimint/fedimint/issues/8227

We have a subtle bug in `subscribe_ln_receive`, where when the payment is an "external" payment, we don't wait for the notes to be claimed. This was originally added in https://github.com/fedimint/fedimint/pull/3820, to add the functionality to create invoices on behalf of users. `subscribe_ln_claim` was then added, and it was assumed that clients would need to use both to wait for the lightning payment to be completed, then the notes to be claimed.

Lots has changed since then, `subscribe_ln_claim` has been deprecated in favor or recurringd API. But we did not cleanup the `is_external` check in `subscribe_ln_receive`, which means sometimes we don't wait for the notes to be claimed. This is causing our CI to be flaky.

I believe the fix is to just remove the `is_external` check and always wait for the notes to be claimed in `subscribe_ln_receive`.