### PR TITLE
refactor(wallet): rename payment event StatusEvent to UpdateEvent

### DIFF
--- a/modules/fedimint-walletv2-client/src/events.rs
+++ b/modules/fedimint-walletv2-client/src/events.rs
@@ -28,14 +28,14 @@ pub enum SendPaymentStatus {
 
 /// Event emitted when a send (peg-out) operation reaches a final state.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
-pub struct SendPaymentStatusEvent {
+pub struct SendPaymentUpdateEvent {
     pub operation_id: OperationId,
     pub status: SendPaymentStatus,
 }
 
-impl Event for SendPaymentStatusEvent {
+impl Event for SendPaymentUpdateEvent {
     const MODULE: Option<ModuleKind> = Some(fedimint_walletv2_common::KIND);
-    const KIND: EventKind = EventKind::from_static("payment-send-status");
+    const KIND: EventKind = EventKind::from_static("payment-send-update");
     const PERSISTENCE: EventPersistence = EventPersistence::Persistent;
 }
 
@@ -64,13 +64,13 @@ pub enum ReceivePaymentStatus {
 
 /// Event emitted when a receive (peg-in) operation reaches a final state.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
-pub struct ReceivePaymentStatusEvent {
+pub struct ReceivePaymentUpdateEvent {
     pub operation_id: OperationId,
     pub status: ReceivePaymentStatus,
 }
 
-impl Event for ReceivePaymentStatusEvent {
+impl Event for ReceivePaymentUpdateEvent {
     const MODULE: Option<ModuleKind> = Some(fedimint_walletv2_common::KIND);
-    const KIND: EventKind = EventKind::from_static("payment-receive-status");
+    const KIND: EventKind = EventKind::from_static("payment-receive-update");
     const PERSISTENCE: EventPersistence = EventPersistence::Persistent;
 }

--- a/modules/fedimint-walletv2-client/src/receive_sm.rs
+++ b/modules/fedimint-walletv2-client/src/receive_sm.rs
@@ -5,7 +5,7 @@ use fedimint_core::core::OperationId;
 use fedimint_core::encoding::{Decodable, Encodable};
 
 use crate::WalletClientContext;
-use crate::events::{ReceivePaymentStatus, ReceivePaymentStatusEvent};
+use crate::events::{ReceivePaymentStatus, ReceivePaymentUpdateEvent};
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct ReceiveStateMachine {
@@ -92,7 +92,7 @@ impl ReceiveStateMachine {
                     .client_ctx
                     .log_event(
                         &mut dbtx.module_tx(),
-                        ReceivePaymentStatusEvent {
+                        ReceivePaymentUpdateEvent {
                             operation_id: old_state.common.operation_id,
                             status: ReceivePaymentStatus::Success,
                         },
@@ -106,7 +106,7 @@ impl ReceiveStateMachine {
                     .client_ctx
                     .log_event(
                         &mut dbtx.module_tx(),
-                        ReceivePaymentStatusEvent {
+                        ReceivePaymentUpdateEvent {
                             operation_id: old_state.common.operation_id,
                             status: ReceivePaymentStatus::Aborted,
                         },

--- a/modules/fedimint-walletv2-client/src/send_sm.rs
+++ b/modules/fedimint-walletv2-client/src/send_sm.rs
@@ -6,7 +6,7 @@ use fedimint_core::encoding::{Decodable, Encodable};
 
 use crate::WalletClientContext;
 use crate::api::WalletFederationApi;
-use crate::events::{SendPaymentStatus, SendPaymentStatusEvent};
+use crate::events::{SendPaymentStatus, SendPaymentUpdateEvent};
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct SendStateMachine {
@@ -106,7 +106,7 @@ impl SendStateMachine {
                     .client_ctx
                     .log_event(
                         &mut dbtx.module_tx(),
-                        SendPaymentStatusEvent {
+                        SendPaymentUpdateEvent {
                             operation_id: old_state.common.operation_id,
                             status: SendPaymentStatus::Success(txid),
                         },
@@ -120,7 +120,7 @@ impl SendStateMachine {
                     .client_ctx
                     .log_event(
                         &mut dbtx.module_tx(),
-                        SendPaymentStatusEvent {
+                        SendPaymentUpdateEvent {
                             operation_id: old_state.common.operation_id,
                             status: SendPaymentStatus::Aborted,
                         },


### PR DESCRIPTION
## Summary
- Rename `SendPaymentStatusEvent` → `SendPaymentUpdateEvent` and `ReceivePaymentStatusEvent` → `ReceivePaymentUpdateEvent` in wallet v2 clients
- Update event kind strings from `payment-{send,receive}-status` to `payment-{send,receive}-update`

🤖 Generated with [Claude Code](https://claude.com/claude-code)