### PR TITLE
fix: add timeout to BOLT12 pay_offer and fix flaky test

### DIFF
--- a/gateway/fedimint-lightning/src/ldk.rs
+++ b/gateway/fedimint-lightning/src/ldk.rs
@@ -9,6 +9,7 @@ use bitcoin::hashes::{Hash, sha256};
 use bitcoin::{FeeRate, Network, OutPoint};
 use fedimint_bip39::Mnemonic;
 use fedimint_core::task::{TaskGroup, TaskHandle, block_in_place};
+use fedimint_core::time::now;
 use fedimint_core::util::{FmtCompact, SafeUrl};
 use fedimint_core::{Amount, BitcoinAmountOrAll, crit};
 use fedimint_gateway_common::{
@@ -841,6 +842,12 @@ impl ILnRpcClient for GatewayLdkClient {
                 })?
         };
 
+        // Timeout for polling LDK payment status. BOLT12 payments involve
+        // onion message round-trips (InvoiceRequest → Invoice → Payment) which
+        // can be slow, but we should not block indefinitely if LDK never
+        // transitions the payment out of Pending.
+        const PAY_OFFER_TIMEOUT: Duration = Duration::from_secs(30);
+        let start = now();
         loop {
             if let Some(payment_details) = self.node.payment(&payment_id) {
                 match payment_details.status {
@@ -866,6 +873,14 @@ impl ILnRpcClient for GatewayLdkClient {
                     }
                 }
             }
+
+            if now().duration_since(start).expect("time goes forward") > PAY_OFFER_TIMEOUT {
+                warn!(target: LOG_LIGHTNING, offer = %offer, payment_id = %payment_id, "Bolt12 payment timed out waiting for status update");
+                return Err(LightningRpcError::FailedPayment {
+                    failure_reason: "Bolt12 payment timed out".to_string(),
+                });
+            }
+
             fedimint_core::runtime::sleep(Duration::from_millis(100)).await;
         }
     }

--- a/gateway/integration_tests/src/main.rs
+++ b/gateway/integration_tests/src/main.rs
@@ -452,8 +452,11 @@ async fn liquidity_test() -> anyhow::Result<()> {
             assert_eq!(lnd_transactions.len(), 0);
 
             info!(target: LOG_TEST, "Testing paying Bolt12 Offers...");
-            // TODO: investigate why the first BOLT12 payment attempt is expiring consistently
-            poll_with_timeout("First BOLT12 payment", Duration::from_secs(30), || async {
+            // The first BOLT12 payment attempt often fails because the LDK
+            // nodes haven't fully established onion message routing paths to
+            // each other yet. The InvoiceRequest expires before the recipient
+            // can respond. Subsequent attempts succeed once routes are known.
+            poll_with_timeout("First BOLT12 payment", Duration::from_secs(120), || async {
                 let offer_with_amount = gw_ldk_second.create_offer(Some(Amount::from_msats(10_000_000))).await.map_err(ControlFlow::Continue)?;
                 gw_ldk.pay_offer(offer_with_amount, None).await.map_err(ControlFlow::Continue)?;
                 assert!(get_transaction(gw_ldk_second, PaymentKind::Bolt12Offer, Amount::from_msats(10_000_000), PaymentStatus::Succeeded).await.is_some());


### PR DESCRIPTION
## Summary
- Added a 30s timeout to the `pay_offer` polling loop in `ldk.rs` — previously it was an unbounded `loop` that could block indefinitely waiting for LDK to transition a payment out of `Pending`
- Increased the `gw_liquidity_test` BOLT12 poll timeout from 30s to 120s so the retry logic actually works (a single `pay_offer` attempt can take up to 30s, so the old 30s outer timeout only allowed ~1 attempt)
- Replaced the `TODO: investigate why the first BOLT12 payment attempt is expiring consistently` with an explanatory comment

## Root cause
The first BOLT12 offer payment in a fresh test environment fails because LDK nodes haven't fully established **onion message routing paths**. The `InvoiceRequest` expires before the recipient can respond with an `Invoice`. Subsequent attempts succeed once routes are discovered.

The retry was ineffective because `pay_offer` blocked longer than the 30s poll timeout, preventing any real retries.

## Test plan
- [ ] `gw_liquidity_test` passes in backwards-compatibility CI (the failing test from #8401)
- [ ] BOLT12 offer payments still work end-to-end in `devimint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)