### PR TITLE
chore: Update Cargo.lock to fix audit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -992,7 +992,7 @@ dependencies = [
  "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "log",
  "prettyplease 0.2.35",
  "proc-macro2",
@@ -6712,7 +6712,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.2",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -8770,9 +8770,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.12"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49df843a9161c85bb8aae55f101bc0bac8bcafd637a620d9122fd7e0b2f7422e"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "getrandom 0.3.3",


### PR DESCRIPTION
Audit is failing:

```
fedimint-ci-audit> Crate:     quinn-proto
fedimint-ci-audit> Version:   0.11.12
fedimint-ci-audit> Title:     Denial of service in Quinn endpoints
fedimint-ci-audit> Date:      2026-03-09
fedimint-ci-audit> ID:        RUSTSEC-2026-0037
fedimint-ci-audit> URL:       https://rustsec.org/advisories/RUSTSEC-2026-0037
fedimint-ci-audit> Severity:  8.7 (high)
fedimint-ci-audit> Solution:  Upgrade to >=0.11.14
```