### PR TITLE
chore: log external notes being issued

### DIFF
--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -1759,6 +1759,15 @@ impl MintClientModule {
         let notes = oob_notes.notes().clone();
         let federation_id_prefix = oob_notes.federation_id_prefix();
 
+        debug!(
+            target: LOG_CLIENT_MODULE_MINT,
+            notes = ?notes
+                .iter_items()
+                .map(|(amount, note)| (amount, note.nonce()))
+                .collect::<Vec<_>>(),
+            "Reissuing external notes"
+        );
+
         ensure!(
             notes.total_amount() > Amount::ZERO,
             "Reissuing zero-amount e-cash isn't supported"


### PR DESCRIPTION
When debugging claiming oob ecash, it is very useful to know which notes exactly were being reissued.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
