### PR TITLE
feat: WalletV2 Taproot

### DIFF
--- a/modules/fedimint-walletv2-common/src/config.rs
+++ b/modules/fedimint-walletv2-common/src/config.rs
@@ -1,11 +1,11 @@
 use std::collections::BTreeMap;
 
-use bitcoin::Network;
 use bitcoin::hashes::{Hash, sha256};
+use bitcoin::{Network, XOnlyPublicKey};
 use fedimint_core::core::ModuleKind;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::{Amount, PeerId, plugin_types_trait_impl_config, weight_to_vbytes};
-use secp256k1::{PublicKey, SecretKey};
+use secp256k1::SecretKey;
 use serde::{Deserialize, Serialize};
 
 use crate::{WalletCommonInit, descriptor};
@@ -32,7 +32,7 @@ pub struct WalletConfigPrivate {
 #[derive(Clone, Debug, Serialize, Deserialize, Encodable, Decodable)]
 pub struct WalletConfigConsensus {
     /// The public keys for the bitcoin multisig
-    pub bitcoin_pks: BTreeMap<PeerId, PublicKey>,
+    pub bitcoin_pks: BTreeMap<PeerId, XOnlyPublicKey>,
     /// Total vbytes of a pegout bitcoin transaction
     pub send_tx_vbytes: u64,
     /// Total vbytes of a pegin bitcoin transaction
@@ -73,7 +73,7 @@ impl WalletConfigConsensus {
     /// | 19        | 539  | 937     |
     /// | 20        | 565  | 991     |
     pub fn new(
-        bitcoin_pks: BTreeMap<PeerId, PublicKey>,
+        bitcoin_pks: BTreeMap<PeerId, XOnlyPublicKey>,
         fee_consensus: FeeConsensus,
         network: Network,
     ) -> Self {
@@ -204,7 +204,7 @@ fn test_fee_consensus() {
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize, Encodable, Decodable)]
 pub struct WalletClientConfig {
     /// The public keys for the bitcoin multisig
-    pub bitcoin_pks: BTreeMap<PeerId, PublicKey>,
+    pub bitcoin_pks: BTreeMap<PeerId, XOnlyPublicKey>,
     /// Total vbytes of a pegout bitcoin transaction
     pub send_tx_vbytes: u64,
     /// Total vbytes of a pegin bitcoin transaction

--- a/modules/fedimint-walletv2-common/src/lib.rs
+++ b/modules/fedimint-walletv2-common/src/lib.rs
@@ -6,6 +6,7 @@
 #![allow(clippy::return_self_not_must_use)]
 
 use std::collections::BTreeMap;
+use std::sync::Arc;
 use std::time::Duration;
 
 use bitcoin::hashes::{Hash, hash160, sha256};
@@ -18,8 +19,10 @@ use fedimint_core::module::{CommonModuleInit, ModuleCommon, ModuleConsensusVersi
 use fedimint_core::{
     NumPeersExt, PeerId, extensible_associated_module_type, plugin_types_trait_impl_common,
 };
-use miniscript::descriptor::Wsh;
-use secp256k1::ecdsa::Signature;
+use miniscript::descriptor::{TapTree, Tr};
+use miniscript::miniscript::decode::Terminal;
+use miniscript::{Miniscript, Tap, Threshold};
+use secp256k1::schnorr::Signature;
 use secp256k1::{PublicKey, Scalar, XOnlyPublicKey};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -42,14 +45,35 @@ pub fn sleep_duration() -> Duration {
     }
 }
 
-pub fn descriptor(pks: &BTreeMap<PeerId, PublicKey>, tweak: &sha256::Hash) -> Wsh<PublicKey> {
-    Wsh::new_sortedmulti(
-        pks.to_num_peers().threshold(),
-        pks.values()
-            .map(|pk| tweak_public_key(pk, tweak))
-            .collect::<Vec<PublicKey>>(),
-    )
-    .expect("Failed to construct Descriptor")
+/// Provably unspendable x-only public key (BIP-341 NUMS point from the
+/// BIP-341 spec). Since no one knows the discrete log of this point,
+/// key-path spending is impossible.
+pub fn nums_point() -> XOnlyPublicKey {
+    XOnlyPublicKey::from_slice(&[
+        0x50, 0x92, 0x9b, 0x74, 0xc1, 0xa0, 0x49, 0x54, 0xb7, 0x8b, 0x4b, 0x60, 0x35, 0xe9, 0x7a,
+        0x5e, 0x07, 0x8a, 0x5a, 0x0f, 0x28, 0xec, 0x96, 0xd5, 0x47, 0xbf, 0xee, 0x9a, 0xce, 0x80,
+        0x3a, 0xc0,
+    ])
+    .expect("Valid x-only public key")
+}
+
+pub fn descriptor(
+    pks: &BTreeMap<PeerId, XOnlyPublicKey>,
+    tweak: &sha256::Hash,
+) -> Tr<XOnlyPublicKey> {
+    let threshold = pks.to_num_peers().threshold();
+    let mut tweaked: Vec<XOnlyPublicKey> = pks
+        .values()
+        .map(|pk| tweak_xonly_public_key(pk, tweak))
+        .collect();
+    tweaked.sort();
+
+    let thresh = Threshold::new(threshold, tweaked).expect("Failed to create multi_a threshold");
+    let ms = Miniscript::<XOnlyPublicKey, Tap>::from_ast(Terminal::MultiA(thresh))
+        .expect("Failed to create multi_a miniscript");
+    let tree = TapTree::Leaf(Arc::new(ms));
+
+    Tr::new(nums_point(), Some(tree)).expect("Failed to construct Tr descriptor")
 }
 
 pub fn tweak_public_key(pk: &PublicKey, tweak: &sha256::Hash) -> PublicKey {
@@ -60,8 +84,19 @@ pub fn tweak_public_key(pk: &PublicKey, tweak: &sha256::Hash) -> PublicKey {
     .expect("Failed to tweak bitcoin public key")
 }
 
+pub fn tweak_xonly_public_key(pk: &XOnlyPublicKey, tweak: &sha256::Hash) -> XOnlyPublicKey {
+    let full_pk = PublicKey::from_x_only_public_key(*pk, secp256k1::Parity::Even);
+    let tweaked = full_pk
+        .add_exp_tweak(
+            secp256k1::SECP256K1,
+            &Scalar::from_be_bytes(tweak.to_byte_array()).expect("Hash is within field order"),
+        )
+        .expect("Failed to tweak bitcoin public key");
+    tweaked.x_only_public_key().0
+}
+
 /// Returns true if the script pubkey potentially belongs to the federation.
-/// This uses a probabilistic filter - only ~1/65536 of P2WSH scripts pass.
+/// This uses a probabilistic filter - only ~1/65536 of P2TR scripts pass.
 pub fn is_potential_receive(script_pubkey: &ScriptBuf, pks_hash: &sha256::Hash) -> bool {
     (script_pubkey, pks_hash)
         .consensus_hash::<sha256::Hash>()

--- a/modules/fedimint-walletv2-server/src/db.rs
+++ b/modules/fedimint-walletv2-server/src/db.rs
@@ -2,7 +2,7 @@ use bitcoin::{TxOut, Txid};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::{PeerId, impl_db_lookup, impl_db_record};
 use fedimint_walletv2_common::TxInfo;
-use secp256k1::ecdsa::Signature;
+use secp256k1::schnorr::Signature;
 use serde::Serialize;
 use strum_macros::EnumIter;
 

--- a/modules/fedimint-walletv2-server/src/lib.rs
+++ b/modules/fedimint-walletv2-server/src/lib.rs
@@ -17,10 +17,10 @@ use std::collections::{BTreeMap, BTreeSet};
 use anyhow::{Context, anyhow, bail, ensure};
 use bitcoin::absolute::LockTime;
 use bitcoin::hashes::{Hash, sha256};
-use bitcoin::secp256k1::Secp256k1;
-use bitcoin::sighash::{EcdsaSighashType, SighashCache};
+use bitcoin::sighash::{Prevouts, SighashCache};
+use bitcoin::taproot::LeafVersion;
 use bitcoin::transaction::Version;
-use bitcoin::{Amount, Network, Sequence, Transaction, TxIn, TxOut, Txid};
+use bitcoin::{Amount, Network, Sequence, TapLeafHash, Transaction, TxIn, TxOut, Txid};
 use common::config::WalletConfigConsensus;
 use common::{
     OutputInfo, WalletCommonInit, WalletConsensusItem, WalletInput, WalletModuleTypes,
@@ -71,13 +71,13 @@ use fedimint_walletv2_common::endpoint_constants::{
 };
 use fedimint_walletv2_common::{
     FederationWallet, MODULE_CONSENSUS_VERSION, TxInfo, WalletInputError, WalletOutputError,
-    descriptor, is_potential_receive, tweak_public_key,
+    descriptor, is_potential_receive, tweak_xonly_public_key,
 };
 use futures::StreamExt;
-use miniscript::descriptor::Wsh;
+use miniscript::descriptor::Tr;
 use rand::rngs::OsRng;
-use secp256k1::ecdsa::Signature;
-use secp256k1::{PublicKey, Scalar, SecretKey};
+use secp256k1::schnorr::Signature;
+use secp256k1::{Keypair, Scalar, SecretKey, XOnlyPublicKey};
 use serde::{Deserialize, Serialize};
 use strum::IntoEnumIterator;
 use tracing::info;
@@ -304,8 +304,13 @@ impl ServerModuleInit for WalletInit {
 
         let bitcoin_pks = bitcoin_sks
             .iter()
-            .map(|(peer, sk)| (*peer, sk.public_key(secp256k1::SECP256K1)))
-            .collect::<BTreeMap<PeerId, PublicKey>>();
+            .map(|(peer, sk)| {
+                (
+                    *peer,
+                    sk.public_key(secp256k1::SECP256K1).x_only_public_key().0,
+                )
+            })
+            .collect::<BTreeMap<PeerId, XOnlyPublicKey>>();
 
         bitcoin_sks
             .into_iter()
@@ -332,9 +337,10 @@ impl ServerModuleInit for WalletInit {
         let fee_consensus = FeeConsensus::new(0).expect("Relative fee is within range");
 
         let (bitcoin_sk, bitcoin_pk) = secp256k1::generate_keypair(&mut OsRng);
+        let bitcoin_xonly_pk = bitcoin_pk.x_only_public_key().0;
 
-        let bitcoin_pks: BTreeMap<PeerId, PublicKey> = peers
-            .exchange_encodable(bitcoin_pk)
+        let bitcoin_pks: BTreeMap<PeerId, XOnlyPublicKey> = peers
+            .exchange_encodable(bitcoin_xonly_pk)
             .await?
             .into_iter()
             .collect();
@@ -356,7 +362,12 @@ impl ServerModuleInit for WalletInit {
                 .bitcoin_pks
                 .get(identity)
                 .ok_or(anyhow::anyhow!("No public key for our identity"))?
-                == &config.private.bitcoin_sk.public_key(secp256k1::SECP256K1),
+                == &config
+                    .private
+                    .bitcoin_sk
+                    .public_key(secp256k1::SECP256K1)
+                    .x_only_public_key()
+                    .0,
             "Bitcoin wallet private key doesn't match multisig pubkey"
         );
 
@@ -409,9 +420,14 @@ impl ServerModule for Wallet {
                 self.verify_signatures(
                     &unsigned_tx,
                     &signatures,
-                    self.cfg.private.bitcoin_sk.public_key(secp256k1::SECP256K1),
+                    self.cfg
+                        .private
+                        .bitcoin_sk
+                        .public_key(secp256k1::SECP256K1)
+                        .x_only_public_key()
+                        .0,
                 )
-                .expect("Our signatures failed verification against our private key");
+                .expect("Our signatures failed verification against out private key");
 
                 WalletConsensusItem::Signatures(key.0, signatures)
             })
@@ -1171,11 +1187,32 @@ impl Wallet {
             .await
     }
 
-    fn descriptor(&self, tweak: &sha256::Hash) -> Wsh<secp256k1::PublicKey> {
+    fn descriptor(&self, tweak: &sha256::Hash) -> Tr<secp256k1::XOnlyPublicKey> {
         descriptor(&self.cfg.consensus.bitcoin_pks, tweak)
     }
 
+    fn tap_leaf_hash(&self, tweak: &sha256::Hash) -> TapLeafHash {
+        let tr = self.descriptor(tweak);
+        let (_, ms) = tr
+            .iter_scripts()
+            .next()
+            .expect("Descriptor always has exactly one script leaf");
+        TapLeafHash::from_script(&ms.encode(), LeafVersion::TapScript)
+    }
+
+    fn build_prevouts(&self, unsigned_tx: &FederationTx) -> Vec<TxOut> {
+        unsigned_tx
+            .spent_tx_outs
+            .iter()
+            .map(|utxo| TxOut {
+                value: utxo.value,
+                script_pubkey: self.descriptor(&utxo.tweak).script_pubkey(),
+            })
+            .collect()
+    }
+
     fn sign_tx(&self, unsigned_tx: &FederationTx) -> Vec<Signature> {
+        let prevouts = self.build_prevouts(unsigned_tx);
         let mut sighash_cache = SighashCache::new(unsigned_tx.tx.clone());
 
         unsigned_tx
@@ -1183,23 +1220,26 @@ impl Wallet {
             .iter()
             .enumerate()
             .map(|(index, utxo)| {
-                let descriptor = self.descriptor(&utxo.tweak).ecdsa_sighash_script_code();
-
-                let p2wsh_sighash = sighash_cache
-                    .p2wsh_signature_hash(index, &descriptor, utxo.value, EcdsaSighashType::All)
-                    .expect("Failed to compute P2WSH segwit sighash");
+                let leaf_hash = self.tap_leaf_hash(&utxo.tweak);
+                let sighash = sighash_cache
+                    .taproot_script_spend_signature_hash(
+                        index,
+                        &Prevouts::All(&prevouts),
+                        leaf_hash,
+                        bitcoin::TapSighashType::Default,
+                    )
+                    .expect("Failed to compute taproot script spend sighash");
 
                 let scalar = &Scalar::from_be_bytes(utxo.tweak.to_byte_array())
                     .expect("Hash is within field order");
 
-                let sk = self
-                    .cfg
-                    .private
-                    .bitcoin_sk
-                    .add_tweak(scalar)
-                    .expect("Failed to tweak bitcoin secret key");
-
-                Secp256k1::new().sign_ecdsa(&p2wsh_sighash.into(), &sk)
+                let keypair =
+                    Keypair::from_secret_key(secp256k1::SECP256K1, &self.cfg.private.bitcoin_sk);
+                let tweaked_keypair = keypair
+                    .add_xonly_tweak(secp256k1::SECP256K1, scalar)
+                    .expect("Failed to tweak bitcoin keypair");
+                secp256k1::SECP256K1
+                    .sign_schnorr(&secp256k1::Message::from(sighash), &tweaked_keypair)
             })
             .collect()
     }
@@ -1208,13 +1248,14 @@ impl Wallet {
         &self,
         unsigned_tx: &FederationTx,
         signatures: &[Signature],
-        pk: PublicKey,
+        pk: XOnlyPublicKey,
     ) -> anyhow::Result<()> {
         ensure!(
             unsigned_tx.spent_tx_outs.len() == signatures.len(),
             "Incorrect number of signatures"
         );
 
+        let prevouts = self.build_prevouts(unsigned_tx);
         let mut sighash_cache = SighashCache::new(unsigned_tx.tx.clone());
 
         for ((index, utxo), signature) in unsigned_tx
@@ -1223,15 +1264,24 @@ impl Wallet {
             .enumerate()
             .zip(signatures.iter())
         {
-            let code = self.descriptor(&utxo.tweak).ecdsa_sighash_script_code();
+            let leaf_hash = self.tap_leaf_hash(&utxo.tweak);
 
-            let p2wsh_sighash = sighash_cache
-                .p2wsh_signature_hash(index, &code, utxo.value, EcdsaSighashType::All)
-                .expect("Failed to compute P2WSH segwit sighash");
+            let sighash = sighash_cache
+                .taproot_script_spend_signature_hash(
+                    index,
+                    &Prevouts::All(&prevouts),
+                    leaf_hash,
+                    bitcoin::TapSighashType::Default,
+                )
+                .expect("Failed to compute taproot script spend sighash");
 
-            let pk = tweak_public_key(&pk, &utxo.tweak);
+            let pk = tweak_xonly_public_key(&pk, &utxo.tweak);
 
-            secp256k1::SECP256K1.verify_ecdsa(&p2wsh_sighash.into(), signature, &pk)?;
+            secp256k1::SECP256K1.verify_schnorr(
+                signature,
+                &secp256k1::Message::from(sighash),
+                &pk,
+            )?;
         }
 
         Ok(())
@@ -1248,25 +1298,34 @@ impl Wallet {
         );
 
         for (index, utxo) in federation_tx.spent_tx_outs.iter().enumerate() {
-            let satisfier: BTreeMap<PublicKey, bitcoin::ecdsa::Signature> = signatures
-                .iter()
-                .map(|(peer, sigs)| {
-                    assert_eq!(sigs.len(), federation_tx.tx.input.len());
+            let leaf_hash = self.tap_leaf_hash(&utxo.tweak);
 
-                    let pk = *self
-                        .cfg
-                        .consensus
-                        .bitcoin_pks
-                        .get(peer)
-                        .expect("Failed to get public key of peer from config");
+            let satisfier: BTreeMap<(XOnlyPublicKey, TapLeafHash), bitcoin::taproot::Signature> =
+                signatures
+                    .iter()
+                    .map(|(peer, sigs)| {
+                        assert_eq!(sigs.len(), federation_tx.tx.input.len());
 
-                    let pk = tweak_public_key(&pk, &utxo.tweak);
+                        let pk = *self
+                            .cfg
+                            .consensus
+                            .bitcoin_pks
+                            .get(peer)
+                            .expect("Failed to get public key of peer from config");
 
-                    (pk, bitcoin::ecdsa::Signature::sighash_all(sigs[index]))
-                })
-                .collect();
+                        let pk = tweak_xonly_public_key(&pk, &utxo.tweak);
 
-            miniscript::Descriptor::Wsh(self.descriptor(&utxo.tweak))
+                        (
+                            (pk, leaf_hash),
+                            bitcoin::taproot::Signature {
+                                signature: sigs[index],
+                                sighash_type: bitcoin::TapSighashType::Default,
+                            },
+                        )
+                    })
+                    .collect();
+
+            miniscript::Descriptor::Tr(self.descriptor(&utxo.tweak))
                 .satisfy(&mut federation_tx.tx.input[index], satisfier)
                 .expect("Failed to satisfy descriptor");
         }
@@ -1395,7 +1454,7 @@ impl Wallet {
             .consensus
             .bitcoin_pks
             .iter()
-            .map(|(peer, pk)| (*peer, tweak_public_key(pk, &wallet.tweak).to_string()))
+            .map(|(peer, pk)| (*peer, tweak_xonly_public_key(pk, &wallet.tweak).to_string()))
             .collect();
 
         let tweak = &Scalar::from_be_bytes(wallet.tweak.to_byte_array())


### PR DESCRIPTION
I don't care too much if we merge this and go with Taproot vs Segwit v0, but I wanted to demonstrate how little code it actually is to do a taproot wallet.

Main changes:
 - `Tr` descriptor instead of `Wsh`
 - `XOnlyPublicKey` instead of `PublicKey`
 - Signing
   - Builds prevouts and computes taproot sighash
   - Commits to all prevouts
   - Commits to `TapLeafHash` of the script path we are spending (there's only 1)
   - Tweaks using `add_xonly_tweak` which handles parity internally
- Verification
   - Same changes as signing but uses our own `tweak_xonly_public_key`
- Finalization
  -  Builds `BTreeMap<(XOnlyPublicKey, TapLeafHash), schnorr::Signature>` which maps a public key and the tapleaf hash to the appropriate signature.
  - `Tr::satisfy` handles building the taproot witness

Advantages
 - Slightly cheaper since Schnorr signatures are smaller than ECDSA
 - Can scale to larger than 20 guardians
 - "Potentially" an easier upgrade path to FROST/ROAST