### PR TITLE
fix(test): mine blocks in await_federation_total_value to prevent deadlock

### DIFF
--- a/modules/fedimint-walletv2-tests/tests/tests.rs
+++ b/modules/fedimint-walletv2-tests/tests/tests.rs
@@ -92,6 +92,7 @@ async fn await_consensus_block_count(
 
 async fn await_federation_total_value(
     client: &ClientHandleArc,
+    bitcoin: &Arc<dyn BitcoinTest>,
     min_value: bitcoin::Amount,
 ) -> anyhow::Result<()> {
     loop {
@@ -103,6 +104,8 @@ async fn await_federation_total_value(
         if current_value >= min_value {
             return Ok(());
         }
+
+        bitcoin.mine_blocks(1).await;
 
         sleep_in_test(
             format!("Waiting for federation total value of {current_value} to reach {min_value}"),
@@ -143,7 +146,7 @@ async fn test_send_and_receive() -> anyhow::Result<()> {
 
     info!("Wait for deposits to be auto-claimed...");
 
-    await_federation_total_value(&client, bsats(290_000)).await?;
+    await_federation_total_value(&client, &bitcoin, bsats(290_000)).await?;
 
     await_client_balance(&client, bsats(290_000)).await?;
 
@@ -166,7 +169,7 @@ async fn test_send_and_receive() -> anyhow::Result<()> {
 
     info!("Wait for deposits to be auto-claimed...");
 
-    await_federation_total_value(&client, bsats(980_000)).await?;
+    await_federation_total_value(&client, &bitcoin, bsats(980_000)).await?;
 
     await_client_balance(&client, bsats(980_000)).await?;
 
@@ -273,7 +276,7 @@ async fn fee_exceeds_one_bitcoin_within_sixteen_pending_txs() -> anyhow::Result<
 
     info!("Wait for deposit to be auto-claimed...");
 
-    await_federation_total_value(&client, Amount::from_sat(99_000_000)).await?;
+    await_federation_total_value(&client, &bitcoin, Amount::from_sat(99_000_000)).await?;
 
     bitcoin.mine_blocks(6).await;
 


### PR DESCRIPTION
## Summary

- Fix flaky `test_send_and_receive` in `fedimint-walletv2-tests` that times out after 90s when the client's congestion control (`pending_tx_chain >= 3`) blocks further deposit claims while no blocks are being mined
- Mine a block on each polling iteration in `await_federation_total_value` so pending federation transactions can confirm and clear the throttle

Prompted by failure in [CI run #22639712857](https://github.com/fedimint/fedimint/actions/runs/22639712857).

## Test plan

- [ ] Run `cargo nextest run -p fedimint-walletv2-tests --test tests test_send_and_receive` multiple times to verify the test no longer deadlocks
- [ ] Verify subsequent hourly CI runs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)