### PR TITLE
fix: atomic event logging in finalize_and_submit_transaction

### DIFF
--- a/fedimint-client-module/src/module/mod.rs
+++ b/fedimint-client-module/src/module/mod.rs
@@ -24,7 +24,7 @@ use fedimint_core::{
     Amount, OutPoint, PeerId, apply, async_trait_maybe_send, dyn_newtype_define, maybe_add_send,
     maybe_add_send_sync,
 };
-use fedimint_eventlog::{Event, EventKind, EventPersistence};
+use fedimint_eventlog::{AnyEvent, Event, EventKind, EventPersistence};
 use fedimint_logging::LOG_CLIENT;
 use futures::Stream;
 use serde::Serialize;
@@ -63,6 +63,7 @@ pub trait ClientContextIface: MaybeSend + MaybeSync {
         operation_type: &str,
         operation_meta_gen: Box<maybe_add_send_sync!(dyn Fn(OutPointRange) -> serde_json::Value)>,
         tx_builder: TransactionBuilder,
+        events: Vec<AnyEvent>,
     ) -> anyhow::Result<OutPointRange>;
 
     // TODO: unify
@@ -353,6 +354,7 @@ where
         operation_type: &str,
         operation_meta_gen: F,
         tx_builder: TransactionBuilder,
+        events: Vec<AnyEvent>,
     ) -> anyhow::Result<OutPointRange>
     where
         F: Fn(OutPointRange) -> Meta + Clone + MaybeSend + MaybeSync + 'static,
@@ -367,6 +369,7 @@ where
                     serde_json::to_value(operation_meta_gen(out_point_range)).expect("Can't fail")
                 }),
                 tx_builder,
+                events,
             )
             .await
     }
@@ -672,6 +675,10 @@ where
                 serde_json::to_value(operation_meta).expect("Can't fail"),
             )
             .await;
+    }
+
+    pub fn make_event<E: Event>(&self, event: E) -> AnyEvent {
+        AnyEvent::from_module_event(event, self.module_instance_id)
     }
 
     pub async fn log_event<E, Cap>(&self, dbtx: &mut DatabaseTransaction<'_, Cap>, event: E)

--- a/fedimint-client/src/client.rs
+++ b/fedimint-client/src/client.rs
@@ -65,8 +65,9 @@ use fedimint_core::{
 };
 use fedimint_derive_secret::DerivableSecret;
 use fedimint_eventlog::{
-    DBTransactionEventLogExt as _, DynEventLogTrimableTracker, Event, EventKind, EventLogEntry,
-    EventLogId, EventLogTrimableId, EventLogTrimableTracker, EventPersistence, PersistedLogEntry,
+    AnyEvent, DBTransactionEventLogExt as _, DynEventLogTrimableTracker, Event, EventKind,
+    EventLogEntry, EventLogId, EventLogTrimableId, EventLogTrimableTracker, EventPersistence,
+    PersistedLogEntry,
 };
 use fedimint_logging::{LOG_CLIENT, LOG_CLIENT_NET_API, LOG_CLIENT_RECOVERY};
 use futures::stream::FuturesUnordered;
@@ -688,6 +689,7 @@ impl Client {
         operation_type: &str,
         operation_meta_gen: F,
         tx_builder: TransactionBuilder,
+        events: Vec<AnyEvent>,
     ) -> anyhow::Result<OutPointRange>
     where
         F: Fn(OutPointRange) -> M + Clone + MaybeSend + MaybeSync,
@@ -702,6 +704,7 @@ impl Client {
                     let operation_type = operation_type.clone();
                     let tx_builder = tx_builder.clone();
                     let operation_meta_gen = operation_meta_gen.clone();
+                    let events = events.clone();
                     Box::pin(async move {
                         if Client::operation_exists_dbtx(dbtx, operation_id).await {
                             bail!("There already exists an operation with id {operation_id:?}")
@@ -719,6 +722,22 @@ impl Client {
                                 operation_meta_gen(out_point_range),
                             )
                             .await;
+
+                        for event in &events {
+                            self.log_event_raw_dbtx(
+                                dbtx,
+                                event.kind.clone(),
+                                event.module_kind.clone().map(|kind| {
+                                    (
+                                        kind,
+                                        event.module_id.expect("Module events must have module_id"),
+                                    )
+                                }),
+                                event.payload.clone(),
+                                event.persistence,
+                            )
+                            .await;
+                        }
 
                         Ok(out_point_range)
                     })
@@ -2203,6 +2222,7 @@ impl ClientContextIface for Client {
         operation_type: &str,
         operation_meta_gen: Box<maybe_add_send_sync!(dyn Fn(OutPointRange) -> serde_json::Value)>,
         tx_builder: TransactionBuilder,
+        events: Vec<AnyEvent>,
     ) -> anyhow::Result<OutPointRange> {
         Client::finalize_and_submit_transaction(
             self,
@@ -2211,6 +2231,7 @@ impl ClientContextIface for Client {
             // |out_point_range| operation_meta_gen(out_point_range),
             &operation_meta_gen,
             tx_builder,
+            events,
         )
         .await
     }

--- a/fedimint-eventlog/src/lib.rs
+++ b/fedimint-eventlog/src/lib.rs
@@ -73,6 +73,7 @@ const TRIMABLE_EVENTLOG_MAX_TRIMMED_EVENTS: usize = 100_000;
 /// and emitted only at runtime.
 ///
 /// Consult [`Event::PERSISTENCE`] to know which event uses which persistence.
+#[derive(Debug, Clone, Copy)]
 pub enum EventPersistence {
     /// Not written anywhere, just broadcasted as notification at runtime
     Transient,
@@ -87,6 +88,36 @@ pub trait Event: serde::Serialize + serde::de::DeserializeOwned {
     const MODULE: Option<ModuleKind>;
     const KIND: EventKind;
     const PERSISTENCE: EventPersistence;
+}
+
+/// A type-erased event that can be logged atomically alongside a transaction.
+///
+/// Created via [`AnyEvent::from_module_event`].
+/// This exists because [`Event`] has `DeserializeOwned` which prevents object
+/// safety, but we only need serialization at submission time.
+#[derive(Clone)]
+pub struct AnyEvent {
+    pub kind: EventKind,
+    pub module_kind: Option<ModuleKind>,
+    pub module_id: Option<ModuleInstanceId>,
+    pub payload: Vec<u8>,
+    pub persistence: EventPersistence,
+}
+
+impl AnyEvent {
+    /// Create from a module event, capturing the module's instance ID.
+    pub fn from_module_event<E: Event>(event: E, module_id: ModuleInstanceId) -> Self {
+        Self {
+            kind: E::KIND,
+            module_kind: E::MODULE,
+            module_id: Some(module_id),
+            payload: serde_json::to_vec(
+                &serde_json::to_value(&event).expect("Serialization can't fail"),
+            )
+            .expect("Serialization can't fail"),
+            persistence: E::PERSISTENCE,
+        }
+    }
 }
 
 /// An counter that resets on every restart, that guarantees that

--- a/fedimint-load-test-tool/src/common.rs
+++ b/fedimint-load-test-tool/src/common.rs
@@ -417,6 +417,7 @@ pub async fn try_remint_denomination(
             MintCommonInit::KIND.as_str(),
             operation_meta_gen,
             tx,
+            vec![],
         )
         .await?
         .txid();

--- a/gateway/fedimint-gateway-server/tests/tests.rs
+++ b/gateway/fedimint-gateway-server/tests/tests.rs
@@ -417,6 +417,7 @@ async fn test_gateway_cannot_claim_invalid_preimage() -> anyhow::Result<()> {
                     fedimint_ln_common::KIND.as_str(),
                     operation_meta_gen,
                     tx,
+                    vec![],
                 )
                 .await?
                 .txid();
@@ -707,6 +708,7 @@ async fn test_gateway_client_intercept_htlc_invalid_offer() -> anyhow::Result<()
                     fedimint_ln_common::KIND.as_str(),
                     operation_meta_gen,
                     tx,
+                    vec![],
                 )
                 .await?
                 .txid();

--- a/modules/fedimint-gw-client/src/lib.rs
+++ b/modules/fedimint-gw-client/src/lib.rs
@@ -491,24 +491,23 @@ impl GatewayClientModule {
             ClientOutputBundle::new(vec![output], vec![client_output_sm]),
         ));
         let operation_meta_gen = |_: OutPointRange| GatewayMeta::Receive;
+        let incoming_event = self.client_ctx.make_event(IncomingPaymentStarted {
+            contract_id,
+            payment_hash: htlc.payment_hash,
+            invoice_amount: htlc.outgoing_amount_msat,
+            contract_amount: amount,
+            operation_id,
+        });
         self.client_ctx
-            .finalize_and_submit_transaction(operation_id, KIND.as_str(), operation_meta_gen, tx)
+            .finalize_and_submit_transaction(
+                operation_id,
+                KIND.as_str(),
+                operation_meta_gen,
+                tx,
+                vec![incoming_event],
+            )
             .await?;
         debug!(?operation_id, "Submitted transaction for HTLC {htlc:?}");
-        let mut dbtx = self.client_ctx.module_db().begin_transaction().await;
-        self.client_ctx
-            .log_event(
-                &mut dbtx,
-                IncomingPaymentStarted {
-                    contract_id,
-                    payment_hash: htlc.payment_hash,
-                    invoice_amount: htlc.outgoing_amount_msat,
-                    contract_amount: amount,
-                    operation_id,
-                },
-            )
-            .await;
-        dbtx.commit_tx().await;
         Ok(operation_id)
     }
 
@@ -533,7 +532,13 @@ impl GatewayClientModule {
         ));
         let operation_meta_gen = |_: OutPointRange| GatewayMeta::Receive;
         self.client_ctx
-            .finalize_and_submit_transaction(operation_id, KIND.as_str(), operation_meta_gen, tx)
+            .finalize_and_submit_transaction(
+                operation_id,
+                KIND.as_str(),
+                operation_meta_gen,
+                tx,
+                vec![],
+            )
             .await?;
         debug!(
             ?operation_id,

--- a/modules/fedimint-gwv2-client/src/lib.rs
+++ b/modules/fedimint-gwv2-client/src/lib.rs
@@ -454,27 +454,21 @@ impl GatewayClientModuleV2 {
         ));
         let transaction = TransactionBuilder::new().with_outputs(client_output);
 
+        let incoming_event = self.client_ctx.make_event(IncomingPaymentStarted {
+            operation_start,
+            incoming_contract_commitment: commitment,
+            invoice_amount: Amount::from_msats(amount_msat),
+        });
+
         self.client_ctx
             .finalize_and_submit_transaction(
                 operation_id,
                 LightningCommonInit::KIND.as_str(),
                 |_| GatewayOperationMetaV2,
                 transaction,
+                vec![incoming_event],
             )
             .await?;
-
-        let mut dbtx = self.client_ctx.module_db().begin_transaction().await;
-        self.client_ctx
-            .log_event(
-                &mut dbtx,
-                IncomingPaymentStarted {
-                    operation_start,
-                    incoming_contract_commitment: commitment,
-                    invoice_amount: Amount::from_msats(amount_msat),
-                },
-            )
-            .await;
-        dbtx.commit_tx().await;
 
         Ok(())
     }
@@ -528,21 +522,13 @@ impl GatewayClientModuleV2 {
                 LightningCommonInit::KIND.as_str(),
                 |_| GatewayOperationMetaV2,
                 transaction,
-            )
-            .await?;
-
-        let mut dbtx = self.client_ctx.module_db().begin_transaction().await;
-        self.client_ctx
-            .log_event(
-                &mut dbtx,
-                IncomingPaymentStarted {
+                vec![self.client_ctx.make_event(IncomingPaymentStarted {
                     operation_start,
                     incoming_contract_commitment: commitment,
                     invoice_amount: Amount::from_msats(amount_msat),
-                },
+                })],
             )
-            .await;
-        dbtx.commit_tx().await;
+            .await?;
 
         Ok(self.await_receive(operation_id).await)
     }

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -1426,29 +1426,21 @@ impl LightningClientModule {
         // to the database fails.
         dbtx.commit_tx_result().await?;
 
+        let send_event = self.client_ctx.make_event(events::SendPaymentEvent {
+            operation_id,
+            amount: Amount::from_msats(amount_msat),
+            fee,
+        });
+
         self.client_ctx
             .finalize_and_submit_transaction(
                 operation_id,
                 LightningCommonInit::KIND.as_str(),
                 operation_meta_gen,
                 tx,
+                vec![send_event],
             )
             .await?;
-
-        let mut event_dbtx = self.client_ctx.module_db().begin_transaction().await;
-
-        self.client_ctx
-            .log_event(
-                &mut event_dbtx,
-                events::SendPaymentEvent {
-                    operation_id,
-                    amount: Amount::from_msats(amount_msat),
-                    fee,
-                },
-            )
-            .await;
-
-        event_dbtx.commit_tx().await;
 
         Ok(OutgoingLightningPayment {
             payment_type: pay_type,
@@ -1729,6 +1721,7 @@ impl LightningClientModule {
                 LightningCommonInit::KIND.as_str(),
                 operation_meta_gen,
                 tx,
+                vec![],
             )
             .await?;
         Ok(operation_id)
@@ -1864,6 +1857,7 @@ impl LightningClientModule {
                 LightningCommonInit::KIND.as_str(),
                 operation_meta_gen,
                 tx,
+                vec![],
             )
             .await?;
 

--- a/modules/fedimint-ln-tests/tests/tests.rs
+++ b/modules/fedimint-ln-tests/tests/tests.rs
@@ -804,7 +804,7 @@ async fn server_rejects_duplicate_offer() -> anyhow::Result<()> {
     }
 
     client1
-        .finalize_and_submit_transaction(operation_id_1, "", |_| (), transaction_builder_1)
+        .finalize_and_submit_transaction(operation_id_1, "", |_| (), transaction_builder_1, vec![])
         .await
         .expect("Tx finalization failed");
     await_tx_accepted(
@@ -817,7 +817,7 @@ async fn server_rejects_duplicate_offer() -> anyhow::Result<()> {
     .expect("First offer should be accepted");
 
     client1
-        .finalize_and_submit_transaction(operation_id_2, "", |_| (), transaction_builder_2)
+        .finalize_and_submit_transaction(operation_id_2, "", |_| (), transaction_builder_2, vec![])
         .await
         .expect("Tx finalization failed");
     await_tx_accepted(

--- a/modules/fedimint-lnv2-client/src/lib.rs
+++ b/modules/fedimint-lnv2-client/src/lib.rs
@@ -628,6 +628,12 @@ impl LightningClientModule {
 
         let transaction = TransactionBuilder::new().with_outputs(client_output);
 
+        let send_event = self.client_ctx.make_event(SendPaymentEvent {
+            operation_id,
+            amount: send_fee.add_to(amount),
+            fee: send_fee.fee(amount),
+        });
+
         self.client_ctx
             .finalize_and_submit_transaction(
                 operation_id,
@@ -642,24 +648,10 @@ impl LightningClientModule {
                     })
                 },
                 transaction,
+                vec![send_event],
             )
             .await
             .map_err(|e| SendPaymentError::FailedToFundPayment(e.to_string()))?;
-
-        let mut dbtx = self.client_ctx.module_db().begin_transaction().await;
-
-        self.client_ctx
-            .log_event(
-                &mut dbtx,
-                SendPaymentEvent {
-                    operation_id,
-                    amount: send_fee.add_to(amount),
-                    fee: send_fee.fee(amount),
-                },
-            )
-            .await;
-
-        dbtx.commit_tx().await;
 
         Ok(operation_id)
     }

--- a/modules/fedimint-lnv2-tests/tests/tests.rs
+++ b/modules/fedimint-lnv2-tests/tests/tests.rs
@@ -337,6 +337,7 @@ async fn claiming_outgoing_contract_triggers_success() -> anyhow::Result<()> {
             TransactionBuilder::new().with_inputs(
                 ClientInputBundle::new_no_sm(vec![client_input]).into_dyn(lnv2_module_id),
             ),
+            vec![],
         )
         .await
         .expect("Failed to claim outgoing contract");

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -1806,33 +1806,22 @@ impl MintClientModule {
             extra_meta: extra_meta.clone(),
         };
 
+        let reissued_event = self.client_ctx.make_event(OOBNotesReissued { amount });
+        let receive_event = self.client_ctx.make_event(ReceivePaymentEvent {
+            operation_id,
+            amount,
+        });
+
         self.client_ctx
             .finalize_and_submit_transaction(
                 operation_id,
                 MintCommonInit::KIND.as_str(),
                 operation_meta_gen,
                 tx,
+                vec![reissued_event, receive_event],
             )
             .await
             .context(ReissueExternalNotesError::AlreadyReissued)?;
-
-        let mut dbtx = self.client_ctx.module_db().begin_transaction().await;
-
-        self.client_ctx
-            .log_event(&mut dbtx, OOBNotesReissued { amount })
-            .await;
-
-        self.client_ctx
-            .log_event(
-                &mut dbtx,
-                ReceivePaymentEvent {
-                    operation_id,
-                    amount,
-                },
-            )
-            .await;
-
-        dbtx.commit_tx().await;
 
         Ok(operation_id)
     }
@@ -2161,6 +2150,7 @@ impl MintClientModule {
                     extra_meta: em_clone.clone(),
                 },
                 TransactionBuilder::new().with_outputs(outputs),
+                vec![],
             )
             .await
             .context("Failed to submit reissuance transaction")?;

--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -54,6 +54,7 @@ async fn issue_ecash(client: &ClientHandleArc, amount: Amount) -> anyhow::Result
             "Issue e-cash via dummy module",
             |_| (),
             TransactionBuilder::new().with_inputs(dummy_input),
+            vec![],
         )
         .await?;
 
@@ -102,6 +103,7 @@ async fn transaction_with_invalid_signature_is_rejected() -> anyhow::Result<()> 
                     .client_ctx
                     .make_client_inputs(ClientInputBundle::new_no_sm(vec![client_input])),
             ),
+            vec![],
         )
         .await
         .expect("Failed to finalize transaction")
@@ -189,7 +191,7 @@ async fn blind_nonce_index() -> anyhow::Result<()> {
 
     let change_range = client_mint
         .client_ctx
-        .finalize_and_submit_transaction(operation_id, "mint", |_| (), tx)
+        .finalize_and_submit_transaction(operation_id, "mint", |_| (), tx, vec![])
         .await?;
 
     client.api().await_transaction(change_range.txid()).await;

--- a/modules/fedimint-mintv2-client/src/lib.rs
+++ b/modules/fedimint-mintv2-client/src/lib.rs
@@ -800,6 +800,7 @@ impl MintClientModule {
                     custom_meta: cm.clone(),
                 },
                 TransactionBuilder::new().with_outputs(output),
+                vec![],
             )
             .await
             .map_err(|_| SendECashError::InsufficientBalance)?;
@@ -907,6 +908,11 @@ impl MintClientModule {
         let input = self.client_ctx.make_client_inputs(input);
         let ec = base32::encode_prefixed(FEDIMINT_PREFIX, &ecash);
 
+        let receive_event = self.client_ctx.make_event(ReceivePaymentEvent {
+            operation_id,
+            amount: ecash.amount(),
+        });
+
         self.client_ctx
             .finalize_and_submit_transaction(
                 operation_id,
@@ -917,23 +923,10 @@ impl MintClientModule {
                     custom_meta: custom_meta.clone(),
                 },
                 TransactionBuilder::new().with_inputs(input),
+                vec![receive_event],
             )
             .await
             .map_err(|_| ReceiveECashError::InsufficientFunds)?;
-
-        let mut dbtx = self.client_ctx.module_db().begin_transaction().await;
-
-        self.client_ctx
-            .log_event(
-                &mut dbtx,
-                ReceivePaymentEvent {
-                    operation_id,
-                    amount: ecash.amount(),
-                },
-            )
-            .await;
-
-        dbtx.commit_tx().await;
 
         Ok(operation_id)
     }

--- a/modules/fedimint-mintv2-tests/tests/tests.rs
+++ b/modules/fedimint-mintv2-tests/tests/tests.rs
@@ -90,6 +90,7 @@ async fn issue_ecash(client: &ClientHandleArc, amount: Amount) -> anyhow::Result
             "Issue e-cash via dummy module",
             |_| (),
             TransactionBuilder::new().with_inputs(dummy_input),
+            vec![],
         )
         .await?;
 

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -1406,6 +1406,12 @@ impl WalletClientModule {
 
             let extra_meta =
                 serde_json::to_value(extra_meta).expect("Failed to serialize extra meta");
+            let send_event = self.client_ctx.make_event(SendPaymentEvent {
+                operation_id,
+                amount: amount + fee.amount(),
+                fee: fee.amount(),
+            });
+
             self.client_ctx
                 .finalize_and_submit_transaction(
                     operation_id,
@@ -1423,23 +1429,9 @@ impl WalletClientModule {
                         }
                     },
                     tx_builder,
+                    vec![send_event],
                 )
                 .await?;
-
-            let mut dbtx = self.client_ctx.module_db().begin_transaction().await;
-
-            self.client_ctx
-                .log_event(
-                    &mut dbtx,
-                    SendPaymentEvent {
-                        operation_id,
-                        amount: amount + fee.amount(),
-                        fee: fee.amount(),
-                    },
-                )
-                .await;
-
-            dbtx.commit_tx().await;
 
             Ok(operation_id)
         }
@@ -1477,6 +1469,7 @@ impl WalletClientModule {
                     extra_meta: extra_meta.clone(),
                 },
                 tx_builder,
+                vec![],
             )
             .await?;
 

--- a/modules/fedimint-walletv2-client/src/lib.rs
+++ b/modules/fedimint-walletv2-client/src/lib.rs
@@ -313,6 +313,13 @@ impl WalletClientModule {
 
         let address_clone = address.clone();
 
+        let send_event = self.client_ctx.make_event(SendPaymentEvent {
+            operation_id,
+            address,
+            value,
+            fee,
+        });
+
         self.client_ctx
             .finalize_and_submit_transaction(
                 operation_id,
@@ -326,25 +333,10 @@ impl WalletClientModule {
                     })
                 },
                 TransactionBuilder::new().with_outputs(client_output_bundle),
+                vec![send_event],
             )
             .await
             .map_err(|_| SendError::InsufficientFunds)?;
-
-        let mut dbtx = self.client_ctx.module_db().begin_transaction().await;
-
-        self.client_ctx
-            .log_event(
-                &mut dbtx,
-                SendPaymentEvent {
-                    operation_id,
-                    address,
-                    value,
-                    fee,
-                },
-            )
-            .await;
-
-        dbtx.commit_tx().await;
 
         Ok(operation_id)
     }
@@ -455,6 +447,13 @@ impl WalletClientModule {
             vec![client_input_sm],
         ));
 
+        let receive_event = self.client_ctx.make_event(ReceivePaymentEvent {
+            operation_id,
+            address: self.derive_address(address_index).as_unchecked().clone(),
+            value,
+            fee,
+        });
+
         let range = self
             .client_ctx
             .finalize_and_submit_transaction(
@@ -468,25 +467,10 @@ impl WalletClientModule {
                     })
                 },
                 TransactionBuilder::new().with_inputs(client_input_bundle),
+                vec![receive_event],
             )
             .await
             .expect("Input amount is sufficient to finalize transaction");
-
-        let mut dbtx = self.client_ctx.module_db().begin_transaction().await;
-
-        self.client_ctx
-            .log_event(
-                &mut dbtx,
-                ReceivePaymentEvent {
-                    operation_id,
-                    address: self.derive_address(address_index).as_unchecked().clone(),
-                    value,
-                    fee,
-                },
-            )
-            .await;
-
-        dbtx.commit_tx().await;
 
         (operation_id, range.txid())
     }


### PR DESCRIPTION
## Summary

- Adds `AnyEvent` type-erased event wrapper in `fedimint-eventlog` and an `events: Vec<AnyEvent>` parameter to `finalize_and_submit_transaction`, so module events are logged atomically within the existing autocommit block
- Fixes race conditions in **8 call sites** across all module generations (v1 + v2) where events were logged in a separate database transaction after transaction submission — if the process crashed in between, the event would be lost
- Affected modules: walletv2, lnv2, ln, mintv2, gwv2, mint, wallet, gw

## Motivation

`finalize_and_submit_transaction` already uses an autocommit block to atomically submit the transaction and log the operation entry. However, module-level events (e.g. `SendPaymentEvent`, `ReceivePaymentEvent`, `IncomingPaymentStarted`) were logged in a **separate** `begin_transaction` → `log_event` → `commit_tx` sequence afterward, creating a window for data loss.

This PR extends the existing autocommit to also log events atomically, and provides an ergonomic API (`make_event` + `vec![event]` parameter) so modules don't need to manage manual autocommit blocks.

## Test plan

- [ ] `cargo check -q` passes with zero errors
- [ ] Existing test suites pass (all test call sites updated with `vec![]`)
- [ ] Verify event log ordering in integration tests (`fedimint-walletv2-tests`, `fedimint-lnv2-tests`, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)