### PR TITLE
feat: add dev command to refresh API versions

### DIFF
--- a/fedimint-cli/src/cli.rs
+++ b/fedimint-cli/src/cli.rs
@@ -393,6 +393,10 @@ Examples:
     /// Show the chain ID (bitcoin block hash at height 1) cached in the client
     /// database
     ChainId,
+    /// Force refresh API versions from the federation, bypassing cached values.
+    /// Queries all peers for their supported API versions and updates the
+    /// cache.
+    RefreshApiVersions,
     /// Trigger a panic to verify backtrace handling
     Panic,
     /// Visualize client internals for debugging

--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -1374,6 +1374,11 @@ impl FedimintCli {
                 }
                 Ok(CliOutput::Raw(json!({})))
             }
+            Command::Dev(DevCmd::RefreshApiVersions) => {
+                let client = self.client_open(&cli).await?;
+                let versions = client.refresh_api_versions().await.map_err_cli()?;
+                Ok(CliOutput::Raw(json!({ "versions": versions })))
+            }
             Command::Completion { shell } => {
                 let bin_path = PathBuf::from(
                     std::env::args_os()

--- a/fedimint-client/src/client.rs
+++ b/fedimint-client/src/client.rs
@@ -1384,6 +1384,24 @@ impl Client {
         .await
     }
 
+    /// Force refresh API versions from the federation, bypassing the cache.
+    ///
+    /// This queries all peers for their supported API versions and calculates
+    /// the common API version set to use. The result is stored in the database
+    /// cache for future use.
+    pub async fn refresh_api_versions(&self) -> anyhow::Result<ApiVersionSet> {
+        Self::refresh_common_api_version_static(
+            &self.config().await,
+            &self.module_inits,
+            &self.api,
+            &self.db,
+            self.task_group.clone(),
+            &self.client_span,
+            true,
+        )
+        .await
+    }
+
     /// Load the common api versions to use from cache and start a background
     /// process to refresh them.
     ///


### PR DESCRIPTION
Add a new `dev refresh-api-versions` CLI command that forces a refresh of API versions from the federation, bypassing the cached values. This queries all peers for their supported API versions and updates the client's cached version set.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
