### PR TITLE
feat(ci): add auto-debug workflow for failed tests

### DIFF
--- a/.github/workflows/auto-debug.yml
+++ b/.github/workflows/auto-debug.yml
@@ -1,0 +1,83 @@
+name: Auto-Debug Failed Tests
+
+on:
+  workflow_run:
+    workflows:
+      - "CI (nix)"
+      - "Backwards-Compatibility"
+    types: [completed]
+    branches:
+      - master
+      - main
+
+jobs:
+  debug-failure:
+    name: Analyze Test Failure
+    # Only run on the main repo, and only when a workflow failed
+    if: >
+      github.repository == 'fedimint/fedimint' &&
+      github.event.workflow_run.conclusion == 'failure' &&
+      (github.event.workflow_run.event == 'push' || github.event.workflow_run.event == 'merge_group')
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Download failure context
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p /tmp/debug-context
+
+          # Get the failed run logs
+          gh run view ${{ github.event.workflow_run.id }} --log-failed > /tmp/debug-context/failure.log 2>&1 || true
+
+          # Get run metadata (include html_url for linking)
+          gh run view ${{ github.event.workflow_run.id }} --json jobs,conclusion,event,headBranch,headSha,url \
+            > /tmp/debug-context/run-info.json 2>&1 || true
+
+          # Truncate if too large (keep last 50k chars for context)
+          if [ -f /tmp/debug-context/failure.log ]; then
+            tail -c 50000 /tmp/debug-context/failure.log > /tmp/debug-context/failure-truncated.log
+            mv /tmp/debug-context/failure-truncated.log /tmp/debug-context/failure.log
+          fi
+
+          # Get existing CI failure issues
+          gh issue list \
+            --label "ci-failure" \
+            --state open \
+            --limit 20 \
+            --json number,title,body,labels,createdAt \
+            > /tmp/debug-context/existing-issues.json 2>&1 || echo "[]" > /tmp/debug-context/existing-issues.json
+
+          echo "=== Context prepared ==="
+          ls -la /tmp/debug-context/
+
+      - name: Generate prompt
+        run: |
+          # Use the shared script to generate the prompt
+          ./scripts/debug-ci-failure.sh --prompt /tmp/debug-context > /tmp/debug-context/prompt.txt
+
+      - name: Analyze failure with Claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            Read and follow the instructions in /tmp/debug-context/prompt.txt exactly.
+          claude_args: |
+            --max-turns 30
+            --allowedTools "Read,Grep,Glob,Bash(gh issue *),Bash(gh run *),Bash(cat *),Bash(head *),Bash(tail *),Bash(wc *),Bash(jq *)"
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "## Auto-Debug Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Workflow:** ${{ github.event.workflow_run.name }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Event:** ${{ github.event.workflow_run.event }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Branch:** ${{ github.event.workflow_run.head_branch }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Failed Run:** ${{ github.event.workflow_run.html_url }}" >> $GITHUB_STEP_SUMMARY

--- a/justfile.fedimint.just
+++ b/justfile.fedimint.just
@@ -31,6 +31,10 @@ test-full-compatibility *VERSIONS="v0.4.4":
 test-upgrades *VERSIONS="v0.8.2 current, v0.9.1 current, v0.10.0 current":
   ./scripts/tests/upgrade-test.sh {{VERSIONS}}
 
+# debug a CI failure using Claude Code (uses Max subscription locally)
+debug-ci-failure *RUN_ID="":
+  ./scripts/debug-ci-failure.sh {{RUN_ID}}
+
 # `cargo udeps` check
 udeps:
   nix build -L .#nightly.test.workspaceCargoUdeps

--- a/scripts/debug-ci-failure.sh
+++ b/scripts/debug-ci-failure.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+# Debug a CI failure using Claude Code
+#
+# Usage:
+#   ./scripts/debug-ci-failure.sh              # Debug most recent failure (local)
+#   ./scripts/debug-ci-failure.sh <run-id>     # Debug specific run (local)
+#   ./scripts/debug-ci-failure.sh --list       # List recent failures
+#   ./scripts/debug-ci-failure.sh --ci <dir>   # CI mode: use pre-downloaded context
+
+set -euo pipefail
+
+# Colors for output (disabled in CI)
+if [ -t 1 ]; then
+    RED='\033[0;31m'
+    GREEN='\033[0;32m'
+    YELLOW='\033[1;33m'
+    NC='\033[0m'
+else
+    RED=''
+    GREEN=''
+    YELLOW=''
+    NC=''
+fi
+
+usage() {
+    echo "Usage: $0 [run-id|--list|--ci <dir>|--prompt <dir>|--help]"
+    echo ""
+    echo "Options:"
+    echo "  <run-id>       Debug a specific GitHub Actions run"
+    echo "  --list         List recent failed runs"
+    echo "  --ci <dir>     CI mode: use pre-downloaded context from <dir>"
+    echo "  --prompt <dir> Output the prompt only (for use with claude-code-action)"
+    echo "  --help         Show this help message"
+}
+
+list_failures() {
+    echo -e "${YELLOW}Recent failed CI runs:${NC}"
+    echo ""
+    gh run list \
+        --status failure \
+        --limit 10 \
+        --json databaseId,displayTitle,workflowName,headBranch,createdAt,conclusion \
+        --jq '.[] | "  \(.databaseId) | \(.workflowName) | \(.headBranch) | \(.createdAt | split("T")[0])"'
+    echo ""
+    echo "Run with a specific ID: $0 <run-id>"
+}
+
+generate_prompt() {
+    local context_dir="$1"
+    local run_info=""
+    local failure_log=""
+    local existing_issues=""
+
+    # Read context files
+    if [ -f "$context_dir/run-info.json" ]; then
+        run_info=$(cat "$context_dir/run-info.json")
+    fi
+    if [ -f "$context_dir/failure.log" ]; then
+        failure_log=$(cat "$context_dir/failure.log")
+    fi
+    if [ -f "$context_dir/existing-issues.json" ]; then
+        existing_issues=$(cat "$context_dir/existing-issues.json")
+    fi
+
+    cat <<EOF
+You are debugging a CI test failure for the Fedimint project.
+
+## Context
+$run_info
+
+## Failure Logs
+$failure_log
+
+## Existing Open CI Issues
+$existing_issues
+
+## Your Task
+
+1. **Read and analyze the failure:**
+   - Identify which specific test(s) failed
+   - Determine the root cause
+   - Classify as: \`flaky-test\`, \`real-bug\`, \`infra-issue\`, or \`dependency-issue\`
+
+2. **Check for existing issues:**
+   - Look for issues that describe the SAME failure (same test, same error message pattern)
+   - If a matching issue exists, note its number
+
+3. **Take action based on your findings:**
+
+   **If an existing issue matches this failure:**
+   - Run: \`gh issue comment <issue-number> --body "<your-comment>"\`
+   - Comment should include: timestamp, commit SHA, brief confirmation it's the same issue
+   - Do NOT create a new issue
+
+   **If this is a NEW failure (no matching issue):**
+   - Run: \`gh issue create --title "<title>" --label "ci-failure" --label "<classification>" --body "<body>"\`
+   - Title format: \`CI: <test-name> failing - <brief-description>\`
+   - Body should include:
+     - Summary of what failed
+     - Error message/stack trace (truncated if long)
+     - Root cause analysis
+     - Suggested fix or investigation steps
+     - Link to failed run
+
+   **If this appears to be an infrastructure/transient issue:**
+   - Do NOT create an issue
+   - Just output your analysis
+
+## Important Notes
+- Be concise in issue descriptions - developers are experienced
+EOF
+}
+
+run_claude_analysis() {
+    local context_dir="$1"
+    claude -p "$(generate_prompt "$context_dir")"
+}
+
+prepare_context_local() {
+    local run_id="$1"
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+
+    echo -e "${GREEN}Fetching logs for run ${run_id}...${NC}"
+
+    # Get run info
+    gh run view "$run_id" --json jobs,conclusion,event,headBranch,headSha,url > "$tmp_dir/run-info.json" 2>&1 || true
+
+    # Get failed logs
+    gh run view "$run_id" --log-failed > "$tmp_dir/failure.log" 2>&1 || true
+
+    # Truncate if too large
+    if [ -f "$tmp_dir/failure.log" ]; then
+        local log_size
+        log_size=$(wc -c < "$tmp_dir/failure.log")
+        if [ "$log_size" -gt 100000 ]; then
+            echo -e "${YELLOW}Log is large (${log_size} bytes), truncating to last 100KB...${NC}"
+            tail -c 100000 "$tmp_dir/failure.log" > "$tmp_dir/failure-truncated.log"
+            mv "$tmp_dir/failure-truncated.log" "$tmp_dir/failure.log"
+        fi
+    fi
+
+    # Get existing issues
+    gh issue list \
+        --label "ci-failure" \
+        --state open \
+        --limit 20 \
+        --json number,title,body,labels,createdAt \
+        > "$tmp_dir/existing-issues.json" 2>&1 || echo "[]" > "$tmp_dir/existing-issues.json"
+
+    # Display run info
+    echo ""
+    echo -e "${GREEN}Run Info:${NC}"
+    jq -r '"  Event: \(.event)\n  Branch: \(.headBranch)\n  Commit: \(.headSha)\n  URL: \(.url)"' "$tmp_dir/run-info.json" 2>/dev/null || echo "  Could not parse run info"
+    echo ""
+
+    echo "$tmp_dir"
+}
+
+debug_local() {
+    local run_id="$1"
+
+    # Check if claude is available
+    if ! command -v claude &> /dev/null; then
+        echo -e "${RED}Error: 'claude' command not found. Please install Claude Code.${NC}"
+        exit 1
+    fi
+
+    local context_dir
+    context_dir=$(prepare_context_local "$run_id")
+
+    echo -e "${GREEN}Analyzing with Claude Code...${NC}"
+    echo ""
+
+    run_claude_analysis "$context_dir"
+
+    # Cleanup
+    rm -rf "$context_dir"
+}
+
+debug_ci() {
+    local context_dir="$1"
+
+    if [ ! -d "$context_dir" ]; then
+        echo "Error: Context directory does not exist: $context_dir"
+        exit 1
+    fi
+
+    run_claude_analysis "$context_dir"
+}
+
+# Main
+case "${1:-}" in
+    --help|-h)
+        usage
+        exit 0
+        ;;
+    --list|-l)
+        list_failures
+        exit 0
+        ;;
+    --ci)
+        if [ -z "${2:-}" ]; then
+            echo "Error: --ci requires a directory argument"
+            usage
+            exit 1
+        fi
+        debug_ci "$2"
+        ;;
+    --prompt)
+        if [ -z "${2:-}" ]; then
+            echo "Error: --prompt requires a directory argument" >&2
+            usage
+            exit 1
+        fi
+        generate_prompt "$2"
+        ;;
+    "")
+        # Get most recent failure
+        echo -e "${GREEN}Finding most recent failed run...${NC}"
+        RUN_ID=$(gh run list --status failure --limit 1 --json databaseId -q '.[0].databaseId')
+        if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
+            echo -e "${YELLOW}No recent failures found.${NC}"
+            exit 0
+        fi
+        echo -e "Found run: ${RUN_ID}"
+        debug_local "$RUN_ID"
+        ;;
+    *)
+        debug_local "$1"
+        ;;
+esac


### PR DESCRIPTION
I want to give automatic debugging of test failures a try, if it's too noisy happy to roll back. Improvement proposals welcome.

Adds automated CI failure debugging using Claude Code:

- GitHub Actions workflow triggers on CI/merge-queue failures
- Uses OAuth token (Max subscription) for zero additional cost
- Checks for existing issues before creating duplicates
- Local helper script: `just debug-ci-failure`

Requires adding CLAUDE_CODE_OAUTH_TOKEN secret (via `claude setup-token`).

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
