### PR TITLE
chore: upgrade rocksdb crate from 0.22.0 to 0.24.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1008,9 +1008,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.71.1"
+version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
  "bitflags 2.9.1",
  "cexpr",
@@ -6659,14 +6659,13 @@ dependencies = [
 
 [[package]]
 name = "librocksdb-sys"
-version = "0.16.0+8.10.0"
+version = "0.17.3+10.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce3d60bc059831dc1c83903fb45c103f75db65c5a7bf22272764d9cc683e348c"
+checksum = "cef2a00ee60fe526157c9023edab23943fae1ce2ab6f4abb2a807c1746835de9"
 dependencies = [
- "bindgen 0.69.5",
+ "bindgen 0.72.1",
  "bzip2-sys",
  "cc",
- "glob",
  "libc",
  "libz-sys",
  "lz4-sys",
@@ -9090,9 +9089,9 @@ dependencies = [
 
 [[package]]
 name = "rocksdb"
-version = "0.22.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd13e55d6d7b8cd0ea569161127567cd587676c99f4472f779a0279aa60a7a7"
+checksum = "ddb7af00d2b17dbd07d82c0063e25411959748ff03e8d4f96134c2ff41fce34f"
 dependencies = [
  "libc",
  "librocksdb-sys",
@@ -10255,9 +10254,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-sys"
-version = "0.5.4+5.3.0-patched"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9402443cb8fd499b6f327e40565234ff34dbda27460c5b47db0db77443dd85d1"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
 dependencies = [
  "cc",
  "libc",
@@ -10265,9 +10264,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemallocator"
-version = "0.5.4"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "965fe0c26be5c56c94e38ba547249074803efd52adfb66de62107d95aab3eaca"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
 dependencies = [
  "libc",
  "tikv-jemalloc-sys",
@@ -12985,7 +12984,6 @@ version = "2.0.15+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
 dependencies = [
- "bindgen 0.71.1",
  "cc",
  "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -290,7 +290,7 @@ reqwest = { version = "0.12.22", features = [
 ], default-features = false }
 rexie = "0.6.2"
 ring = "0.17.14"
-rocksdb = { version = "0.22.0" }
+rocksdb = { version = "0.24.0" }
 rustls-pki-types = { version = "1.12.0" }
 scopeguard = "1.2.0"
 secp256k1 = { version = "0.29.0", default-features = false }
@@ -314,7 +314,7 @@ tempfile = "3.20.0"
 test-log = { version = "0.2", features = ["trace"], default-features = false }
 thiserror = "2.0.12"
 threshold_crypto = { version = "0.2.1", package = "fedimint-threshold-crypto" }
-tikv-jemallocator = "0.5"
+tikv-jemallocator = "0.6"
 time = "0.3.41"
 tokio = "1.48.0"
 tokio-rustls = { version = "0.26.0", features = ["aws_lc_rs"] }

--- a/nix/flakebox.nix
+++ b/nix/flakebox.nix
@@ -153,6 +153,10 @@ let
         pkgs.rocksdb_8_11.override { enableLiburing = false; }
       }/lib/";
 
+      # librocksdb-sys 0.17+ no longer links stdc++ when using a pre-built
+      # RocksDB library (regression from 0.16). Inject it via target RUSTFLAGS.
+      "CARGO_TARGET_${lib.toUpper build_arch_underscores}_RUSTFLAGS" = "-C link-arg=-lstdc++";
+
       # does not produce static lib in most versions
       "SNAPPY_${build_arch_underscores}_STATIC" = "true";
       "SNAPPY_${build_arch_underscores}_LIB_DIR" = "${pkgs.pkgsStatic.snappy}/lib/";


### PR DESCRIPTION
## Summary
- Upgrade `rocksdb` crate from 0.22.0 to 0.24.0
- Upgrade `tikv-jemallocator` from 0.5 to 0.6 (required for jemalloc compatibility with rocksdb 0.24)
- Bumps underlying RocksDB C++ library from 8.10.0 to 9.10.0
- Add `-lstdc++` to target RUSTFLAGS in `nix/flakebox.nix` — `librocksdb-sys` 0.17 no longer links stdc++ when using a pre-built RocksDB library (regression from 0.16)

## Test plan
- [x] `cargo check -p fedimint-rocksdb` compiles cleanly
- [x] `cargo test -p fedimint-rocksdb` — all 19 tests pass
- [ ] CI passes