### PR TITLE
chore(fedimint-cli): rename `join-federation` to `join`

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -186,7 +186,7 @@ Commands:
   print-secret     Print the secret key of the client
   admin
   dev
-  join-federation  Join a federation using it's InviteCode
+  join             Join a federation using its InviteCode
   completion
   help             Print this message or the help of the given subcommand(s)
 

--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -100,7 +100,7 @@ enum CliOutput {
         federation_id: FederationId,
     },
 
-    JoinFederation {
+    Join {
         joined: String,
     },
 
@@ -421,7 +421,8 @@ enum Command {
     },
 
     /// Join a federation using its InviteCode
-    JoinFederation {
+    #[clap(alias = "join-federation")]
+    Join {
         invite_code: String,
     },
 
@@ -922,7 +923,7 @@ impl FedimintCli {
 
                 Ok(CliOutput::InviteCode { invite_code })
             }
-            Command::JoinFederation { invite_code } => {
+            Command::Join { invite_code } => {
                 {
                     let invite_code: InviteCode = InviteCode::from_str(&invite_code)
                         .map_err_cli_msg("invalid invite code")?;
@@ -931,7 +932,7 @@ impl FedimintCli {
                     let _client = self.client_join(&cli, invite_code).await?;
                 }
 
-                Ok(CliOutput::JoinFederation {
+                Ok(CliOutput::Join {
                     joined: invite_code,
                 })
             }


### PR DESCRIPTION
There is nothing else to join, why do I have to type so much?

The old usage is an alias for backward-compat.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
