### PR TITLE
chore(devimint): ldk and ldk2 logs were not showing, updated to correct path

### DIFF
--- a/misc/mprocs.yaml
+++ b/misc/mprocs.yaml
@@ -19,9 +19,9 @@ procs:
   lnd:
     shell: tail -n +0 -F $FM_LOGS_DIR/lnd.log
   ldk:
-    shell: tail -n +0 -F $FM_DATA_DIR/gatewayd-ldk-0/ldk_node/logs/ldk_node_latest.log
+    shell: tail -n +0 -F $FM_DATA_DIR/gatewayd-ldk-0/ldk_node/ldk_node.log
   ldk2:
-    shell: tail -n +0 -F $FM_DATA_DIR/gatewayd-ldk-1/ldk_node/logs/ldk_node_latest.log
+    shell: tail -n +0 -F $FM_DATA_DIR/gatewayd-ldk-1/ldk_node/ldk_node.log
   bitcoind:
     shell: tail -n +0 -F $FM_LOGS_DIR/bitcoind.log
   devimint:


### PR DESCRIPTION
## Summary
When I started the devimint env by running `just mprocs` I found that the logs for `ldk` and `ldk2` did not show

What I found when I checked the path that it was attempting to tail
```
ls /tmp/nix-shell.SaIA70/devimint-2163951-939/gatewayd-ldk-0/ldk_node/
ldk_node_data.sqlite  ldk_node.log

ls /tmp/nix-shell.SaIA70/devimint-2163951-939/gatewayd-ldk-1/ldk_node/
ldk_node_data.sqlite  ldk_node.log
```

### When this changed
From the research I was able to do, it looks like it was updated in this PR https://github.com/lightningdevkit/ldk-node/pull/394

### Before
![Screenshot 2026-03-07 at 9 41 44 AM](https://github.com/user-attachments/assets/0f388dfe-d707-469e-9166-cb3c906bc594)
![Screenshot 2026-03-07 at 9 41 49 AM](https://github.com/user-attachments/assets/ef990604-6924-4273-b944-818df05a3836)

### After
![Screenshot 2026-03-07 at 9 43 09 AM](https://github.com/user-attachments/assets/4b39d5da-cdd4-42e8-a691-d2fb68817ff1)
![Screenshot 2026-03-07 at 9 43 16 AM](https://github.com/user-attachments/assets/4955e42c-bbe6-4ae2-bb77-4931792647c6)