### PR TITLE
feat(ui): add display toggle for federation balance

### DIFF
--- a/gateway/fedimint-gateway-ui/src/federation.rs
+++ b/gateway/fedimint-gateway-ui/src/federation.rs
@@ -75,6 +75,68 @@ pub fn scripts() -> Markup {
                     new bootstrap.Tooltip(el);
                 });
             });
+
+            // Format amount based on selected unit
+            function formatAmount(msats, unit) {
+                if (unit === 'btc') {
+                    const btc = msats / 100000000000;
+                    return btc.toFixed(8) + ' BTC';
+                } else if (unit === 'sats') {
+                    const sats = msats / 1000;
+                    if (Number.isInteger(sats)) {
+                        return sats.toLocaleString() + ' sats';
+                    }
+                    return sats.toLocaleString(undefined, {minimumFractionDigits: 0, maximumFractionDigits: 3}) + ' sats';
+                } else {
+                    return msats.toLocaleString() + ' msats';
+                }
+            }
+
+            // Update all amount displays within a federation card
+            function updateAmounts(fedId, unit) {
+                const card = document.getElementById('fed-card-' + fedId);
+                if (!card) return;
+
+                card.querySelectorAll('[data-msats]').forEach(function(el) {
+                    const msats = parseInt(el.getAttribute('data-msats'), 10);
+                    const display = el.querySelector('.amount-display');
+                    if (display) {
+                        display.textContent = formatAmount(msats, unit);
+                    }
+                });
+            }
+
+            // Get currently selected unit for a federation
+            function getSelectedUnit(fedId) {
+                const checked = document.querySelector('input[name="unit-' + fedId + '"]:checked');
+                if (checked) {
+                    return checked.value;
+                }
+                return 'btc';
+            }
+
+            // Initialize unit toggle listeners
+            document.addEventListener('DOMContentLoaded', function() {
+                document.querySelectorAll('.unit-toggle').forEach(function(toggle) {
+                    const fedId = toggle.getAttribute('data-fed-id');
+                    toggle.querySelectorAll('input[type="radio"]').forEach(function(radio) {
+                        radio.addEventListener('change', function(e) {
+                            updateAmounts(fedId, e.target.value);
+                        });
+                    });
+                });
+            });
+
+            // Re-apply unit formatting after HTMX swaps
+            document.addEventListener('htmx:afterSwap', function(evt) {
+                // Find the federation card this swap belongs to
+                const card = evt.target.closest('[id^="fed-card-"]');
+                if (card) {
+                    const fedId = card.id.replace('fed-card-', '');
+                    const unit = getSelectedUnit(fedId);
+                    updateAmounts(fedId, unit);
+                }
+            });
             "#))
         }
     )
@@ -97,25 +159,42 @@ pub fn render<E: Display>(
             .unwrap_or("Never".to_string());
 
 
+        @let fed_id_str = fed.federation_id.to_string();
+        @let btc_value = fed.balance_msat.msats as f64 / 100_000_000_000.0;
+
         div class="row gy-4 mt-2" {
             div class="col-12" {
-                div class="card h-100" {
+                div class="card h-100" id=(format!("fed-card-{}", fed_id_str)) {
                     div class="card-header dashboard-header d-flex justify-content-between align-items-center" {
                         div {
                             (fed.federation_name.clone().unwrap_or("Unnamed Federation".to_string()))
                         }
 
-                        form method="post" action={(format!("/ui/federations/{}/leave", fed.federation_id))} {
-                            button type="submit"
-                                class="btn btn-outline-danger btn-sm"
-                                title="Leave Federation"
-                                onclick=("return confirm('Are you sure you want to leave this federation? You will need to re-connect the federation to access any remaining balance.');")
-                            { "📤" }
+                        div class="d-flex align-items-center gap-2" {
+                            // Unit toggle
+                            div class="btn-group btn-group-sm unit-toggle" role="group" data-fed-id=(fed_id_str) {
+                                input type="radio" class="btn-check" name=(format!("unit-{}", fed_id_str)) id=(format!("unit-btc-{}", fed_id_str)) value="btc" checked;
+                                label class="btn btn-outline-primary" for=(format!("unit-btc-{}", fed_id_str)) { "BTC" }
+
+                                input type="radio" class="btn-check" name=(format!("unit-{}", fed_id_str)) id=(format!("unit-sats-{}", fed_id_str)) value="sats";
+                                label class="btn btn-outline-primary" for=(format!("unit-sats-{}", fed_id_str)) { "sats" }
+
+                                input type="radio" class="btn-check" name=(format!("unit-{}", fed_id_str)) id=(format!("unit-msats-{}", fed_id_str)) value="msats";
+                                label class="btn btn-outline-primary" for=(format!("unit-msats-{}", fed_id_str)) { "msats" }
+                            }
+
+                            form method="post" action={(format!("/ui/federations/{}/leave", fed.federation_id))} {
+                                button type="submit"
+                                    class="btn btn-outline-danger btn-sm"
+                                    title="Leave Federation"
+                                    onclick=("return confirm('Are you sure you want to leave this federation? You will need to re-connect the federation to access any remaining balance.');")
+                                { "📤" }
+                            }
                         }
                     }
                     div class="card-body" {
-                        div id=(format!("balance-{}", fed.federation_id)) class=(balance_class) {
-                            "Balance: " strong { (fed.balance_msat) }
+                        div id=(format!("balance-{}", fed.federation_id)) class=(balance_class) data-msats=(fed.balance_msat.msats) {
+                            "Balance: " strong class="amount-display" { (format!("{:.8} BTC", btc_value)) }
                         }
                         div class="alert alert-secondary py-1 px-2 small" {
                             "Last Backup: " strong { (last_backup_str) }
@@ -861,6 +940,8 @@ pub async fn withdraw_confirm_handler<E: Display>(
                 "alert alert-success"
             };
 
+            let balance_btc = updated_balance.msats as f64 / 100_000_000_000.0;
+
             html! {
                 // Success message (swaps into result div)
                 div class="alert alert-success" {
@@ -872,9 +953,10 @@ pub async fn withdraw_confirm_handler<E: Display>(
                 // Out-of-band swap to update balance banner
                 div id=(format!("balance-{}", federation_id))
                     class=(balance_class)
+                    data-msats=(updated_balance.msats)
                     hx-swap-oob="true"
                 {
-                    "Balance: " strong { (updated_balance) }
+                    "Balance: " strong class="amount-display" { (format!("{:.8} BTC", balance_btc)) }
                 }
             }
         }
@@ -924,6 +1006,8 @@ pub async fn spend_ecash_handler<E: Display>(
                 "alert alert-success"
             };
 
+            let balance_btc = updated_balance.msats as f64 / 100_000_000_000.0;
+
             html! {
                 div class="card card-body bg-light" {
                     div class="d-flex justify-content-between align-items-center mb-2" {
@@ -955,9 +1039,10 @@ pub async fn spend_ecash_handler<E: Display>(
                 // Out-of-band swap to update balance banner
                 div id=(format!("balance-{}", federation_id))
                     class=(balance_class)
+                    data-msats=(updated_balance.msats)
                     hx-swap-oob="true"
                 {
-                    "Balance: " strong { (updated_balance) }
+                    "Balance: " strong class="amount-display" { (format!("{:.8} BTC", balance_btc)) }
                 }
             }
         }
@@ -1024,6 +1109,8 @@ pub async fn receive_ecash_handler<E: Display>(
                 "alert alert-success"
             };
 
+            let balance_btc = updated_balance.msats as f64 / 100_000_000_000.0;
+
             html! {
                 div class=(balance_class) {
                     div class="d-flex justify-content-between align-items-center" {
@@ -1035,9 +1122,10 @@ pub async fn receive_ecash_handler<E: Display>(
                 // Out-of-band swap to update balance banner
                 div id=(format!("balance-{}", federation_id))
                     class=(balance_class)
+                    data-msats=(updated_balance.msats)
                     hx-swap-oob="true"
                 {
-                    "Balance: " strong { (updated_balance) }
+                    "Balance: " strong class="amount-display" { (format!("{:.8} BTC", balance_btc)) }
                 }
             }
         }


### PR DESCRIPTION
I personally find it very hard to view balances in msats, especially when they're large. This PR adds a tiny bit of javascript to toggle how balances are displayed.

<img width="2676" height="200" alt="image" src="https://github.com/user-attachments/assets/e6647594-6b04-45d5-bece-2bfd8bde51d9" />

<img width="2676" height="200" alt="image" src="https://github.com/user-attachments/assets/a1380634-1bd5-46a1-9537-5d5ec53524a7" />

<img width="2676" height="200" alt="image" src="https://github.com/user-attachments/assets/d7a67540-b0f6-4503-80d5-e525dfb68e3a" />
