### PR TITLE
feat(mint-client): include nonce in notes_json output

### DIFF
--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -285,8 +285,26 @@ impl OOBNotes {
         for notes in &self.0 {
             match notes {
                 OOBNotesPart::Notes(notes) => {
-                    let notes_json = serde_json::to_value(notes)?;
-                    notes_map.insert("notes".to_string(), notes_json);
+                    let notes_json: serde_json::Map<String, serde_json::Value> = notes
+                        .iter()
+                        .map(|(amount, notes_vec)| {
+                            let notes_with_nonce: Vec<serde_json::Value> = notes_vec
+                                .iter()
+                                .map(|note| {
+                                    serde_json::json!({
+                                        "signature": note.signature,
+                                        "spend_key": note.spend_key,
+                                        "nonce": note.nonce(),
+                                    })
+                                })
+                                .collect();
+                            (
+                                amount.msats.to_string(),
+                                serde_json::Value::Array(notes_with_nonce),
+                            )
+                        })
+                        .collect();
+                    notes_map.insert("notes".to_string(), serde_json::Value::Object(notes_json));
                 }
                 OOBNotesPart::FederationIdPrefix(prefix) => {
                     notes_map.insert(


### PR DESCRIPTION
The nonce is derived from the spend key's public key. Including it explicitly in the JSON output makes it easier for consumers to access the nonce without needing to derive it themselves.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
