### PR TITLE
fix: impossible to tell why bitcoind connection starts on start [backport 0.10]

### DIFF
--- a/fedimint-server-core/src/bitcoin_rpc.rs
+++ b/fedimint-server-core/src/bitcoin_rpc.rs
@@ -7,10 +7,10 @@ use fedimint_core::Feerate;
 use fedimint_core::bitcoin::{Block, BlockHash, Network, Transaction};
 use fedimint_core::envs::BitcoinRpcConfig;
 use fedimint_core::task::TaskGroup;
-use fedimint_core::util::SafeUrl;
+use fedimint_core::util::{FmtCompactAnyhow as _, SafeUrl};
 use fedimint_logging::LOG_SERVER;
 use tokio::sync::watch;
-use tracing::debug;
+use tracing::{debug, warn};
 
 use crate::dashboard_ui::ServerBitcoinRpcStatus;
 
@@ -43,7 +43,12 @@ impl ServerBitcoinRpcMonitor {
                     Ok(new_status) => {
                         status_sender.send_replace(Some(new_status));
                     }
-                    Err(..) => {
+                    Err(err) => {
+                        warn!(
+                            target: LOG_SERVER,
+                            err = %err.fmt_compact_anyhow(),
+                            "Bitcoin status update failed"
+                        );
                         status_sender.send_replace(None);
                     }
                 }


### PR DESCRIPTION
If bitcoind is misconfigured the user just gets panic eventually, with no more detailed info.

Fix #8265

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
