### PR TITLE
fix(walletv2): minimum fee rate vote and adjust config minimum feerate

### DIFF
--- a/modules/fedimint-walletv2-common/src/config.rs
+++ b/modules/fedimint-walletv2-common/src/config.rs
@@ -39,7 +39,7 @@ pub struct WalletConfigConsensus {
     pub receive_tx_vbytes: u64,
     /// The minimum feerate doubles for each pending transaction in the stack,
     /// protecting against catastrophic feerate estimation errors
-    pub min_feerate: u64,
+    pub feerate_base: u64,
     /// The minimum amount a user can send on chain
     pub dust_limit: bitcoin::Amount,
     /// Fees taken by the guardians to process wallet inputs and outputs
@@ -117,7 +117,11 @@ impl WalletConfigConsensus {
                     + change_input_weight
                     + change_output_weight,
             ),
-            min_feerate: 1000,
+            // This is intentionally lower than the 1 sat/vB minimum feerate
+            // vote floor. This allows for at least three pending transactions
+            // which only pay the consensus feerate before the exponential
+            // doubling kicks in.
+            feerate_base: 250,
             dust_limit: bitcoin::Amount::from_sat(10_000),
             fee_consensus,
             network,

--- a/modules/fedimint-walletv2-server/src/lib.rs
+++ b/modules/fedimint-walletv2-server/src/lib.rs
@@ -96,6 +96,10 @@ pub const CONFIRMATION_FINALITY_DELAY: u64 = 6;
 /// consensus item to limit the work done in one `process_consensus_item` step.
 const MAX_BLOCK_COUNT_INCREMENT: u64 = 5;
 
+/// Minimum fee rate vote of 1 sat/vB to ensure we never propose a fee rate
+/// below what Bitcoin Core will relay.
+const MIN_FEERATE_VOTE_SATS_PER_KVB: u64 = 1000;
+
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Encodable, Decodable)]
 pub struct FederationTx {
     pub tx: Transaction,
@@ -426,7 +430,10 @@ impl ServerModule for Wallet {
             ));
 
             items.push(WalletConsensusItem::Feerate(Some(
-                status.fee_rate.sats_per_kvb,
+                status
+                    .fee_rate
+                    .sats_per_kvb
+                    .max(MIN_FEERATE_VOTE_SATS_PER_KVB),
             )));
         } else {
             // Bitcoin backend not connected, retract fee rate vote
@@ -1132,7 +1139,7 @@ impl Wallet {
         let feerate = self
             .consensus_feerate(dbtx)
             .await?
-            .max(self.cfg.consensus.min_feerate << pending_txs.len());
+            .max(self.cfg.consensus.feerate_base << pending_txs.len());
 
         let tx_fee = tx_vbytes.saturating_mul(feerate).saturating_div(1000);
 

--- a/modules/fedimint-walletv2-tests/tests/tests.rs
+++ b/modules/fedimint-walletv2-tests/tests/tests.rs
@@ -90,7 +90,7 @@ async fn await_federation_total_value(
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn fee_exceeds_one_bitcoin_within_seventeen_pending_txs() -> anyhow::Result<()> {
+async fn fee_exceeds_one_bitcoin_with_many_pending_txs() -> anyhow::Result<()> {
     let fixtures = fixtures();
 
     let fed = fixtures.new_fed_not_degraded().await;
@@ -120,7 +120,7 @@ async fn fee_exceeds_one_bitcoin_within_seventeen_pending_txs() -> anyhow::Resul
 
     let address = bitcoin.get_new_address().await.as_unchecked().clone();
 
-    for _ in 0..17 {
+    for _ in 0..19 {
         let send_fee = client
             .get_first_module::<WalletClientModule>()?
             .send_fee()


### PR DESCRIPTION
## Summary

This pr gives us a bit more breathing room with the minimum feerate safeguard to capitalize on currently low fees and deliver good UX - A lot of exchanges still don't support lightning so this might be an important first impression. Also we can have at least three pending transactions now before the minimum feerate can start to drive up the fee. This allows to stack at least three transactions now with the current consensus federate.

- Clamp the fee rate consensus vote to at least 1000 sat/kvB on the server side
- Lower the config `min_feerate` to 250 to delay the minimum feerate hike by two more pending transactions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)