### PR TITLE
feat: `PeginFromOnchain` and `PegoutToOnchain` Gateway APIs

### DIFF
--- a/gateway/fedimint-gateway-client/src/ecash_commands.rs
+++ b/gateway/fedimint-gateway-client/src/ecash_commands.rs
@@ -5,12 +5,12 @@ use fedimint_core::config::FederationId;
 use fedimint_core::util::SafeUrl;
 use fedimint_core::{Amount, BitcoinAmountOrAll};
 use fedimint_gateway_client::{
-    backup, get_deposit_address, receive_ecash, recheck_address, spend_ecash, withdraw,
-    withdraw_to_onchain,
+    backup, get_deposit_address, pegin_from_onchain, receive_ecash, recheck_address, spend_ecash,
+    withdraw, withdraw_to_onchain,
 };
 use fedimint_gateway_common::{
-    BackupPayload, DepositAddressPayload, DepositAddressRecheckPayload, ReceiveEcashPayload,
-    SpendEcashPayload, WithdrawPayload, WithdrawToOnchainPayload,
+    BackupPayload, DepositAddressPayload, DepositAddressRecheckPayload, PeginFromOnchainPayload,
+    ReceiveEcashPayload, SpendEcashPayload, WithdrawPayload, WithdrawToOnchainPayload,
 };
 use fedimint_ln_common::client::GatewayApi;
 use fedimint_mint_client::OOBNotes;
@@ -36,6 +36,18 @@ pub enum EcashCommands {
         address: bitcoin::Address<NetworkUnchecked>,
         #[clap(long)]
         federation_id: FederationId,
+    },
+    /// Send funds from the gateway's onchain wallet to the federation's ecash
+    /// wallet
+    PeginFromOnchain {
+        #[clap(long)]
+        federation_id: FederationId,
+        /// The amount to pegin
+        #[clap(long)]
+        amount: BitcoinAmountOrAll,
+        /// The fee rate to use in satoshis per vbyte.
+        #[clap(long)]
+        fee_rate_sats_per_vbyte: u64,
     },
     /// Claim funds from a gateway federation to an on-chain address.
     Pegout {
@@ -97,6 +109,24 @@ impl EcashCommands {
                     },
                 )
                 .await?;
+                print_response(response);
+            }
+            Self::PeginFromOnchain {
+                federation_id,
+                amount,
+                fee_rate_sats_per_vbyte,
+            } => {
+                let response = pegin_from_onchain(
+                    client,
+                    base_url,
+                    PeginFromOnchainPayload {
+                        federation_id,
+                        amount,
+                        fee_rate_sats_per_vbyte,
+                    },
+                )
+                .await?;
+
                 print_response(response);
             }
             Self::Pegout {

--- a/gateway/fedimint-gateway-client/src/lib.rs
+++ b/gateway/fedimint-gateway-client/src/lib.rs
@@ -20,12 +20,13 @@ use fedimint_gateway_common::{
     ListTransactionsPayload, ListTransactionsResponse, MNEMONIC_ENDPOINT, MnemonicResponse,
     OPEN_CHANNEL_ENDPOINT, OpenChannelRequest, PAY_INVOICE_FOR_OPERATOR_ENDPOINT,
     PAY_OFFER_FOR_OPERATOR_ENDPOINT, PAYMENT_LOG_ENDPOINT, PAYMENT_SUMMARY_ENDPOINT,
-    PayInvoiceForOperatorPayload, PayOfferPayload, PayOfferResponse, PaymentLogPayload,
-    PaymentLogResponse, PaymentSummaryPayload, PaymentSummaryResponse, RECEIVE_ECASH_ENDPOINT,
-    ReceiveEcashPayload, ReceiveEcashResponse, SEND_ONCHAIN_ENDPOINT, SET_FEES_ENDPOINT,
-    SPEND_ECASH_ENDPOINT, STOP_ENDPOINT, SendOnchainRequest, SetFeesPayload, SetMnemonicPayload,
-    SpendEcashPayload, SpendEcashResponse, WITHDRAW_ENDPOINT, WITHDRAW_TO_ONCHAIN_ENDPOINT,
-    WithdrawPayload, WithdrawResponse, WithdrawToOnchainPayload,
+    PEGIN_FROM_ONCHAIN_ENDPOINT, PayInvoiceForOperatorPayload, PayOfferPayload, PayOfferResponse,
+    PaymentLogPayload, PaymentLogResponse, PaymentSummaryPayload, PaymentSummaryResponse,
+    PeginFromOnchainPayload, RECEIVE_ECASH_ENDPOINT, ReceiveEcashPayload, ReceiveEcashResponse,
+    SEND_ONCHAIN_ENDPOINT, SET_FEES_ENDPOINT, SPEND_ECASH_ENDPOINT, STOP_ENDPOINT,
+    SendOnchainRequest, SetFeesPayload, SetMnemonicPayload, SpendEcashPayload, SpendEcashResponse,
+    WITHDRAW_ENDPOINT, WITHDRAW_TO_ONCHAIN_ENDPOINT, WithdrawPayload, WithdrawResponse,
+    WithdrawToOnchainPayload,
 };
 use fedimint_ln_common::Method;
 use fedimint_ln_common::client::GatewayApi;
@@ -59,6 +60,21 @@ pub async fn get_deposit_address(
 ) -> ServerResult<Address<NetworkUnchecked>> {
     client
         .request(base_url, Method::POST, ADDRESS_ENDPOINT, Some(payload))
+        .await
+}
+
+pub async fn pegin_from_onchain(
+    client: &GatewayApi,
+    base_url: &SafeUrl,
+    payload: PeginFromOnchainPayload,
+) -> ServerResult<Txid> {
+    client
+        .request(
+            base_url,
+            Method::POST,
+            PEGIN_FROM_ONCHAIN_ENDPOINT,
+            Some(payload),
+        )
         .await
 }
 

--- a/gateway/fedimint-gateway-common/src/lib.rs
+++ b/gateway/fedimint-gateway-common/src/lib.rs
@@ -48,6 +48,7 @@ pub const PAY_INVOICE_FOR_OPERATOR_ENDPOINT: &str = "/pay_invoice_for_operator";
 pub const PAY_OFFER_FOR_OPERATOR_ENDPOINT: &str = "/pay_offer_for_operator";
 pub const PAYMENT_LOG_ENDPOINT: &str = "/payment_log";
 pub const PAYMENT_SUMMARY_ENDPOINT: &str = "/payment_summary";
+pub const PEGIN_FROM_ONCHAIN_ENDPOINT: &str = "/pegin_from_onchain";
 pub const RECEIVE_ECASH_ENDPOINT: &str = "/receive_ecash";
 pub const SET_FEES_ENDPOINT: &str = "/set_fees";
 pub const STOP_ENDPOINT: &str = "/stop";
@@ -84,6 +85,13 @@ pub struct ConfigPayload {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct DepositAddressPayload {
     pub federation_id: FederationId,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct PeginFromOnchainPayload {
+    pub federation_id: FederationId,
+    pub amount: BitcoinAmountOrAll,
+    pub fee_rate_sats_per_vbyte: u64,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -79,10 +79,10 @@ use fedimint_gateway_common::{
     LightningMode, ListTransactionsPayload, ListTransactionsResponse, MnemonicResponse,
     OpenChannelRequest, PayInvoiceForOperatorPayload, PayOfferPayload, PayOfferResponse,
     PaymentLogPayload, PaymentLogResponse, PaymentStats, PaymentSummaryPayload,
-    PaymentSummaryResponse, ReceiveEcashPayload, ReceiveEcashResponse, RegisteredProtocol,
-    SendOnchainRequest, SetFeesPayload, SetMnemonicPayload, SpendEcashPayload, SpendEcashResponse,
-    V1_API_ENDPOINT, WithdrawPayload, WithdrawPreviewPayload, WithdrawPreviewResponse,
-    WithdrawResponse, WithdrawToOnchainPayload,
+    PaymentSummaryResponse, PeginFromOnchainPayload, ReceiveEcashPayload, ReceiveEcashResponse,
+    RegisteredProtocol, SendOnchainRequest, SetFeesPayload, SetMnemonicPayload, SpendEcashPayload,
+    SpendEcashResponse, V1_API_ENDPOINT, WithdrawPayload, WithdrawPreviewPayload,
+    WithdrawPreviewResponse, WithdrawResponse, WithdrawToOnchainPayload,
 };
 use fedimint_gateway_server_db::{GatewayDbtxNcExt as _, get_gatewayd_database_migrations};
 pub use fedimint_gateway_ui::IAdminGateway;
@@ -1438,6 +1438,26 @@ impl Gateway {
             quoted_fees: None,
         };
         self.handle_withdraw_msg(withdraw).await
+    }
+
+    /// Deposits the specified amount from the gateway's onchain wallet into the
+    /// Federation's ecash wallet
+    pub async fn handle_pegin_from_onchain_msg(
+        &self,
+        payload: PeginFromOnchainPayload,
+    ) -> AdminResult<Txid> {
+        let deposit = DepositAddressPayload {
+            federation_id: payload.federation_id,
+        };
+        let address = self.handle_address_msg(deposit).await?;
+        let send_onchain = SendOnchainRequest {
+            address: address.into_unchecked(),
+            amount: payload.amount,
+            fee_rate_sats_per_vbyte: payload.fee_rate_sats_per_vbyte,
+        };
+        let txid = self.handle_send_onchain_msg(send_onchain).await?;
+
+        Ok(txid)
     }
 
     /// Registers the gateway with each specified federation.

--- a/gateway/fedimint-gateway-server/src/rpc_server.rs
+++ b/gateway/fedimint-gateway-server/src/rpc_server.rs
@@ -23,11 +23,12 @@ use fedimint_gateway_common::{
     INVITE_CODES_ENDPOINT, LEAVE_FED_ENDPOINT, LIST_CHANNELS_ENDPOINT, LIST_TRANSACTIONS_ENDPOINT,
     LeaveFedPayload, ListTransactionsPayload, MNEMONIC_ENDPOINT, OPEN_CHANNEL_ENDPOINT,
     OpenChannelRequest, PAY_INVOICE_FOR_OPERATOR_ENDPOINT, PAY_OFFER_FOR_OPERATOR_ENDPOINT,
-    PAYMENT_LOG_ENDPOINT, PAYMENT_SUMMARY_ENDPOINT, PayInvoiceForOperatorPayload, PayOfferPayload,
-    PaymentLogPayload, PaymentSummaryPayload, RECEIVE_ECASH_ENDPOINT, ReceiveEcashPayload,
-    SEND_ONCHAIN_ENDPOINT, SET_FEES_ENDPOINT, SPEND_ECASH_ENDPOINT, STOP_ENDPOINT,
-    SendOnchainRequest, SetFeesPayload, SetMnemonicPayload, SpendEcashPayload, V1_API_ENDPOINT,
-    WITHDRAW_ENDPOINT, WITHDRAW_TO_ONCHAIN_ENDPOINT, WithdrawPayload, WithdrawToOnchainPayload,
+    PAYMENT_LOG_ENDPOINT, PAYMENT_SUMMARY_ENDPOINT, PEGIN_FROM_ONCHAIN_ENDPOINT,
+    PayInvoiceForOperatorPayload, PayOfferPayload, PaymentLogPayload, PaymentSummaryPayload,
+    PeginFromOnchainPayload, RECEIVE_ECASH_ENDPOINT, ReceiveEcashPayload, SEND_ONCHAIN_ENDPOINT,
+    SET_FEES_ENDPOINT, SPEND_ECASH_ENDPOINT, STOP_ENDPOINT, SendOnchainRequest, SetFeesPayload,
+    SetMnemonicPayload, SpendEcashPayload, V1_API_ENDPOINT, WITHDRAW_ENDPOINT,
+    WITHDRAW_TO_ONCHAIN_ENDPOINT, WithdrawPayload, WithdrawToOnchainPayload,
 };
 use fedimint_gateway_ui::IAdminGateway;
 use fedimint_ln_common::gateway_endpoint_constants::{
@@ -277,6 +278,13 @@ fn routes(gateway: Arc<Gateway>, task_group: TaskGroup, handlers: &mut Handlers)
     );
     let authenticated_routes = register_post_handler(
         handlers,
+        PEGIN_FROM_ONCHAIN_ENDPOINT,
+        pegin_from_onchain,
+        is_authenticated,
+        authenticated_routes,
+    );
+    let authenticated_routes = register_post_handler(
+        handlers,
         CONNECT_FED_ENDPOINT,
         connect_fed,
         is_authenticated,
@@ -491,6 +499,16 @@ async fn address(
     Json(payload): Json<DepositAddressPayload>,
 ) -> Result<Json<serde_json::Value>, GatewayError> {
     let address = gateway.handle_address_msg(payload).await?;
+    Ok(Json(json!(address)))
+}
+
+/// Pegs in funds from the gateway's onchain wallet
+#[instrument(target = LOG_GATEWAY, skip_all, err, fields(?payload))]
+async fn pegin_from_onchain(
+    Extension(gateway): Extension<Arc<Gateway>>,
+    Json(payload): Json<PeginFromOnchainPayload>,
+) -> Result<Json<serde_json::Value>, GatewayError> {
+    let address = gateway.handle_pegin_from_onchain_msg(payload).await?;
     Ok(Json(json!(address)))
 }
 


### PR DESCRIPTION
Adds two simple APIs: `PeginFromOnchain` and `PegoutToOnchain`. Both APIs are possible today, but this just automates it and allows the user to not need to deal with addresses.

Will be useful for agents who don't have permissions to send all funds away.