### PR TITLE
fix: devimint iroh test does not await payment

### DIFF
--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -861,6 +861,10 @@ pub async fn cli_tests(dev_fed: DevFed) -> Result<()> {
         gw_ldk
             .pay_invoice(Bolt11Invoice::from_str(&recv.invoice).expect("Could not parse invoice"))
             .await?;
+        let operation_id = recv.operation_id;
+        cmd!(client, "await-invoice", operation_id.fmt_full())
+            .run()
+            .await?;
     }
 
     info!("Testing outgoing payment from client to LDK via LND gateway");


### PR DESCRIPTION
I have unfortunately still been seeing flakes like this even though I thought I fixed it: https://github.com/fedimint/fedimint/actions/runs/22451613274/job/65021357460?pr=8323

Looking a little closer, it appears the Iroh test payment that I added does not wait for the client's notes to be issued. This would explain why the race condition has been happening and why it has been happening more recently (v0.10 and on).