### PR TITLE
fix(ci): fail on skipped jobs [0.10]

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -690,7 +690,8 @@ jobs:
         if: >-
           ${{
             contains(needs.*.result, 'failure') ||
-            contains(needs.*.result, 'cancelled')
+            contains(needs.*.result, 'cancelled') ||
+            contains(needs.*.result, 'skipped')
           }}
         run: exit 1
 


### PR DESCRIPTION
Backport from master to a little ci bug that can lead to merging broken PRs.
<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
