### PR TITLE
chore(ci): split status into status-pr and status-mq

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -684,10 +684,25 @@ jobs:
             echo "SUCCESS: NixOS system is $age_days days old (within $MAX_AGE_DAYS day limit)"
           fi
 
-  status:
-    name: Status
+  status-pr:
+    name: Status (PR)
+    needs: [lint, shell, build]
+    if: ${{ always() && github.event_name == 'pull_request' }}
+    runs-on: [self-hosted, linux, x64]
+    steps:
+      - name: Check status of all jobs
+        if: >-
+          ${{
+            contains(needs.*.result, 'failure') ||
+            contains(needs.*.result, 'cancelled') ||
+            contains(needs.*.result, 'skipped')
+          }}
+        run: exit 1
+
+  status-mq:
+    name: Status (MQ)
     needs: [lint, shell, build, cross, containers, pkgs, check-packages-features]
-    if: ${{ always() }}
+    if: ${{ always() && github.event_name == 'merge_group' }}
     runs-on: [self-hosted, linux, x64]
     steps:
       - name: Check status of all jobs
@@ -706,7 +721,7 @@ jobs:
     runs-on: [self-hosted, linux, x64]
     # note: we don't depend on `audit` because it will
     # be often broken, and we can't fix it immediately
-    needs: [ lint, build, shell, cross, containers, pkgs, check-packages-features]
+    needs: [lint, build, shell, cross, containers, pkgs, check-packages-features]
 
     steps:
     - name: Discord notifications on failure


### PR DESCRIPTION
It's surprisingly hard to get this done in any better way.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
