### PR TITLE
feat(ui): connectivity indicator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4470,6 +4470,7 @@ dependencies = [
  "fedimint-core",
  "maud",
  "serde",
+ "tokio",
 ]
 
 [[package]]

--- a/fedimint-server-ui/src/dashboard/mod.rs
+++ b/fedimint-server-ui/src/dashboard/mod.rs
@@ -18,7 +18,10 @@ use fedimint_metrics::{Encoder, REGISTRY, TextEncoder};
 use fedimint_server_core::dashboard_ui::{DashboardApiModuleExt, DynDashboardApi};
 use fedimint_ui_common::assets::WithStaticRoutesExt;
 use fedimint_ui_common::auth::UserAuth;
-use fedimint_ui_common::{LOGIN_ROUTE, ROOT_ROUTE, UiState, dashboard_layout, login_form_response};
+use fedimint_ui_common::{
+    CONNECTIVITY_CHECK_ROUTE, LOGIN_ROUTE, ROOT_ROUTE, UiState, connectivity_check_handler,
+    dashboard_layout, login_form_response,
+};
 use maud::html;
 use {fedimint_lnv2_server, fedimint_meta_server, fedimint_wallet_server};
 
@@ -337,6 +340,10 @@ pub fn router(api: DynDashboardApi) -> Router {
         .route(DOWNLOAD_BACKUP_ROUTE, get(download_backup))
         .route(CHANGE_PASSWORD_ROUTE, post(change_password))
         .route(METRICS_ROUTE, get(metrics_handler))
+        .route(
+            CONNECTIVITY_CHECK_ROUTE,
+            get(connectivity_check_handler::<DynDashboardApi>),
+        )
         .with_static_routes();
 
     // routeradd LNv2 gateway routes if the module exists

--- a/fedimint-server-ui/src/setup.rs
+++ b/fedimint-server-ui/src/setup.rs
@@ -11,7 +11,10 @@ use fedimint_core::module::ApiAuth;
 use fedimint_server_core::setup_ui::DynSetupApi;
 use fedimint_ui_common::assets::WithStaticRoutesExt;
 use fedimint_ui_common::auth::UserAuth;
-use fedimint_ui_common::{LOGIN_ROUTE, LoginInput, ROOT_ROUTE, UiState, login_form_response};
+use fedimint_ui_common::{
+    CONNECTIVITY_CHECK_ROUTE, LOGIN_ROUTE, LoginInput, ROOT_ROUTE, UiState,
+    connectivity_check_handler, connectivity_widget, login_form_response,
+};
 use maud::{DOCTYPE, Markup, PreEscaped, html};
 use qrcode::QrCode;
 use serde::Deserialize;
@@ -65,6 +68,7 @@ pub fn setup_layout(title: &str, content: Markup) -> Markup {
                         }
                     }
                 }
+                (connectivity_widget())
                 script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous" {}
                 script src="/assets/html5-qrcode.min.js" {}
             }
@@ -582,6 +586,10 @@ pub fn router(api: DynSetupApi) -> Router {
         .route(ADD_SETUP_CODE_ROUTE, post(post_add_setup_code))
         .route(RESET_SETUP_CODES_ROUTE, post(post_reset_setup_codes))
         .route(START_DKG_ROUTE, post(post_start_dkg))
+        .route(
+            CONNECTIVITY_CHECK_ROUTE,
+            get(connectivity_check_handler::<DynSetupApi>),
+        )
         .with_static_routes()
         .with_state(UiState::new(api))
 }

--- a/fedimint-ui-common/Cargo.toml
+++ b/fedimint-ui-common/Cargo.toml
@@ -18,6 +18,7 @@ axum-extra = { workspace = true, features = ["cookie"] }
 fedimint-core = { workspace = true }
 maud = { workspace = true }
 serde = { workspace = true }
+tokio = { workspace = true, features = ["net", "time"] }
 
 [lints]
 workspace = true

--- a/fedimint-ui-common/src/lib.rs
+++ b/fedimint-ui-common/src/lib.rs
@@ -1,14 +1,22 @@
 pub mod assets;
 pub mod auth;
 
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::time::Duration;
+
+use axum::extract::State;
 use axum::response::{Html, IntoResponse};
+use axum_extra::extract::CookieJar;
 use fedimint_core::hex::ToHex;
 use fedimint_core::secp256k1::rand::{Rng, thread_rng};
 use maud::{DOCTYPE, Markup, html};
 use serde::Deserialize;
+use tokio::net::TcpStream;
+use tokio::time::timeout;
 
 pub const ROOT_ROUTE: &str = "/";
 pub const LOGIN_ROUTE: &str = "/login";
+pub const CONNECTIVITY_CHECK_ROUTE: &str = "/ui/connectivity-check";
 
 /// Generic state for both setup and dashboard UIs
 #[derive(Clone)]
@@ -114,8 +122,67 @@ pub fn dashboard_layout(content: Markup, title: &str, version: Option<&str>) -> 
 
                     (content)
                 }
+                (connectivity_widget())
                 script src="/assets/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous" {}
             }
         }
     }
+}
+
+/// Fixed-position div that loads the connectivity status fragment via htmx.
+pub fn connectivity_widget() -> Markup {
+    html! {
+        div
+            style="position: fixed; bottom: 1rem; right: 1rem; z-index: 1050;"
+            hx-get=(CONNECTIVITY_CHECK_ROUTE)
+            hx-trigger="load, every 30s"
+            hx-swap="innerHTML"
+        {}
+    }
+}
+
+async fn check_tcp_connect(addr: SocketAddr) -> bool {
+    timeout(Duration::from_secs(3), TcpStream::connect(addr))
+        .await
+        .is_ok_and(|r| r.is_ok())
+}
+
+/// Handler that checks internet connectivity by attempting TCP connections
+/// to well-known anycast IPs and returns an HTML fragment.
+/// Manually checks auth cookie to avoid `UserAuth` extractor's redirect,
+/// which would cause htmx to swap the entire login page into the widget.
+pub async fn connectivity_check_handler<Api: Send + Sync + 'static>(
+    State(state): State<UiState<Api>>,
+    jar: CookieJar,
+) -> Html<String> {
+    // Check auth manually — return empty fragment if not authenticated
+    let authenticated = jar
+        .get(&state.auth_cookie_name)
+        .is_some_and(|c| c.value() == state.auth_cookie_value);
+
+    if !authenticated {
+        return Html(String::new());
+    }
+
+    let check_1 = check_tcp_connect(SocketAddr::new(IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1)), 443));
+    let check_2 = check_tcp_connect(SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 53));
+
+    let (r1, r2) = tokio::join!(check_1, check_2);
+    let is_connected = r1 || r2;
+
+    let markup = if is_connected {
+        html! {
+            span class="badge bg-success" style="font-size: 0.75rem;" {
+                "Internet connection OK"
+            }
+        }
+    } else {
+        html! {
+            span class="badge bg-danger" style="font-size: 0.75rem;" {
+                "Internet connection unavailable"
+            }
+        }
+    };
+
+    Html(markup.into_string())
 }


### PR DESCRIPTION
One of the failure modes we've observed when people report failing DKG is one of the guardians actually not having working internet connection. Seems like it can happen on some of nodes in the box, where users can get to the UI locally/via Tor, while the outside internet connectivity doesn't work.

Seems to me that a small network connectivity indicator might help with issues like that.

Seems more useful in the setup, but for now I added it to both setup and normal dashboard.

<img width="1906" height="1340" alt="Screenshot From 2026-02-20 13-11-13" src="https://github.com/user-attachments/assets/c9ef74e2-d736-4ab6-9d3b-b0f641e68bbc" />
<img width="782" height="391" alt="Screenshot From 2026-02-20 13-07-33" src="https://github.com/user-attachments/assets/605b4a1c-f70e-41d6-a609-d7a39917bae3" />


<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
