### PR TITLE
feat(walletv2): add tx vbytes and min feerate to client config

### DIFF
--- a/modules/fedimint-walletv2-common/src/config.rs
+++ b/modules/fedimint-walletv2-common/src/config.rs
@@ -205,6 +205,13 @@ fn test_fee_consensus() {
 pub struct WalletClientConfig {
     /// The public keys for the bitcoin multisig
     pub bitcoin_pks: BTreeMap<PeerId, PublicKey>,
+    /// Total vbytes of a pegout bitcoin transaction
+    pub send_tx_vbytes: u64,
+    /// Total vbytes of a pegin bitcoin transaction
+    pub receive_tx_vbytes: u64,
+    /// The minimum feerate doubles for each pending transaction in the stack,
+    /// protecting against catastrophic feerate estimation errors
+    pub feerate_base: u64,
     /// The minimum amount a user can send on chain
     pub dust_limit: bitcoin::Amount,
     /// Fees taken by the guardians to process wallet inputs and outputs

--- a/modules/fedimint-walletv2-server/src/lib.rs
+++ b/modules/fedimint-walletv2-server/src/lib.rs
@@ -368,8 +368,12 @@ impl ServerModuleInit for WalletInit {
         config: &ServerModuleConsensusConfig,
     ) -> anyhow::Result<WalletClientConfig> {
         let config = WalletConfigConsensus::from_erased(config)?;
+
         Ok(WalletClientConfig {
             bitcoin_pks: config.bitcoin_pks,
+            send_tx_vbytes: config.send_tx_vbytes,
+            receive_tx_vbytes: config.receive_tx_vbytes,
+            feerate_base: config.feerate_base,
             dust_limit: config.dust_limit,
             fee_consensus: config.fee_consensus,
             network: config.network,


### PR DESCRIPTION
## Summary
- Add `send_tx_vbytes`, `receive_tx_vbytes`, and `min_feerate` to `WalletClientConfig` in case we ever want to use them in the client or display them to the user

🤖 Generated with [Claude Code](https://claude.com/claude-code)