### PR TITLE
docs: the user should cd into the fedimint folder before starting next step

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -41,7 +41,7 @@ curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix 
 Then fork and clone the Fedimint repo.
 
 ```bash
-git clone https://github.com/your-username/fedimint.git
+git clone https://github.com/your-username/fedimint.git && cd fedimint
 ```
 
 Then enter the nix developer environment.


### PR DESCRIPTION
## Summary
A very small nit, feel free to close if not wanted/need

In the `HACKING.md` doc, it is assumed the user would know to `cd` into the `fedimint` directory. Just adding that here