### PR TITLE
feat: set explicit QUIC idle timeout and keep-alive for iroh API endp…

### DIFF
--- a/fedimint-connectors/src/iroh.rs
+++ b/fedimint-connectors/src/iroh.rs
@@ -16,6 +16,7 @@ use fedimint_core::module::{
     ApiError, ApiMethod, ApiRequestErased, FEDIMINT_API_ALPN, FEDIMINT_GATEWAY_ALPN,
     IrohApiRequest, IrohGatewayRequest, IrohGatewayResponse,
 };
+use fedimint_core::net::iroh::{IROH_IDLE_TIMEOUT, IROH_KEEP_ALIVE_INTERVAL};
 
 /// The maximum number of bytes we are willing to buffer when reading an API
 /// response from an iroh QUIC stream. This must be large enough to accommodate
@@ -195,7 +196,10 @@ impl IrohConnector {
                     }
                 }
 
-                let endpoint = builder.bind().await?;
+                let endpoint = builder
+                    .transport_config(quic_transport_config())
+                    .bind()
+                    .await?;
                 debug!(
                     target: LOG_NET_IROH,
                     node_id = %endpoint.node_id(),
@@ -239,7 +243,10 @@ impl IrohConnector {
                 }
             }
 
-            let endpoint = builder.bind().await?;
+            let endpoint = builder
+                .transport_config(quic_transport_config_next())
+                .bind()
+                .await?;
             debug!(
                 target: LOG_NET_IROH,
                 node_id = %endpoint.id(),
@@ -515,6 +522,32 @@ impl IrohConnector {
 
         Ok(conn)
     }
+}
+
+/// QUIC transport config with explicit idle timeout and keep-alive
+/// for the stable iroh endpoint.
+fn quic_transport_config() -> iroh::endpoint::TransportConfig {
+    let mut config = iroh::endpoint::TransportConfig::default();
+    config.max_idle_timeout(Some(
+        IROH_IDLE_TIMEOUT
+            .try_into()
+            .expect("idle timeout fits in IdleTimeout"),
+    ));
+    config.keep_alive_interval(Some(IROH_KEEP_ALIVE_INTERVAL));
+    config
+}
+
+/// QUIC transport config with explicit idle timeout and keep-alive
+/// for the next iroh endpoint.
+fn quic_transport_config_next() -> iroh_next::endpoint::QuicTransportConfig {
+    iroh_next::endpoint::QuicTransportConfig::builder()
+        .max_idle_timeout(Some(
+            IROH_IDLE_TIMEOUT
+                .try_into()
+                .expect("idle timeout fits in IdleTimeout"),
+        ))
+        .keep_alive_interval(IROH_KEEP_ALIVE_INTERVAL)
+        .build()
 }
 
 fn node_addr_stable_to_next(stable: &iroh::NodeAddr) -> iroh_next::EndpointAddr {

--- a/fedimint-core/src/net/iroh.rs
+++ b/fedimint-core/src/net/iroh.rs
@@ -1,10 +1,12 @@
 use std::net::SocketAddr;
+use std::time::Duration;
 
 use anyhow::Context;
 use fedimint_core::util::SafeUrl;
 use fedimint_logging::LOG_NET_IROH;
 use iroh::defaults::DEFAULT_STUN_PORT;
 use iroh::discovery::pkarr::{PkarrPublisher, PkarrResolver};
+use iroh::endpoint::TransportConfig;
 use iroh::{Endpoint, RelayMode, RelayNode, RelayUrl, SecretKey};
 use iroh_relay::RelayQuicConfig;
 use tracing::{debug, info, warn};
@@ -20,6 +22,12 @@ const DEFAULT_IROH_RELAYS: [&str; 2] = [
     "https://euc1-1.relay.elsirion.fedimint.iroh.link/",
     "https://use1-1.relay.elsirion.fedimint.iroh.link/",
 ];
+
+/// QUIC idle timeout used for iroh API endpoints.
+pub const IROH_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// QUIC keep-alive interval used for iroh API endpoints.
+pub const IROH_KEEP_ALIVE_INTERVAL: Duration = Duration::from_secs(30);
 
 pub async fn build_iroh_endpoint(
     secret_key: SecretKey,
@@ -103,10 +111,21 @@ pub async fn build_iroh_endpoint(
         );
     }
 
+    let mut transport_config = TransportConfig::default();
+    transport_config.max_idle_timeout(Some(
+        IROH_IDLE_TIMEOUT
+            .try_into()
+            .expect("idle timeout fits in IdleTimeout"),
+    ));
+    // Iroh's default builder sets keep_alive_interval to 1s, but since we're
+    // providing a custom TransportConfig we need to set it explicitly.
+    transport_config.keep_alive_interval(Some(IROH_KEEP_ALIVE_INTERVAL));
+
     let builder = builder
         .relay_mode(relay_mode)
         .secret_key(secret_key)
-        .alpns(vec![alpn.to_vec()]);
+        .alpns(vec![alpn.to_vec()])
+        .transport_config(transport_config);
 
     let builder = match bind_addr {
         SocketAddr::V4(addr_v4) => builder.bind_addr_v4(addr_v4),


### PR DESCRIPTION
…oint

Set max_idle_timeout to 60s and keep_alive_interval to 30s on the server-side iroh QUIC transport config to ensure dead connections are cleaned up and don't exhaust the connection limit.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
