### PR TITLE
feat(client): add pkarr fallback for guardian metadata refresh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3148,6 +3148,7 @@ dependencies = [
  "fedimint-logging",
  "fedimint-metrics",
  "futures",
+ "pkarr",
  "reqwest 0.12.28",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3233,6 +3233,7 @@ dependencies = [
  "fedimint-logging",
  "fedimint-metrics",
  "futures",
+ "pkarr",
  "reqwest 0.12.28",
  "serde",
  "serde_json",

--- a/fedimint-client/Cargo.toml
+++ b/fedimint-client/Cargo.toml
@@ -17,6 +17,8 @@ normal = ["aquamarine"]
 rustc-args = ["--cfg", "tokio_unstable"]
 
 [features]
+pkarr = ["dep:pkarr"]
+pkarr-dht = ["pkarr", "pkarr/dht"]
 tor = ["fedimint-client-module/tor"]
 
 [lib]
@@ -39,6 +41,7 @@ fedimint-eventlog = { workspace = true }
 fedimint-logging = { workspace = true }
 fedimint-metrics = { workspace = true }
 futures = { workspace = true }
+pkarr = { workspace = true, features = ["relays"], optional = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/fedimint-client/Cargo.toml
+++ b/fedimint-client/Cargo.toml
@@ -17,6 +17,8 @@ normal = ["aquamarine"]
 rustc-args = ["--cfg", "tokio_unstable"]
 
 [features]
+pkarr = ["dep:pkarr"]
+pkarr-dht = ["pkarr", "pkarr/dht"]
 tor = ["fedimint-client-module/tor"]
 
 uniffi = [
@@ -47,6 +49,7 @@ fedimint-eventlog = { workspace = true }
 fedimint-logging = { workspace = true }
 fedimint-metrics = { workspace = true }
 futures = { workspace = true }
+pkarr = { workspace = true, features = ["relays"], optional = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/fedimint-client/src/guardian_metadata/mod.rs
+++ b/fedimint-client/src/guardian_metadata/mod.rs
@@ -10,9 +10,8 @@ use fedimint_core::envs::is_running_in_test_env;
 use fedimint_core::net::guardian_metadata::SignedGuardianMetadata;
 use fedimint_core::runtime::{self, sleep};
 use fedimint_core::secp256k1::SECP256K1;
-use fedimint_core::util::backoff_util::custom_backoff;
 use fedimint_core::util::{FmtCompact as _, FmtCompactAnyhow as _};
-use fedimint_core::{NumPeersExt as _, PeerId, impl_db_lookup, impl_db_record};
+use fedimint_core::{PeerId, impl_db_lookup, impl_db_record};
 use fedimint_logging::LOG_CLIENT;
 use futures::stream::{FuturesUnordered, StreamExt as _};
 use tracing::debug;
@@ -37,6 +36,19 @@ impl_db_lookup!(
     query_prefix = GuardianMetadataPrefix
 );
 
+#[cfg(feature = "pkarr")]
+mod pkarr;
+
+/// Extra time to wait for additional peer responses after the minimum
+/// required have been collected.
+fn extra_response_wait() -> Duration {
+    if is_running_in_test_env() {
+        Duration::from_millis(1)
+    } else {
+        Duration::from_secs(30)
+    }
+}
+
 /// Fetches guardian metadata from guardians, validates them and updates the
 /// DB if any new more up to date ones are found.
 pub(crate) async fn run_guardian_metadata_refresh_task(client_inner: Arc<Client>) {
@@ -48,14 +60,19 @@ pub(crate) async fn run_guardian_metadata_refresh_task(client_inner: Arc<Client>
             let results = fetch_guardian_metadata_from_at_least_num_of_peers(
                 1,
                 api,
+                guardian_pub_keys.keys().copied().collect(),
                 &guardian_pub_keys,
-                if is_running_in_test_env() {
-                    Duration::from_millis(1)
-                } else {
-                    Duration::from_secs(30)
-                },
+                extra_response_wait(),
             )
             .await;
+
+            #[cfg(feature = "pkarr")]
+            let results = if results.is_empty() {
+                pkarr::try_pkarr_fallback(&client_inner, &guardian_pub_keys).await
+            } else {
+                results
+            };
+
             store_guardian_metadata_updates_from_peers(
                 client_inner.db(),
                 &guardian_pub_keys,
@@ -90,21 +107,19 @@ pub(crate) async fn store_guardian_metadata_updates_from_peers(
 
 pub(crate) type PeersSignedGuardianMetadata = BTreeMap<PeerId, SignedGuardianMetadata>;
 
-/// Fetch responses from at least `num_responses_required` of peers.
+/// Fetch responses from at least `num_responses_required` of the requested
+/// peers.
 ///
-/// Will wait a little bit extra in hopes of collecting more than strictly
-/// needed responses.
+/// Each requested peer is tried once. If enough responses are collected, this
+/// waits a little bit extra in hopes of collecting more than strictly needed
+/// responses.
 pub(crate) async fn fetch_guardian_metadata_from_at_least_num_of_peers(
     num_responses_required: usize,
     api: &DynGlobalApi,
+    query_peer_ids: Vec<PeerId>,
     guardian_pub_keys: &BTreeMap<PeerId, bitcoin::secp256k1::PublicKey>,
     extra_response_wait: Duration,
 ) -> Vec<PeersSignedGuardianMetadata> {
-    let num_peers = guardian_pub_keys.to_num_peers();
-    // Keep trying, initially somewhat aggressively, but after a while retry very
-    // slowly, because chances for response are getting lower and lower.
-    let mut backoff = custom_backoff(Duration::from_millis(200), Duration::from_secs(600), None);
-
     // Make a single request to a peer after a delay
     async fn make_request(
         delay: Duration,
@@ -140,7 +155,7 @@ pub(crate) async fn fetch_guardian_metadata_from_at_least_num_of_peers(
 
     let mut requests = FuturesUnordered::new();
 
-    for peer_id in num_peers.peer_ids() {
+    for peer_id in query_peer_ids {
         requests.push(make_request(
             Duration::ZERO,
             peer_id,
@@ -177,12 +192,6 @@ pub(crate) async fn fetch_guardian_metadata_from_at_least_num_of_peers(
                     err = %err.fmt_compact_anyhow(),
                     "Failed to fetch guardian metadata from peer"
                 );
-                requests.push(make_request(
-                    backoff.next().expect("Keeps retrying"),
-                    peer_id,
-                    api,
-                    guardian_pub_keys,
-                ));
             }
             Ok(metadata) => {
                 responses.push(metadata);

--- a/fedimint-client/src/guardian_metadata/mod.rs
+++ b/fedimint-client/src/guardian_metadata/mod.rs
@@ -38,6 +38,12 @@ impl_db_lookup!(
 
 #[cfg(feature = "pkarr")]
 mod pkarr;
+#[cfg(test)]
+mod tests;
+
+const NORMAL_REFRESH_INTERVAL: Duration = Duration::from_secs(60 * 60);
+const INITIAL_FAILED_REFRESH_INTERVAL: Duration = Duration::from_secs(30);
+const MAX_FAILED_REFRESH_INTERVAL: Duration = Duration::from_secs(10 * 60);
 
 /// Extra time to wait for additional peer responses after the minimum
 /// required have been collected.
@@ -54,7 +60,9 @@ fn extra_response_wait() -> Duration {
 pub(crate) async fn run_guardian_metadata_refresh_task(client_inner: Arc<Client>) {
     // Wait for the guardian keys to be available
     let guardian_pub_keys = client_inner.get_guardian_public_keys_blocking().await;
+    let mut failed_refresh_interval = INITIAL_FAILED_REFRESH_INTERVAL;
     loop {
+        let received_response;
         if let Err(err) = {
             let api: &DynGlobalApi = &client_inner.api;
             let results = fetch_guardian_metadata_from_at_least_num_of_peers(
@@ -73,6 +81,7 @@ pub(crate) async fn run_guardian_metadata_refresh_task(client_inner: Arc<Client>
                 results
             };
 
+            received_response = !results.is_empty();
             store_guardian_metadata_updates_from_peers(
                 client_inner.db(),
                 &guardian_pub_keys,
@@ -86,10 +95,25 @@ pub(crate) async fn run_guardian_metadata_refresh_task(client_inner: Arc<Client>
         let duration = if is_running_in_test_env() {
             Duration::from_secs(1)
         } else {
-            // Check once an hour if there are new metadata
-            Duration::from_secs(3600)
+            next_refresh_interval(received_response, &mut failed_refresh_interval)
         };
         sleep(duration).await;
+    }
+}
+
+fn next_refresh_interval(
+    received_response: bool,
+    failed_refresh_interval: &mut Duration,
+) -> Duration {
+    if received_response {
+        *failed_refresh_interval = INITIAL_FAILED_REFRESH_INTERVAL;
+        NORMAL_REFRESH_INTERVAL
+    } else {
+        let interval = *failed_refresh_interval;
+        *failed_refresh_interval = failed_refresh_interval
+            .saturating_mul(2)
+            .min(MAX_FAILED_REFRESH_INTERVAL);
+        interval
     }
 }
 

--- a/fedimint-client/src/guardian_metadata/pkarr.rs
+++ b/fedimint-client/src/guardian_metadata/pkarr.rs
@@ -1,0 +1,191 @@
+use std::collections::BTreeMap;
+
+use fedimint_api_client::api::DynGlobalApi;
+use fedimint_core::PeerId;
+use fedimint_core::db::{Database, IDatabaseTransactionOpsCoreTyped};
+use fedimint_core::envs::{
+    FM_PKARR_DHT_ENABLE_ENV, FM_PKARR_ENABLE_ENV, FM_PKARR_RELAYS_ENABLE_ENV, is_env_var_set,
+};
+use fedimint_core::net::guardian_metadata::SignedGuardianMetadata;
+use fedimint_core::util::{FmtCompact as _, FmtCompactAnyhow as _, SafeUrl};
+use fedimint_logging::LOG_CLIENT;
+use futures::stream::StreamExt as _;
+use pkarr::dns::rdata::RData;
+use tracing::{debug, warn};
+
+use super::{
+    GuardianMetadataPrefix, PeersSignedGuardianMetadata,
+    fetch_guardian_metadata_from_at_least_num_of_peers,
+};
+use crate::Client;
+
+/// Resolve guardian API URLs via Pkarr network using cached `pkarr_id_z32`
+/// from locally stored guardian metadata.
+///
+/// Respects the same env vars as the server-side publisher:
+/// - `FM_PKARR_ENABLE` (default: enabled) — master switch for pkarr
+/// - `FM_PKARR_DHT_ENABLE` (default: disabled) — also use Mainline DHT
+///   (requires the `pkarr-dht` compile-time feature)
+/// - `FM_PKARR_RELAYS_ENABLE` (default: enabled) — use Pkarr relays
+async fn resolve_api_urls_via_pkarr(db: &Database) -> BTreeMap<PeerId, SafeUrl> {
+    let pkarr_enabled =
+        fedimint_core::envs::is_env_var_set_opt(FM_PKARR_ENABLE_ENV).unwrap_or(true);
+
+    if !pkarr_enabled {
+        debug!(
+            target: LOG_CLIENT,
+            "Pkarr resolve disabled"
+        );
+        return BTreeMap::new();
+    }
+
+    // DHT requires both the compile-time feature and the runtime env var
+    let dht_enabled = cfg!(feature = "pkarr-dht") && is_env_var_set(FM_PKARR_DHT_ENABLE_ENV);
+    let relays_enabled =
+        fedimint_core::envs::is_env_var_set_opt(FM_PKARR_RELAYS_ENABLE_ENV).unwrap_or(true);
+
+    if !dht_enabled && !relays_enabled {
+        debug!(
+            target: LOG_CLIENT,
+            "Pkarr resolve disabled (both DHT and relays disabled)"
+        );
+        return BTreeMap::new();
+    }
+
+    let mut dbtx = db.begin_transaction_nc().await;
+    let cached_metadata: BTreeMap<PeerId, SignedGuardianMetadata> = dbtx
+        .find_by_prefix(&GuardianMetadataPrefix)
+        .await
+        .map(|(key, metadata)| (key.0, metadata))
+        .collect()
+        .await;
+    drop(dbtx);
+
+    let mut builder = pkarr::Client::builder();
+    if !dht_enabled {
+        builder.no_dht();
+    }
+    if !relays_enabled {
+        builder.no_relays();
+    }
+    let pkarr_client = match builder.build() {
+        Ok(c) => c,
+        Err(e) => {
+            debug!(
+                target: LOG_CLIENT,
+                err = %e.fmt_compact(),
+                "Failed to build pkarr client"
+            );
+            return BTreeMap::new();
+        }
+    };
+
+    let resolve_futures: Vec<_> = cached_metadata
+        .iter()
+        .filter_map(|(peer_id, meta)| {
+            let pkarr_id = meta.guardian_metadata().pkarr_id_z32.clone();
+            if pkarr_id.is_empty() {
+                return None;
+            }
+            let client = &pkarr_client;
+            let peer_id = *peer_id;
+            Some(async move {
+                let pk = match pkarr::PublicKey::try_from(pkarr_id.as_str()) {
+                    Ok(pk) => pk,
+                    Err(e) => {
+                        warn!(
+                            target: LOG_CLIENT,
+                            %peer_id,
+                            err = %e.fmt_compact(),
+                            "Failed to parse pkarr public key"
+                        );
+                        return None;
+                    }
+                };
+
+                let signed_packet = match client.resolve(&pk).await {
+                    Some(sp) => sp,
+                    None => {
+                        warn!(
+                            target: LOG_CLIENT,
+                            %peer_id,
+                            "No pkarr record found"
+                        );
+                        return None;
+                    }
+                };
+
+                for record in signed_packet
+                    .resource_records(fedimint_core::net::guardian_metadata::PKARR_API_RECORD_NAME)
+                {
+                    if let RData::TXT(txt) = &record.rdata
+                        && let Ok(url_str) = String::try_from(txt.clone())
+                        && let Ok(url) = url_str.parse()
+                    {
+                        return Some((peer_id, url));
+                    }
+                }
+
+                warn!(
+                    target: LOG_CLIENT,
+                    %peer_id,
+                    "No fedimint_api TXT record in pkarr response"
+                );
+                None
+            })
+        })
+        .collect();
+
+    futures::future::join_all(resolve_futures)
+        .await
+        .into_iter()
+        .flatten()
+        .collect()
+}
+
+/// If no guardians were reachable via normal API, try resolving their
+/// current URLs from the Pkarr network and retry the metadata fetch.
+pub(crate) async fn try_pkarr_fallback(
+    client_inner: &Client,
+    guardian_pub_keys: &BTreeMap<PeerId, bitcoin::secp256k1::PublicKey>,
+) -> Vec<PeersSignedGuardianMetadata> {
+    debug!(
+        target: LOG_CLIENT,
+        "Normal API unreachable, trying pkarr fallback"
+    );
+
+    let pkarr_urls = resolve_api_urls_via_pkarr(client_inner.db()).await;
+    if pkarr_urls.is_empty() {
+        return vec![];
+    }
+
+    // Only query guardians whose URLs were resolved via Pkarr. Keep using the
+    // full guardian key map below, because a reachable guardian can return
+    // signed metadata for all peers and each returned entry still needs to be
+    // verified against the corresponding peer's public key.
+    let query_peer_ids = pkarr_urls.keys().copied().collect();
+    let pkarr_api = match DynGlobalApi::new(
+        client_inner.endpoints().clone(),
+        pkarr_urls,
+        client_inner.api_secret().as_deref(),
+    ) {
+        Ok(api) => api,
+        Err(e) => {
+            debug!(
+                target: LOG_CLIENT,
+                err = %e.fmt_compact_anyhow(),
+                "Failed to build pkarr fallback API client"
+            );
+            return vec![];
+        }
+    };
+
+    fetch_guardian_metadata_from_at_least_num_of_peers(
+        1,
+        &pkarr_api,
+        query_peer_ids,
+        guardian_pub_keys,
+        super::extra_response_wait(),
+    )
+    .await
+}

--- a/fedimint-client/src/guardian_metadata/pkarr.rs
+++ b/fedimint-client/src/guardian_metadata/pkarr.rs
@@ -1,0 +1,199 @@
+use std::collections::BTreeMap;
+
+use fedimint_api_client::api::DynGlobalApi;
+use fedimint_core::PeerId;
+use fedimint_core::db::{Database, IDatabaseTransactionOpsCoreTyped};
+use fedimint_core::envs::{
+    FM_PKARR_DHT_ENABLE_ENV, FM_PKARR_ENABLE_ENV, FM_PKARR_RELAYS_ENABLE_ENV, is_env_var_set,
+};
+use fedimint_core::net::guardian_metadata::SignedGuardianMetadata;
+use fedimint_core::util::{FmtCompact as _, FmtCompactAnyhow as _, SafeUrl};
+use fedimint_logging::LOG_CLIENT;
+use futures::stream::StreamExt as _;
+use pkarr::dns::rdata::RData;
+use tracing::{debug, warn};
+
+use super::{
+    GuardianMetadataPrefix, PeersSignedGuardianMetadata,
+    fetch_guardian_metadata_from_at_least_num_of_peers,
+};
+use crate::Client;
+
+/// Resolve guardian API URLs via Pkarr network using cached `pkarr_id_z32`
+/// from locally stored guardian metadata.
+///
+/// Respects the same env vars as the server-side publisher:
+/// - `FM_PKARR_ENABLE` (default: enabled) — master switch for pkarr
+/// - `FM_PKARR_DHT_ENABLE` (default: disabled) — also use Mainline DHT
+///   (requires the `pkarr-dht` compile-time feature)
+/// - `FM_PKARR_RELAYS_ENABLE` (default: enabled) — use Pkarr relays
+async fn resolve_api_urls_via_pkarr(db: &Database) -> BTreeMap<PeerId, SafeUrl> {
+    let pkarr_enabled =
+        fedimint_core::envs::is_env_var_set_opt(FM_PKARR_ENABLE_ENV).unwrap_or(true);
+
+    if !pkarr_enabled {
+        debug!(
+            target: LOG_CLIENT,
+            "Pkarr resolve disabled"
+        );
+        return BTreeMap::new();
+    }
+
+    // DHT requires both the compile-time feature and the runtime env var
+    let dht_enabled = cfg!(feature = "pkarr-dht") && is_env_var_set(FM_PKARR_DHT_ENABLE_ENV);
+    let relays_enabled =
+        fedimint_core::envs::is_env_var_set_opt(FM_PKARR_RELAYS_ENABLE_ENV).unwrap_or(true);
+
+    if !dht_enabled && !relays_enabled {
+        debug!(
+            target: LOG_CLIENT,
+            "Pkarr resolve disabled (both DHT and relays disabled)"
+        );
+        return BTreeMap::new();
+    }
+
+    let mut dbtx = db.begin_transaction_nc().await;
+    let cached_metadata: BTreeMap<PeerId, SignedGuardianMetadata> = dbtx
+        .find_by_prefix(&GuardianMetadataPrefix)
+        .await
+        .map(|(key, metadata)| (key.0, metadata))
+        .collect()
+        .await;
+    drop(dbtx);
+
+    let Some(pkarr_client) = build_pkarr_client(dht_enabled, relays_enabled) else {
+        return BTreeMap::new();
+    };
+
+    let resolve_futures: Vec<_> = cached_metadata
+        .iter()
+        .filter_map(|(peer_id, meta)| {
+            let pkarr_id = meta.guardian_metadata().pkarr_id_z32.clone();
+            if pkarr_id.is_empty() {
+                return None;
+            }
+            let client = &pkarr_client;
+            let peer_id = *peer_id;
+            Some(async move {
+                let pk = match pkarr::PublicKey::try_from(pkarr_id.as_str()) {
+                    Ok(pk) => pk,
+                    Err(e) => {
+                        warn!(
+                            target: LOG_CLIENT,
+                            %peer_id,
+                            err = %e.fmt_compact(),
+                            "Failed to parse pkarr public key"
+                        );
+                        return None;
+                    }
+                };
+
+                let signed_packet = match client.resolve(&pk).await {
+                    Some(sp) => sp,
+                    None => {
+                        warn!(
+                            target: LOG_CLIENT,
+                            %peer_id,
+                            "No pkarr record found"
+                        );
+                        return None;
+                    }
+                };
+
+                for record in signed_packet
+                    .resource_records(fedimint_core::net::guardian_metadata::PKARR_API_RECORD_NAME)
+                {
+                    if let RData::TXT(txt) = &record.rdata
+                        && let Ok(url_str) = String::try_from(txt.clone())
+                        && let Ok(url) = url_str.parse()
+                    {
+                        return Some((peer_id, url));
+                    }
+                }
+
+                warn!(
+                    target: LOG_CLIENT,
+                    %peer_id,
+                    "No fedimint_api TXT record in pkarr response"
+                );
+                None
+            })
+        })
+        .collect();
+
+    futures::future::join_all(resolve_futures)
+        .await
+        .into_iter()
+        .flatten()
+        .collect()
+}
+
+fn build_pkarr_client(dht_enabled: bool, relays_enabled: bool) -> Option<pkarr::Client> {
+    let mut builder = pkarr::Client::builder();
+    if !dht_enabled {
+        builder.no_dht();
+    }
+    if !relays_enabled {
+        builder.no_relays();
+    }
+    let pkarr_client = match builder.build() {
+        Ok(c) => c,
+        Err(e) => {
+            debug!(
+                target: LOG_CLIENT,
+                err = %e.fmt_compact(),
+                "Failed to build pkarr client"
+            );
+            return None;
+        }
+    };
+
+    Some(pkarr_client)
+}
+
+/// If no guardians were reachable via normal API, try resolving their
+/// current URLs from the Pkarr network and retry the metadata fetch.
+pub(crate) async fn try_pkarr_fallback(
+    client_inner: &Client,
+    guardian_pub_keys: &BTreeMap<PeerId, bitcoin::secp256k1::PublicKey>,
+) -> Vec<PeersSignedGuardianMetadata> {
+    debug!(
+        target: LOG_CLIENT,
+        "Normal API unreachable, trying pkarr fallback"
+    );
+
+    let pkarr_urls = resolve_api_urls_via_pkarr(client_inner.db()).await;
+    if pkarr_urls.is_empty() {
+        return vec![];
+    }
+
+    // Only query guardians whose URLs were resolved via Pkarr. Keep using the
+    // full guardian key map below, because a reachable guardian can return
+    // signed metadata for all peers and each returned entry still needs to be
+    // verified against the corresponding peer's public key.
+    let query_peer_ids = pkarr_urls.keys().copied().collect();
+    let pkarr_api = match DynGlobalApi::new(
+        client_inner.endpoints().clone(),
+        pkarr_urls,
+        client_inner.api_secret().as_deref(),
+    ) {
+        Ok(api) => api,
+        Err(e) => {
+            debug!(
+                target: LOG_CLIENT,
+                err = %e.fmt_compact_anyhow(),
+                "Failed to build pkarr fallback API client"
+            );
+            return vec![];
+        }
+    };
+
+    fetch_guardian_metadata_from_at_least_num_of_peers(
+        1,
+        &pkarr_api,
+        query_peer_ids,
+        guardian_pub_keys,
+        super::extra_response_wait(),
+    )
+    .await
+}

--- a/fedimint-client/src/guardian_metadata/pkarr.rs
+++ b/fedimint-client/src/guardian_metadata/pkarr.rs
@@ -88,7 +88,7 @@ async fn resolve_api_urls_via_pkarr(db: &Database) -> BTreeMap<PeerId, SafeUrl> 
                     }
                 };
 
-                let signed_packet = match client.resolve(&pk).await {
+                let signed_packet = match client.resolve_most_recent(&pk).await {
                     Some(sp) => sp,
                     None => {
                         warn!(

--- a/fedimint-client/src/guardian_metadata/tests.rs
+++ b/fedimint-client/src/guardian_metadata/tests.rs
@@ -1,0 +1,46 @@
+use std::time::Duration;
+
+use super::{
+    INITIAL_FAILED_REFRESH_INTERVAL, MAX_FAILED_REFRESH_INTERVAL, NORMAL_REFRESH_INTERVAL,
+    next_refresh_interval,
+};
+
+#[test]
+fn failed_refreshes_back_off_and_success_resets_interval() {
+    let mut failed_refresh_interval = INITIAL_FAILED_REFRESH_INTERVAL;
+
+    assert_eq!(
+        next_refresh_interval(false, &mut failed_refresh_interval),
+        Duration::from_secs(30)
+    );
+    assert_eq!(
+        next_refresh_interval(false, &mut failed_refresh_interval),
+        Duration::from_secs(60)
+    );
+    assert_eq!(
+        next_refresh_interval(false, &mut failed_refresh_interval),
+        Duration::from_secs(120)
+    );
+    assert_eq!(
+        next_refresh_interval(false, &mut failed_refresh_interval),
+        Duration::from_secs(240)
+    );
+    assert_eq!(
+        next_refresh_interval(false, &mut failed_refresh_interval),
+        Duration::from_secs(480)
+    );
+    assert_eq!(
+        next_refresh_interval(false, &mut failed_refresh_interval),
+        MAX_FAILED_REFRESH_INTERVAL
+    );
+    assert_eq!(
+        next_refresh_interval(false, &mut failed_refresh_interval),
+        MAX_FAILED_REFRESH_INTERVAL
+    );
+
+    assert_eq!(
+        next_refresh_interval(true, &mut failed_refresh_interval),
+        NORMAL_REFRESH_INTERVAL
+    );
+    assert_eq!(failed_refresh_interval, INITIAL_FAILED_REFRESH_INTERVAL);
+}

--- a/fedimint-core/src/envs.rs
+++ b/fedimint-core/src/envs.rs
@@ -156,13 +156,16 @@ pub const FM_IROH_PKARR_PUBLISHER_ENABLE_ENV: &str = "FM_IROH_PKARR_PUBLISHER_EN
 /// Env var to disable Iroh's use of relays
 pub const FM_IROH_RELAYS_ENABLE_ENV: &str = "FM_IROH_RELAYS_ENABLE";
 
-/// Env var to disable all pkarr publishing (enabled by default)
+/// Env var to disable all pkarr publishing and client-side resolution (enabled
+/// by default)
 pub const FM_PKARR_ENABLE_ENV: &str = "FM_PKARR_ENABLE";
 
-/// Env var to enable pkarr DHT publishing (disabled by default)
+/// Env var to enable pkarr DHT publishing and client-side resolution (disabled
+/// by default)
 pub const FM_PKARR_DHT_ENABLE_ENV: &str = "FM_PKARR_DHT_ENABLE";
 
-/// Env var to disable pkarr relay publishing (enabled by default)
+/// Env var to disable pkarr relay publishing and client-side resolution
+/// (enabled by default)
 pub const FM_PKARR_RELAYS_ENABLE_ENV: &str = "FM_PKARR_RELAYS_ENABLE";
 
 /// Env var to override tcp api connectivity

--- a/fedimint-core/src/envs.rs
+++ b/fedimint-core/src/envs.rs
@@ -189,13 +189,16 @@ pub const FM_IROH_PKARR_PUBLISHER_ENABLE_ENV: &str = "FM_IROH_PKARR_PUBLISHER_EN
 /// Env var to disable Iroh's use of relays
 pub const FM_IROH_RELAYS_ENABLE_ENV: &str = "FM_IROH_RELAYS_ENABLE";
 
-/// Env var to disable all pkarr publishing (enabled by default)
+/// Env var to disable all pkarr publishing and client-side resolution (enabled
+/// by default)
 pub const FM_PKARR_ENABLE_ENV: &str = "FM_PKARR_ENABLE";
 
-/// Env var to enable pkarr DHT publishing (disabled by default)
+/// Env var to enable pkarr DHT publishing and client-side resolution (disabled
+/// by default)
 pub const FM_PKARR_DHT_ENABLE_ENV: &str = "FM_PKARR_DHT_ENABLE";
 
-/// Env var to disable pkarr relay publishing (enabled by default)
+/// Env var to disable pkarr relay publishing and client-side resolution
+/// (enabled by default)
 pub const FM_PKARR_RELAYS_ENABLE_ENV: &str = "FM_PKARR_RELAYS_ENABLE";
 
 /// Env var to override tcp api connectivity

--- a/fedimint-core/src/net/guardian_metadata.rs
+++ b/fedimint-core/src/net/guardian_metadata.rs
@@ -6,6 +6,11 @@ use serde::{Deserialize, Serialize};
 use crate::util::SafeUrl;
 
 const GUARDIAN_METADATA_MESSAGE_TAG: &[u8] = b"fedimint-guardian-metadata";
+
+/// Pkarr DNS TXT record name used by guardians to publish their API URL.
+///
+/// Used by `fedimint-server` to publish and `fedimint-client` to resolve.
+pub const PKARR_API_RECORD_NAME: &str = "fedimint_api";
 /// Allow messages with timestamps up to 1 hour in the future
 const MAX_FUTURE_TIMESTAMP_SECS: u64 = 3600;
 

--- a/fedimint-server/src/net/api/pkarr_publish.rs
+++ b/fedimint-server/src/net/api/pkarr_publish.rs
@@ -165,7 +165,9 @@ fn build_signed_packet(
 ) -> Result<SignedPacket, pkarr::errors::SignedPacketBuildError> {
     SignedPacket::builder()
         .txt(
-            pkarr::dns::Name::new_unchecked("fedimint_api"),
+            pkarr::dns::Name::new_unchecked(
+                fedimint_core::net::guardian_metadata::PKARR_API_RECORD_NAME,
+            ),
             url.try_into().expect("API URL should be valid TXT data"),
             TXT_RECORD_TTL,
         )


### PR DESCRIPTION
When no federation guardian is reachable via normal API (all peers offline/unreachable), the client falls back to resolving each guardian's current API URL from the Pkarr network using cached `pkarr_id_z32` from previously stored guardian metadata. It builds a temporary API client from the discovered URLs and retries the metadata fetch. Since each guardian's metadata endpoint returns its full collection of all peers' metadata, reaching any single guardian is sufficient.

This all-or-nothing approach minimizes how often the client uses Pkarr, which may be a privacy downgrade compared to direct guardian connections. As long as the client can reach any single guardian, it receives metadata updates for all peers, since guardians exchange metadata among themselves.

Two compile-time feature flags on `fedimint-client`:
- `pkarr` — enables the fallback using relays only (wasm-safe)
- `pkarr-dht` — additionally enables Mainline DHT support (not wasm-safe)

At runtime, the same env vars used by the server-side publisher control behavior:
- `FM_PKARR_ENABLE` (default: enabled) — master switch for pkarr
- `FM_PKARR_DHT_ENABLE` (default: disabled) — also use Mainline DHT (requires `pkarr-dht` feature at compile time)
- `FM_PKARR_RELAYS_ENABLE` (default: enabled) — use Pkarr relays

Fetched metadata still goes through the existing Schnorr signature verification, so a malicious Pkarr record cannot forge valid metadata.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->

