### PR TITLE
chore: add tarball bundling for macos

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -459,8 +459,7 @@ jobs:
           done
 
   pkgs:
-    # TODO: Remove 'pull_request' trigger after MacOS tarball bundling is verified working
-    if: github.repository == 'fedimint/fedimint' && (github.event_name == 'pull_request' || startsWith(github.ref, 'refs/heads/releases') || github.ref_type == 'tag')
+    if: github.repository == 'fedimint/fedimint' && (startsWith(github.ref, 'refs/heads/releases') || github.ref_type == 'tag')
     name: "Release packages: ${{ matrix.build.flake-output }} on ${{ matrix.platform.name }}"
 
     strategy:


### PR DESCRIPTION
With the proliferation of agents running on MacOS, IMO it would be good to offer prebuilt binaries for MacOS users.

This PR attempts to provide that by re-writing the dynamic libs that currently point to nix using `dylibbundler` and then creating a tarball that can be distributed.