### PR TITLE
feat: devimint added fixed port for gateways UI

### DIFF
--- a/devimint/src/cli.rs
+++ b/devimint/src/cli.rs
@@ -18,8 +18,8 @@ use tracing::{debug, error, info, trace, warn};
 use crate::devfed::DevJitFed;
 use crate::envs::{
     FM_DEVIMINT_STATIC_DATA_DIR_ENV, FM_FED_SIZE_ENV, FM_FEDERATIONS_BASE_PORT_ENV,
-    FM_INVITE_CODE_ENV, FM_LINK_TEST_DIR_ENV, FM_NUM_FEDS_ENV, FM_OFFLINE_NODES_ENV,
-    FM_PRE_DKG_ENV, FM_TEST_DIR_ENV,
+    FM_GATEWAY_BASE_PORT_ENV, FM_INVITE_CODE_ENV, FM_LINK_TEST_DIR_ENV, FM_NUM_FEDS_ENV,
+    FM_OFFLINE_NODES_ENV, FM_PRE_DKG_ENV, FM_TEST_DIR_ENV,
 };
 use crate::util::{ProcessManager, poll};
 use crate::vars::mkdir;
@@ -70,6 +70,10 @@ pub struct CommonArgs {
     /// Force a base federations port, e.g. for convenience during dev tasks
     #[clap(long, env = FM_FEDERATIONS_BASE_PORT_ENV)]
     pub federations_base_port: Option<u16>,
+
+    /// Force a base gateway port, e.g. for convenience during dev tasks
+    #[clap(long, env = FM_GATEWAY_BASE_PORT_ENV)]
+    pub gateway_base_port: Option<u16>,
 }
 
 impl CommonArgs {
@@ -153,6 +157,7 @@ pub async fn setup(arg: CommonArgs) -> Result<(ProcessManager, TaskGroup)> {
         arg.fed_size,
         arg.offline_nodes,
         arg.federations_base_port,
+        arg.gateway_base_port,
     )
     .await?;
 

--- a/devimint/src/envs.rs
+++ b/devimint/src/envs.rs
@@ -43,6 +43,9 @@ pub const FM_OFFLINE_NODES_ENV: &str = "FM_OFFLINE_NODES";
 // Fix base port for federation (fedimintds) port range
 pub const FM_FEDERATIONS_BASE_PORT_ENV: &str = "FM_FEDERATIONS_BASE_PORT";
 
+// Fix base port for gateway (gatewayd) port range
+pub const FM_GATEWAY_BASE_PORT_ENV: &str = "FM_GATEWAY_BASE_PORT";
+
 // Env variable to set a federation's invite code
 pub const FM_INVITE_CODE_ENV: &str = "FM_INVITE_CODE";
 

--- a/devimint/src/vars.rs
+++ b/devimint/src/vars.rs
@@ -117,8 +117,17 @@ pub fn utf8(path: &Path) -> &str {
     path.as_os_str().to_str().expect("must be valid utf8")
 }
 
+// Port offsets from FM_GATEWAY_BASE_PORT when set: 0-2 are Iroh ports for each
+// gateway, 3-4 LND, 5-6 LDK, 7-8 LDK2
+const GATEWAY_PORT_OFFSET_LND: u16 = 3;
+const GATEWAY_PORT_OFFSET_LND_METRICS: u16 = 4;
+const GATEWAY_PORT_OFFSET_LDK: u16 = 5;
+const GATEWAY_PORT_OFFSET_LDK_METRICS: u16 = 6;
+const GATEWAY_PORT_OFFSET_LDK2: u16 = 7;
+const GATEWAY_PORT_OFFSET_LDK2_METRICS: u16 = 8;
+
 declare_vars! {
-    Global = (test_dir: &Path, num_feds: usize, fed_size: usize, offline_nodes: usize, federation_base_ports: u16, num_gateways: usize, gw_base_port: u16) =>
+    Global = (test_dir: &Path, num_feds: usize, fed_size: usize, offline_nodes: usize, federation_base_ports: u16, num_gateways: usize, gateway_base_port: Option<u16>) =>
     {
         FM_USE_UNKNOWN_MODULE: String = std::env::var(FM_USE_UNKNOWN_MODULE_ENV).unwrap_or_else(|_| "1".into()); env: "FM_USE_UNKNOWN_MODULE";
 
@@ -150,18 +159,40 @@ declare_vars! {
         FM_PORT_LND_REST: u16 = port_alloc(1)?; env: "FM_PORT_LND_REST";
         FM_PORT_ESPLORA: u16 = port_alloc(1)?; env: "FM_PORT_ESPLORA";
         FM_PORT_ESPLORA_MONITORING: u16 = port_alloc(1)?; env: "FM_PORT_ESPLORA_MONITORING";
-        FM_PORT_GW_LND: u16 = port_alloc(1)?; env: "FM_PORT_GW_LND";
-        FM_PORT_GW_LND_METRICS: u16 = port_alloc(1)?; env: "FM_PORT_GW_LND_METRICS";
-        FM_PORT_GW_LDK: u16 = port_alloc(1)?; env: "FM_PORT_GW_LDK";
-        FM_PORT_GW_LDK_METRICS: u16 = port_alloc(1)?; env: "FM_PORT_GW_LDK_METRICS";
-        FM_PORT_GW_LDK2: u16 = port_alloc(1)?; env: "FM_PORT_GW_LDK2";
-        FM_PORT_GW_LDK2_METRICS: u16 = port_alloc(1)?; env: "FM_PORT_GW_LDK2_METRICS";
+        FM_PORT_GW_LND: u16 = match gateway_base_port {
+            Some(b) => b + GATEWAY_PORT_OFFSET_LND,
+            None => port_alloc(1)?,
+        }; env: "FM_PORT_GW_LND";
+        FM_PORT_GW_LND_METRICS: u16 = match gateway_base_port {
+            Some(b) => b + GATEWAY_PORT_OFFSET_LND_METRICS,
+            None => port_alloc(1)?,
+        }; env: "FM_PORT_GW_LND_METRICS";
+        FM_PORT_GW_LDK: u16 = match gateway_base_port {
+            Some(b) => b + GATEWAY_PORT_OFFSET_LDK,
+            None => port_alloc(1)?,
+        }; env: "FM_PORT_GW_LDK";
+        FM_PORT_GW_LDK_METRICS: u16 = match gateway_base_port {
+            Some(b) => b + GATEWAY_PORT_OFFSET_LDK_METRICS,
+            None => port_alloc(1)?,
+        }; env: "FM_PORT_GW_LDK_METRICS";
+        FM_PORT_GW_LDK2: u16 = match gateway_base_port {
+            Some(b) => b + GATEWAY_PORT_OFFSET_LDK2,
+            None => port_alloc(1)?,
+        }; env: "FM_PORT_GW_LDK2";
+        FM_PORT_GW_LDK2_METRICS: u16 = match gateway_base_port {
+            Some(b) => b + GATEWAY_PORT_OFFSET_LDK2_METRICS,
+            None => port_alloc(1)?,
+        }; env: "FM_PORT_GW_LDK2_METRICS";
         FM_PORT_FAUCET: u16 = 15243u16; env: "FM_PORT_FAUCET";
         FM_PORT_RECURRINGD: u16 = port_alloc(1)?; env: "FM_PORT_RECURRINGD";
         FM_PORT_RECURRINGDV2: u16 = port_alloc(1)?; env: "FM_PORT_RECURRINGDV2";
 
         FM_FEDERATION_BASE_PORT: u16 = federation_base_ports; env: "FM_FEDERATION_BASE_PORT";
         fedimintd_overrides: FederationsNetOverrides = FederationsNetOverrides::new(FM_FEDERATION_BASE_PORT, num_feds, NumPeers::from(fed_size)); env: "NOT_USED_FOR_ANYTHING";
+        gw_base_port: u16 = match gateway_base_port {
+            Some(b) => b,
+            None => port_alloc(3)?,
+        }; env: "NOT_USED_FOR_ANYTHING";
         gatewayd_overrides: GatewaydNetOverrides = GatewaydNetOverrides::new(gw_base_port, num_gateways); env: "NOT_USED_FOR_ANYTHING";
 
         FM_LND_DIR: PathBuf = mkdir(FM_TEST_DIR.join("lnd")).await?; env: "FM_LND_DIR";
@@ -228,6 +259,7 @@ impl Global {
         fed_size: usize,
         offline_nodes: usize,
         federations_base_port: Option<u16>,
+        gateway_base_port: Option<u16>,
     ) -> anyhow::Result<Self> {
         let federations_base_port = if let Some(federations_base_port) = federations_base_port {
             federations_base_port
@@ -239,7 +271,6 @@ impl Global {
             )?
         };
         let num_gateways: usize = 3;
-        let gw_base_port = port_alloc(num_gateways as u16).unwrap();
         let this = Self::init(
             test_dir,
             num_feds,
@@ -247,7 +278,7 @@ impl Global {
             offline_nodes,
             federations_base_port,
             num_gateways,
-            gw_base_port,
+            gateway_base_port,
         )
         .await?;
         Ok(this)

--- a/justfile.fedimint.just
+++ b/justfile.fedimint.just
@@ -150,7 +150,10 @@ devimint-env-pre-dkg *PARAMS:
   @>&2 echo "fedimint-1 UI: http://localhost:2006"
   @>&2 echo "fedimint-2 UI: http://localhost:2010"
   @>&2 echo "fedimint-3 UI: http://localhost:2014"
-  env FM_FEDERATIONS_BASE_PORT=2000 FM_PRE_DKG=true ./scripts/dev/devimint-env.sh {{PARAMS}}
+  @>&2 echo "gateway LND UI: http://localhost:8173"
+  @>&2 echo "gateway LDK UI: http://localhost:8175"
+  @>&2 echo "gateway LDK2 UI: http://localhost:8177"
+  env FM_FEDERATIONS_BASE_PORT=2000 FM_GATEWAY_BASE_PORT=8170 FM_PRE_DKG=true ./scripts/dev/devimint-env.sh {{PARAMS}}
 
 # Spawn devimint post-dkg on fixed port numbers (useful for UI work)
 devimint-env-post-dkg *PARAMS:
@@ -158,7 +161,10 @@ devimint-env-post-dkg *PARAMS:
   @>&2 echo "fedimint-1 UI: http://localhost:2006"
   @>&2 echo "fedimint-2 UI: http://localhost:2010"
   @>&2 echo "fedimint-3 UI: http://localhost:2014"
-  env FM_FEDERATIONS_BASE_PORT=2000 ./scripts/dev/devimint-env.sh {{PARAMS}}
+  @>&2 echo "gateway LND UI: http://localhost:8173"
+  @>&2 echo "gateway LDK UI: http://localhost:8175"
+  @>&2 echo "gateway LDK2 UI: http://localhost:8177"
+  env FM_FEDERATIONS_BASE_PORT=2000 FM_GATEWAY_BASE_PORT=8170 ./scripts/dev/devimint-env.sh {{PARAMS}}
 
 devimint-env-tmux *PARAMS:
   ./scripts/dev/tmuxinator/run.sh {{PARAMS}}


### PR DESCRIPTION
## Summary
Motivated by https://github.com/fedimint/fedimint/pull/8370#issuecomment-4018053682

Let me know if this looks good, I was able to test by running `just devimint-env-pre-dkg` and then navigating to `http://localhost:8173/` from there I was able to sign on with the default password of `theresnosecondbest`

This adds a new env var `FM_GATEWAY_BASE_PORT`

---

@dpc let me know if this is what you meant by the gateway's not having a fixed address?