### PR TITLE
fix: parse FM_IROH_RELAY env var as comma-separated list

### DIFF
--- a/fedimintd/src/lib.rs
+++ b/fedimintd/src/lib.rs
@@ -162,7 +162,7 @@ struct ServerOpts {
     iroh_dns: Option<SafeUrl>,
 
     /// Optional URLs of the Iroh relays to use for registering
-    #[arg(long, env = FM_IROH_RELAY_ENV, requires = "enable_iroh")]
+    #[arg(long, env = FM_IROH_RELAY_ENV, requires = "enable_iroh", value_delimiter = ',')]
     iroh_relays: Vec<SafeUrl>,
 
     /// Number of checkpoints from the current session to retain on disk

--- a/gateway/fedimint-gateway-server/src/config.rs
+++ b/gateway/fedimint-gateway-server/src/config.rs
@@ -124,7 +124,7 @@ pub struct GatewayOpts {
     iroh_dns: Option<SafeUrl>,
 
     /// Optional URLs of the Iroh relays to use for registering
-    #[arg(long, env = FM_IROH_RELAY_ENV)]
+    #[arg(long, env = FM_IROH_RELAY_ENV, value_delimiter = ',')]
     iroh_relays: Vec<SafeUrl>,
 
     #[arg(long, env = FM_GATEWAY_SKIP_SETUP_ENV, default_value_t = false)]


### PR DESCRIPTION
## Summary

- Clap does not split env var values on commas for `Vec` arguments by default. When `FM_IROH_RELAY` was set to a comma-separated list of relay URLs, the entire string was parsed as a single value instead of being split into multiple URLs.
- This meant iroh only ever saw one (malformed) relay URL and couldn't do latency-based relay selection between multiple configured relays.
- Adds `value_delimiter = ','` to the `iroh_relays` clap arg in both `fedimintd` and `fedimint-gateway-server`.

## Test plan

- [ ] Set `FM_IROH_RELAY` to two comma-separated relay URLs and verify both appear in iroh's relay map
- [ ] Verify iroh selects the lowest-latency relay instead of always picking the first one

🤖 Generated with [Claude Code](https://claude.com/claude-code)