### PR TITLE
Replace RwLock with Mutexes

### DIFF
--- a/fedimint-client/src/client.rs
+++ b/fedimint-client/src/client.rs
@@ -131,7 +131,7 @@ pub(crate) struct PrimaryModuleCandidates {
 /// and resource freeing of the [`Client`].
 pub struct Client {
     final_client: FinalClientIface,
-    config: tokio::sync::RwLock<ClientConfig>,
+    config: tokio::sync::Mutex<ClientConfig>,
     api_secret: Option<String>,
     decoders: ModuleDecoderRegistry,
     connectors: ConnectorRegistry,
@@ -340,7 +340,7 @@ impl Client {
     }
 
     pub async fn config(&self) -> ClientConfig {
-        self.config.read().await.clone()
+        self.config.lock().await.clone()
     }
 
     // TODO: change to `-> Option<&str>`
@@ -1705,7 +1705,7 @@ impl Client {
                 let (guardian_pub_keys, new_config) = self.fetch_and_update_config(config).await;
 
                 dbtx.insert_entry(&ClientConfigKey, &new_config).await;
-                *(self.config.write().await) = new_config;
+                *(self.config.lock().await) = new_config;
                 guardian_pub_keys
             }
         }

--- a/fedimint-client/src/client/builder.rs
+++ b/fedimint-client/src/client/builder.rs
@@ -986,7 +986,7 @@ impl ClientBuilder {
 
         let client_inner = Arc::new(Client {
             final_client: final_client.clone(),
-            config: tokio::sync::RwLock::new(config.clone()),
+            config: tokio::sync::Mutex::new(config.clone()),
             api_secret,
             decoders,
             db: db.clone(),

--- a/fedimint-client/src/sm/executor.rs
+++ b/fedimint-client/src/sm/executor.rs
@@ -75,7 +75,7 @@ pub struct Executor {
 
 struct ExecutorInner {
     db: Database,
-    state: std::sync::RwLock<ExecutorState>,
+    state: std::sync::Mutex<ExecutorState>,
     module_contexts: BTreeMap<ModuleInstanceId, DynContext>,
     valid_module_ids: BTreeSet<ModuleInstanceId>,
     notifier: Notifier,
@@ -253,7 +253,7 @@ impl Executor {
                 match self
                     .inner
                     .state
-                    .read()
+                    .lock()
                     .expect("locking failed")
                     .gen_context(&state)
                 {
@@ -386,7 +386,7 @@ impl Executor {
         let Some((shutdown_receiver, sm_update_rx)) = self
             .inner
             .state
-            .write()
+            .lock()
             .expect("locking can't fail")
             .start(context_gen.clone())
         else {
@@ -890,7 +890,7 @@ impl ExecutorInner {
 impl ExecutorInner {
     /// See [`Executor::stop_executor`].
     fn stop_executor(&self) -> Option<()> {
-        let mut state = self.state.write().expect("Locking can't fail");
+        let mut state = self.state.lock().expect("Locking can't fail");
 
         state.stop()
     }
@@ -948,7 +948,7 @@ impl ExecutorBuilder {
         let inner = Arc::new(ExecutorInner {
             db,
             log_ordering_wakeup_tx,
-            state: std::sync::RwLock::new(ExecutorState::Unstarted { sm_update_rx }),
+            state: std::sync::Mutex::new(ExecutorState::Unstarted { sm_update_rx }),
             module_contexts: self.module_contexts,
             valid_module_ids: self.valid_module_ids,
             notifier,

--- a/fedimint-core/src/db/mem_impl.rs
+++ b/fedimint-core/src/db/mem_impl.rs
@@ -34,7 +34,7 @@ pub enum DatabaseOperation {
 
 #[derive(Default)]
 pub struct MemDatabase {
-    data: std::sync::RwLock<OrdMap<Vec<u8>, Vec<u8>>>,
+    data: std::sync::Mutex<OrdMap<Vec<u8>, Vec<u8>>>,
 }
 
 impl fmt::Debug for MemDatabase {
@@ -72,7 +72,7 @@ impl MemDatabase {
 impl IRawDatabase for MemDatabase {
     type Transaction<'a> = MemTransaction<'a>;
     async fn begin_transaction<'a>(&'a self) -> MemTransaction<'a> {
-        let db_copy = self.data.read().expect("Poisoned rwlock").clone();
+        let db_copy = self.data.lock().expect("Poisoned mutex").clone();
         MemTransaction {
             operations: Vec::new(),
             tx_data: db_copy,
@@ -177,7 +177,7 @@ impl IDatabaseTransactionOps for MemTransaction<'_> {}
 impl IRawDatabaseTransaction for MemTransaction<'_> {
     #[allow(clippy::significant_drop_tightening)]
     async fn commit_tx(self) -> DatabaseResult<()> {
-        let mut data = self.db.data.write().expect("Poisoned rwlock");
+        let mut data = self.db.data.lock().expect("Poisoned mutex");
         let mut data_copy = data.clone();
         for op in self.operations {
             match op {

--- a/fedimint-testing/src/btc/mock.rs
+++ b/fedimint-testing/src/btc/mock.rs
@@ -45,7 +45,7 @@ struct FakeBitcoinTestInner {
 
 #[derive(Clone, Debug)]
 pub struct FakeBitcoinTest {
-    inner: Arc<std::sync::RwLock<FakeBitcoinTestInner>>,
+    inner: Arc<std::sync::Mutex<FakeBitcoinTestInner>>,
 }
 
 impl Default for FakeBitcoinTest {
@@ -65,7 +65,7 @@ impl FakeBitcoinTest {
             txid_to_block_height: BTreeMap::new(),
         };
         let res = FakeBitcoinTest {
-            inner: std::sync::RwLock::new(inner).into(),
+            inner: Arc::new(std::sync::Mutex::new(inner)),
         };
 
         // We always need one custom block for the ChainId
@@ -139,7 +139,7 @@ impl FakeBitcoinTest {
     }
 
     fn mine_blocks_no_async(&self, block_num: u64) -> Vec<bitcoin::BlockHash> {
-        let mut inner = self.inner.write().unwrap();
+        let mut inner = self.inner.lock().unwrap();
 
         let FakeBitcoinTestInner {
             ref mut blocks,
@@ -170,7 +170,7 @@ impl BitcoinTest for FakeBitcoinTest {
     async fn prepare_funding_wallet(&self) {
         // In fake wallet this might not be technically necessary,
         // but it makes it behave more like the `RealBitcoinTest`.
-        let block_count = self.inner.write().unwrap().blocks.len() as u64;
+        let block_count = self.inner.lock().unwrap().blocks.len() as u64;
         if block_count < 100 {
             self.mine_blocks(100 - block_count).await;
         }
@@ -181,7 +181,7 @@ impl BitcoinTest for FakeBitcoinTest {
         address: &Address,
         amount: bitcoin::Amount,
     ) -> (TxOutProof, Transaction) {
-        let mut inner = self.inner.write().unwrap();
+        let mut inner = self.inner.lock().unwrap();
 
         let transaction = FakeBitcoinTest::new_transaction(
             vec![TxOut {
@@ -231,7 +231,7 @@ impl BitcoinTest for FakeBitcoinTest {
         self.mine_blocks(1).await;
         let sats = self
             .inner
-            .read()
+            .lock()
             .unwrap()
             .blocks
             .iter()
@@ -244,7 +244,7 @@ impl BitcoinTest for FakeBitcoinTest {
     async fn get_mempool_tx_fee(&self, txid: &Txid) -> Amount {
         loop {
             let (pending, addresses) = {
-                let inner = self.inner.read().unwrap();
+                let inner = self.inner.lock().unwrap();
                 (inner.pending.clone(), inner.addresses.clone())
             };
 
@@ -272,19 +272,19 @@ impl BitcoinTest for FakeBitcoinTest {
 
     async fn get_tx_block_height(&self, txid: &Txid) -> Option<u64> {
         self.inner
-            .read()
-            .expect("RwLock poisoned")
+            .lock()
+            .expect("Mutex poisoned")
             .txid_to_block_height
             .get(txid)
             .map(|height| height.to_owned() as u64)
     }
 
     async fn get_block_count(&self) -> u64 {
-        self.inner.read().expect("RwLock poisoned").blocks.len() as u64
+        self.inner.lock().expect("Mutex poisoned").blocks.len() as u64
     }
 
     async fn get_mempool_tx(&self, txid: &Txid) -> Option<bitcoin::Transaction> {
-        let inner = self.inner.read().unwrap();
+        let inner = self.inner.lock().unwrap();
         let mempool_transactions = inner.pending.clone();
         mempool_transactions
             .iter()
@@ -296,7 +296,7 @@ impl BitcoinTest for FakeBitcoinTest {
 #[async_trait]
 impl IBitcoindRpc for FakeBitcoinTest {
     async fn get_tx_block_height(&self, txid: &bitcoin::Txid) -> Result<Option<u64>> {
-        for (height, block) in self.inner.read().unwrap().blocks.iter().enumerate() {
+        for (height, block) in self.inner.lock().unwrap().blocks.iter().enumerate() {
             if block.txdata.iter().any(|tx| &tx.compute_txid() == txid) {
                 return Ok(Some(height as u64));
             }
@@ -312,18 +312,18 @@ impl IBitcoindRpc for FakeBitcoinTest {
         &self,
         script: &bitcoin::ScriptBuf,
     ) -> Result<Vec<bitcoin::Transaction>> {
-        let inner = self.inner.read().unwrap();
+        let inner = self.inner.lock().unwrap();
         Ok(inner.scripts.get(script).cloned().unwrap_or_default())
     }
 
     async fn get_txout_proof(&self, txid: bitcoin::Txid) -> Result<TxOutProof> {
-        let inner = self.inner.read().unwrap();
+        let inner = self.inner.lock().unwrap();
         let proof = inner.proofs.get(&txid);
         Ok(proof.ok_or(format_err!("No proof stored"))?.clone())
     }
 
     async fn get_info(&self) -> Result<BlockchainInfo> {
-        let inner = self.inner.read().unwrap();
+        let inner = self.inner.lock().unwrap();
         let count = inner.blocks.len() as u64;
         let synced = inner.pending.is_empty();
         Ok(BlockchainInfo {
@@ -355,12 +355,12 @@ impl IServerBitcoinRpc for FakeBitcoinTest {
     }
 
     async fn get_block_count(&self) -> Result<u64> {
-        Ok(self.inner.read().unwrap().blocks.len() as u64)
+        Ok(self.inner.lock().unwrap().blocks.len() as u64)
     }
 
     async fn get_block_hash(&self, height: u64) -> Result<bitcoin::BlockHash> {
         self.inner
-            .read()
+            .lock()
             .unwrap()
             .blocks
             .get(height as usize)
@@ -370,7 +370,7 @@ impl IServerBitcoinRpc for FakeBitcoinTest {
 
     async fn get_block(&self, block_hash: &bitcoin::BlockHash) -> Result<bitcoin::Block> {
         self.inner
-            .read()
+            .lock()
             .unwrap()
             .blocks
             .iter()
@@ -384,7 +384,7 @@ impl IServerBitcoinRpc for FakeBitcoinTest {
     }
 
     async fn submit_transaction(&self, transaction: bitcoin::Transaction) {
-        let mut inner = self.inner.write().unwrap();
+        let mut inner = self.inner.lock().unwrap();
         inner.pending.push(transaction);
 
         let mut filtered = BTreeMap::<Vec<OutPoint>, bitcoin::Transaction>::new();

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -120,7 +120,7 @@ use fedimint_wallet_client::{PegOutFees, WalletClientInit, WalletClientModule, W
 use futures::stream::StreamExt;
 use lightning_invoice::{Bolt11Invoice, RoutingFees};
 use rand::rngs::OsRng;
-use tokio::sync::RwLock;
+use tokio::sync::{Mutex, RwLock};
 use tracing::{debug, info, info_span, warn};
 
 use crate::envs::FM_GATEWAY_MNEMONIC_ENV;
@@ -230,7 +230,7 @@ pub struct Gateway {
     lightning_mode: LightningMode,
 
     /// The current state of the Gateway.
-    state: Arc<RwLock<GatewayState>>,
+    state: Arc<Mutex<GatewayState>>,
 
     /// Builder struct that allows the gateway to build a Fedimint client, which
     /// handles the communication with a federation.
@@ -580,7 +580,7 @@ impl Gateway {
         Ok(Self {
             federation_manager: Arc::new(RwLock::new(FederationManager::new())),
             lightning_mode,
-            state: Arc::new(RwLock::new(gateway_state)),
+            state: Arc::new(Mutex::new(gateway_state)),
             client_builder,
             gateway_db: gateway_db.clone(),
             listen: gateway_parameters.listen,
@@ -626,7 +626,7 @@ impl Gateway {
     }
 
     async fn get_state(&self) -> GatewayState {
-        self.state.read().await.clone()
+        self.state.lock().await.clone()
     }
 
     /// Reads and serializes structures from the Gateway's database for the
@@ -867,7 +867,7 @@ impl Gateway {
                         break;
                     };
 
-                    let state_guard = self.state.read().await;
+                    let state_guard = self.state.lock().await;
                     if let GatewayState::Running { ref lightning_context } = *state_guard {
                         // Spawn a subtask to handle each payment in parallel
                         let gateway = self.clone();
@@ -1105,7 +1105,7 @@ impl Gateway {
 
     /// Helper function for atomically changing the Gateway's internal state.
     async fn set_gateway_state(&self, state: GatewayState) {
-        let mut lock = self.state.write().await;
+        let mut lock = self.state.lock().await;
         *lock = state;
     }
 
@@ -1625,7 +1625,7 @@ impl IAdminGateway for Gateway {
                 federations: vec![],
                 federation_fake_scids: None,
                 version_hash: fedimint_build_code_version_env!().to_string(),
-                gateway_state: self.state.read().await.to_string(),
+                gateway_state: self.state.lock().await.to_string(),
                 lightning_info: LightningInfo::NotConnected,
                 lightning_mode: self.lightning_mode.clone(),
                 registrations: self
@@ -1660,7 +1660,7 @@ impl IAdminGateway for Gateway {
             federations,
             federation_fake_scids: Some(channels),
             version_hash: fedimint_build_code_version_env!().to_string(),
-            gateway_state: self.state.read().await.to_string(),
+            gateway_state: self.state.lock().await.to_string(),
             lightning_info,
             lightning_mode: self.lightning_mode.clone(),
             registrations: self
@@ -2231,8 +2231,8 @@ impl IAdminGateway for Gateway {
     /// Instructs the gateway to shutdown, but only after all incoming payments
     /// have been handled.
     async fn handle_shutdown_msg(&self, task_group: TaskGroup) -> AdminResult<()> {
-        // Take the write lock on the state so that no additional payments are processed
-        let mut state_guard = self.state.write().await;
+        // Take the lock on the state so that no additional payments are processed
+        let mut state_guard = self.state.lock().await;
         if let GatewayState::Running { lightning_context } = state_guard.clone() {
             *state_guard = GatewayState::ShuttingDown { lightning_context };
 

--- a/gateway/fedimint-lightning/src/ldk.rs
+++ b/gateway/fedimint-lightning/src/ldk.rs
@@ -24,7 +24,7 @@ use lightning::offers::offer::{Offer, OfferId};
 use lightning::types::payment::{PaymentHash, PaymentPreimage};
 use lightning_invoice::{Bolt11Invoice, Bolt11InvoiceDescription, Description};
 use tokio::sync::mpsc::Sender;
-use tokio::sync::{RwLock, oneshot};
+use tokio::sync::{Mutex, oneshot};
 use tokio_stream::wrappers::ReceiverStream;
 use tracing::{debug, error, info, warn};
 
@@ -63,7 +63,7 @@ pub struct GatewayLdkClient {
     /// the API handler from the event handler when the channel has been
     /// opened and is now pending.
     pending_channels:
-        Arc<RwLock<BTreeMap<UserChannelId, oneshot::Sender<anyhow::Result<OutPoint>>>>>,
+        Arc<Mutex<BTreeMap<UserChannelId, oneshot::Sender<anyhow::Result<OutPoint>>>>>,
 }
 
 impl std::fmt::Debug for GatewayLdkClient {
@@ -147,7 +147,7 @@ impl GatewayLdkClient {
         let task_group = TaskGroup::new();
 
         let node_clone = node.clone();
-        let pending_channels = Arc::new(RwLock::new(BTreeMap::new()));
+        let pending_channels = Arc::new(Mutex::new(BTreeMap::new()));
         let pending_channels_clone = pending_channels.clone();
         task_group.spawn("ldk lightning node event handler", |handle| async move {
             loop {
@@ -177,7 +177,7 @@ impl GatewayLdkClient {
         htlc_stream_sender: &Sender<InterceptPaymentRequest>,
         handle: &TaskHandle,
         pending_channels: Arc<
-            RwLock<BTreeMap<UserChannelId, oneshot::Sender<anyhow::Result<OutPoint>>>>,
+            Mutex<BTreeMap<UserChannelId, oneshot::Sender<anyhow::Result<OutPoint>>>>,
         >,
     ) {
         // We manually check for task termination in case we receive a payment while the
@@ -223,7 +223,7 @@ impl GatewayLdkClient {
                 funding_txo,
             } => {
                 info!(target: LOG_LIGHTNING, %channel_id, "LDK Channel is pending");
-                let mut channels = pending_channels.write().await;
+                let mut channels = pending_channels.lock().await;
                 if let Some(sender) = channels.remove(&UserChannelId(user_channel_id)) {
                     let _ = sender.send(Ok(funding_txo));
                 } else {
@@ -240,7 +240,7 @@ impl GatewayLdkClient {
                 reason,
             } => {
                 info!(target: LOG_LIGHTNING, %channel_id, "LDK Channel is closed");
-                let mut channels = pending_channels.write().await;
+                let mut channels = pending_channels.lock().await;
                 if let Some(sender) = channels.remove(&UserChannelId(user_channel_id)) {
                     let reason = if let Some(reason) = reason {
                         reason.to_string()
@@ -561,7 +561,7 @@ impl ILnRpcClient for GatewayLdkClient {
         let (tx, rx) = oneshot::channel::<anyhow::Result<OutPoint>>();
 
         {
-            let mut channels = self.pending_channels.write().await;
+            let mut channels = self.pending_channels.lock().await;
             let user_channel_id = self
                 .node
                 .open_announced_channel(

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -285,8 +285,26 @@ impl OOBNotes {
         for notes in &self.0 {
             match notes {
                 OOBNotesPart::Notes(notes) => {
-                    let notes_json = serde_json::to_value(notes)?;
-                    notes_map.insert("notes".to_string(), notes_json);
+                    let notes_json: serde_json::Map<String, serde_json::Value> = notes
+                        .iter()
+                        .map(|(amount, notes_vec)| {
+                            let notes_with_nonce: Vec<serde_json::Value> = notes_vec
+                                .iter()
+                                .map(|note| {
+                                    serde_json::json!({
+                                        "signature": note.signature,
+                                        "spend_key": note.spend_key,
+                                        "nonce": note.nonce(),
+                                    })
+                                })
+                                .collect();
+                            (
+                                amount.msats.to_string(),
+                                serde_json::Value::Array(notes_with_nonce),
+                            )
+                        })
+                        .collect();
+                    notes_map.insert("notes".to_string(), serde_json::Value::Object(notes_json));
                 }
                 OOBNotesPart::FederationIdPrefix(prefix) => {
                     notes_map.insert(

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -33,7 +33,7 @@ use std::fmt;
 use std::fmt::{Display, Formatter};
 use std::io::Read;
 use std::str::FromStr;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use anyhow::{Context as _, anyhow, bail, ensure};
@@ -118,7 +118,7 @@ const MINT_E_CASH_TYPE_CHILD_ID: ChildId = ChildId(0);
 
 #[derive(Clone)]
 struct PeerSelector {
-    latency: Arc<RwLock<BTreeMap<PeerId, Duration>>>,
+    latency: Arc<Mutex<BTreeMap<PeerId, Duration>>>,
 }
 
 impl PeerSelector {
@@ -129,12 +129,12 @@ impl PeerSelector {
             .collect();
 
         Self {
-            latency: Arc::new(RwLock::new(latency)),
+            latency: Arc::new(Mutex::new(latency)),
         }
     }
 
     fn choose_peer(&self) -> PeerId {
-        let latency = self.latency.read().expect("poisoned");
+        let latency = self.latency.lock().expect("poisoned");
 
         let peer_a = latency.iter().choose(&mut thread_rng()).expect("no peers");
         let peer_b = latency.iter().choose(&mut thread_rng()).expect("no peers");
@@ -148,7 +148,7 @@ impl PeerSelector {
 
     fn report(&self, peer: PeerId, duration: Duration) {
         self.latency
-            .write()
+            .lock()
             .expect("poisoned")
             .entry(peer)
             .and_modify(|latency| *latency = *latency * 9 / 10 + duration / 10)
@@ -156,7 +156,7 @@ impl PeerSelector {
     }
 
     fn remove(&self, peer: PeerId) {
-        self.latency.write().expect("poisoned").remove(&peer);
+        self.latency.lock().expect("poisoned").remove(&peer);
     }
 }
 


### PR DESCRIPTION
Many uses of `RwLocks` turn out to be suboptimal (more complex implementation, no performance benefit) and could be replaced with `Mutex`es. This PR changes one occurrence per commit so we can pick and choose which ones make sense to replace. 


<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
