### PR TITLE
chore(gatway): improve the feedback on mnemonic initialization

### DIFF
--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -729,8 +729,20 @@ impl Gateway {
                     }
 
                     if let GatewayState::NotConfigured{ .. } = self_copy.get_state().await {
-                        info!(target: LOG_GATEWAY, "Waiting for the mnemonic to be set before starting lightning receive loop.");
+                        info!(
+                            target: LOG_GATEWAY,
+                            "Waiting for the mnemonic to be set before starting lightning receive loop."
+                        );
+                        info!(
+                            target: LOG_GATEWAY,
+                            "You might need to provide it from the UI or refer to documentation w.r.t how to initialize it."
+                        );
+
                         let _ = mnemonic_receiver.recv().await;
+                        info!(
+                            target: LOG_GATEWAY,
+                            "Received mnemonic, attempting to start lightning receive loop"
+                        );
                     }
 
                     let payment_stream_task_group = tg.make_subgroup();


### PR DESCRIPTION
Users might be surprised why their gateway is not starting, so best to give them some extra info about it in the logs.

Made after a quick debugging session internally at Fedi.
<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
