### PR TITLE
feat(ci): add Start9 s9pk build workflow for fedimintd

### DIFF
--- a/.github/workflows/ci-start9-fedimintd.yml
+++ b/.github/workflows/ci-start9-fedimintd.yml
@@ -1,0 +1,108 @@
+name: "Build Start9 fedimintd Package"
+
+# Runs after CI (nix) completes, which publishes the fedimint/fedimintd
+# Docker Hub image that the s9pk Dockerfile depends on
+on:
+  workflow_run:
+    workflows: ["CI (nix)"]
+    types: [completed]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-fedimintd-s9pk:
+    name: "Build fedimintd.s9pk"
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      startsWith(github.event.workflow_run.head_branch, 'v')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 180
+    env:
+      IS_PRERELEASE: ${{
+          contains(github.event.workflow_run.head_branch, 'beta') ||
+          contains(github.event.workflow_run.head_branch, 'rc')
+        }}
+    steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Install system dependencies
+        run: |
+          sudo rm /etc/apt/sources.list.d/microsoft-prod.list
+          sudo apt-get update
+          sudo apt-get install -y git build-essential openssl libssl-dev libc6-dev clang libclang-dev ca-certificates curl
+      - name: Install yq
+        run: |
+          curl -sS https://webi.sh/yq | sh
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+      - name: Install deno
+        run: |
+          curl -fsSL https://deno.land/install.sh | sh
+          echo "$HOME/.deno/bin" >> $GITHUB_PATH
+      # start-os v0.3.5.1 doesn't compile on newer Rust versions
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.85.1"
+      - name: Install cargo tools
+        run: |
+          # web-static-pack-packer 0.5.2 requires rustc 1.88+
+          cargo install --force --locked toml-cli "web-static-pack-packer@0.5.0"
+          cargo install --git=https://github.com/Start9Labs/md-packer.git --branch=main
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Checkout start-os SDK
+        uses: actions/checkout@v4
+        with:
+          repository: Start9Labs/start-os
+          ref: v0.3.5.1
+          submodules: recursive
+      - name: Cache start-sdk
+        uses: actions/cache@v4
+        id: cache
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-${{ runner.arch }}-start-sdk-${{ hashFiles('**/install-sdk.sh') }}
+      - name: Build start-sdk
+        run: |
+          if [ -z "$(command -v start-sdk)" ]; then
+            export RUSTFLAGS=""
+            export OS_ARCH=$(uname -m)
+            mkdir -p web/dist/static
+            ./check-git-hash.sh
+            cargo update -p time --manifest-path=core/Cargo.toml
+            cd core && ./install-sdk.sh
+            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          fi
+      - name: Checkout fedimint
+        uses: actions/checkout@v4
+      - name: Build s9pk
+        id: build
+        working-directory: fedimint-startos
+        run: |
+          start-sdk init
+          make
+          VERSION=$(yq -oy '.version' manifest.yaml)
+          mv fedimintd.s9pk "fedimintd-v${VERSION}.s9pk"
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+      - name: Upload s9pk
+        uses: actions/upload-artifact@v6
+        with:
+          name: fedimintd-v${{ steps.build.outputs.version }}.s9pk
+          path: fedimint-startos/fedimintd-v*.s9pk
+      - name: Attach to release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event.workflow_run.head_branch }}
+          files: fedimint-startos/fedimintd-v*.s9pk
+          prerelease: ${{ env.IS_PRERELEASE }}


### PR DESCRIPTION
Adds a GitHub Actions workflow that builds the `fedimintd.s9pk` Start9 package as part of the release process. Until now, building the s9pk required someone to have a dedicated Ubuntu environment with all the dependencies from the fedimint-startos [README](https://github.com/fedimint/fedimint/blob/516e90f3b55a46244d86ff1f042a03086a99521e/fedimint-startos/README.md) manually installed. This automates that process in CI. The workflow triggers after `CI (nix)` completes on a tag push (when the `fedimint/fedimintd` Docker Hub image is available), builds the package, and attaches it to the GitHub release.

## How it works

The build follows the same steps as the fedimint-startos [README](https://github.com/fedimint/fedimint/blob/516e90f3b55a46244d86ff1f042a03086a99521e/fedimint-startos/README.md): install the Start9 SDK, set up Docker buildx with QEMU for cross-arch builds, then run `make` to produce the s9pk for both x86_64 and aarch64. The [Core Lightning Start9 workflow](https://github.com/Start9Labs/cln-startos/blob/master/.github/workflows/buildService.yml) was used as a starting reference, but the SDK setup is inlined rather than using `k0gen/sdk@v1.3.3` since that action targets the `sdk` branch of start-os which has moved to 0.4.x. This workflow pins to `start-os v0.3.5.1` to match the current fedimint-startos package. There are a few version pins and workarounds noted in comments throughout the workflow that were needed to get the v0.3.5.1 SDK building on current GitHub runners.

## Verified

- Successful build on fork: https://github.com/bradleystachurski/fedimint/actions/runs/22239770923
- Tested install of v0.9.1 and upgrade to v0.10.0 on a Start9 VM, both worked without issues

## Known unknowns

The build itself is proven end to end on my fork. What hasn't been tested is the `workflow_run` trigger actually firing after `CI (nix)` completes on a real tag push, and `softprops/action-gh-release` attaching the artifact to the correct release. These can only be verified on the first real tag push to `fedimint/fedimint`. If something doesn't fire correctly, the build steps are solid and it would just be a matter of adjusting the trigger or release config.

## For future releases

Bump the version in `fedimint-startos/Dockerfile` (`FROM fedimint/fedimintd:<version>`) and `fedimint-startos/manifest.yaml` as part of the release version bump.

## Fork testing

To test on your own fork, apply these changes and push:

```diff
diff --git a/.github/workflows/ci-start9-fedimintd.yml b/.github/workflows/ci-start9-fedimintd.yml
index bcff9a1965a..b08408028d5 100644
--- a/.github/workflows/ci-start9-fedimintd.yml
+++ b/.github/workflows/ci-start9-fedimintd.yml
@@ -1,11 +1,8 @@
 name: "Build Start9 fedimintd Package"

-# Runs after CI (nix) completes, which publishes the fedimint/fedimintd
-# Docker Hub image that the s9pk Dockerfile depends on
 on:
-  workflow_run:
-    workflows: ["CI (nix)"]
-    types: [completed]
+  push:
+    branches: [2026-02-19-start9-workflow]

 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -14,16 +11,8 @@ concurrency:
 jobs:
   build-fedimintd-s9pk:
     name: "Build fedimintd.s9pk"
-    if: >
-      github.event.workflow_run.conclusion == 'success' &&
-      startsWith(github.event.workflow_run.head_branch, 'v')
     runs-on: ubuntu-24.04
     timeout-minutes: 180
-    env:
-      IS_PRERELEASE: ${{
-          contains(github.event.workflow_run.head_branch, 'beta') ||
-          contains(github.event.workflow_run.head_branch, 'rc')
-        }}
     steps:
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -100,9 +102,3 @@ jobs:
         with:
           name: fedimintd-v${{ steps.build.outputs.version }}.s9pk
           path: fedimint-startos/fedimintd-v*.s9pk
-      - name: Attach to release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ github.event.workflow_run.head_branch }}
-          files: fedimint-startos/fedimintd-v*.s9pk
-          prerelease: ${{ env.IS_PRERELEASE }}
```