### PR TITLE
chore(dev): revert to stable toolchain

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,3 @@
-cargo-features = ["codegen-backend"]
 
 [workspace]
 members = [
@@ -348,9 +347,6 @@ dbg_macro = "deny"
 literal_string_with_formatting_args = "deny"
 
 [profile.dev]
-# Note: cranelift backend is enabled via CARGO_PROFILE_DEV_CODEGEN_BACKEND
-# env var in flake.nix shellHook, only on x86_64-linux where it's supported.
-# codegen-backend = "cranelift"
 debug = "line-tables-only"
 # Workaround: https://github.com/rust-lang/cargo/issues/12457 which causes
 #             https://github.com/ipetkov/crane/issues/370
@@ -372,6 +368,7 @@ ff = { opt-level = 3 }
 group = { opt-level = 3 }
 hashbrown = { opt-level = 3 }
 libc = { opt-level = 3 }
+librocksdb-sys = { opt-level = 3 }
 memchr = { opt-level = 3 }
 pairing = { opt-level = 3 }
 parity-scale-codec = { opt-level = 3 }
@@ -379,18 +376,13 @@ ppv-lite86 = { opt-level = 3 }
 rand = { opt-level = 3 }
 rand_chacha = { opt-level = 3 }
 rand_core = { opt-level = 3 }
-ring = { opt-level = 3 }
-tikv-jemalloc-sys = { opt-level = 3 }
-# due to some miscompilation(?) this seems actually neccessary,
-# otherwise we see segfaults in Nix sandbox
-aws-lc-rs = { codegen-backend = "llvm" }
-aws-lc-sys = { codegen-backend = "llvm" }
-librocksdb-sys = { opt-level = 3 }
 regex = { opt-level = 3 }
-rustls = { opt-level = 3, codegen-backend = "llvm" }
+ring = { opt-level = 3 }
+rustls = { opt-level = 3 }
 secp256k1 = { opt-level = 3 }
 secp256k1-sys = { opt-level = 3 }
 subtle = { opt-level = 3 }
+tikv-jemalloc-sys = { opt-level = 3 }
 zeroize = { opt-level = 3 }
 
 [profile.dev.package."*"] # external dependencies

--- a/flake.nix
+++ b/flake.nix
@@ -105,7 +105,7 @@
             };
             linker.wild.enable = false;
 
-            toolchain.channel = "latest";
+            toolchain.channel = "stable";
 
             toolchain.components = [
               "rustc"
@@ -114,9 +114,6 @@
               "rust-analyzer"
               "rust-src"
               "llvm-tools"
-            ]
-            ++ lib.optionals (system == "x86_64-linux") [
-              "rustc-codegen-cranelift-preview"
             ];
 
             just.rules.clippy = {
@@ -356,14 +353,11 @@
                   fi
 
                   # librocksdb-sys 0.17+ no longer links stdc++ when using a prebuilt library via ROCKSDB_LIB_DIR
-                  export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS="$CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS -C link-arg=-lstdc++ -Zthreads=0"
+                  export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS="$CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS -C link-arg=-lstdc++"
 
                   export CARGO_BUILD_TARGET_DIR="''${CARGO_BUILD_TARGET_DIR:-''${REPO_ROOT}/target-nix}"
                   export FM_DISCOVER_API_VERSION_TIMEOUT=10
 
-                  ${lib.optionalString (system == "x86_64-linux") ''
-                    export CARGO_PROFILE_DEV_CODEGEN_BACKEND=cranelift
-                  ''}
                   export FLAKEBOX_GIT_LS_IGNORE=fedimint-ui-common/assets/
                   export FLAKEBOX_GIT_LS_TEXT_IGNORE=fedimint-ui-common/assets/
                   [ -f "$REPO_ROOT/.shrc.local" ] && source "$REPO_ROOT/.shrc.local"


### PR DESCRIPTION
There's some breakage between fenix and Rust nightly toolchain on MacOS.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
