### PR TITLE
fix(ui): add max guardian limit of 19 to setup form

### DIFF
--- a/fedimint-server-ui/src/setup.rs
+++ b/fedimint-server-ui/src/setup.rs
@@ -158,7 +158,7 @@ async fn setup_form(State(state): State<UiState<DynSetupApi>>) -> impl IntoRespo
                             "Total number of guardians (including you)"
                         }
                         input type="number" class="form-control" id="federation_size"
-                            name="federation_size" min="1";
+                            name="federation_size" min="1" max="19";
                         small class="form-text text-muted" {
                             "At least 4, or 1. Recommended: 4, 7, 10, 13."
                         }


### PR DESCRIPTION
## Summary
- Adds `max="19"` to the federation size input in the guardian setup UI
- Bitcoin's `OP_CHECKMULTISIG` limits scripts to 20 public keys, so federations with >19 guardians would produce non-standard or invalid on-chain transactions

## Test plan
- [ ] Verify the setup form input rejects values above 19
- [ ] Verify values 1-19 are still accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)