### PR TITLE
feat(devimint): adds optional --host or FM_UI_BIND_HOST env var to bind to an address

### DIFF
--- a/devimint/src/cli.rs
+++ b/devimint/src/cli.rs
@@ -70,6 +70,10 @@ pub struct CommonArgs {
     /// Force a base federations port, e.g. for convenience during dev tasks
     #[clap(long, env = FM_FEDERATIONS_BASE_PORT_ENV)]
     pub federations_base_port: Option<u16>,
+
+    /// Bind guardian UI on all interfaces (0.0.0.0) for external access
+    #[clap(long)]
+    pub host: bool,
 }
 
 impl CommonArgs {
@@ -153,6 +157,7 @@ pub async fn setup(arg: CommonArgs) -> Result<(ProcessManager, TaskGroup)> {
         arg.fed_size,
         arg.offline_nodes,
         arg.federations_base_port,
+        arg.host.then_some("0.0.0.0"),
     )
     .await?;
 

--- a/devimint/src/envs.rs
+++ b/devimint/src/envs.rs
@@ -43,6 +43,9 @@ pub const FM_OFFLINE_NODES_ENV: &str = "FM_OFFLINE_NODES";
 // Fix base port for federation (fedimintds) port range
 pub const FM_FEDERATIONS_BASE_PORT_ENV: &str = "FM_FEDERATIONS_BASE_PORT";
 
+// Bind address host for guardian UI (e.g. 0.0.0.0 for external access)
+pub const FM_UI_BIND_HOST_ENV: &str = "FM_UI_BIND_HOST";
+
 // Env variable to set a federation's invite code
 pub const FM_INVITE_CODE_ENV: &str = "FM_INVITE_CODE";
 

--- a/devimint/src/vars.rs
+++ b/devimint/src/vars.rs
@@ -118,8 +118,9 @@ pub fn utf8(path: &Path) -> &str {
 }
 
 declare_vars! {
-    Global = (test_dir: &Path, num_feds: usize, fed_size: usize, offline_nodes: usize, federation_base_ports: u16, num_gateways: usize, gw_base_port: u16) =>
+    Global = (test_dir: &Path, num_feds: usize, fed_size: usize, offline_nodes: usize, federation_base_ports: u16, num_gateways: usize, gw_base_port: u16, ui_bind_host: String) =>
     {
+        FM_UI_BIND_HOST: String = ui_bind_host; env: crate::envs::FM_UI_BIND_HOST_ENV;
         FM_USE_UNKNOWN_MODULE: String = std::env::var(FM_USE_UNKNOWN_MODULE_ENV).unwrap_or_else(|_| "1".into()); env: "FM_USE_UNKNOWN_MODULE";
 
         FM_FORCE_API_SECRETS: ApiSecrets = std::env::var(FM_FORCE_API_SECRETS_ENV).ok().and_then(|s| {
@@ -228,6 +229,7 @@ impl Global {
         fed_size: usize,
         offline_nodes: usize,
         federations_base_port: Option<u16>,
+        ui_bind_host: Option<&str>,
     ) -> anyhow::Result<Self> {
         let federations_base_port = if let Some(federations_base_port) = federations_base_port {
             federations_base_port
@@ -240,6 +242,10 @@ impl Global {
         };
         let num_gateways: usize = 3;
         let gw_base_port = port_alloc(num_gateways as u16).unwrap();
+        let ui_bind_host = ui_bind_host
+            .map(String::from)
+            .or_else(|| std::env::var(crate::envs::FM_UI_BIND_HOST_ENV).ok())
+            .unwrap_or_else(|| "127.0.0.1".to_string());
         let this = Self::init(
             test_dir,
             num_feds,
@@ -248,6 +254,7 @@ impl Global {
             federations_base_port,
             num_gateways,
             gw_base_port,
+            ui_bind_host,
         )
         .await?;
         Ok(this)
@@ -264,7 +271,7 @@ declare_vars! {
         FM_BIND_API: String = format!("127.0.0.1:{}", overrides.api.port()); env: "FM_BIND_API";
         FM_P2P_URL: String =  format!("fedimint://127.0.0.1:{}", overrides.p2p.port()); env: "FM_P2P_URL";
         FM_API_URL: String =  format!("ws://127.0.0.1:{}", overrides.api.port()); env: "FM_API_URL";
-        FM_BIND_UI: String = format!("127.0.0.1:{}", overrides.base_port + FEDIMINTD_UI_PORT_OFFSET); env: "FM_BIND_UI";
+        FM_BIND_UI: String = format!("{}:{}", globals.FM_UI_BIND_HOST, overrides.base_port + FEDIMINTD_UI_PORT_OFFSET); env: "FM_BIND_UI";
         FM_BIND_METRICS_API: String = format!("127.0.0.1:{}", overrides.base_port + FEDIMINTD_METRICS_PORT_OFFSET); env: "FM_BIND_METRICS_API";
         FM_BIND_METRICS: String = format!("127.0.0.1:{}", overrides.base_port + FEDIMINTD_METRICS_PORT_OFFSET); env: "FM_BIND_METRICS";
         FM_DATA_DIR: PathBuf = mkdir(globals.FM_DATA_DIR.join(format!("fedimintd-{federation_name}-{peer_id}"))).await?; env: "FM_DATA_DIR";


### PR DESCRIPTION
## Motivation
I was having trouble connecting to the Guardian UI and that was because I was trying to connect over tailscale. This was because the URL was set to `127.0.0.1` and not `0.0.0.0`. Other [projects like vite](https://vite.dev/config/server-options#server-host) have a `--host` option to resolve this, so I figured that it makes sense to do the same here.

## Changes

- devimint
    - `--host`
        When set, the guardian UI is bound to `0.0.0.0` instead of `127.0.0.1`, so it’s reachable from other hosts (e.g. via Tailscale or Wireguard).
     - `FM_UI_BIND_HOST`
Optional env var to set the UI bind host (e.g. `0.0.0.0` or a specific IP). Default when not set and --host is not used remains `127.0.0.1`.
    - Default behavior is unchanged: UI still binds to `127.0.0.1` unless `--host` or `FM_UI_BIND_HOST` is used.

## Usage

- CLI
    - Add `--host` to the devimint command so the UI listens on all interfaces:
        `devimint --host dev-fed --exec bash -c 'mprocs -c misc/mprocs.yaml ...'`
         Or with the fixed-port helper:
          `FM_FEDERATIONS_BASE_PORT=2000 just devimint-env-post-dkg --host`
    - Env var (no CLI change)
        `FM_UI_BIND_HOST=0.0.0.0 just mprocs`