### PR TITLE
feat: iroh client API 1.0 migration

### DIFF
--- a/docs/networking.md
+++ b/docs/networking.md
@@ -42,7 +42,8 @@ to the original API bind port plus 10. The Iroh 1.0 listener uses the default
 1.x relay set; `FM_IROH_RELAY` remains exclusive to the Iroh 0.35 API. This
 migration endpoint is only supported for a federation configured with the
 legacy Iroh API. Its runtime default is independent of the DKG-only
-`FM_ENABLE_IROH` option.
+`FM_ENABLE_IROH` option. Existing federations configured without the legacy
+Iroh API continue without either Iroh listener and log a warning.
 
 Guardian metadata advertises the new identity in an optional field ignored by
 older clients. Capable clients use the advertised identity without falling back

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -18,7 +18,8 @@ a quorum (the required threshold of guardians) runs mutually compatible
 software, so guardians may be upgraded in a staggered sequence. However, the old
 transport loses quorum before the new transport gains it. Upgrade the guardians
 in close succession to minimize this interval, during which neither group has
-quorum and consensus cannot make progress.
+quorum and consensus cannot make progress. Rolling back across the incompatible
+transport boundary is unsupported.
 
 `FM_IROH_RELAY` remains the Iroh 0.35 API relay setting.
 `FM_IROH_P2P_RELAY` configures Iroh 1.x relays for guardian P2P. If the latter is
@@ -30,3 +31,25 @@ available. Without a relay address, it publishes its direct IP addresses instead
 so other guardians can discover it by endpoint ID. This fallback is required for
 relay-disabled deployments, but discloses the guardian's direct P2P addresses to
 the configured Pkarr service.
+
+## Transitional Iroh 1.0 client API
+
+The client-facing API keeps its original identity and Iroh 0.35 listener for
+deployed clients. `FM_IROH_NEXT_ENABLE=true` additionally starts an Iroh 1.0
+listener with a separately derived identity. Its bind address is configured by
+`FM_BIND_API_NEXT` and defaults to the original API bind port plus 10. The Iroh
+1.0 listener uses the default 1.x relay set; `FM_IROH_RELAY` remains exclusive
+to the Iroh 0.35 API. This migration endpoint is only supported for a
+federation configured with the legacy Iroh API. Enabling it at runtime does not
+require setting the DKG-only `FM_ENABLE_IROH` option again.
+
+Guardian metadata advertises the new identity in an optional field ignored by
+older clients. Capable clients use the advertised identity without falling back
+to the original identity. A client that learns the metadata while already
+running applies it when reopened.
+
+This rollout is forward-only. Once a guardian advertises its Iroh 1.0 API
+identity, that listener must remain enabled and reachable. Disabling it or
+downgrading to a binary without the listener is unsupported. After
+advertisement, setting `FM_IROH_NEXT_ENABLE=false` or omitting the setting makes
+startup fail while the persisted advertisement exists.

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -35,13 +35,14 @@ the configured Pkarr service.
 ## Transitional Iroh 1.0 client API
 
 The client-facing API keeps its original identity and Iroh 0.35 listener for
-deployed clients. `FM_IROH_NEXT_ENABLE=true` additionally starts an Iroh 1.0
-listener with a separately derived identity. Its bind address is configured by
-`FM_BIND_API_NEXT` and defaults to the original API bind port plus 10. The Iroh
-1.0 listener uses the default 1.x relay set; `FM_IROH_RELAY` remains exclusive
-to the Iroh 0.35 API. This migration endpoint is only supported for a
-federation configured with the legacy Iroh API. Enabling it at runtime does not
-require setting the DKG-only `FM_ENABLE_IROH` option again.
+deployed clients. It also starts an Iroh 1.0 listener with a separately derived
+identity by default. Set `FM_IROH_NEXT_ENABLE=false` to disable it before it is
+advertised. Its bind address is configured by `FM_BIND_API_NEXT` and defaults
+to the original API bind port plus 10. The Iroh 1.0 listener uses the default
+1.x relay set; `FM_IROH_RELAY` remains exclusive to the Iroh 0.35 API. This
+migration endpoint is only supported for a federation configured with the
+legacy Iroh API. Its runtime default is independent of the DKG-only
+`FM_ENABLE_IROH` option.
 
 Guardian metadata advertises the new identity in an optional field ignored by
 older clients. Capable clients use the advertised identity without falling back
@@ -51,5 +52,5 @@ running applies it when reopened.
 This rollout is forward-only. Once a guardian advertises its Iroh 1.0 API
 identity, that listener must remain enabled and reachable. Disabling it or
 downgrading to a binary without the listener is unsupported. After
-advertisement, setting `FM_IROH_NEXT_ENABLE=false` or omitting the setting makes
-startup fail while the persisted advertisement exists.
+advertisement, setting `FM_IROH_NEXT_ENABLE=false` makes startup fail while the
+persisted advertisement exists. Omitting the setting keeps the listener enabled.

--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -1351,11 +1351,11 @@ impl FedimintCli {
             Command::Admin(AdminCmd::SignGuardianMetadata { api_urls, pkarr_id }) => {
                 let client = self.client_open(&cli).await?;
 
-                let metadata = fedimint_core::net::guardian_metadata::GuardianMetadata {
+                let metadata = fedimint_core::net::guardian_metadata::GuardianMetadata::new(
                     api_urls,
-                    pkarr_id_z32: pkarr_id,
-                    timestamp_secs: fedimint_core::time::duration_since_epoch().as_secs(),
-                };
+                    pkarr_id,
+                    fedimint_core::time::duration_since_epoch().as_secs(),
+                );
 
                 let signed_metadata = cli
                     .admin_client(

--- a/fedimint-client/src/api_announcements.rs
+++ b/fedimint-client/src/api_announcements.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 use anyhow::{Context, bail};
 use fedimint_api_client::api::DynGlobalApi;
+use fedimint_connectors::iroh_next_endpoint_url;
 use fedimint_core::config::ClientConfig;
 use fedimint_core::db::{Database, IDatabaseTransactionOpsCoreTyped};
 use fedimint_core::encoding::{Decodable, Encodable};
@@ -17,11 +18,14 @@ use fedimint_core::util::{FmtCompactAnyhow as _, SafeUrl};
 use fedimint_core::{NumPeersExt as _, PeerId, impl_db_lookup, impl_db_record};
 use fedimint_logging::LOG_CLIENT;
 use futures::stream::{FuturesUnordered, StreamExt as _};
-use tracing::debug;
+use tracing::{debug, warn};
 
 use crate::Client;
 use crate::db::DbKeyPrefix;
 use crate::guardian_metadata::GuardianMetadataPrefix;
+
+#[cfg(test)]
+mod tests;
 
 #[derive(Clone, Debug, Encodable, Decodable)]
 pub struct ApiAnnouncementKey(pub PeerId);
@@ -228,7 +232,11 @@ pub(crate) async fn store_api_announcement_updates(
 /// 1. Guardian metadata (if available) - uses first URL from api_urls
 /// 2. API announcement (if available)
 /// 3. Configured URL (fallback)
-pub async fn get_api_urls(db: &Database, cfg: &ClientConfig) -> BTreeMap<PeerId, SafeUrl> {
+pub async fn get_api_urls(
+    db: &Database,
+    cfg: &ClientConfig,
+    client_iroh_next_enabled: bool,
+) -> BTreeMap<PeerId, SafeUrl> {
     let mut dbtx = db.begin_transaction_nc().await;
 
     // Load guardian metadata for all peers
@@ -247,13 +255,17 @@ pub async fn get_api_urls(db: &Database, cfg: &ClientConfig) -> BTreeMap<PeerId,
         .collect()
         .await;
 
-    // For each peer: prefer guardian metadata, then API announcement, then config
+    // For each peer: prefer guardian metadata, then API announcement, then config.
+    // When the client supports iroh-next and the guardian advertises an
+    // iroh-next endpoint, replace the original iroh:// identity with the
+    // advertised identity. The original identity is not retained as a fallback.
     cfg.global
         .api_endpoints
         .iter()
-        .map(|(peer_id, peer_url)| {
-            let url = guardian_metadata
-                .get(peer_id)
+        .filter_map(|(peer_id, peer_url)| {
+            let metadata = guardian_metadata.get(peer_id);
+
+            let mut url = metadata
                 .and_then(|m| m.guardian_metadata().api_urls.first().cloned())
                 .or_else(|| {
                     api_announcements
@@ -261,7 +273,39 @@ pub async fn get_api_urls(db: &Database, cfg: &ClientConfig) -> BTreeMap<PeerId,
                         .map(|a| a.api_announcement.api_url.clone())
                 })
                 .unwrap_or_else(|| peer_url.url.clone());
-            (*peer_id, url)
+
+            // If the resolved URL is iroh:// and iroh-next endpoint preference is
+            // enabled, swap in the advertised iroh-next endpoint.
+            if url.scheme() == "iroh"
+                && client_iroh_next_enabled
+                && let Some(m) = metadata
+            {
+                let gm = m.guardian_metadata();
+                if let Some(endpoint) = &gm.iroh_next_endpoint {
+                    match iroh_next_endpoint_url(endpoint) {
+                        Ok(next_url) => {
+                            debug!(
+                                target: LOG_CLIENT,
+                                %peer_id,
+                                %next_url,
+                                "Using iroh-next endpoint from guardian metadata",
+                            );
+                            url = next_url;
+                        }
+                        Err(err) => {
+                            warn!(
+                                target: LOG_CLIENT,
+                                %peer_id,
+                                err = %err.fmt_compact_anyhow(),
+                                "Ignoring peer with invalid advertised iroh-next endpoint",
+                            );
+                            return None;
+                        }
+                    }
+                }
+            }
+
+            Some((*peer_id, url))
         })
         .collect()
 }

--- a/fedimint-client/src/api_announcements/tests.rs
+++ b/fedimint-client/src/api_announcements/tests.rs
@@ -1,0 +1,153 @@
+use std::collections::BTreeMap;
+
+use fedimint_core::config::{ClientConfig, GlobalClientConfig, PeerUrl};
+use fedimint_core::db::mem_impl::MemDatabase;
+use fedimint_core::db::{Database, IDatabaseTransactionOpsCoreTyped};
+use fedimint_core::module::CORE_CONSENSUS_VERSION;
+use fedimint_core::module::registry::ModuleRegistry;
+use fedimint_core::net::guardian_metadata::GuardianMetadata;
+use fedimint_core::secp256k1::rand;
+use fedimint_core::util::SafeUrl;
+use fedimint_core::{PeerId, secp256k1};
+use serde::Deserialize;
+
+use super::get_api_urls;
+use crate::guardian_metadata::GuardianMetadataKey;
+
+const STABLE_ENDPOINT_ID: &str = "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a";
+const NEXT_ENDPOINT_ID: &str = "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c";
+
+fn test_config(peer_id: PeerId, url: SafeUrl) -> ClientConfig {
+    ClientConfig {
+        global: GlobalClientConfig {
+            api_endpoints: BTreeMap::from([(
+                peer_id,
+                PeerUrl {
+                    url,
+                    name: "peer".to_owned(),
+                },
+            )]),
+            broadcast_public_keys: None,
+            consensus_version: CORE_CONSENSUS_VERSION,
+            meta: BTreeMap::new(),
+        },
+        modules: BTreeMap::new(),
+    }
+}
+
+async fn insert_guardian_metadata(
+    db: &Database,
+    peer_id: PeerId,
+    api_url: SafeUrl,
+    endpoint: Option<&str>,
+) {
+    let ctx = secp256k1::Secp256k1::new();
+    let keypair = secp256k1::Keypair::new(&ctx, &mut rand::thread_rng());
+    let mut metadata = GuardianMetadata::new(vec![api_url], "pkarr-id".to_owned(), 1);
+    metadata.iroh_next_endpoint = endpoint.map(str::to_owned);
+
+    let signed = metadata.sign(&ctx, &keypair);
+    let mut dbtx = db.begin_transaction().await;
+    dbtx.insert_entry(&GuardianMetadataKey(peer_id), &signed)
+        .await;
+    dbtx.commit_tx().await;
+}
+
+#[tokio::test]
+async fn advertised_iroh_next_endpoint_rewrites_iroh_url_to_metadata_endpoint() {
+    let db = Database::new(MemDatabase::new(), ModuleRegistry::default());
+    let peer_id = PeerId::from(0);
+    let stable_url = SafeUrl::parse(&format!("iroh://{STABLE_ENDPOINT_ID}")).expect("valid URL");
+    let next_endpoint = NEXT_ENDPOINT_ID;
+    insert_guardian_metadata(&db, peer_id, stable_url.clone(), Some(next_endpoint)).await;
+
+    let urls = get_api_urls(&db, &test_config(peer_id, stable_url), true).await;
+
+    assert_eq!(
+        urls.get(&peer_id),
+        Some(&SafeUrl::parse(&format!("iroh://{next_endpoint}/v1")).expect("valid URL"))
+    );
+}
+
+#[tokio::test]
+async fn missing_endpoint_or_disabled_iroh_next_does_not_rewrite_iroh_url() {
+    let stable_url = SafeUrl::parse(&format!("iroh://{STABLE_ENDPOINT_ID}")).expect("valid URL");
+    let peer_id = PeerId::from(0);
+
+    for (advertised_endpoint, client_iroh_next_enabled) in
+        [(None, true), (Some(NEXT_ENDPOINT_ID), false)]
+    {
+        let db = Database::new(MemDatabase::new(), ModuleRegistry::default());
+        insert_guardian_metadata(&db, peer_id, stable_url.clone(), advertised_endpoint).await;
+
+        let urls = get_api_urls(
+            &db,
+            &test_config(peer_id, stable_url.clone()),
+            client_iroh_next_enabled,
+        )
+        .await;
+
+        assert_eq!(urls.get(&peer_id), Some(&stable_url));
+    }
+}
+
+#[tokio::test]
+async fn non_iroh_url_is_not_rewritten_to_advertised_iroh_next_endpoint() {
+    let db = Database::new(MemDatabase::new(), ModuleRegistry::default());
+    let peer_id = PeerId::from(0);
+    let stable_url = SafeUrl::parse("wss://example.com/ws/").expect("valid URL");
+    insert_guardian_metadata(&db, peer_id, stable_url.clone(), Some(NEXT_ENDPOINT_ID)).await;
+
+    let urls = get_api_urls(&db, &test_config(peer_id, stable_url.clone()), true).await;
+
+    assert_eq!(urls.get(&peer_id), Some(&stable_url));
+}
+
+#[tokio::test]
+async fn malformed_advertised_iroh_next_endpoint_does_not_fall_back() {
+    let db = Database::new(MemDatabase::new(), ModuleRegistry::default());
+    let peer_id = PeerId::from(0);
+    let stable_url = SafeUrl::parse(&format!("iroh://{STABLE_ENDPOINT_ID}")).expect("valid URL");
+    insert_guardian_metadata(&db, peer_id, stable_url.clone(), Some("not-an-endpoint-id")).await;
+
+    let urls = get_api_urls(&db, &test_config(peer_id, stable_url), true).await;
+
+    assert!(!urls.contains_key(&peer_id));
+}
+
+#[test]
+fn legacy_guardian_metadata_ignores_next_endpoint_and_keeps_stable_url() {
+    #[derive(Deserialize)]
+    struct LegacyGuardianMetadata {
+        api_urls: Vec<SafeUrl>,
+        pkarr_id_z32: String,
+        timestamp_secs: u64,
+    }
+
+    let stable_url = SafeUrl::parse(&format!("iroh://{STABLE_ENDPOINT_ID}")).expect("valid URL");
+    let metadata = GuardianMetadata::new(vec![stable_url.clone()], "pkarr-id".to_owned(), 1)
+        .with_iroh_next_endpoint(NEXT_ENDPOINT_ID.to_owned());
+
+    let legacy: LegacyGuardianMetadata =
+        serde_json::from_slice(&serde_json::to_vec(&metadata).expect("serializes"))
+            .expect("legacy clients ignore the new optional field");
+
+    assert_eq!(legacy.api_urls, vec![stable_url]);
+    assert_eq!(legacy.pkarr_id_z32, "pkarr-id");
+    assert_eq!(legacy.timestamp_secs, 1);
+}
+
+#[test]
+fn current_guardian_metadata_accepts_legacy_payload_without_next_endpoint() {
+    let stable_url = SafeUrl::parse(&format!("iroh://{STABLE_ENDPOINT_ID}")).expect("valid URL");
+    let legacy_payload = serde_json::json!({
+        "api_urls": [stable_url],
+        "pkarr_id_z32": "pkarr-id",
+        "timestamp_secs": 1,
+    });
+
+    let metadata: GuardianMetadata =
+        serde_json::from_value(legacy_payload).expect("legacy metadata remains valid");
+
+    assert_eq!(metadata.iroh_next_endpoint, None);
+}

--- a/fedimint-client/src/client.rs
+++ b/fedimint-client/src/client.rs
@@ -181,6 +181,7 @@ pub struct Client {
     log_event_added_transient_tx: broadcast::Sender<EventLogEntry>,
     request_hook: ApiRequestHook,
     iroh_enable_dht: bool,
+    iroh_enable_next: bool,
     /// User-provided Bitcoin RPC client for modules to use
     ///
     /// Stored here for potential future access; currently passed to modules
@@ -2098,7 +2099,7 @@ impl Client {
 
     /// Returns a list of guardian API URLs
     pub async fn get_peer_urls(&self) -> BTreeMap<PeerId, SafeUrl> {
-        get_api_urls(&self.db, &self.config().await).await
+        get_api_urls(&self.db, &self.config().await, self.iroh_enable_next).await
     }
 
     /// Create an invite code with the api endpoint of the given peer which can
@@ -2507,6 +2508,12 @@ impl Client {
 
     pub fn iroh_enable_dht(&self) -> bool {
         self.iroh_enable_dht
+    }
+
+    /// Whether compatible iroh-next endpoints from guardian metadata are
+    /// preferred.
+    pub fn iroh_enable_next(&self) -> bool {
+        self.iroh_enable_next
     }
 
     pub(crate) async fn run_core_migrations(

--- a/fedimint-client/src/client/builder.rs
+++ b/fedimint-client/src/client/builder.rs
@@ -124,6 +124,7 @@ pub struct ClientBuilder {
     log_event_added_transient_tx: broadcast::Sender<EventLogEntry>,
     request_hook: ApiRequestHook,
     iroh_enable_dht: bool,
+    iroh_enable_next: bool,
     bitcoind_rpc_factory: Option<BitcoindRpcFactory>,
     bitcoind_rpc_no_chain_id_factory: Option<BitcoindRpcNoChainIdFactory>,
 }
@@ -147,6 +148,7 @@ impl ClientBuilder {
             log_event_added_transient_tx,
             request_hook: Arc::new(|api| api),
             iroh_enable_dht: true,
+            iroh_enable_next: true,
             bitcoind_rpc_factory: None,
             bitcoind_rpc_no_chain_id_factory: None,
         }
@@ -162,6 +164,7 @@ impl ClientBuilder {
             log_event_added_transient_tx: client.log_event_added_transient_tx.clone(),
             request_hook: client.request_hook.clone(),
             iroh_enable_dht: client.iroh_enable_dht,
+            iroh_enable_next: client.iroh_enable_next,
             // Note: bitcoind_rpc_factory is not cloned from existing client
             // since it's a one-time factory that's consumed during build
             bitcoind_rpc_factory: None,
@@ -583,6 +586,10 @@ impl ClientBuilder {
         Ok(client)
     }
 
+    fn should_enable_iroh_next(&self, connectors: &ConnectorRegistry) -> bool {
+        self.iroh_enable_next && connectors.iroh_next_enabled()
+    }
+
     // TODO: remove config argument
     /// Build a [`Client`] but do not start the executor
     #[allow(clippy::too_many_arguments)]
@@ -621,7 +628,8 @@ impl ClientBuilder {
         let config = Self::config_decoded(config, &decoders)?;
         let fed_id = config.calculate_federation_id();
         let db = db_no_decoders.with_decoders(decoders.clone());
-        let peer_urls = get_api_urls(&db, &config).await;
+        let iroh_enable_next = self.should_enable_iroh_next(&connectors);
+        let peer_urls = get_api_urls(&db, &config, iroh_enable_next).await;
         let api = match self.admin_creds.as_ref() {
             Some(admin_creds) => FederationApi::new(
                 connectors.clone(),
@@ -1037,6 +1045,7 @@ impl ClientBuilder {
             client_recovery_progress_receiver,
             meta_service: self.meta_service,
             iroh_enable_dht: self.iroh_enable_dht,
+            iroh_enable_next,
             user_bitcoind_rpc,
             user_bitcoind_rpc_no_chain_id: self.bitcoind_rpc_no_chain_id_factory,
         });

--- a/fedimint-connectors/src/iroh.rs
+++ b/fedimint-connectors/src/iroh.rs
@@ -216,8 +216,11 @@ impl IrohConnector {
                     .address_lookup(iroh_next::address_lookup::PkarrResolver::builder(iroh_dns));
             }
 
-            // As a client, we don't need to register on any relays
-            let mut builder = builder.relay_mode(iroh_next::RelayMode::Disabled);
+            // Server iroh-next endpoints publish relay-only address records by
+            // default (the iroh 1.0 publishers filter out direct addresses), so
+            // the client must be able to dial via relays; `RelayMode::Disabled`
+            // would disable dialing them, not just registration.
+            let mut builder = builder.relay_mode(iroh_next::RelayMode::Default);
 
             #[cfg(not(target_family = "wasm"))]
             if iroh_enable_dht {

--- a/fedimint-connectors/src/iroh.rs
+++ b/fedimint-connectors/src/iroh.rs
@@ -301,6 +301,12 @@ impl crate::Connector for IrohConnector {
                 source,
                 url: url.to_owned(),
             })?;
+        let next_only = crate::is_iroh_next_endpoint_url(url).map_err(|source| {
+            ServerError::InvalidPeerUrl {
+                source,
+                url: url.to_owned(),
+            }
+        })?;
         let mut futures = FuturesUnordered::<
             Pin<
                 Box<
@@ -310,6 +316,15 @@ impl crate::Connector for IrohConnector {
             >,
         >::new();
         let connection_override = self.connection_overrides.get(&node_id).cloned();
+
+        // Advertised Iroh 1.0 identities carry an internal `/v1` marker so we
+        // avoid attempting the incompatible 0.35 stack for safety and efficiency.
+        if next_only {
+            return self
+                .make_new_connection_next(&self.next, node_id, connection_override)
+                .await
+                .map(super::IGuardianConnection::into_dyn);
+        }
 
         let self_clone = self.clone();
         futures.push(Box::pin({
@@ -844,11 +859,49 @@ impl IGatewayConnection for Connection {
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr as _;
+
+    use fedimint_core::PeerId;
+    use fedimint_core::config::FederationId;
+    use fedimint_core::invite_code::InviteCode;
     use fedimint_core::module::ApiMethod;
+    use fedimint_core::util::SafeUrl;
 
     use super::{
         IROH_REQUEST_TIMEOUT_DEFAULT, IROH_REQUEST_TIMEOUT_LONG_POLL, request_timeout_for_method,
     };
+    use crate::{iroh_next_endpoint_url, is_iroh_next_endpoint_url, preserve_iroh_next_marker};
+
+    const TEST_ENDPOINT_ID: &str =
+        "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c";
+
+    #[test]
+    fn advertised_iroh_next_url_selects_only_the_next_stack() {
+        let next_url = iroh_next_endpoint_url(TEST_ENDPOINT_ID).expect("valid endpoint ID");
+        assert!(is_iroh_next_endpoint_url(&next_url).expect("valid Iroh API URL path"));
+
+        let invite = InviteCode::new(next_url, PeerId::from(0), FederationId::dummy(), None);
+        let round_tripped =
+            InviteCode::from_str(&invite.to_string()).expect("invite code round-trips");
+        assert!(is_iroh_next_endpoint_url(&round_tripped.url()).expect("valid Iroh API URL path"));
+
+        let stable_url =
+            SafeUrl::parse(&format!("iroh://{TEST_ENDPOINT_ID}")).expect("valid Iroh URL");
+        assert!(!is_iroh_next_endpoint_url(&stable_url).expect("valid Iroh API URL path"));
+
+        let replacement = SafeUrl::parse(
+            "iroh://d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+        )
+        .expect("valid replacement URL");
+        let replacement = preserve_iroh_next_marker(&round_tripped.url(), &replacement);
+        assert!(is_iroh_next_endpoint_url(&replacement).expect("valid Iroh API URL path"));
+    }
+
+    #[test]
+    fn unknown_iroh_api_version_path_is_rejected() {
+        let url = SafeUrl::parse(&format!("iroh://{TEST_ENDPOINT_ID}/v2")).expect("valid Iroh URL");
+        assert!(is_iroh_next_endpoint_url(&url).is_err());
+    }
 
     /// Every `await_*` endpoint currently exposed by fedimint modules
     /// should be classified as long-poll. If a new endpoint is added

--- a/fedimint-connectors/src/lib.rs
+++ b/fedimint-connectors/src/lib.rs
@@ -10,12 +10,15 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fmt::{self, Debug};
 use std::net::SocketAddr;
 use std::pin::Pin;
+use std::str::FromStr as _;
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::{anyhow, bail};
+use anyhow::{Context as _, anyhow, bail};
 use async_trait::async_trait;
-use fedimint_core::envs::{FM_WS_API_CONNECT_OVERRIDES_ENV, parse_kv_list_from_env};
+use fedimint_core::envs::{
+    FM_WS_API_CONNECT_OVERRIDES_ENV, is_running_in_test_env, parse_kv_list_from_env,
+};
 use fedimint_core::module::{ApiMethod, ApiRequestErased};
 use fedimint_core::util::backoff_util::{FibonacciBackoff, custom_backoff};
 use fedimint_core::util::{FmtCompact, FmtCompactAnyhow, SafeUrl};
@@ -30,6 +33,43 @@ use tracing::trace;
 use crate::error::ServerError;
 use crate::metrics::{CONNECTION_ATTEMPTS_TOTAL, CONNECTION_DURATION_SECONDS};
 use crate::ws::WebsocketConnector;
+
+const IROH_NEXT_PATH: &str = "/v1";
+
+/// Parse an advertised Iroh 1.0 endpoint ID into its API URL.
+///
+/// The `/v1` path is an internal transport-selection marker. It prevents the
+/// connector from attempting Iroh 0.35 against an Iroh 1.0-only identity,
+/// avoiding both an inappropriate connection attempt and its overhead.
+pub fn iroh_next_endpoint_url(endpoint: &str) -> anyhow::Result<SafeUrl> {
+    let endpoint_id =
+        iroh_next::EndpointId::from_str(endpoint).context("Invalid Iroh 1.0 endpoint ID")?;
+    SafeUrl::parse(&format!("iroh://{endpoint_id}{IROH_NEXT_PATH}"))
+        .context("Invalid Iroh 1.0 endpoint URL")
+}
+
+fn is_iroh_next_endpoint_url(url: &SafeUrl) -> anyhow::Result<bool> {
+    match url.path() {
+        "" | "/" => Ok(false),
+        IROH_NEXT_PATH => Ok(true),
+        path => bail!("Unsupported Iroh API URL path: {path}"),
+    }
+}
+
+fn preserve_iroh_next_marker(original: &SafeUrl, replacement: &SafeUrl) -> SafeUrl {
+    // An Iroh-to-Iroh override changes the destination, not the selected wire
+    // version. Cross-protocol overrides deliberately replace the whole route.
+    if original.scheme() == "iroh"
+        && original.path() == IROH_NEXT_PATH
+        && replacement.scheme() == "iroh"
+    {
+        let mut replacement = replacement.clone().to_unsafe();
+        replacement.set_path(IROH_NEXT_PATH);
+        replacement.into()
+    } else {
+        replacement.clone()
+    }
+}
 
 pub type ServerResult<T> = Result<T, ServerError>;
 
@@ -57,6 +97,8 @@ pub struct ConnectorRegistryBuilder {
     iroh_dns: Option<SafeUrl>,
     /// Enable Pkarr DHT discovery
     iroh_pkarr_dht: bool,
+    /// Enable compatible iroh-next endpoint preference from guardian metadata
+    iroh_next: bool,
 
     /// Enable Websocket API handling at all?
     ws_enable: bool,
@@ -69,6 +111,8 @@ pub struct ConnectorRegistryBuilder {
 impl ConnectorRegistryBuilder {
     #[allow(clippy::unused_async)] // Leave room for async in the future
     pub async fn bind(self) -> anyhow::Result<ConnectorRegistry> {
+        let iroh_next = self.iroh_next && self.iroh_enable;
+
         // Create initialization functions for each connector type
         let mut connectors_lazy: BTreeMap<String, (ConnectorInitFn, OnceCell<DynConnector>)> =
             BTreeMap::new();
@@ -126,6 +170,7 @@ impl ConnectorRegistryBuilder {
                 connection_overrides: self.connection_overrides,
                 initialized: SetOnce::new(),
                 path_change,
+                iroh_next,
             }
             .into(),
         })
@@ -178,6 +223,15 @@ impl ConnectorRegistryBuilder {
         }
     }
 
+    /// Enable use of compatible iroh-next endpoints advertised in guardian
+    /// metadata.
+    pub fn iroh_next(self, enable: bool) -> Self {
+        Self {
+            iroh_next: enable,
+            ..self
+        }
+    }
+
     pub fn ws_force_tor(self, enable: bool) -> Self {
         Self {
             ws_force_tor: enable,
@@ -204,6 +258,12 @@ impl ConnectorRegistryBuilder {
         // TODO: read rest of the env
         for (k, v) in parse_kv_list_from_env::<_, SafeUrl>(FM_WS_API_CONNECT_OVERRIDES_ENV)? {
             self = self.with_connection_override(k, v);
+        }
+
+        // Disable iroh-next endpoint preference in test/devimint environments
+        // where iroh-next server endpoints are not running.
+        if is_running_in_test_env() {
+            self.iroh_next = false;
         }
 
         Ok(Self { ..self })
@@ -234,6 +294,9 @@ struct ConnectorRegistryInner {
     /// Ticks whenever a connector observes a transport-level path change
     /// (e.g. iroh relay → direct). Only Iroh bumps this today.
     path_change: Arc<watch::Sender<u64>>,
+    /// Whether compatible iroh-next endpoints advertised in guardian metadata
+    /// are used.
+    iroh_next: bool,
 }
 
 /// A set of available connectivity protocols a client can use to make
@@ -258,11 +321,18 @@ impl fmt::Debug for ConnectorRegistry {
         f.debug_struct("ConnectorRegistry")
             .field("connectors_lazy", &self.inner.connectors_lazy.len())
             .field("connection_overrides", &self.inner.connection_overrides)
+            .field("iroh_next", &self.inner.iroh_next)
             .finish()
     }
 }
 
 impl ConnectorRegistry {
+    /// Whether compatible iroh-next endpoints advertised in guardian metadata
+    /// are used.
+    pub fn iroh_next_enabled(&self) -> bool {
+        self.inner.iroh_next
+    }
+
     /// Create a builder with recommended defaults intended for client-side
     /// usage
     ///
@@ -272,6 +342,7 @@ impl ConnectorRegistry {
             iroh_enable: true,
             iroh_dns: None,
             iroh_pkarr_dht: false,
+            iroh_next: true,
             ws_enable: true,
             ws_force_tor: false,
             http_enable: true,
@@ -287,6 +358,7 @@ impl ConnectorRegistry {
             iroh_enable: true,
             iroh_dns: None,
             iroh_pkarr_dht: true,
+            iroh_next: true,
             ws_enable: true,
             ws_force_tor: false,
             http_enable: false,
@@ -302,6 +374,7 @@ impl ConnectorRegistry {
             iroh_enable: true,
             iroh_dns: None,
             iroh_pkarr_dht: false,
+            iroh_next: false,
             ws_enable: true,
             ws_force_tor: false,
             http_enable: true,
@@ -352,7 +425,12 @@ impl ConnectorRegistry {
         );
         let _ = self.inner.initialized.set(());
 
-        let url = match self.inner.connection_overrides.get(url) {
+        let replacement = self
+            .inner
+            .connection_overrides
+            .get(url)
+            .map(|replacement| preserve_iroh_next_marker(url, replacement));
+        let url = match replacement.as_ref() {
             Some(replacement) => {
                 trace!(
                     target: LOG_NET,

--- a/fedimint-core/src/net/guardian_metadata.rs
+++ b/fedimint-core/src/net/guardian_metadata.rs
@@ -15,6 +15,9 @@ pub struct GuardianMetadata {
     /// z-base32 encoded Pkarr id
     pub pkarr_id_z32: String,
     pub timestamp_secs: u64,
+    /// Iroh-next 1.0-compatible API endpoint node ID (public key) when enabled
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub iroh_next_endpoint: Option<String>,
 }
 
 #[derive(Debug, Clone, Eq, Hash, PartialEq)]
@@ -142,7 +145,14 @@ impl GuardianMetadata {
             api_urls,
             pkarr_id_z32,
             timestamp_secs,
+            iroh_next_endpoint: None,
         }
+    }
+
+    /// Set the iroh-next 1.0-compatible API endpoint node ID.
+    pub fn with_iroh_next_endpoint(mut self, endpoint: String) -> Self {
+        self.iroh_next_endpoint = Some(endpoint);
+        self
     }
 
     pub fn sign<C: secp256k1::Signing>(

--- a/fedimint-server/src/consensus/api.rs
+++ b/fedimint-server/src/consensus/api.rs
@@ -602,30 +602,13 @@ impl ConsensusApi {
         &self,
         new_metadata: fedimint_core::net::guardian_metadata::GuardianMetadata,
     ) -> fedimint_core::net::guardian_metadata::SignedGuardianMetadata {
-        use crate::net::api::guardian_metadata::GuardianMetadataKey;
-
-        let ctx = secp256k1::Secp256k1::new();
-        let signed_metadata =
-            new_metadata.sign(&ctx, &self.cfg.private.broadcast_secret_key.keypair(&ctx));
-
-        self.db
-            .autocommit(
-                |dbtx, _| {
-                    let signed_metadata_inner = signed_metadata.clone();
-                    Box::pin(async move {
-                        dbtx.insert_entry(
-                            &GuardianMetadataKey(self.cfg.local.identity),
-                            &signed_metadata_inner,
-                        )
-                        .await;
-
-                        Result::<_, ()>::Ok(signed_metadata_inner)
-                    })
-                },
-                None,
-            )
-            .await
-            .expect("Will not terminate on error")
+        sign_guardian_metadata_preserving_iroh_endpoint(
+            &self.db,
+            self.cfg.local.identity,
+            &self.cfg.private.broadcast_secret_key,
+            new_metadata,
+        )
+        .await
     }
 
     async fn get_invite_code(&self, api_secret: Option<String>) -> InviteCode {
@@ -641,6 +624,38 @@ impl ConsensusApi {
             api_secret,
         )
     }
+}
+
+async fn sign_guardian_metadata_preserving_iroh_endpoint(
+    db: &Database,
+    identity: PeerId,
+    broadcast_secret_key: &secp256k1::SecretKey,
+    new_metadata: fedimint_core::net::guardian_metadata::GuardianMetadata,
+) -> fedimint_core::net::guardian_metadata::SignedGuardianMetadata {
+    use crate::net::api::guardian_metadata::GuardianMetadataKey;
+
+    db.autocommit(
+        |dbtx, _| {
+            let mut new_metadata = new_metadata.clone();
+            Box::pin(async move {
+                new_metadata.iroh_next_endpoint = dbtx
+                    .get_value(&GuardianMetadataKey(identity))
+                    .await
+                    .and_then(|metadata| metadata.guardian_metadata().iroh_next_endpoint.clone());
+
+                let ctx = secp256k1::Secp256k1::new();
+                let signed_metadata = new_metadata.sign(&ctx, &broadcast_secret_key.keypair(&ctx));
+
+                dbtx.insert_entry(&GuardianMetadataKey(identity), &signed_metadata)
+                    .await;
+
+                Result::<_, ()>::Ok(signed_metadata)
+            })
+        },
+        None,
+    )
+    .await
+    .expect("Will not terminate on error")
 }
 
 #[async_trait]
@@ -1097,4 +1112,67 @@ pub(crate) async fn backup_statistics_static(
     }
 
     backup_stats
+}
+
+#[cfg(test)]
+mod tests {
+    use fedimint_core::db::IRawDatabaseExt as _;
+    use fedimint_core::db::mem_impl::MemDatabase;
+    use fedimint_core::net::guardian_metadata::GuardianMetadata;
+
+    use super::*;
+    use crate::net::api::guardian_metadata::GuardianMetadataKey;
+
+    #[tokio::test]
+    async fn admin_metadata_update_preserves_persisted_iroh_endpoint() {
+        let db: Database = MemDatabase::new().into_database();
+        let identity = PeerId::from(0);
+        let broadcast_secret_key =
+            secp256k1::SecretKey::from_slice(&[42; 32]).expect("valid test key");
+        let ctx = secp256k1::Secp256k1::new();
+
+        let existing = GuardianMetadata::new(
+            vec!["wss://old.example".parse().expect("valid URL")],
+            "old-pkarr".to_owned(),
+            1,
+        )
+        .with_iroh_next_endpoint("persisted-iroh-id".to_owned())
+        .sign(&ctx, &broadcast_secret_key.keypair(&ctx));
+        let mut dbtx = db.begin_transaction().await;
+        dbtx.insert_entry(&GuardianMetadataKey(identity), &existing)
+            .await;
+        dbtx.commit_tx().await;
+
+        let updated = GuardianMetadata::new(
+            vec!["wss://new.example".parse().expect("valid URL")],
+            "new-pkarr".to_owned(),
+            2,
+        );
+        let signed = sign_guardian_metadata_preserving_iroh_endpoint(
+            &db,
+            identity,
+            &broadcast_secret_key,
+            updated,
+        )
+        .await;
+
+        assert_eq!(
+            signed.guardian_metadata().iroh_next_endpoint.as_deref(),
+            Some("persisted-iroh-id")
+        );
+        assert_eq!(
+            signed.guardian_metadata().api_urls,
+            vec!["wss://new.example".parse().expect("valid URL")]
+        );
+        assert_eq!(signed.guardian_metadata().pkarr_id_z32, "new-pkarr");
+        assert_eq!(
+            db.begin_transaction_nc()
+                .await
+                .get_value(&GuardianMetadataKey(identity))
+                .await
+                .expect("metadata was persisted")
+                .tagged_hash(),
+            signed.tagged_hash()
+        );
+    }
 }

--- a/fedimint-server/src/consensus/iroh_api.rs
+++ b/fedimint-server/src/consensus/iroh_api.rs
@@ -1,0 +1,541 @@
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use fedimint_core::core::ModuleInstanceId;
+use fedimint_core::module::{ApiEndpoint, ApiError, ApiMethod, IrohApiRequest};
+use fedimint_core::task::TaskGroup;
+use fedimint_core::util::FmtCompactAnyhow as _;
+use fedimint_logging::LOG_NET_API;
+use fedimint_metrics::prometheus::HistogramTimer;
+use fedimint_server_core::DynServerModule;
+use futures::FutureExt as _;
+use iroh::Endpoint;
+use iroh::endpoint::{Incoming, RecvStream, SendStream, VarInt};
+use serde_json::Value;
+use tokio::sync::Semaphore;
+use tracing::warn;
+
+use super::api::{ConsensusApi, server_endpoints};
+use crate::connection_limits::ConnectionLimits;
+use crate::metrics::{
+    IROH_API_CONNECTION_DURATION_SECONDS, IROH_API_CONNECTION_IDLE_TIMEOUT_TOTAL,
+    IROH_API_CONNECTIONS_ACTIVE, IROH_API_REQUEST_DURATION_SECONDS, IROH_API_REQUEST_RESPONSE_CODE,
+};
+use crate::net::api::HasApiContext;
+
+/// How long an Iroh API connection may stay idle before the server closes it.
+const IROH_API_CONNECTION_IDLE_TIMEOUT: Duration = Duration::from_secs(5 * 60);
+
+/// Application-level QUIC error code for expected idle Iroh API connection
+/// reaping.
+const IROH_API_CONNECTION_IDLE_TIMEOUT_ERROR_CODE: u32 = 0;
+
+/// Application-level QUIC close reason for idle Iroh API connection reaping.
+const IROH_API_CONNECTION_IDLE_TIMEOUT_ERROR_REASON: &[u8] = b"idle timeout";
+
+pub(super) async fn run_iroh_api(
+    api: Arc<IrohApiState>,
+    endpoint: Endpoint,
+    task_group: TaskGroup,
+) {
+    loop {
+        match endpoint.accept().await {
+            Some(incoming) => {
+                let permit = acquire_iroh_api_permit(
+                    &api.parallel_connections_limit,
+                    api.limits.max_connections,
+                    "0.35",
+                    "connection",
+                )
+                .await;
+                task_group.spawn_cancellable_silent(
+                    "handle-iroh-connection",
+                    handle_incoming(
+                        api.clone(),
+                        task_group.clone(),
+                        incoming,
+                        permit,
+                        api.limits.max_requests_per_connection,
+                    )
+                    .then(|result| async {
+                        if let Err(err) = result {
+                            warn!(target: LOG_NET_API, err = %err.fmt_compact_anyhow(), "Failed to handle iroh connection");
+                        }
+                    }),
+                );
+            }
+            None => return,
+        }
+    }
+}
+
+type CoreApi = BTreeMap<String, ApiEndpoint<ConsensusApi>>;
+type ModuleApi = BTreeMap<ModuleInstanceId, BTreeMap<String, ApiEndpoint<DynServerModule>>>;
+
+pub(super) struct IrohApiState {
+    consensus: ConsensusApi,
+    core: CoreApi,
+    modules: ModuleApi,
+    limits: ConnectionLimits,
+    parallel_connections_limit: Arc<Semaphore>,
+}
+
+impl IrohApiState {
+    pub(super) fn new(consensus: ConsensusApi, limits: ConnectionLimits) -> Arc<Self> {
+        let core_api = server_endpoints()
+            .into_iter()
+            .map(|endpoint| (endpoint.path.to_string(), endpoint))
+            .collect();
+
+        let module_api = consensus
+            .modules
+            .iter_modules()
+            .map(|(id, _, module)| {
+                let api_endpoints = module
+                    .api_endpoints()
+                    .into_iter()
+                    .map(|endpoint| (endpoint.path.to_string(), endpoint))
+                    .collect::<BTreeMap<String, ApiEndpoint<DynServerModule>>>();
+
+                (id, api_endpoints)
+            })
+            .collect();
+
+        Arc::new(Self {
+            consensus,
+            core: core_api,
+            modules: module_api,
+            parallel_connections_limit: Arc::new(Semaphore::new(limits.max_connections)),
+            limits,
+        })
+    }
+}
+
+async fn acquire_iroh_api_permit(
+    limit: &Arc<Semaphore>,
+    max: usize,
+    version: &'static str,
+    resource: &'static str,
+) -> tokio::sync::OwnedSemaphorePermit {
+    if limit.available_permits() == 0 {
+        warn!(
+            target: LOG_NET_API,
+            limit = max,
+            version,
+            resource,
+            "Iroh API limit reached, blocking"
+        );
+    }
+    limit
+        .clone()
+        .acquire_owned()
+        .await
+        .expect("semaphore should not be closed")
+}
+
+struct ActiveIrohApiConnection {
+    _duration: HistogramTimer,
+}
+
+impl ActiveIrohApiConnection {
+    fn new() -> Self {
+        IROH_API_CONNECTIONS_ACTIVE.inc();
+        Self {
+            _duration: IROH_API_CONNECTION_DURATION_SECONDS.start_timer(),
+        }
+    }
+}
+
+impl Drop for ActiveIrohApiConnection {
+    fn drop(&mut self) {
+        IROH_API_CONNECTIONS_ACTIVE.dec();
+    }
+}
+
+async fn handle_incoming(
+    api: Arc<IrohApiState>,
+    task_group: TaskGroup,
+    incoming: Incoming,
+    connection_permit: tokio::sync::OwnedSemaphorePermit,
+    iroh_api_max_requests_per_connection: usize,
+) -> anyhow::Result<()> {
+    let connection = incoming.accept()?.await?;
+    handle_iroh_api_connection(
+        api,
+        task_group,
+        VersionedIrohConnection::Legacy(connection),
+        connection_permit,
+        iroh_api_max_requests_per_connection,
+        IrohApiVersion::Legacy,
+    )
+    .await
+}
+
+#[derive(Clone, Copy)]
+enum IrohApiVersion {
+    Legacy,
+    Next,
+}
+
+impl IrohApiVersion {
+    fn log_label(self) -> &'static str {
+        match self {
+            Self::Legacy => "0.35",
+            Self::Next => "1.0",
+        }
+    }
+
+    fn metric_label(self) -> &'static str {
+        match self {
+            Self::Legacy => "default",
+            Self::Next => "next",
+        }
+    }
+
+    fn request_task_name(self) -> &'static str {
+        match self {
+            Self::Legacy => "handle-iroh-request",
+            Self::Next => "handle-iroh-next-request",
+        }
+    }
+}
+
+enum VersionedIrohConnection {
+    Legacy(iroh::endpoint::Connection),
+    Next(iroh_next::endpoint::Connection),
+}
+
+impl VersionedIrohConnection {
+    async fn accept_bi(&self) -> anyhow::Result<(VersionedSendStream, VersionedRecvStream)> {
+        Ok(match self {
+            Self::Legacy(connection) => {
+                let (send, recv) = connection.accept_bi().await?;
+                (
+                    VersionedSendStream::Legacy(send),
+                    VersionedRecvStream::Legacy(recv),
+                )
+            }
+            Self::Next(connection) => {
+                let (send, recv) = connection.accept_bi().await?;
+                (
+                    VersionedSendStream::Next(send),
+                    VersionedRecvStream::Next(recv),
+                )
+            }
+        })
+    }
+
+    fn close_for_idle_timeout(&self) {
+        match self {
+            Self::Legacy(connection) => connection.close(
+                VarInt::from_u32(IROH_API_CONNECTION_IDLE_TIMEOUT_ERROR_CODE),
+                IROH_API_CONNECTION_IDLE_TIMEOUT_ERROR_REASON,
+            ),
+            Self::Next(connection) => connection.close(
+                iroh_next::endpoint::VarInt::from_u32(IROH_API_CONNECTION_IDLE_TIMEOUT_ERROR_CODE),
+                IROH_API_CONNECTION_IDLE_TIMEOUT_ERROR_REASON,
+            ),
+        }
+    }
+}
+
+enum VersionedSendStream {
+    Legacy(SendStream),
+    Next(iroh_next::endpoint::SendStream),
+}
+
+impl VersionedSendStream {
+    async fn write_response(mut self, response: &[u8]) -> anyhow::Result<()> {
+        match &mut self {
+            Self::Legacy(send) => {
+                send.write_all(response).await?;
+                send.finish()?;
+            }
+            Self::Next(send) => {
+                send.write_all(response).await?;
+                send.finish()?;
+            }
+        }
+        Ok(())
+    }
+}
+
+enum VersionedRecvStream {
+    Legacy(RecvStream),
+    Next(iroh_next::endpoint::RecvStream),
+}
+
+impl VersionedRecvStream {
+    async fn read_request(&mut self) -> anyhow::Result<Vec<u8>> {
+        Ok(match self {
+            Self::Legacy(recv) => recv.read_to_end(100_000).await?,
+            Self::Next(recv) => recv.read_to_end(100_000).await?,
+        })
+    }
+}
+
+async fn handle_iroh_api_connection(
+    api: Arc<IrohApiState>,
+    task_group: TaskGroup,
+    connection: VersionedIrohConnection,
+    _connection_permit: tokio::sync::OwnedSemaphorePermit,
+    max_requests: usize,
+    version: IrohApiVersion,
+) -> anyhow::Result<()> {
+    let parallel_requests_limit = Arc::new(Semaphore::new(max_requests));
+    let _metrics = ActiveIrohApiConnection::new();
+
+    loop {
+        let accept_result = fedimint_core::runtime::timeout(
+            IROH_API_CONNECTION_IDLE_TIMEOUT,
+            connection.accept_bi(),
+        )
+        .await;
+
+        let (send_stream, recv_stream) = match accept_result {
+            Ok(streams) => streams?,
+            Err(_) if parallel_requests_limit.available_permits() < max_requests => continue,
+            Err(_) => {
+                IROH_API_CONNECTION_IDLE_TIMEOUT_TOTAL.inc();
+                tracing::debug!(
+                    target: LOG_NET_API,
+                    version = version.log_label(),
+                    idle_timeout_secs = IROH_API_CONNECTION_IDLE_TIMEOUT.as_secs(),
+                    "Closing idle Iroh API connection"
+                );
+                connection.close_for_idle_timeout();
+                return Ok(());
+            }
+        };
+
+        let permit = acquire_iroh_api_permit(
+            &parallel_requests_limit,
+            max_requests,
+            version.log_label(),
+            "request",
+        )
+        .await;
+        task_group.spawn_cancellable_silent(
+            version.request_task_name(),
+            handle_iroh_api_stream(
+                api.clone(),
+                send_stream,
+                recv_stream,
+                permit,
+                version.metric_label(),
+            )
+            .then(|result| async {
+                if let Err(err) = result {
+                    warn!(target: LOG_NET_API, err = %err.fmt_compact_anyhow(), "Failed to handle Iroh API request");
+                }
+            }),
+        );
+    }
+}
+
+async fn handle_iroh_api_stream(
+    api: Arc<IrohApiState>,
+    send_stream: VersionedSendStream,
+    mut recv_stream: VersionedRecvStream,
+    _request_permit: tokio::sync::OwnedSemaphorePermit,
+    metric_label: &'static str,
+) -> anyhow::Result<()> {
+    let request = recv_stream.read_request().await?;
+    let response = handle_iroh_api_request(&api, &request, metric_label).await?;
+    send_stream.write_response(&response).await
+}
+
+async fn handle_iroh_api_request(
+    api: &IrohApiState,
+    request: &[u8],
+    version_label: &'static str,
+) -> anyhow::Result<Vec<u8>> {
+    let request = serde_json::from_slice::<IrohApiRequest>(request)?;
+    let method = request.method.to_string();
+    let timer = IROH_API_REQUEST_DURATION_SECONDS
+        .with_label_values(&[&method])
+        .start_timer();
+    let response = await_response(api, request).await;
+    timer.observe_duration();
+
+    let response_code = response
+        .as_ref()
+        .map_or_else(|err| err.code.to_string(), |_| "0".to_string());
+    IROH_API_REQUEST_RESPONSE_CODE
+        .with_label_values(&[method.as_str(), response_code.as_str(), version_label])
+        .inc();
+
+    Ok(serde_json::to_vec(&response)?)
+}
+
+async fn await_response(api: &IrohApiState, request: IrohApiRequest) -> Result<Value, ApiError> {
+    match request.method {
+        ApiMethod::Core(method) => {
+            let endpoint = api.core.get(&method).ok_or(ApiError::not_found(method))?;
+
+            let (state, context) = api.consensus.context(&request.request, None).await;
+
+            (endpoint.handler)(state, context, request.request).await
+        }
+        ApiMethod::Module(module_id, method) => {
+            let endpoint = api
+                .modules
+                .get(&module_id)
+                .ok_or(ApiError::not_found(module_id.to_string()))?
+                .get(&method)
+                .ok_or(ApiError::not_found(method))?;
+
+            let (state, context) = api
+                .consensus
+                .context(&request.request, Some(module_id))
+                .await;
+
+            (endpoint.handler)(state, context, request.request).await
+        }
+    }
+}
+
+// --- iroh-next API endpoint functions ---
+
+pub(super) async fn run_iroh_api_next(
+    api: Arc<IrohApiState>,
+    endpoint: iroh_next::Endpoint,
+    task_group: TaskGroup,
+) {
+    loop {
+        match endpoint.accept().await {
+            Some(incoming) => {
+                let permit = acquire_iroh_api_permit(
+                    &api.parallel_connections_limit,
+                    api.limits.max_connections,
+                    "1.0",
+                    "connection",
+                )
+                .await;
+                task_group.spawn_cancellable_silent(
+                    "handle-iroh-next-connection",
+                    handle_incoming_next(
+                        api.clone(),
+                        task_group.clone(),
+                        incoming,
+                        permit,
+                        api.limits.max_requests_per_connection,
+                    )
+                    .then(|result| async {
+                        if let Err(err) = result {
+                            warn!(target: LOG_NET_API, err = %err.fmt_compact_anyhow(), "Failed to handle iroh-next connection");
+                        }
+                    }),
+                );
+            }
+            None => return,
+        }
+    }
+}
+
+async fn handle_incoming_next(
+    api: Arc<IrohApiState>,
+    task_group: TaskGroup,
+    incoming: iroh_next::endpoint::Incoming,
+    connection_permit: tokio::sync::OwnedSemaphorePermit,
+    iroh_api_max_requests_per_connection: usize,
+) -> anyhow::Result<()> {
+    let connection = incoming.accept()?.await?;
+    handle_iroh_api_connection(
+        api,
+        task_group,
+        VersionedIrohConnection::Next(connection),
+        connection_permit,
+        iroh_api_max_requests_per_connection,
+        IrohApiVersion::Next,
+    )
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::SocketAddr;
+
+    use anyhow::Context as _;
+    use iroh_next::endpoint::presets::Minimal;
+    use iroh_next::{EndpointAddr, RelayMode, SecretKey, TransportAddr};
+
+    use super::*;
+
+    const TEST_ALPN: &[u8] = b"fedimint-iroh-api-adapter-test";
+
+    #[tokio::test]
+    async fn shared_connection_limit_applies_across_versions() {
+        let limit = Arc::new(Semaphore::new(1));
+        let legacy_permit = acquire_iroh_api_permit(&limit, 1, "0.35", "connection").await;
+
+        assert!(
+            tokio::time::timeout(
+                Duration::from_millis(20),
+                acquire_iroh_api_permit(&limit, 1, "1.0", "connection"),
+            )
+            .await
+            .is_err()
+        );
+
+        drop(legacy_permit);
+        let _permit = tokio::time::timeout(
+            Duration::from_secs(1),
+            acquire_iroh_api_permit(&limit, 1, "1.0", "connection"),
+        )
+        .await
+        .expect("v1 acquires the shared permit after the legacy connection releases it");
+    }
+
+    #[tokio::test]
+    async fn iroh_v1_request_uses_shared_stream_adapter() -> anyhow::Result<()> {
+        let server = iroh_next::Endpoint::builder(Minimal)
+            .relay_mode(RelayMode::Disabled)
+            .secret_key(SecretKey::from_bytes(&[11; 32]))
+            .alpns(vec![TEST_ALPN.to_vec()])
+            .bind_addr(SocketAddr::from(([127, 0, 0, 1], 0)))?
+            .bind()
+            .await?;
+        let client = iroh_next::Endpoint::builder(Minimal)
+            .relay_mode(RelayMode::Disabled)
+            .bind()
+            .await?;
+        let server_addr = EndpointAddr::from_parts(
+            server.id(),
+            server.bound_sockets().into_iter().map(TransportAddr::Ip),
+        );
+        let (client_done_tx, client_done_rx) = tokio::sync::oneshot::channel();
+
+        let server_request = async {
+            let incoming = server.accept().await.context("server endpoint closed")?;
+            let connection = incoming.accept()?.await?;
+            let (send, mut recv) = VersionedIrohConnection::Next(connection)
+                .accept_bi()
+                .await?;
+            assert_eq!(recv.read_request().await?, b"request");
+            send.write_response(b"response").await?;
+            client_done_rx.await?;
+            anyhow::Ok(())
+        };
+        let client_request = async {
+            let connection = client.connect(server_addr, TEST_ALPN).await?;
+            let (mut send, mut recv) = connection.open_bi().await?;
+            send.write_all(b"request").await?;
+            send.finish()?;
+            let response = recv.read_to_end(100_000).await?;
+            anyhow::ensure!(response == b"response");
+            client_done_tx.send(()).expect("server is still running");
+            anyhow::Ok(())
+        };
+
+        tokio::time::timeout(Duration::from_secs(10), async {
+            tokio::try_join!(server_request, client_request)
+        })
+        .await
+        .context("Iroh v1 adapter test timed out")??;
+        client.close().await;
+        server.close().await;
+        Ok(())
+    }
+}

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -12,7 +12,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::bail;
+use anyhow::{Context as _, bail};
 use async_channel::Sender;
 use db::{ServerDbMigrationContext, get_global_database_migrations};
 use fedimint_api_client::api::DynGlobalApi;
@@ -63,6 +63,58 @@ struct IrohApiEndpoints {
     next: Option<iroh_next::Endpoint>,
 }
 
+fn eligible_iroh_next_api_settings(
+    has_legacy_iroh_api: bool,
+    iroh_next_api_settings: Option<&IrohNextApiSettings>,
+) -> Option<&IrohNextApiSettings> {
+    if iroh_next_api_settings.is_some() && !has_legacy_iroh_api {
+        warn!(
+            target: LOG_CONSENSUS,
+            "Not starting the transitional Iroh 1.0 API because this federation was configured \
+             without the legacy Iroh API"
+        );
+        None
+    } else {
+        iroh_next_api_settings
+    }
+}
+
+fn resolve_iroh_next_api_bind(
+    api_bind: SocketAddr,
+    iroh_next_api_settings: Option<&IrohNextApiSettings>,
+) -> anyhow::Result<Option<SocketAddr>> {
+    iroh_next_api_settings
+        .map(|settings| {
+            settings.bind_override().map_or_else(
+                || {
+                    let mut bind = api_bind;
+                    bind.set_port(
+                        bind.port()
+                            .checked_add(10)
+                            .context("Default Iroh 1.0 API bind port would overflow")?,
+                    );
+                    anyhow::Ok(bind)
+                },
+                anyhow::Ok,
+            )
+        })
+        .transpose()
+}
+
+#[cfg(test)]
+#[test]
+fn ineligible_iroh_next_api_does_not_validate_unused_default_bind() {
+    let api_bind = "127.0.0.1:65535".parse().expect("valid socket address");
+    let settings = IrohNextApiSettings::new(None);
+    let settings = eligible_iroh_next_api_settings(false, Some(&settings));
+
+    assert!(
+        resolve_iroh_next_api_bind(api_bind, settings)
+            .expect("ineligible listener should be skipped")
+            .is_none()
+    );
+}
+
 async fn prepare_iroh_api_endpoints(
     cfg: &ServerConfig,
     api_bind: SocketAddr,
@@ -70,13 +122,6 @@ async fn prepare_iroh_api_endpoints(
     iroh_relays: Vec<SafeUrl>,
     iroh_next_api_settings: Option<&IrohNextApiSettings>,
 ) -> anyhow::Result<IrohApiEndpoints> {
-    if iroh_next_api_settings.is_some() && cfg.private.iroh_api_sk.is_none() {
-        bail!(
-            "The transitional Iroh 1.0 API can only be enabled for a federation configured with \
-             the legacy Iroh API"
-        );
-    }
-
     let legacy = if let Some(iroh_api_sk) = cfg.private.iroh_api_sk.clone() {
         Some(
             build_iroh_endpoint(
@@ -92,12 +137,10 @@ async fn prepare_iroh_api_endpoints(
         None
     };
 
-    let next = if let Some(next_settings) = iroh_next_api_settings {
+    let next_bind = resolve_iroh_next_api_bind(api_bind, iroh_next_api_settings)?;
+    let next = if let Some(bind) = next_bind {
         let next_api_sk = derive_iroh_v1_api_secret_key(&cfg.private.broadcast_secret_key);
-        Some(
-            build_iroh_v1_endpoint(next_api_sk, next_settings.bind, iroh_dns, FEDIMINT_API_ALPN)
-                .await?,
-        )
+        Some(build_iroh_v1_endpoint(next_api_sk, bind, iroh_dns, FEDIMINT_API_ALPN).await?)
     } else {
         None
     };
@@ -155,6 +198,9 @@ pub async fn run(
     iroh_next_api_settings: Option<&IrohNextApiSettings>,
 ) -> anyhow::Result<()> {
     cfg.validate_config(&cfg.local.identity, &module_init_registry)?;
+
+    let iroh_next_api_settings =
+        eligible_iroh_next_api_settings(cfg.private.iroh_api_sk.is_some(), iroh_next_api_settings);
 
     let mut global_dbtx = db.begin_transaction().await;
     apply_migrations_server_dbtx(

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -3,6 +3,7 @@ pub mod api;
 pub mod db;
 pub mod debug;
 pub mod engine;
+mod iroh_api;
 pub mod transaction;
 
 use std::collections::BTreeMap;
@@ -23,54 +24,109 @@ use fedimint_core::db::{Database, apply_migrations_dbtx, verify_module_db_integr
 use fedimint_core::envs::is_running_in_test_env;
 use fedimint_core::epoch::ConsensusItem;
 use fedimint_core::module::registry::ModuleRegistry;
-use fedimint_core::module::{
-    ApiAuth, ApiEndpoint, ApiError, ApiMethod, FEDIMINT_API_ALPN, IrohApiRequest,
-};
+use fedimint_core::module::{ApiAuth, FEDIMINT_API_ALPN};
 use fedimint_core::net::iroh::build_iroh_endpoint;
 use fedimint_core::net::peers::DynP2PConnections;
 use fedimint_core::task::{TaskGroup, sleep};
-use fedimint_core::util::{FmtCompactAnyhow as _, SafeUrl};
-use fedimint_logging::{LOG_CONSENSUS, LOG_CORE, LOG_NET_API};
+use fedimint_core::util::SafeUrl;
+use fedimint_logging::{LOG_CONSENSUS, LOG_CORE};
 use fedimint_server_core::bitcoin_rpc::{DynServerBitcoinRpc, ServerBitcoinRpcMonitor};
 use fedimint_server_core::dashboard_ui::IDashboardApi;
 use fedimint_server_core::migration::apply_migrations_server_dbtx;
 use fedimint_server_core::{DynServerModule, ServerModuleInitRegistry};
-use futures::FutureExt;
-use iroh::Endpoint;
-use iroh::endpoint::{Incoming, RecvStream, SendStream, VarInt};
 use jsonrpsee::RpcModule;
 use jsonrpsee::server::ServerHandle;
-use serde_json::Value;
 use tokio::net::TcpListener;
-use tokio::sync::{Semaphore, watch};
+use tokio::sync::watch;
 use tracing::{debug, info, warn};
 
 use crate::config::{ServerConfig, ServerConfigLocal};
 use crate::connection_limits::ConnectionLimits;
-use crate::consensus::api::{ConsensusApi, server_endpoints};
+use crate::consensus::api::ConsensusApi;
 use crate::consensus::engine::ConsensusEngine;
+use crate::consensus::iroh_api::{IrohApiState, run_iroh_api, run_iroh_api_next};
 use crate::db::verify_server_db_integrity_dbtx;
-use crate::metrics::{
-    IROH_API_CONNECTION_DURATION_SECONDS, IROH_API_CONNECTION_IDLE_TIMEOUT_TOTAL,
-    IROH_API_CONNECTIONS_ACTIVE, IROH_API_REQUEST_DURATION_SECONDS, IROH_API_REQUEST_RESPONSE_CODE,
-};
+use crate::net::api::ApiSecrets;
 use crate::net::api::announcement::get_api_urls;
-use crate::net::api::{ApiSecrets, HasApiContext};
+use crate::net::api::guardian_metadata::{
+    prepare_guardian_metadata_service, reconcile_guardian_metadata, start_guardian_metadata_service,
+};
+use crate::net::iroh::{build_iroh_v1_endpoint, derive_iroh_v1_api_secret_key};
 use crate::net::p2p::P2PStatusReceivers;
-use crate::{DashboardUiRouter, net, update_server_info_version_dbtx};
+use crate::{DashboardUiRouter, IrohNextApiSettings, net, update_server_info_version_dbtx};
 
 /// How many txs can be stored in memory before blocking the API
 const TRANSACTION_BUFFER: usize = 1000;
 
-/// How long an iroh API connection may stay idle before the server closes it.
-const IROH_API_CONNECTION_IDLE_TIMEOUT: Duration = Duration::from_secs(5 * 60);
+struct IrohApiEndpoints {
+    legacy: Option<iroh::Endpoint>,
+    next: Option<iroh_next::Endpoint>,
+}
 
-/// Application-level QUIC error code for expected idle iroh API connection
-/// reaping.
-const IROH_API_CONNECTION_IDLE_TIMEOUT_ERROR_CODE: u32 = 0;
+async fn prepare_iroh_api_endpoints(
+    cfg: &ServerConfig,
+    api_bind: SocketAddr,
+    iroh_dns: Option<SafeUrl>,
+    iroh_relays: Vec<SafeUrl>,
+    iroh_next_api_settings: Option<&IrohNextApiSettings>,
+) -> anyhow::Result<IrohApiEndpoints> {
+    if iroh_next_api_settings.is_some() && cfg.private.iroh_api_sk.is_none() {
+        bail!(
+            "The transitional Iroh 1.0 API can only be enabled for a federation configured with \
+             the legacy Iroh API"
+        );
+    }
 
-/// Application-level QUIC close reason for idle iroh API connection reaping.
-const IROH_API_CONNECTION_IDLE_TIMEOUT_ERROR_REASON: &[u8] = b"idle timeout";
+    let legacy = if let Some(iroh_api_sk) = cfg.private.iroh_api_sk.clone() {
+        Some(
+            build_iroh_endpoint(
+                iroh_api_sk,
+                api_bind,
+                iroh_dns.clone(),
+                iroh_relays,
+                FEDIMINT_API_ALPN,
+            )
+            .await?,
+        )
+    } else {
+        None
+    };
+
+    let next = if let Some(next_settings) = iroh_next_api_settings {
+        let next_api_sk = derive_iroh_v1_api_secret_key(&cfg.private.broadcast_secret_key);
+        Some(
+            build_iroh_v1_endpoint(next_api_sk, next_settings.bind, iroh_dns, FEDIMINT_API_ALPN)
+                .await?,
+        )
+    } else {
+        None
+    };
+
+    Ok(IrohApiEndpoints { legacy, next })
+}
+
+fn spawn_iroh_api_tasks(
+    consensus_api: ConsensusApi,
+    iroh_api_limits: ConnectionLimits,
+    endpoints: IrohApiEndpoints,
+    task_group: &TaskGroup,
+) {
+    let iroh_api = IrohApiState::new(consensus_api, iroh_api_limits);
+
+    if let Some(endpoint) = endpoints.legacy {
+        task_group.spawn_cancellable(
+            "iroh-api",
+            run_iroh_api(iroh_api.clone(), endpoint, task_group.clone()),
+        );
+    }
+
+    if let Some(endpoint) = endpoints.next {
+        task_group.spawn_cancellable(
+            "iroh-next-api",
+            run_iroh_api_next(iroh_api, endpoint, task_group.clone()),
+        );
+    }
+}
 
 #[allow(clippy::too_many_arguments)]
 pub async fn run(
@@ -96,6 +152,7 @@ pub async fn run(
     db_checkpoint_retention: u64,
     session_timeout: Duration,
     iroh_api_limits: ConnectionLimits,
+    iroh_next_api_settings: Option<&IrohNextApiSettings>,
 ) -> anyhow::Result<()> {
     cfg.validate_config(&cfg.local.identity, &module_init_registry)?;
 
@@ -232,6 +289,21 @@ pub async fn run(
         task_group: task_group.clone(),
     };
 
+    let guardian_metadata_api =
+        prepare_guardian_metadata_service(&db, &cfg, force_api_secrets.get_active()).await?;
+
+    let iroh_api_endpoints = prepare_iroh_api_endpoints(
+        &cfg,
+        api_bind,
+        iroh_dns,
+        iroh_relays,
+        iroh_next_api_settings,
+    )
+    .await?;
+
+    let guardian_metadata_updated =
+        reconcile_guardian_metadata(&db, &cfg, iroh_next_api_settings).await?;
+
     info!(target: LOG_CONSENSUS, "Starting Consensus Api...");
 
     let api_handler = start_consensus_api(
@@ -242,23 +314,20 @@ pub async fn run(
     )
     .await;
 
-    if let Some(iroh_api_sk) = cfg.private.iroh_api_sk.clone()
-        && let Err(e) = Box::pin(start_iroh_api(
-            iroh_api_sk,
-            api_bind,
-            iroh_dns,
-            iroh_relays,
-            consensus_api.clone(),
-            task_group,
-            iroh_api_limits,
-        ))
-        .await
-    {
-        // clean up ws api before propagating error
-        api_handler.stop().expect("Just started");
-        api_handler.stopped().await;
-        return Err(e);
-    }
+    spawn_iroh_api_tasks(
+        consensus_api.clone(),
+        iroh_api_limits,
+        iroh_api_endpoints,
+        task_group,
+    );
+
+    start_guardian_metadata_service(
+        &db,
+        task_group,
+        &cfg,
+        guardian_metadata_api,
+        guardian_metadata_updated,
+    );
 
     info!(target: LOG_CONSENSUS, "Starting Submission of Module CI proposals...");
 
@@ -434,244 +503,4 @@ fn submit_module_ci_proposals(
             }
         },
     );
-}
-
-async fn start_iroh_api(
-    secret_key: iroh::SecretKey,
-    api_bind: SocketAddr,
-    iroh_dns: Option<SafeUrl>,
-    iroh_relays: Vec<SafeUrl>,
-    consensus_api: ConsensusApi,
-    task_group: &TaskGroup,
-    iroh_api_limits: ConnectionLimits,
-) -> anyhow::Result<()> {
-    let endpoint = build_iroh_endpoint(
-        secret_key,
-        api_bind,
-        iroh_dns,
-        iroh_relays,
-        FEDIMINT_API_ALPN,
-    )
-    .await?;
-    task_group.spawn_cancellable(
-        "iroh-api",
-        run_iroh_api(consensus_api, endpoint, task_group.clone(), iroh_api_limits),
-    );
-
-    Ok(())
-}
-
-async fn run_iroh_api(
-    consensus_api: ConsensusApi,
-    endpoint: Endpoint,
-    task_group: TaskGroup,
-    iroh_api_limits: ConnectionLimits,
-) {
-    let core_api = server_endpoints()
-        .into_iter()
-        .map(|endpoint| (endpoint.path.to_string(), endpoint))
-        .collect::<BTreeMap<String, ApiEndpoint<ConsensusApi>>>();
-
-    let module_api = consensus_api
-        .modules
-        .iter_modules()
-        .map(|(id, _, module)| {
-            let api_endpoints = module
-                .api_endpoints()
-                .into_iter()
-                .map(|endpoint| (endpoint.path.to_string(), endpoint))
-                .collect::<BTreeMap<String, ApiEndpoint<DynServerModule>>>();
-
-            (id, api_endpoints)
-        })
-        .collect::<BTreeMap<ModuleInstanceId, BTreeMap<String, ApiEndpoint<DynServerModule>>>>();
-
-    let consensus_api = Arc::new(consensus_api);
-    let core_api = Arc::new(core_api);
-    let module_api = Arc::new(module_api);
-    let parallel_connections_limit = Arc::new(Semaphore::new(iroh_api_limits.max_connections));
-
-    loop {
-        match endpoint.accept().await {
-            Some(incoming) => {
-                if parallel_connections_limit.available_permits() == 0 {
-                    warn!(
-                        target: LOG_NET_API,
-                        limit = iroh_api_limits.max_connections,
-                        "Iroh API connection limit reached, blocking new connections"
-                    );
-                }
-                let permit = parallel_connections_limit
-                    .clone()
-                    .acquire_owned()
-                    .await
-                    .expect("semaphore should not be closed");
-                task_group.spawn_cancellable_silent(
-                    "handle-iroh-connection",
-                    handle_incoming(
-                        consensus_api.clone(),
-                        core_api.clone(),
-                        module_api.clone(),
-                        task_group.clone(),
-                        incoming,
-                        permit,
-                        iroh_api_limits.max_requests_per_connection,
-                    )
-                    .then(|result| async {
-                        if let Err(err) = result {
-                            warn!(target: LOG_NET_API, err = %err.fmt_compact_anyhow(), "Failed to handle iroh connection");
-                        }
-                    }),
-                );
-            }
-            None => return,
-        }
-    }
-}
-
-async fn handle_incoming(
-    consensus_api: Arc<ConsensusApi>,
-    core_api: Arc<BTreeMap<String, ApiEndpoint<ConsensusApi>>>,
-    module_api: Arc<BTreeMap<ModuleInstanceId, BTreeMap<String, ApiEndpoint<DynServerModule>>>>,
-    task_group: TaskGroup,
-    incoming: Incoming,
-    _connection_permit: tokio::sync::OwnedSemaphorePermit,
-    iroh_api_max_requests_per_connection: usize,
-) -> anyhow::Result<()> {
-    let connection = incoming.accept()?.await?;
-    let parallel_requests_limit = Arc::new(Semaphore::new(iroh_api_max_requests_per_connection));
-
-    IROH_API_CONNECTIONS_ACTIVE.inc();
-    let connection_timer = IROH_API_CONNECTION_DURATION_SECONDS.start_timer();
-    scopeguard::defer! {
-        IROH_API_CONNECTIONS_ACTIVE.dec();
-        connection_timer.observe_duration();
-    }
-
-    loop {
-        let accept_result = fedimint_core::runtime::timeout(
-            IROH_API_CONNECTION_IDLE_TIMEOUT,
-            connection.accept_bi(),
-        )
-        .await;
-
-        let (send_stream, recv_stream) = match accept_result {
-            Ok(streams) => streams?,
-            Err(_)
-                if parallel_requests_limit.available_permits()
-                    < iroh_api_max_requests_per_connection =>
-            {
-                continue;
-            }
-            Err(_) => {
-                IROH_API_CONNECTION_IDLE_TIMEOUT_TOTAL.inc();
-                tracing::debug!(
-                    target: LOG_NET_API,
-                    idle_timeout_secs = IROH_API_CONNECTION_IDLE_TIMEOUT.as_secs(),
-                    "Closing idle iroh API connection"
-                );
-                connection.close(
-                    VarInt::from_u32(IROH_API_CONNECTION_IDLE_TIMEOUT_ERROR_CODE),
-                    IROH_API_CONNECTION_IDLE_TIMEOUT_ERROR_REASON,
-                );
-                return Ok(());
-            }
-        };
-
-        if parallel_requests_limit.available_permits() == 0 {
-            warn!(
-                target: LOG_NET_API,
-                limit = iroh_api_max_requests_per_connection,
-                "Iroh API request limit reached for connection, blocking new requests"
-            );
-        }
-        let permit = parallel_requests_limit
-            .clone()
-            .acquire_owned()
-            .await
-            .expect("semaphore should not be closed");
-        task_group.spawn_cancellable_silent(
-            "handle-iroh-request",
-            handle_request(
-                consensus_api.clone(),
-                core_api.clone(),
-                module_api.clone(),
-                send_stream,
-                recv_stream,
-                permit,
-            )
-            .then(|result| async {
-                if let Err(err) = result {
-                    warn!(target: LOG_NET_API, err = %err.fmt_compact_anyhow(), "Failed to handle iroh request");
-                }
-            }),
-        );
-    }
-}
-
-async fn handle_request(
-    consensus_api: Arc<ConsensusApi>,
-    core_api: Arc<BTreeMap<String, ApiEndpoint<ConsensusApi>>>,
-    module_api: Arc<BTreeMap<ModuleInstanceId, BTreeMap<String, ApiEndpoint<DynServerModule>>>>,
-    mut send_stream: SendStream,
-    mut recv_stream: RecvStream,
-    _request_permit: tokio::sync::OwnedSemaphorePermit,
-) -> anyhow::Result<()> {
-    let request = recv_stream.read_to_end(100_000).await?;
-
-    let request = serde_json::from_slice::<IrohApiRequest>(&request)?;
-
-    let method = request.method.to_string();
-    let timer = IROH_API_REQUEST_DURATION_SECONDS
-        .with_label_values(&[&method])
-        .start_timer();
-
-    let response = await_response(consensus_api, core_api, module_api, request).await;
-
-    timer.observe_duration();
-
-    let response_code = response
-        .as_ref()
-        .map_or_else(|err| err.code.to_string(), |_| "0".to_string());
-    IROH_API_REQUEST_RESPONSE_CODE
-        .with_label_values(&[method.as_str(), response_code.as_str(), "default"])
-        .inc();
-
-    let response = serde_json::to_vec(&response)?;
-
-    send_stream.write_all(&response).await?;
-
-    send_stream.finish()?;
-
-    Ok(())
-}
-
-async fn await_response(
-    consensus_api: Arc<ConsensusApi>,
-    core_api: Arc<BTreeMap<String, ApiEndpoint<ConsensusApi>>>,
-    module_api: Arc<BTreeMap<ModuleInstanceId, BTreeMap<String, ApiEndpoint<DynServerModule>>>>,
-    request: IrohApiRequest,
-) -> Result<Value, ApiError> {
-    match request.method {
-        ApiMethod::Core(method) => {
-            let endpoint = core_api.get(&method).ok_or(ApiError::not_found(method))?;
-
-            let (state, context) = consensus_api.context(&request.request, None).await;
-
-            (endpoint.handler)(state, context, request.request).await
-        }
-        ApiMethod::Module(module_id, method) => {
-            let endpoint = module_api
-                .get(&module_id)
-                .ok_or(ApiError::not_found(module_id.to_string()))?
-                .get(&method)
-                .ok_or(ApiError::not_found(method))?;
-
-            let (state, context) = consensus_api
-                .context(&request.request, Some(module_id))
-                .await;
-
-            (endpoint.handler)(state, context, request.request).await
-        }
-    }
 }

--- a/fedimint-server/src/lib.rs
+++ b/fedimint-server/src/lib.rs
@@ -77,11 +77,24 @@ pub mod net;
 /// Fedimint toplevel config
 pub mod config;
 
-/// Runtime settings for the transitional Iroh 1.0 API listener.
+/// Requested settings for the transitional Iroh 1.0 API listener.
 #[derive(Debug, Clone)]
 pub struct IrohNextApiSettings {
-    /// Socket address on which to bind the Iroh 1.0 API endpoint.
-    pub bind: SocketAddr,
+    /// Optional explicit socket address on which to bind the Iroh 1.0 API
+    /// endpoint.
+    bind: Option<SocketAddr>,
+}
+
+impl IrohNextApiSettings {
+    /// Request the transitional listener, optionally overriding its bind
+    /// address.
+    pub fn new(bind: Option<SocketAddr>) -> Self {
+        Self { bind }
+    }
+
+    pub(crate) fn bind_override(&self) -> Option<SocketAddr> {
+        self.bind
+    }
 }
 
 /// A function/closure type for handling dashboard UI

--- a/fedimint-server/src/lib.rs
+++ b/fedimint-server/src/lib.rs
@@ -24,6 +24,7 @@ extern crate fedimint_core;
 pub mod connection_limits;
 pub mod db;
 
+use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -61,7 +62,6 @@ use crate::db::{ServerInfo, ServerInfoKey};
 use crate::fedimint_core::net::peers::IP2PConnections;
 use crate::metrics::initialize_gauge_metrics;
 use crate::net::api::announcement::start_api_announcement_service;
-use crate::net::api::guardian_metadata::start_guardian_metadata_service;
 use crate::net::api::pkarr_publish::start_pkarr_publish_service;
 use crate::net::p2p::{ReconnectP2PConnections, p2p_status_channels};
 use crate::net::p2p_connector::{IP2PConnector, TlsTcpConnector};
@@ -76,6 +76,13 @@ pub mod net;
 
 /// Fedimint toplevel config
 pub mod config;
+
+/// Runtime settings for the transitional Iroh 1.0 API listener.
+#[derive(Debug, Clone)]
+pub struct IrohNextApiSettings {
+    /// Socket address on which to bind the Iroh 1.0 API endpoint.
+    pub bind: SocketAddr,
+}
 
 /// A function/closure type for handling dashboard UI
 pub type DashboardUiRouter = Box<dyn Fn(DynDashboardApi) -> axum::Router + Send>;
@@ -148,6 +155,51 @@ pub async fn run_with_iroh_p2p_relays(
     iroh_api_limits: ConnectionLimits,
     iroh_p2p_relays: Vec<SafeUrl>,
 ) -> anyhow::Result<()> {
+    run_with_iroh_p2p_relays_and_next_api(
+        data_dir,
+        auth_ui,
+        auth_api,
+        force_api_secrets,
+        settings,
+        db,
+        code_version_str,
+        code_version_hash,
+        module_init_registry,
+        task_group,
+        bitcoin_rpc,
+        setup_ui_router,
+        dashboard_ui_router,
+        db_checkpoint_retention,
+        session_timeout,
+        iroh_api_limits,
+        iroh_p2p_relays,
+        None,
+    )
+    .await
+}
+
+/// Run a server with explicit guardian P2P relays and an optional Iroh 1.0 API.
+#[allow(clippy::too_many_arguments)]
+pub async fn run_with_iroh_p2p_relays_and_next_api(
+    data_dir: PathBuf,
+    auth_ui: Option<ApiAuth>,
+    auth_api: Option<ApiAuth>,
+    force_api_secrets: ApiSecrets,
+    settings: ConfigGenSettings,
+    db: Database,
+    code_version_str: String,
+    code_version_hash: String,
+    module_init_registry: ServerModuleInitRegistry,
+    task_group: TaskGroup,
+    bitcoin_rpc: DynServerBitcoinRpc,
+    setup_ui_router: SetupUiRouter,
+    dashboard_ui_router: DashboardUiRouter,
+    db_checkpoint_retention: u64,
+    session_timeout: Duration,
+    iroh_api_limits: ConnectionLimits,
+    iroh_p2p_relays: Vec<SafeUrl>,
+    iroh_next_api_settings: Option<IrohNextApiSettings>,
+) -> anyhow::Result<()> {
     let (cfg, connections, p2p_status_receivers) = match get_config(&data_dir)? {
         Some(cfg) => {
             let connector = if cfg.consensus.iroh_endpoints.is_empty() {
@@ -218,7 +270,6 @@ pub async fn run_with_iroh_p2p_relays(
     initialize_gauge_metrics(&task_group, &db).await;
 
     start_api_announcement_service(&db, &task_group, &cfg, force_api_secrets.get_active()).await?;
-    start_guardian_metadata_service(&db, &task_group, &cfg, force_api_secrets.get_active()).await?;
     start_pkarr_publish_service(&db, &task_group, &cfg).await?;
 
     info!(target: LOG_CONSENSUS, "Starting consensus...");
@@ -250,6 +301,7 @@ pub async fn run_with_iroh_p2p_relays(
         db_checkpoint_retention,
         session_timeout,
         iroh_api_limits,
+        iroh_next_api_settings.as_ref(),
     ))
     .await?;
 

--- a/fedimint-server/src/net/api/guardian_metadata.rs
+++ b/fedimint-server/src/net/api/guardian_metadata.rs
@@ -15,8 +15,39 @@ use futures::stream::StreamExt;
 use tokio::select;
 use tracing::{debug, info};
 
+use crate::IrohNextApiSettings;
 use crate::config::ServerConfig;
 use crate::db::DbKeyPrefix;
+use crate::net::iroh::derive_iroh_v1_api_secret_key;
+
+fn ensure_iroh_next_remains_available(
+    existing_endpoint: Option<&str>,
+    configured_endpoint: Option<&str>,
+) -> anyhow::Result<()> {
+    if let Some(existing_endpoint) = existing_endpoint {
+        anyhow::ensure!(
+            configured_endpoint == Some(existing_endpoint),
+            "Iroh 1.0 API endpoint {existing_endpoint} was previously advertised and must remain \
+             enabled unchanged; disabling or rotating it is unsupported"
+        );
+    }
+    Ok(())
+}
+
+fn reconcile_iroh_next_endpoint(
+    metadata: &mut GuardianMetadata,
+    configured_endpoint: Option<String>,
+) -> anyhow::Result<bool> {
+    ensure_iroh_next_remains_available(
+        metadata.iroh_next_endpoint.as_deref(),
+        configured_endpoint.as_deref(),
+    )?;
+    if metadata.iroh_next_endpoint == configured_endpoint {
+        return Ok(false);
+    }
+    metadata.iroh_next_endpoint = configured_endpoint;
+    Ok(true)
+}
 
 #[derive(Clone, Debug, Encodable, Decodable)]
 pub struct GuardianMetadataKey(pub PeerId);
@@ -35,29 +66,38 @@ impl_db_lookup!(
     query_prefix = GuardianMetadataPrefix
 );
 
-pub async fn start_guardian_metadata_service(
+/// Build the federation API client used to publish guardian metadata.
+pub async fn prepare_guardian_metadata_service(
+    db: &Database,
+    cfg: &ServerConfig,
+    api_secret: Option<String>,
+) -> anyhow::Result<DynGlobalApi> {
+    DynGlobalApi::new(
+        ConnectorRegistry::build_from_server_env()?.bind().await?,
+        super::announcement::get_api_urls(db, &cfg.consensus).await,
+        api_secret.as_deref(),
+    )
+}
+
+/// Store and publish this guardian's current metadata.
+pub fn start_guardian_metadata_service(
     db: &Database,
     tg: &TaskGroup,
     cfg: &ServerConfig,
-    api_secret: Option<String>,
-) -> anyhow::Result<()> {
+    api_client: DynGlobalApi,
+    metadata_updated: bool,
+) {
     const INITIAL_DELAY_SECONDS: u64 = 5;
     const FAILURE_RETRY_SECONDS: u64 = 60;
     const SUCCESS_RETRY_SECONDS: u64 = 600;
 
-    let initial_delay = if insert_signed_guardian_metadata_if_not_present(db, cfg).await {
+    let initial_delay = if metadata_updated {
         Duration::ZERO
     } else {
         Duration::from_secs(INITIAL_DELAY_SECONDS)
     };
 
     let db = db.clone();
-    let api_client = DynGlobalApi::new(
-        ConnectorRegistry::build_from_server_env()?.bind().await?,
-        super::announcement::get_api_urls(&db, &cfg.consensus).await,
-        api_secret.as_deref(),
-    )?;
-
     let our_peer_id = cfg.local.identity;
     tg.spawn_cancellable("submit-guardian-metadata", async move {
         // Give other servers some time to start up in case they were just restarted together
@@ -131,45 +171,102 @@ pub async fn start_guardian_metadata_service(
             }
         }
     });
-
-    Ok(())
 }
 
-/// Checks if we already have a signed guardian metadata for our own identity
-/// in the database and creates one if not.
+/// Reconciles and signs the server-owned Iroh endpoint in guardian metadata.
 ///
-/// Return `true` fresh metadata was inserted because it was not present
-async fn insert_signed_guardian_metadata_if_not_present(db: &Database, cfg: &ServerConfig) -> bool {
+/// Existing administrator-owned URLs and Pkarr ID are preserved. Returns `true`
+/// if metadata was inserted or updated and should be broadcast.
+pub async fn reconcile_guardian_metadata(
+    db: &Database,
+    cfg: &ServerConfig,
+    iroh_next_api_settings: Option<&IrohNextApiSettings>,
+) -> anyhow::Result<bool> {
+    let key = GuardianMetadataKey(cfg.local.identity);
     let mut dbtx = db.begin_transaction().await;
-    if dbtx
-        .get_value(&GuardianMetadataKey(cfg.local.identity))
-        .await
-        .is_some()
-    {
-        return false;
+    let existing = dbtx.get_value(&key).await;
+
+    let mut guardian_metadata = existing.as_ref().map_or_else(
+        || {
+            GuardianMetadata::new(
+                cfg.consensus
+                    .api_endpoints()
+                    .get(&cfg.local.identity)
+                    .map(|endpoint| vec![endpoint.url.clone()])
+                    .unwrap_or_default(),
+                super::pkarr_publish::pkarr_id_z32(&cfg.private.broadcast_secret_key),
+                0,
+            )
+        },
+        |existing| existing.guardian_metadata().clone(),
+    );
+
+    let iroh_next_endpoint = iroh_next_api_settings.map(|_| {
+        derive_iroh_v1_api_secret_key(&cfg.private.broadcast_secret_key)
+            .public()
+            .to_string()
+    });
+
+    let endpoint_changed =
+        reconcile_iroh_next_endpoint(&mut guardian_metadata, iroh_next_endpoint)?;
+    if existing.is_some() && !endpoint_changed {
+        return Ok(false);
     }
 
-    let timestamp_secs = fedimint_core::time::now()
+    let now = fedimint_core::time::now()
         .duration_since(UNIX_EPOCH)
         .expect("System time should be after UNIX_EPOCH")
         .as_secs();
+    guardian_metadata.timestamp_secs = existing.as_ref().map_or(now, |metadata| {
+        now.max(
+            metadata
+                .guardian_metadata()
+                .timestamp_secs
+                .saturating_add(1),
+        )
+    });
 
-    let guardian_metadata = GuardianMetadata::new(
-        cfg.consensus
-            .api_endpoints()
-            .get(&cfg.local.identity)
-            .map(|endpoint| vec![endpoint.url.clone()])
-            .unwrap_or_default(),
-        super::pkarr_publish::pkarr_id_z32(&cfg.private.broadcast_secret_key),
-        timestamp_secs,
-    );
     let ctx = secp256k1::Secp256k1::new();
     let signed_metadata =
         guardian_metadata.sign(&ctx, &cfg.private.broadcast_secret_key.keypair(&ctx));
 
-    dbtx.insert_entry(&GuardianMetadataKey(cfg.local.identity), &signed_metadata)
-        .await;
+    dbtx.insert_entry(&key, &signed_metadata).await;
     dbtx.commit_tx().await;
 
-    true
+    Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use fedimint_core::net::guardian_metadata::GuardianMetadata;
+
+    use super::{ensure_iroh_next_remains_available, reconcile_iroh_next_endpoint};
+
+    #[test]
+    fn iroh_next_advertisement_is_forward_only() {
+        assert!(ensure_iroh_next_remains_available(None, None).is_ok());
+        assert!(ensure_iroh_next_remains_available(None, Some("new")).is_ok());
+        assert!(ensure_iroh_next_remains_available(Some("existing"), Some("existing")).is_ok());
+        assert!(ensure_iroh_next_remains_available(Some("existing"), Some("new")).is_err());
+        assert!(ensure_iroh_next_remains_available(Some("existing"), None).is_err());
+    }
+
+    #[test]
+    fn reconciliation_preserves_administrator_owned_metadata() {
+        let api_urls = vec!["wss://guardian.example".parse().expect("valid URL")];
+        let mut metadata = GuardianMetadata::new(api_urls.clone(), "pkarr-id".to_owned(), 42);
+
+        assert!(
+            reconcile_iroh_next_endpoint(&mut metadata, Some("iroh-id".to_owned()))
+                .expect("first advertisement is allowed")
+        );
+        assert_eq!(metadata.api_urls, api_urls);
+        assert_eq!(metadata.pkarr_id_z32, "pkarr-id");
+        assert_eq!(metadata.timestamp_secs, 42);
+        assert_eq!(metadata.iroh_next_endpoint.as_deref(), Some("iroh-id"));
+        assert!(
+            !reconcile_iroh_next_endpoint(&mut metadata, Some("iroh-id".to_owned()))
+                .expect("unchanged advertisement is allowed")
+        );
+    }
 }

--- a/fedimint-server/src/net/iroh.rs
+++ b/fedimint-server/src/net/iroh.rs
@@ -1,0 +1,130 @@
+use std::net::SocketAddr;
+
+use anyhow::Context as _;
+use fedimint_core::envs::{
+    FM_IROH_DHT_ENABLE_ENV, FM_IROH_N0_DISCOVERY_ENABLE_ENV, FM_IROH_PKARR_PUBLISHER_ENABLE_ENV,
+    FM_IROH_PKARR_RESOLVER_ENABLE_ENV, FM_IROH_RELAYS_ENABLE_ENV, is_env_var_set,
+    is_env_var_set_opt,
+};
+use fedimint_core::net::iroh::{IROH_IDLE_TIMEOUT, IROH_KEEP_ALIVE_INTERVAL};
+use fedimint_core::secp256k1::SecretKey;
+use fedimint_core::util::SafeUrl;
+use fedimint_derive_secret::{ChildId, DerivableSecret};
+use fedimint_logging::LOG_NET_IROH;
+use iroh_next::address_lookup::{DnsAddressLookup, PkarrPublisher, PkarrResolver};
+use iroh_next::endpoint::QuicTransportConfig;
+use iroh_next::endpoint::presets::Minimal;
+use iroh_next::{Endpoint, RelayMode};
+use tracing::{debug, info, warn};
+
+/// Child key used for the Iroh 1.0 API endpoint.
+const IROH_V1_API_CHILD_ID: ChildId = ChildId(0);
+
+/// Derive the Iroh 1.0 API secret key from the guardian broadcast key.
+pub(crate) fn derive_iroh_v1_api_secret_key(broadcast_sk: &SecretKey) -> iroh_next::SecretKey {
+    let root = DerivableSecret::new_root(&broadcast_sk.secret_bytes(), b"fedimint-iroh-next");
+    let seed: [u8; 32] = root.child_key(IROH_V1_API_CHILD_ID).to_random_bytes();
+    iroh_next::SecretKey::from_bytes(&seed)
+}
+
+/// Build an Iroh 1.0 server endpoint.
+pub(crate) async fn build_iroh_v1_endpoint(
+    secret_key: iroh_next::SecretKey,
+    bind_addr: SocketAddr,
+    iroh_dns: Option<SafeUrl>,
+    alpn: &[u8],
+) -> anyhow::Result<Endpoint> {
+    let relay_mode = if is_env_var_set_opt(FM_IROH_RELAYS_ENABLE_ENV).unwrap_or(true) {
+        RelayMode::Default
+    } else {
+        warn!(target: LOG_NET_IROH, "Iroh 1.0 relays are disabled");
+        RelayMode::Disabled
+    };
+
+    let mut builder = Endpoint::builder(Minimal);
+
+    if let Some(iroh_dns) = iroh_dns.map(SafeUrl::to_unsafe) {
+        if is_env_var_set_opt(FM_IROH_PKARR_PUBLISHER_ENABLE_ENV).unwrap_or(true) {
+            builder = builder.address_lookup(PkarrPublisher::builder(iroh_dns.clone()));
+        } else {
+            warn!(target: LOG_NET_IROH, "Iroh 1.0 pkarr publisher is disabled");
+        }
+
+        if is_env_var_set_opt(FM_IROH_PKARR_RESOLVER_ENABLE_ENV).unwrap_or(true) {
+            builder = builder.address_lookup(PkarrResolver::builder(iroh_dns));
+        } else {
+            warn!(target: LOG_NET_IROH, "Iroh 1.0 pkarr resolver is disabled");
+        }
+    }
+
+    if is_env_var_set(FM_IROH_DHT_ENABLE_ENV) {
+        debug!(target: LOG_NET_IROH, "Iroh 1.0 DHT is enabled");
+        builder = builder.address_lookup(iroh_mainline_address_lookup::DhtAddressLookup::builder());
+    } else {
+        info!(target: LOG_NET_IROH, "Iroh 1.0 DHT is disabled");
+    }
+
+    if is_env_var_set_opt(FM_IROH_N0_DISCOVERY_ENABLE_ENV).unwrap_or(true) {
+        if is_env_var_set_opt(FM_IROH_PKARR_PUBLISHER_ENABLE_ENV).unwrap_or(true) {
+            builder = builder.address_lookup(PkarrPublisher::n0_dns());
+        }
+        builder = builder.address_lookup(DnsAddressLookup::n0_dns());
+
+        if is_env_var_set_opt(FM_IROH_PKARR_RESOLVER_ENABLE_ENV).unwrap_or(true) {
+            builder = builder.address_lookup(PkarrResolver::n0_dns());
+        }
+    } else {
+        warn!(target: LOG_NET_IROH, "Iroh 1.0 n0 discovery is disabled");
+    }
+
+    let transport_config = QuicTransportConfig::builder()
+        .max_idle_timeout(Some(
+            IROH_IDLE_TIMEOUT
+                .try_into()
+                .expect("idle timeout fits in IdleTimeout"),
+        ))
+        .keep_alive_interval(IROH_KEEP_ALIVE_INTERVAL)
+        .build();
+
+    let endpoint = Box::pin(
+        builder
+            .relay_mode(relay_mode)
+            .secret_key(secret_key)
+            .alpns(vec![alpn.to_vec()])
+            .transport_config(transport_config)
+            .clear_ip_transports()
+            .bind_addr(bind_addr)
+            .context("Invalid Iroh 1.0 bind address")?
+            .bind(),
+    )
+    .await
+    .context("Failed to bind Iroh 1.0 endpoint")?;
+
+    info!(
+        target: LOG_NET_IROH,
+        %bind_addr,
+        endpoint_id = %endpoint.id(),
+        endpoint_id_pkarr = %z32::encode(endpoint.id().as_bytes()),
+        "Iroh 1.0 API server endpoint"
+    );
+
+    Ok(endpoint)
+}
+
+#[cfg(test)]
+mod tests {
+    use fedimint_core::secp256k1::SecretKey;
+
+    use super::derive_iroh_v1_api_secret_key;
+
+    #[test]
+    fn iroh_v1_api_key_derivation_is_stable() {
+        let broadcast_sk = SecretKey::from_slice(&[1; 32]).expect("valid test key");
+        assert_eq!(
+            derive_iroh_v1_api_secret_key(&broadcast_sk)
+                .public()
+                .to_string(),
+            "e4b678498c23a7444ac2daf4aed336e88c2fa51c10e973f4ec57ae493e25fcf3"
+        );
+    }
+}

--- a/fedimint-server/src/net/mod.rs
+++ b/fedimint-server/src/net/mod.rs
@@ -1,4 +1,5 @@
 pub mod api;
+pub(crate) mod iroh;
 pub mod p2p;
 pub mod p2p_connection;
 pub mod p2p_connector;

--- a/fedimint-testing/src/federation.rs
+++ b/fedimint-testing/src/federation.rs
@@ -404,6 +404,7 @@ impl FederationTestBuilder {
                         max_connections: 1000,
                         max_requests_per_connection: 100,
                     },
+                    None,
                 ))
                 .await
                 .expect("Could not initialise consensus");

--- a/fedimintd-envs/src/lib.rs
+++ b/fedimintd-envs/src/lib.rs
@@ -46,6 +46,10 @@ pub const FM_BITCOIND_USERNAME_ENV: &str = "FM_BITCOIND_USERNAME";
 
 pub const FM_BITCOIND_PASSWORD_ENV: &str = "FM_BITCOIND_PASSWORD";
 
+pub const FM_IROH_NEXT_ENABLE_ENV: &str = "FM_IROH_NEXT_ENABLE";
+
+pub const FM_BIND_API_NEXT_ENV: &str = "FM_BIND_API_NEXT";
+
 // TODO: Eventually Iroh should provide something better than this.
 // <https://github.com/n0-computer/iroh/discussions/3212>
 pub const FM_IROH_API_MAX_REQUESTS_PER_CONNECTION_ENV: &str =

--- a/fedimintd/src/lib.rs
+++ b/fedimintd/src/lib.rs
@@ -35,6 +35,7 @@ use fedimint_logging::{LOG_CORE, LOG_SERVER, TracingSetup};
 use fedimint_meta_server::MetaInit;
 use fedimint_mint_server::MintInit;
 use fedimint_rocksdb::RocksDb;
+use fedimint_server::IrohNextApiSettings;
 use fedimint_server::config::ConfigGenSettings;
 use fedimint_server::config::io::{DB_FILE, PLAINTEXT_PASSWORD};
 use fedimint_server::core::ServerModuleInitRegistry;
@@ -48,14 +49,14 @@ use fedimint_server_core::bitcoin_rpc::IServerBitcoinRpc;
 use fedimint_unknown_server::UnknownInit;
 use fedimint_wallet_server::WalletInit;
 use fedimintd_envs::{
-    FM_API_URL_ENV, FM_BIND_API_ENV, FM_BIND_METRICS_ENV, FM_BIND_P2P_ENV,
+    FM_API_URL_ENV, FM_BIND_API_ENV, FM_BIND_API_NEXT_ENV, FM_BIND_METRICS_ENV, FM_BIND_P2P_ENV,
     FM_BIND_TOKIO_CONSOLE_ENV, FM_BIND_UI_ENV, FM_BITCOIN_NETWORK_ENV, FM_BITCOIND_PASSWORD_ENV,
     FM_BITCOIND_URL_ENV, FM_BITCOIND_URL_PASSWORD_FILE_ENV, FM_BITCOIND_USERNAME_ENV,
     FM_DATA_DIR_ENV, FM_DB_CHECKPOINT_RETENTION_ENV, FM_DISABLE_META_MODULE_ENV,
     FM_ENABLE_IROH_ENV, FM_ESPLORA_URL_ENV, FM_FORCE_API_SECRETS_ENV,
     FM_IROH_API_MAX_CONNECTIONS_ENV, FM_IROH_API_MAX_REQUESTS_PER_CONNECTION_ENV,
-    FM_IROH_P2P_RELAY_ENV, FM_P2P_URL_ENV, FM_PASSWORD_API_ENV, FM_PASSWORD_UI_ENV,
-    FM_SESSION_TIMEOUT_SECS_ENV,
+    FM_IROH_NEXT_ENABLE_ENV, FM_IROH_P2P_RELAY_ENV, FM_P2P_URL_ENV, FM_PASSWORD_API_ENV,
+    FM_PASSWORD_UI_ENV, FM_SESSION_TIMEOUT_SECS_ENV,
 };
 use futures::FutureExt as _;
 #[cfg(all(
@@ -247,6 +248,18 @@ struct ServerOpts {
     /// Maximum number of parallel requests per Iroh API connection
     #[arg(long = "iroh-api-max-requests-per-connection", env = FM_IROH_API_MAX_REQUESTS_PER_CONNECTION_ENV, default_value = "50")]
     iroh_api_max_requests_per_connection: usize,
+
+    /// Enable the transitional Iroh 1.0 API endpoint alongside Iroh 0.35.
+    ///
+    /// For a federation configured with the legacy Iroh API, this is a runtime
+    /// setting independent of the DKG-only `--enable-iroh` option. Once the
+    /// endpoint is advertised, it must remain enabled.
+    #[arg(long, env = FM_IROH_NEXT_ENABLE_ENV)]
+    enable_iroh_next: bool,
+
+    /// Bind address for the transitional Iroh 1.0 API endpoint
+    #[arg(long, env = FM_BIND_API_NEXT_ENV)]
+    bind_api_next: Option<SocketAddr>,
 }
 
 impl ServerOpts {
@@ -368,13 +381,32 @@ pub async fn run(
         fedimint_metrics::spawn_api_server(*bind_metrics, root_task_group.clone()).await?;
     }
 
+    let enable_iroh = server_opts.enable_iroh.unwrap_or(!is_running_in_test_env());
+    let iroh_next_api_settings = if server_opts.enable_iroh_next {
+        let bind = server_opts.bind_api_next.map_or_else(
+            || {
+                let mut bind = server_opts.bind_api;
+                bind.set_port(bind.port().checked_add(10).with_context(|| {
+                    format!(
+                        "Default Iroh 1.0 API bind port would overflow; set {FM_BIND_API_NEXT_ENV}"
+                    )
+                })?);
+                anyhow::Ok(bind)
+            },
+            anyhow::Ok,
+        )?;
+        Some(IrohNextApiSettings { bind })
+    } else {
+        None
+    };
+
     let settings = ConfigGenSettings {
         p2p_bind: server_opts.bind_p2p,
         api_bind: server_opts.bind_api,
         ui_bind: server_opts.bind_ui,
         p2p_url: server_opts.p2p_url.clone(),
         api_url: server_opts.api_url.clone(),
-        enable_iroh: server_opts.enable_iroh.unwrap_or(!is_running_in_test_env()),
+        enable_iroh,
         iroh_dns: server_opts.iroh_dns.clone(),
         iroh_relays: server_opts.iroh_relays.clone(),
         network: server_opts.bitcoin_network,
@@ -451,7 +483,7 @@ pub async fn run(
     let task_group = root_task_group.clone();
     let code_version_hash = code_version_hash.to_string();
     root_task_group.spawn_cancellable("main", async move {
-        fedimint_server::run_with_iroh_p2p_relays(
+        fedimint_server::run_with_iroh_p2p_relays_and_next_api(
             server_opts.data_dir,
             auth_ui,
             auth_api,
@@ -472,6 +504,7 @@ pub async fn run(
                 server_opts.iroh_api_max_requests_per_connection,
             ),
             server_opts.iroh_p2p_relays,
+            iroh_next_api_settings,
         )
         .await
         .unwrap_or_else(|err| panic!("Main task returned error: {}", err.fmt_compact_anyhow()));

--- a/fedimintd/src/lib.rs
+++ b/fedimintd/src/lib.rs
@@ -391,19 +391,7 @@ pub async fn run(
 
     let enable_iroh = server_opts.enable_iroh.unwrap_or(!is_running_in_test_env());
     let iroh_next_api_settings = if server_opts.enable_iroh_next {
-        let bind = server_opts.bind_api_next.map_or_else(
-            || {
-                let mut bind = server_opts.bind_api;
-                bind.set_port(bind.port().checked_add(10).with_context(|| {
-                    format!(
-                        "Default Iroh 1.0 API bind port would overflow; set {FM_BIND_API_NEXT_ENV}"
-                    )
-                })?);
-                anyhow::Ok(bind)
-            },
-            anyhow::Ok,
-        )?;
-        Some(IrohNextApiSettings { bind })
+        Some(IrohNextApiSettings::new(server_opts.bind_api_next))
     } else {
         None
     };

--- a/fedimintd/src/lib.rs
+++ b/fedimintd/src/lib.rs
@@ -252,9 +252,17 @@ struct ServerOpts {
     /// Enable the transitional Iroh 1.0 API endpoint alongside Iroh 0.35.
     ///
     /// For a federation configured with the legacy Iroh API, this is a runtime
-    /// setting independent of the DKG-only `--enable-iroh` option. Once the
-    /// endpoint is advertised, it must remain enabled.
-    #[arg(long, env = FM_IROH_NEXT_ENABLE_ENV)]
+    /// setting independent of the DKG-only `--enable-iroh` option. It is
+    /// enabled by default. Once the endpoint is advertised, it must remain
+    /// enabled.
+    #[arg(
+        long,
+        env = FM_IROH_NEXT_ENABLE_ENV,
+        default_value_t = true,
+        action = clap::ArgAction::Set,
+        num_args = 0..=1,
+        default_missing_value = "true",
+    )]
     enable_iroh_next: bool,
 
     /// Bind address for the transitional Iroh 1.0 API endpoint
@@ -561,15 +569,8 @@ pub fn default_modules() -> ServerModuleInitRegistry {
 mod tests {
     use super::*;
 
-    fn parse_server_opts_with_enable_iroh_env(value: &str) -> ServerOpts {
-        let previous = std::env::var_os(FM_ENABLE_IROH_ENV);
-        // This test does not spawn threads while mutating the process
-        // environment.
-        unsafe {
-            std::env::set_var(FM_ENABLE_IROH_ENV, value);
-        }
-
-        let opts = ServerOpts::try_parse_from([
+    fn server_opts_args() -> Vec<&'static str> {
+        vec![
             "fedimintd",
             "--data-dir",
             "/tmp/fedimintd-test",
@@ -579,7 +580,22 @@ mod tests {
             "user",
             "--bitcoind-password",
             "pass",
-        ]);
+        ]
+    }
+
+    fn parse_server_opts() -> ServerOpts {
+        ServerOpts::try_parse_from(server_opts_args()).expect("server opts should parse")
+    }
+
+    fn parse_server_opts_with_enable_iroh_env(value: &str) -> ServerOpts {
+        let previous = std::env::var_os(FM_ENABLE_IROH_ENV);
+        // This test does not spawn threads while mutating the process
+        // environment.
+        unsafe {
+            std::env::set_var(FM_ENABLE_IROH_ENV, value);
+        }
+
+        let opts = parse_server_opts();
 
         // This test does not spawn threads while mutating the process
         // environment.
@@ -591,7 +607,7 @@ mod tests {
             }
         }
 
-        opts.expect("server opts should parse")
+        opts
     }
 
     #[test]
@@ -604,6 +620,21 @@ mod tests {
             parse_server_opts_with_enable_iroh_env("0").enable_iroh,
             Some(false)
         );
+    }
+
+    #[test]
+    fn iroh_next_api_defaults_to_enabled_and_accepts_false() {
+        let command = ServerOpts::command();
+        let enable_iroh_next = command
+            .get_arguments()
+            .find(|arg| arg.get_id() == "enable_iroh_next")
+            .expect("enable-iroh-next argument exists");
+        assert_eq!(enable_iroh_next.get_default_values(), ["true"]);
+
+        let mut args = server_opts_args();
+        args.push("--enable-iroh-next=false");
+        let opts = ServerOpts::try_parse_from(args).expect("explicit false should parse");
+        assert!(!opts.enable_iroh_next);
     }
 
     #[test]

--- a/nix/modules/fedimintd.nix
+++ b/nix/modules/fedimintd.nix
@@ -125,6 +125,35 @@ let
             description = "Address to bind on for Iroh endpoint for API connections";
           };
         };
+        api_iroh_next = {
+          enable = mkOption {
+            type = types.bool;
+            default = false;
+            description = ''
+              Enable the transitional Iroh 1.0 client API for federations
+              configured with the legacy Iroh API.
+
+              WARNING: Once this endpoint is advertised, setting this option to
+              false or omitting it makes fedimintd startup fail. The endpoint
+              must remain enabled and reachable.
+            '';
+          };
+          openFirewall = mkOption {
+            type = types.bool;
+            default = true;
+            description = "Opens the UDP port for fedimintd's transitional Iroh 1.0 API endpoint";
+          };
+          port = mkOption {
+            type = types.port;
+            default = 8184;
+            description = "UDP port to bind the transitional Iroh 1.0 API endpoint";
+          };
+          bind = mkOption {
+            type = types.str;
+            default = "0.0.0.0";
+            description = "Address to bind the transitional Iroh 1.0 API endpoint";
+          };
+        };
         ui = {
           openFirewall = mkOption {
             type = types.bool;
@@ -292,6 +321,7 @@ in
           fedimintdName: cfg:
           (
             lib.optional cfg.api_iroh.openFirewall cfg.api_iroh.port
+            ++ lib.optional (cfg.api_iroh_next.enable && cfg.api_iroh_next.openFirewall) cfg.api_iroh_next.port
             ++ lib.optional cfg.p2p.openFirewall cfg.p2p.port
           )
         ) eachFedimintd
@@ -332,6 +362,11 @@ in
 
               (lib.optionalAttrs (cfg.api_ws.url != null) {
                 FM_API_URL = cfg.api_ws.url;
+              })
+
+              (lib.optionalAttrs cfg.api_iroh_next.enable {
+                FM_IROH_NEXT_ENABLE = "true";
+                FM_BIND_API_NEXT = "${cfg.api_iroh_next.bind}:${toString cfg.api_iroh_next.port}";
               })
 
               cfg.environment
@@ -375,7 +410,8 @@ in
                 "tcp:${builtins.toString cfg.api_ws.port}"
                 "tcp:${builtins.toString cfg.ui.port}"
                 "udp:${builtins.toString cfg.api_iroh.port}"
-              ];
+              ]
+              ++ lib.optional cfg.api_iroh_next.enable "udp:${builtins.toString cfg.api_iroh_next.port}";
               SystemCallArchitectures = "native";
               SystemCallFilter = [
                 "@system-service"

--- a/nix/modules/fedimintd.nix
+++ b/nix/modules/fedimintd.nix
@@ -128,14 +128,14 @@ let
         api_iroh_next = {
           enable = mkOption {
             type = types.bool;
-            default = false;
+            default = true;
             description = ''
               Enable the transitional Iroh 1.0 client API for federations
               configured with the legacy Iroh API.
 
               WARNING: Once this endpoint is advertised, setting this option to
-              false or omitting it makes fedimintd startup fail. The endpoint
-              must remain enabled and reachable.
+              false makes fedimintd startup fail. The endpoint must remain
+              enabled and reachable.
             '';
           };
           openFirewall = mkOption {
@@ -348,6 +348,7 @@ in
                 FM_BIND_API_IROH = "${cfg.api_iroh.bind}:${toString cfg.api_iroh.port}";
                 FM_BIND_UI = "${cfg.ui.bind}:${toString cfg.ui.port}";
                 FM_DATA_DIR = cfg.dataDir;
+                FM_IROH_NEXT_ENABLE = lib.boolToString cfg.api_iroh_next.enable;
                 FM_BITCOIN_NETWORK = cfg.bitcoin.network;
                 FM_BITCOIND_URL = cfg.bitcoin.bitcoindUrl;
                 FM_ESPLORA_URL = cfg.bitcoin.esploraUrl;
@@ -365,7 +366,6 @@ in
               })
 
               (lib.optionalAttrs cfg.api_iroh_next.enable {
-                FM_IROH_NEXT_ENABLE = "true";
                 FM_BIND_API_NEXT = "${cfg.api_iroh_next.bind}:${toString cfg.api_iroh_next.port}";
               })
 

--- a/nix/tests/fedimintd.nix
+++ b/nix/tests/fedimintd.nix
@@ -29,6 +29,7 @@ pkgs.testers.runNixOSTest {
         api_ws = {
           url = "wss://example.com";
         };
+        api_iroh_next.enable = true;
         bitcoin = {
           network = "signet";
           esploraUrl = "https://mutinynet.com/api";
@@ -39,10 +40,20 @@ pkgs.testers.runNixOSTest {
 
   testScript =
     { nodes, ... }:
+    assert builtins.elem nodes.machine.services.fedimintd.mainnet.api_iroh_next.port
+      nodes.machine.networking.firewall.allowedUDPPorts;
     ''
       start_all()
 
       machine.wait_for_unit("fedimintd-mainnet.service")
+      machine.succeed(
+          "systemctl show fedimintd-mainnet.service --property=Environment"
+          " | grep -q 'FM_IROH_NEXT_ENABLE=true'"
+      )
+      machine.succeed(
+          "systemctl show fedimintd-mainnet.service --property=Environment"
+          " | grep -q 'FM_BIND_API_NEXT=0.0.0.0:8184'"
+      )
       machine.wait_for_open_port(${toString nodes.machine.services.fedimintd.mainnet.api_ws.port})
     '';
 }

--- a/nix/tests/fedimintd.nix
+++ b/nix/tests/fedimintd.nix
@@ -7,6 +7,40 @@
   fedimintdPackage,
 }:
 
+let
+  fedimintdInstance = {
+    enable = true;
+    package = fedimintdPackage;
+    passwordUi = "pass";
+    passwordApi = "pass";
+    p2p = {
+      url = "fedimint://example.com:8173";
+    };
+    api_ws = {
+      url = "wss://example.com";
+    };
+    bitcoin = {
+      network = "signet";
+      esploraUrl = "https://mutinynet.com/api";
+    };
+    environment = { };
+  };
+
+  disabledConfig =
+    (import "${pkgs.path}/nixos/lib/eval-config.nix" {
+      system = pkgs.stdenv.hostPlatform.system;
+      modules = [
+        fedimintdModule
+        {
+          disabledModules = [ "services/networking/fedimintd.nix" ];
+          services.fedimintd."mainnet" = fedimintdInstance // {
+            api_iroh_next.enable = false;
+          };
+        }
+      ];
+    }).config;
+  disabledEnvironment = disabledConfig.systemd.services."fedimintd-mainnet".environment;
+in
 pkgs.testers.runNixOSTest {
   name = "fedimintd";
 
@@ -18,30 +52,15 @@ pkgs.testers.runNixOSTest {
       # Disable the upstream nixpkgs module to avoid conflicts
       disabledModules = [ "services/networking/fedimintd.nix" ];
 
-      services.fedimintd."mainnet" = {
-        enable = true;
-        package = fedimintdPackage;
-        passwordUi = "pass";
-        passwordApi = "pass";
-        p2p = {
-          url = "fedimint://example.com:8173";
-        };
-        api_ws = {
-          url = "wss://example.com";
-        };
-        api_iroh_next.enable = true;
-        bitcoin = {
-          network = "signet";
-          esploraUrl = "https://mutinynet.com/api";
-        };
-        environment = { };
-      };
+      services.fedimintd."mainnet" = fedimintdInstance;
     };
 
   testScript =
     { nodes, ... }:
     assert builtins.elem nodes.machine.services.fedimintd.mainnet.api_iroh_next.port
       nodes.machine.networking.firewall.allowedUDPPorts;
+    assert disabledEnvironment.FM_IROH_NEXT_ENABLE == "false";
+    assert !(disabledEnvironment ? FM_BIND_API_NEXT);
     ''
       start_all()
 

--- a/scripts/tests/wasm-test.sh
+++ b/scripts/tests/wasm-test.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 
 export RUST_LOG="${RUST_LOG:-info}"
 
+# This federation is configured with the WebSocket API only.
+export FM_IROH_NEXT_ENABLE=false
+
 source scripts/_common.sh
 build_workspace
 add_target_dir_to_path


### PR DESCRIPTION
*PR published by Tau*

## Depends on #8815

This PR is stacked on #8815 (`feat(server): upgrade guardian P2P to Iroh 1.0`). GitHub cannot target another fork-only PR branch as the base of this upstream PR, so the base remains `master` and the GitHub diff includes #8815 until that PR merges. The #8400 delta is two API-only commits on top of #8815: the connectivity change and its NixOS wiring.

## Summary

Add a temporary client-server API migration path that runs Iroh 1.0 alongside the existing Iroh 0.35 API. The original API identity and 0.35 listener remain unchanged for deployed clients, while capable clients can recognize a separate identity advertised in guardian metadata and connect over Iroh 1.0.

## Details

The server deterministically derives a distinct Iroh 1.0 API identity, binds an opt-in listener, and advertises that identity through a new backward-compatible optional guardian-metadata field. Existing clients ignore the field and continue using the original identity over Iroh 0.35. When an Iroh URL is selected, capable clients replace the original identity with the advertised 1.0 identity; they do not retain or silently retry the original Iroh identity. Independently selected WSS URLs remain WSS.

Both listeners share API dispatch, request handling, metrics, request limits, and one global connection semaphore. Endpoints are bound and guardian metadata is reconciled before the WS/admin API becomes reachable. Metadata reconciliation preserves administrator-owned API URLs and Pkarr IDs, updates only the server-owned Iroh 1.0 identity, and avoids timestamp churn.

This rollout is forward-only: after a guardian advertises the v1 identity, setting enablement to false or omitting it makes startup fail; identity rotation is also rejected. The listener must remain enabled and reachable. The runtime enable setting is independent of the DKG-only `FM_ENABLE_IROH` flag for federations configured with the legacy Iroh API; enabling it for a WS-only federation fails clearly. The v1 listener uses Iroh 1.0 default relays rather than reinterpreting legacy `FM_IROH_RELAY`.

The NixOS module adds opt-in `api_iroh_next` enable/bind/port/firewall wiring, defaults the API-only UDP listener to port 8184, and permits it through systemd socket policy. It does not alter P2P settings or firewall rules.

This intentionally supports exactly the two hardcoded Iroh versions used during the migration window. It does not add generalized endpoint candidates, failover, or guardian P2P changes. Guardian P2P behavior and configuration come entirely from #8815.

## Reviewing

Please review these compatibility and operational invariants carefully:

- old clients continue using the unchanged original API ID over Iroh 0.35;
- capable clients replacing an Iroh URL use only the newly advertised derived ID over Iroh 1.0;
- malformed present 1.0 IDs do not silently fall back to the original ID;
- once advertised, the v1 identity cannot be disabled or rotated;
- the API-only delta on top of #8815 does not change P2P behavior or configuration.

A known temporary limitation is that metadata learned by an already-running client takes effect when the client is reopened; this PR deliberately does not add live mutable endpoint candidates.

## Testing

- focused server/client compilation and all-target clippy
- client endpoint-selection and metadata compatibility tests
- forward-only disable/rotation rejection and fixed derivation-vector tests
- real local Iroh 1.0 listener/shared stream-adapter request coverage
- shared cross-version connection-cap contention coverage
- reconciliation field-preservation and DB-backed admin metadata transaction coverage
- `just final-lint`
- Nix formatting/parsing and evaluated firewall/service environment assertions
- `nix build -L .#ci.vmTestFedimintd.driver`

Independent architecture, maintainability, reliability, and style reviews passed after fixes for startup ordering, metadata races, shared connection limits, runtime eligibility, identity rotation, and duplicated transport handlers. A final researcher review found no material concerns, confirmed the strict zero-P2P delta, and prompted explicit omitted-setting UX plus focused central-path regression tests.

