### PR TITLE
chore(deps): bump aws-lc-sys to 0.38 and aws-lc-rs to 1.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,7 +363,7 @@ dependencies = [
  "memchr",
  "proc-macro2",
  "quote",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "serde",
  "serde_derive",
  "syn 2.0.104",
@@ -634,9 +634,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.13.3"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c953fe1ba023e6b7730c0d4b031d06f267f23a46167dcbd40316644b10a17ba"
+checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -644,11 +644,11 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.30.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbfd150b5dbdb988bcc8fb1fe787eb6b7ee6180ca24da683b61ea5405f3d43ff"
+checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
 dependencies = [
- "bindgen 0.69.5",
+ "bindgen",
  "cc",
  "cmake",
  "dunce",
@@ -985,29 +985,6 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.69.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
-dependencies = [
- "bitflags 2.9.1",
- "cexpr",
- "clang-sys",
- "itertools 0.12.1",
- "lazy_static",
- "lazycell",
- "log",
- "prettyplease 0.2.35",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 1.1.0",
- "shlex",
- "syn 2.0.104",
- "which",
-]
-
-[[package]]
-name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
@@ -1016,10 +993,12 @@ dependencies = [
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
+ "log",
+ "prettyplease 0.2.35",
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "shlex",
  "syn 2.0.104",
 ]
@@ -2380,7 +2359,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6306,7 +6285,7 @@ dependencies = [
  "iroh-quinn-proto",
  "iroh-quinn-udp",
  "pin-project-lite",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls 0.23.28",
  "socket2 0.5.10",
  "thiserror 2.0.12",
@@ -6326,7 +6305,7 @@ dependencies = [
  "iroh-quinn-proto",
  "iroh-quinn-udp",
  "pin-project-lite",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls 0.23.28",
  "socket2 0.5.10",
  "thiserror 2.0.12",
@@ -6345,7 +6324,7 @@ dependencies = [
  "getrandom 0.2.16",
  "rand 0.8.5",
  "ring",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls 0.23.28",
  "rustls-pki-types",
  "slab",
@@ -6608,7 +6587,7 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "rand 0.8.5",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -6720,12 +6699,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "libc"
 version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6764,7 +6737,7 @@ version = "0.17.3+10.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cef2a00ee60fe526157c9023edab23943fae1ce2ab6f4abb2a807c1746835de9"
 dependencies = [
- "bindgen 0.72.1",
+ "bindgen",
  "bzip2-sys",
  "cc",
  "libc",
@@ -8785,7 +8758,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls 0.23.28",
  "socket2 0.5.10",
  "thiserror 2.0.12",
@@ -8805,7 +8778,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.1",
  "ring",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls 0.23.28",
  "rustls-pki-types",
  "slab",
@@ -9245,12 +9218,6 @@ name = "rustc-demangle"
 version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"

--- a/fedimint-connectors/Cargo.toml
+++ b/fedimint-connectors/Cargo.toml
@@ -50,7 +50,7 @@ z32 = { workspace = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 arti-client = { workspace = true, optional = true }
-aws-lc-sys = { version = "0.30", features = ["bindgen"] }
+aws-lc-sys = { version = "0.38", features = ["bindgen"] }
 curve25519-dalek = { workspace = true, optional = true }
 iroh = { workspace = true, default-features = false, features = [
     "discovery-pkarr-dht",

--- a/fedimint-core/Cargo.toml
+++ b/fedimint-core/Cargo.toml
@@ -67,7 +67,7 @@ url = { workspace = true, features = ["serde"] }
 z32 = { workspace = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-aws-lc-sys = { version = "0.30", features = ["bindgen"] }
+aws-lc-sys = { version = "0.38", features = ["bindgen"] }
 iroh = { workspace = true, default-features = false, features = [
     "discovery-pkarr-dht",
 ] }

--- a/fedimint-testing/Cargo.toml
+++ b/fedimint-testing/Cargo.toml
@@ -22,7 +22,7 @@ path = "src/lib.rs"
 anyhow = { workspace = true }
 async-stream = { workspace = true }
 async-trait = { workspace = true }
-aws-lc-sys = { version = "0.30", features = ["bindgen"] }
+aws-lc-sys = { version = "0.38", features = ["bindgen"] }
 axum = { workspace = true }
 bcrypt = { workspace = true }
 bitcoin = { workspace = true }


### PR DESCRIPTION
## Summary

- Bumps `aws-lc-sys` from 0.30 to 0.38 and `aws-lc-rs` from 1.13.3 to 1.16.1
- Replaces #8347 which only bumped `aws-lc-sys`, creating two versions in the dependency tree and breaking Android cross-compilation

## Problem with #8347

Bumping only the direct `aws-lc-sys` dependency to 0.38 left `aws-lc-rs 1.13.3` still depending on `aws-lc-sys 0.30.0`. With two semver-incompatible versions, Cargo's feature unification no longer applied the `bindgen` feature to the old 0.30.0. Without `bindgen`, `aws-lc-sys 0.30.0` fell back to external bindgen which picked up host glibc headers and failed with `fatal error: 'gnu/stubs-32.h' file not found` when cross-compiling for 32-bit Android targets.

## Fix

Also bump `aws-lc-rs` to 1.16.1 (which depends on `aws-lc-sys ^0.38.0`), collapsing back to a single `aws-lc-sys` version with unified `bindgen` feature.

## Test plan

- [ ] CI cross-compilation jobs for armv7-android, aarch64-android, x86_64-android, wasm32-unknown pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)