### PR TITLE
fix: make cargo audit output sane

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -30,3 +30,7 @@ ignore = [
   # atomic-polyfill is unmaintained, waiting for the update chain to reach iroh
   "RUSTSEC-2023-0089",
 ]
+
+[output]
+quiet = true
+show_tree = false


### PR DESCRIPTION
That tree is useless and massive.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
