### PR TITLE
fix: api breakage in one of the backports [0.10]

### DIFF
--- a/fedimintd/src/bin/main.rs
+++ b/fedimintd/src/bin/main.rs
@@ -1,5 +1,3 @@
-use std::convert::Infallible;
-
 use fedimint_core::fedimint_build_code_version_env;
 #[cfg(not(any(target_env = "msvc", target_os = "ios", target_os = "android")))]
 use tikv_jemallocator::Jemalloc;
@@ -10,7 +8,7 @@ use tikv_jemallocator::Jemalloc;
 static GLOBAL: Jemalloc = Jemalloc;
 
 #[tokio::main]
-async fn main() -> anyhow::Result<Infallible> {
+async fn main() -> anyhow::Result<()> {
     fedimintd::run(
         fedimintd::default_modules(),
         fedimint_build_code_version_env!(),

--- a/fedimintd/src/lib.rs
+++ b/fedimintd/src/lib.rs
@@ -8,7 +8,6 @@
 
 mod metrics;
 
-use std::convert::Infallible;
 use std::env;
 use std::net::SocketAddr;
 use std::path::PathBuf;
@@ -251,7 +250,7 @@ pub async fn run(
     module_init_registry: ServerModuleInitRegistry,
     code_version_hash: &str,
     code_version_vendor_suffix: Option<&str>,
-) -> anyhow::Result<Infallible> {
+) -> ! {
     assert_eq!(
         env!("FEDIMINT_BUILD_CODE_VERSION").len(),
         code_version_hash.len(),
@@ -293,7 +292,9 @@ pub async fn run(
             url = %format!("http://{}/metrics", bind_metrics),
             "Initializing metrics server",
         );
-        fedimint_metrics::spawn_api_server(*bind_metrics, root_task_group.clone()).await?;
+        fedimint_metrics::spawn_api_server(*bind_metrics, root_task_group.clone())
+            .await
+            .expect("Failed to spawn metrics server");
     }
 
     let settings = ConfigGenSettings {
@@ -404,6 +405,7 @@ pub async fn run(
 
     drop(timing_total_runtime);
 
+    // Should we ever shut down without an error code?
     std::process::exit(-1);
 }
 


### PR DESCRIPTION
Reverting accidental API breakage.
<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
