### PR TITLE
fix(lnurl): use untagged serde for LnurlResponse and avoid Url type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3731,8 +3731,8 @@ dependencies = [
  "lightning-invoice",
  "reqwest 0.12.22",
  "serde",
+ "serde_json",
  "serde_with",
- "url",
 ]
 
 [[package]]
@@ -4177,7 +4177,6 @@ dependencies = [
  "fedimint-tpe",
  "lightning-invoice",
  "serde",
- "serde_json",
  "tokio",
  "tower-http",
  "tracing",

--- a/fedimint-lnurl/Cargo.toml
+++ b/fedimint-lnurl/Cargo.toml
@@ -17,4 +17,6 @@ lightning-invoice = { workspace = true, features = ["serde"] }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_with = { workspace = true }
-url = { workspace = true }
+
+[dev-dependencies]
+serde_json.workspace = true

--- a/fedimint-lnurl/src/lib.rs
+++ b/fedimint-lnurl/src/lib.rs
@@ -3,59 +3,58 @@ use lightning_invoice::Bolt11Invoice;
 use serde::{Deserialize, Serialize};
 use serde_with::hex::Hex;
 use serde_with::serde_as;
-use url::Url;
-
-/// Generic LNURL response wrapper that handles the status field.
-/// All LNURL responses follow the {"status": "OK"|"ERROR", ...} pattern.
+/// Generic LNURL response wrapper that handles the error case.
+/// Successful responses deserialize directly into `Ok(T)`, while error
+/// responses with `{"status": "ERROR", "reason": "..."}` fall back to `Error`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "status")]
+#[serde(untagged)]
 pub enum LnurlResponse<T> {
-    #[serde(rename = "OK")]
     Ok(T),
-    #[serde(rename = "ERROR")]
-    Error { reason: String },
+    Error { status: String, reason: String },
 }
 
 impl<T> LnurlResponse<T> {
+    pub fn error(reason: impl Into<String>) -> Self {
+        Self::Error {
+            status: "ERROR".to_string(),
+            reason: reason.into(),
+        }
+    }
+
     pub fn into_result(self) -> Result<T, String> {
         match self {
             Self::Ok(data) => Ok(data),
-            Self::Error { reason } => Err(reason),
+            Self::Error { reason, .. } => Err(reason),
         }
     }
 }
 
-/// Decode a bech32-encoded LNURL string to a URL
-pub fn parse_lnurl(s: &str) -> Option<Url> {
-    let (hrp, data) = bech32::decode(s).ok()?;
+/// Decode a bech32-encoded LNURL string to a URL string
+pub fn parse_lnurl(s: &str) -> Option<String> {
+    let (hrp, data) = bech32::decode(&s.to_lowercase()).ok()?;
 
     if hrp.as_str() != "lnurl" {
         return None;
     }
 
-    String::from_utf8(data)
-        .ok()
-        .and_then(|s| Url::parse(&s).ok())
+    String::from_utf8(data).ok()
 }
 
 /// Encode a URL as a bech32 LNURL string
-pub fn encode_lnurl(url: &Url) -> String {
-    bech32::encode::<Bech32>(
-        Hrp::parse("lnurl").expect("valid hrp"),
-        url.as_str().as_bytes(),
-    )
-    .expect("encoding succeeds")
+pub fn encode_lnurl(url: &str) -> String {
+    bech32::encode::<Bech32>(Hrp::parse("lnurl").expect("valid hrp"), url.as_bytes())
+        .expect("encoding succeeds")
 }
 
 /// Parse a lightning address (user@domain) to its LNURL-pay endpoint URL
-pub fn parse_address(s: &str) -> Option<Url> {
+pub fn parse_address(s: &str) -> Option<String> {
     let (user, domain) = s.split_once('@')?;
 
     if user.is_empty() || domain.is_empty() {
         return None;
     }
 
-    Url::parse(&format!("https://{domain}/.well-known/lnurlp/{user}")).ok()
+    Some(format!("https://{domain}/.well-known/lnurlp/{user}"))
 }
 
 pub fn pay_request_tag() -> String {
@@ -92,14 +91,16 @@ pub struct VerifyResponse {
 }
 
 /// Fetch and parse an LNURL-pay response
-pub async fn request(url: &Url) -> Result<PayResponse, String> {
-    reqwest::get(url.clone())
+pub async fn request(url: &str) -> Result<PayResponse, String> {
+    let response = reqwest::get(url)
         .await
-        .map_err(|e| e.to_string())?
+        .map_err(|_| "Failed to fetch lnurl pay response".to_string())?
         .json::<LnurlResponse<PayResponse>>()
         .await
-        .map_err(|e| e.to_string())?
-        .into_result()
+        .map_err(|_| "Failed to parse lnurl pay response".to_string())?
+        .into_result()?;
+
+    Ok(response)
 }
 
 /// Fetch an invoice from an LNURL-pay callback
@@ -108,21 +109,33 @@ pub async fn get_invoice(
     amount_msat: u64,
 ) -> Result<InvoiceResponse, String> {
     if amount_msat < response.min_sendable {
-        return Err("Amount too low".to_string());
+        return Err(format!(
+            "Minimum amount is {} sats",
+            response.min_sendable / 1000
+        ));
     }
 
     if amount_msat > response.max_sendable {
-        return Err("Amount too high".to_string());
+        return Err(format!(
+            "Maximum amount is {} sats",
+            response.max_sendable / 1000
+        ));
     }
 
-    let callback_url = format!("{}?amount={}", response.callback, amount_msat);
+    let separator = if response.callback.contains('?') {
+        '&'
+    } else {
+        '?'
+    };
+
+    let callback_url = format!("{}{}amount={}", response.callback, separator, amount_msat);
 
     reqwest::get(callback_url)
         .await
-        .map_err(|e| e.to_string())?
+        .map_err(|_| "Failed to fetch lnurl callback response".to_string())?
         .json::<LnurlResponse<InvoiceResponse>>()
         .await
-        .map_err(|e| e.to_string())?
+        .map_err(|_| "Failed to parse lnurl callback response".to_string())?
         .into_result()
 }
 
@@ -130,9 +143,62 @@ pub async fn get_invoice(
 pub async fn verify_invoice(url: &str) -> Result<VerifyResponse, String> {
     reqwest::get(url)
         .await
-        .map_err(|e| e.to_string())?
+        .map_err(|_| "Failed to fetch lnurl verify response".to_string())?
         .json::<LnurlResponse<VerifyResponse>>()
         .await
-        .map_err(|e| e.to_string())?
+        .map_err(|_| "Failed to parse lnurl verify response".to_string())?
         .into_result()
+}
+
+#[test]
+fn parse_lnurl_official_test_vector_lud_01() {
+    let lnurl = "LNURL1DP68GURN8GHJ7UM9WFMXJCM99E3K7MF0V9CXJ0M385EKVCENXC6R2C35XVUKXEFCV5MKVV34X5EKZD3EV56NYD3HXQURZEPEXEJXXEPNXSCRVWFNV9NXZCN9XQ6XYEFHVGCXXCMYXYMNSERXFQ5FNS";
+    let expected = "https://service.com/api?q=3fc3645b439ce8e7f2553a69e5267081d96dcd340693afabe04be7b0ccd178df";
+
+    assert_eq!(parse_lnurl(lnurl).unwrap(), expected);
+}
+
+#[test]
+fn parse_pay_response_lud_06() {
+    let json = r#"{
+        "callback": "https://example.com/lnurl/pay/callback",
+        "maxSendable": 100000000,
+        "minSendable": 1000,
+        "metadata": "[[\"text/plain\",\"Pay to example.com\"]]",
+        "tag": "payRequest"
+    }"#;
+
+    let response: LnurlResponse<PayResponse> = serde_json::from_str(json).unwrap();
+
+    let pay = response.into_result().unwrap();
+
+    assert_eq!(pay.tag, "payRequest");
+    assert_eq!(pay.callback, "https://example.com/lnurl/pay/callback");
+    assert_eq!(pay.min_sendable, 1000);
+    assert_eq!(pay.max_sendable, 100000000);
+}
+
+#[test]
+fn parse_error_response() {
+    let json = r#"{"status": "ERROR", "reason": "Invalid request"}"#;
+
+    let response: LnurlResponse<PayResponse> = serde_json::from_str(json).unwrap();
+
+    assert_eq!(response.into_result().unwrap_err(), "Invalid request");
+}
+
+#[test]
+fn parse_verify_response_lud_21() {
+    let json = r#"{
+        "status": "OK",
+        "settled": true,
+        "preimage": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    }"#;
+
+    let response: LnurlResponse<VerifyResponse> = serde_json::from_str(json).unwrap();
+
+    let verify = response.into_result().unwrap();
+
+    assert!(verify.settled);
+    assert!(verify.preimage.is_some());
 }

--- a/fedimint-recurringd/src/lib.rs
+++ b/fedimint-recurringd/src/lib.rs
@@ -216,10 +216,10 @@ impl RecurringInvoiceServer {
     }
 
     fn create_lnurl(&self, payment_code_id: PaymentCodeId) -> String {
-        let url = format!("{}lnv1/paycodes/{}", self.base_url, payment_code_id)
-            .parse()
-            .expect("valid URL");
-        encode_lnurl(&url)
+        encode_lnurl(&format!(
+            "{}lnv1/paycodes/{}",
+            self.base_url, payment_code_id
+        ))
     }
 
     pub async fn lnurl_pay(

--- a/fedimint-recurringd/src/main.rs
+++ b/fedimint-recurringd/src/main.rs
@@ -160,9 +160,7 @@ async fn lnurl_pay(
             .await
         {
             Ok(response) => LnurlResponse::Ok(response),
-            Err(e) => LnurlResponse::Error {
-                reason: e.to_string(),
-            },
+            Err(e) => LnurlResponse::error(e.to_string()),
         },
     )
 }
@@ -179,9 +177,7 @@ async fn lnurl_pay_invoice(
             .await
         {
             Ok(invoice) => LnurlResponse::Ok(invoice),
-            Err(e) => LnurlResponse::Error {
-                reason: e.to_string(),
-            },
+            Err(e) => LnurlResponse::error(e.to_string()),
         },
     )
 }

--- a/fedimint-recurringdv2/Cargo.toml
+++ b/fedimint-recurringdv2/Cargo.toml
@@ -25,7 +25,6 @@ fedimint-lnv2-common = { workspace = true }
 fedimint-logging = { workspace = true }
 lightning-invoice = { workspace = true }
 serde = { workspace = true }
-serde_json = { workspace = true }
 tokio = { workspace = true }
 tower-http = { workspace = true }
 tpe = { workspace = true }

--- a/modules/fedimint-lnv2-client/src/lib.rs
+++ b/modules/fedimint-lnv2-client/src/lib.rs
@@ -1079,11 +1079,9 @@ impl LightningClientModule {
             },
         );
 
-        let url = format!("{recurringd}pay/{payload}")
-            .parse()
-            .expect("valid URL");
-
-        Ok(fedimint_lnurl::encode_lnurl(&url))
+        Ok(fedimint_lnurl::encode_lnurl(&format!(
+            "{recurringd}pay/{payload}"
+        )))
     }
 
     fn spawn_receive_lnurl_task(


### PR DESCRIPTION
## Summary

This is a follow up to https://github.com/fedimint/fedimint/pull/8235

While porting Conduit and the Cashup Terminal to use fedimint-lnurl I actually founds a bug namely that successful LNURL responses don't include a status field. Furthermore returning a Url instead of a String is more tricky for the integrators to work with. 

While addressing that I realized the recurringdv2 was not yet fully ported to fedimint-lnurl which I addressed here as well.

Conduit and the Cashup Terminal now both run with this pr branch and I tested it manually against Conduit itself as well as Blink so it should work fine now - getting the lnurl spec right is trickier then expected. 

- Switch `LnurlResponse` to untagged serde since successful LNURL responses don't include a status field
- Replace `Url` with `String` in `fedimint-lnurl` public API to avoid URL normalization issues (e.g. trailing slashes, lowercasing) that would break database encoding compatibility
- Remove `url` and `lnurl` crate dependencies in favor of the simpler `fedimint-lnurl` crate

🤖 Generated with [Claude Code](https://claude.com/claude-code)