### PR TITLE
feat(ui): add remote alias to channels tab

### DIFF
--- a/devimint/src/gatewayd.rs
+++ b/devimint/src/gatewayd.rs
@@ -596,6 +596,9 @@ impl Gatewayd {
                     serde_json::from_value::<bitcoin::OutPoint>(v.clone())
                         .expect("Could not deserialize outpoint")
                 });
+                let remote_node_alias = channel
+                    .get("remote_node_alias")
+                    .map(std::string::ToString::to_string);
                 Ok(ChannelInfo {
                     remote_pubkey: remote_pubkey
                         .parse()
@@ -605,6 +608,7 @@ impl Gatewayd {
                     inbound_liquidity_sats,
                     is_active,
                     funding_outpoint,
+                    remote_node_alias,
                 })
             })
             .collect::<Result<Vec<ChannelInfo>>>()?;

--- a/gateway/fedimint-gateway-common/src/lib.rs
+++ b/gateway/fedimint-gateway-common/src/lib.rs
@@ -324,6 +324,7 @@ pub struct ChannelInfo {
     pub inbound_liquidity_sats: u64,
     pub is_active: bool,
     pub funding_outpoint: Option<OutPoint>,
+    pub remote_node_alias: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/gateway/fedimint-gateway-ui/src/lightning.rs
+++ b/gateway/fedimint-gateway-ui/src/lightning.rs
@@ -850,6 +850,7 @@ where
                             thead {
                                 tr {
                                     th { "Remote PubKey" }
+                                    th { "Alias" }
                                     th { "Funding OutPoint" }
                                     th { "Size (sats)" }
                                     th { "Active" }
@@ -872,6 +873,13 @@ where
 
                                     tr {
                                         td { (ch.remote_pubkey.to_string()) }
+                                        td {
+                                            @if let Some(alias) = &ch.remote_node_alias {
+                                                (alias)
+                                            } @else {
+                                                span class="text-muted" { "-" }
+                                            }
+                                        }
                                         td { (funding_outpoint) }
                                         td { (ch.channel_size_sats) }
                                         td {
@@ -916,7 +924,7 @@ where
                                     }
 
                                     tr class="collapse" id=(row_id) {
-                                        td colspan="6" {
+                                        td colspan="7" {
                                             div class="card card-body" {
                                                 form
                                                     hx-post=(CLOSE_CHANNEL_ROUTE)

--- a/gateway/fedimint-lightning/src/lnd.rs
+++ b/gateway/fedimint-lightning/src/lnd.rs
@@ -1370,6 +1370,11 @@ impl ILnRpcClient for GatewayLndClient {
                             inbound_liquidity_sats,
                             is_active: channel.active,
                             funding_outpoint,
+                            remote_node_alias: if channel.peer_alias.is_empty() {
+                                None
+                            } else {
+                                Some(channel.peer_alias.clone())
+                            },
                         }
                     })
                     .collect(),


### PR DESCRIPTION
Adds the channel's remote peer alias so that channels are easier to identify in the UI.

<img width="2699" height="439" alt="image" src="https://github.com/user-attachments/assets/078c8647-85da-4855-b3d7-a2f02d508d97" />
