### PR TITLE
feat: added lighting_alias to routing_info_v2 struct

### DIFF
--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -2715,6 +2715,7 @@ impl Gateway {
             .await
             .map(|module_public_key| RoutingInfo {
                 lightning_public_key: context.lightning_public_key,
+                lightning_alias: Some(context.lightning_alias.clone()),
                 module_public_key,
                 send_fee_default: lightning_fee + transaction_fee,
                 // The base fee ensures that the gateway does not loose sats sending the payment due

--- a/modules/fedimint-lnv2-common/src/gateway_api.rs
+++ b/modules/fedimint-lnv2-common/src/gateway_api.rs
@@ -145,6 +145,12 @@ pub struct RoutingInfo {
     /// gateways invoices the senders client uses it to differentiate between a
     /// direct swap between fedimints and a lightning swap.
     pub lightning_public_key: PublicKey,
+    /// The human-readable alias of the gateway's lightning node, if available.
+    ///
+    /// This field is optional for backwards-compatibility with older gateways
+    /// that do not yet provide an alias in their `routing_info` responses.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lightning_alias: Option<String>,
     /// The public key of the gateways client module. This key is used to claim
     /// or cancel outgoing contracts and refund incoming contracts.
     pub module_public_key: PublicKey,

--- a/modules/fedimint-lnv2-tests/tests/mock.rs
+++ b/modules/fedimint-lnv2-tests/tests/mock.rs
@@ -92,6 +92,7 @@ impl GatewayConnection for MockGatewayConnection {
     ) -> Result<Option<RoutingInfo>, ServerError> {
         Ok(Some(RoutingInfo {
             lightning_public_key: self.keypair.public_key(),
+            lightning_alias: Some("mock-gateway".to_string()),
             module_public_key: self.keypair.public_key(),
             send_fee_default: PaymentFee::TRANSACTION_FEE_DEFAULT,
             send_fee_minimum: PaymentFee::TRANSACTION_FEE_DEFAULT,


### PR DESCRIPTION
## Motivation
This should resolve https://github.com/fedimint/fedimint/issues/8351

## Summary
This adds the `lightning_alias` to `RoutingInfo`

also `routing_info_v2` now returns `lightning_alias`

@m1sterc001guy let me know if this looks good, I'm still relativly new to contributing to this project.

I can also take a look at https://github.com/fedimint/ecash-app to update there aswell.