### PR TITLE
feat: automatically determine max supported module API version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10294,9 +10294,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876ac351060d4f882bb1032b6369eb0aef79ad9df1ea8bc404874d8cc3d0cd98"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -11265,7 +11265,7 @@ checksum = "ae2a4cf385da23d1d53bc15cdfa5c2109e93d8d362393c801e87da2f72f0e201"
 dependencies = [
  "indexmap 2.9.0",
  "serde_core",
- "serde_spanned 1.1.0",
+ "serde_spanned 1.1.1",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
@@ -11306,9 +11306,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow 1.0.1",
 ]
@@ -11321,9 +11321,9 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d282ade6016312faf3e41e57ebbba0c073e4056dab1232ab1cb624199648f8ed"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"

--- a/fedimint-core/src/module/mod.rs
+++ b/fedimint-core/src/module/mod.rs
@@ -482,7 +482,7 @@ pub trait TypedApiEndpoint {
 
     /// example: /transaction
     const PATH: &'static str;
-
+    const VERSION: ApiVersion;
     type Param: serde::de::DeserializeOwned + Send;
     type Response: serde::Serialize;
 
@@ -525,6 +525,7 @@ macro_rules! __api_endpoint {
         impl $crate::module::TypedApiEndpoint for Endpoint {
             #[allow(deprecated)]
             const PATH: &'static str = $path;
+            const VERSION: $crate::module::ApiVersion = $version_introduced;
             type State = $state_ty;
             type Param = $param_ty;
             type Response = $resp_ty;
@@ -534,10 +535,6 @@ macro_rules! __api_endpoint {
                 $context: &'context mut $crate::module::ApiEndpointContext,
                 $param: Self::Param,
             ) -> ::std::result::Result<Self::Response, $crate::module::ApiError> {
-                {
-                    // just to enforce the correct type
-                    const __API_VERSION: $crate::module::ApiVersion = $version_introduced;
-                }
                 $body
             }
         }
@@ -569,6 +566,7 @@ pub struct ApiEndpoint<M> {
     ///   * Reference to the module which defined it
     ///   * Request parameters parsed into JSON `[Value](serde_json::Value)`
     pub handler: HandlerFn<M>,
+    pub version: ApiVersion,
 }
 
 /// Global request ID used for logging
@@ -607,6 +605,7 @@ impl ApiEndpoint<()> {
 
         ApiEndpoint {
             path: E::PATH,
+            version: E::VERSION,
             handler: Box::new(|m, mut context, request| {
                 Box::pin(async move {
                     let request = request

--- a/fedimint-server-core/src/init.rs
+++ b/fedimint-server-core/src/init.rs
@@ -16,7 +16,7 @@ use fedimint_core::core::{ModuleInstanceId, ModuleKind};
 use fedimint_core::db::{Database, DatabaseVersion};
 use fedimint_core::module::{
     CommonModuleInit, CoreConsensusVersion, IDynCommonModuleInit, ModuleConsensusVersion,
-    ModuleInit, SupportedModuleApiVersions,
+    ModuleInit,
 };
 use fedimint_core::task::TaskGroup;
 use fedimint_core::{NumPeers, PeerId, apply, async_trait_maybe_send, dyn_newtype_define};
@@ -65,8 +65,6 @@ pub struct ConfigGenModuleArgs {
 #[apply(async_trait_maybe_send!)]
 pub trait IServerModuleInit: IDynCommonModuleInit {
     fn as_common(&self) -> &(dyn IDynCommonModuleInit + Send + Sync + 'static);
-
-    fn supported_api_versions(&self) -> SupportedModuleApiVersions;
 
     /// Initialize the [`DynServerModule`] instance from its config
     #[allow(clippy::too_many_arguments)]
@@ -194,8 +192,6 @@ pub trait ServerModuleInit: ModuleInit + Sized {
     /// checking purposes.
     fn versions(&self, core: CoreConsensusVersion) -> &[ModuleConsensusVersion];
 
-    fn supported_api_versions(&self) -> SupportedModuleApiVersions;
-
     fn kind() -> ModuleKind {
         <Self as ModuleInit>::Common::KIND
     }
@@ -267,10 +263,6 @@ where
 {
     fn as_common(&self) -> &(dyn IDynCommonModuleInit + Send + Sync + 'static) {
         self
-    }
-
-    fn supported_api_versions(&self) -> SupportedModuleApiVersions {
-        <Self as ServerModuleInit>::supported_api_versions(self)
     }
 
     async fn init(

--- a/fedimint-server-core/src/lib.rs
+++ b/fedimint-server-core/src/lib.rs
@@ -487,20 +487,27 @@ where
     fn api_endpoints(&self) -> Vec<ApiEndpoint<DynServerModule>> {
         <Self as ServerModule>::api_endpoints(self)
             .into_iter()
-            .map(|ApiEndpoint { path, handler }| ApiEndpoint {
-                path,
-                handler: Box::new(
-                    move |module: &DynServerModule,
-                          context: ApiEndpointContext,
-                          value: ApiRequestErased| {
-                        let typed_module = module
-                            .as_any()
-                            .downcast_ref::<T>()
-                            .expect("the dispatcher should always call with the right module");
-                        Box::pin(handler(typed_module, context, value))
-                    },
-                ),
-            })
+            .map(
+                |ApiEndpoint {
+                     path,
+                     version,
+                     handler,
+                 }| ApiEndpoint {
+                    path,
+                    version,
+                    handler: Box::new(
+                        move |module: &DynServerModule,
+                              context: ApiEndpointContext,
+                              value: ApiRequestErased| {
+                            let typed_module = module
+                                .as_any()
+                                .downcast_ref::<T>()
+                                .expect("the dispatcher should always call with the right module");
+                            Box::pin(handler(typed_module, context, value))
+                        },
+                    ),
+                },
+            )
             .collect()
     }
 }

--- a/fedimint-server/src/config/mod.rs
+++ b/fedimint-server/src/config/mod.rs
@@ -12,9 +12,10 @@ pub use fedimint_core::config::{
 use fedimint_core::core::{ModuleInstanceId, ModuleKind};
 use fedimint_core::envs::{is_env_var_set, is_running_in_test_env};
 use fedimint_core::invite_code::InviteCode;
+use fedimint_core::module::registry::ModuleRegistry;
 use fedimint_core::module::{
     ApiAuth, ApiVersion, CORE_CONSENSUS_VERSION, CoreConsensusVersion, MultiApiVersion,
-    SupportedApiVersionsSummary, SupportedCoreApiVersions,
+    SupportedApiVersionsSummary, SupportedCoreApiVersions, SupportedModuleApiVersions,
 };
 use fedimint_core::net::peers::{DynP2PConnections, Recipient};
 use fedimint_core::setup_code::{PeerEndpoints, PeerSetupCode};
@@ -23,7 +24,9 @@ use fedimint_core::util::SafeUrl;
 use fedimint_core::{NumPeersExt, PeerId, secp256k1, timing};
 use fedimint_logging::LOG_NET_PEER_DKG;
 use fedimint_server_core::config::PeerHandleOpsExt as _;
-use fedimint_server_core::{ConfigGenModuleArgs, DynServerModuleInit, ServerModuleInitRegistry};
+use fedimint_server_core::{
+    ConfigGenModuleArgs, DynServerModule, DynServerModuleInit, ServerModuleInitRegistry,
+};
 use futures::future::select_all;
 use hex::{FromHex, ToHex};
 use peer_handle::PeerHandle;
@@ -82,19 +85,32 @@ impl ServerConfig {
 
     pub(crate) fn supported_api_versions_summary(
         modules: &BTreeMap<ModuleInstanceId, ServerModuleConsensusConfig>,
-        module_inits: &ServerModuleInitRegistry,
+        module_registry: &ModuleRegistry<DynServerModule>,
     ) -> SupportedApiVersionsSummary {
         SupportedApiVersionsSummary {
             core: Self::supported_api_versions(),
             modules: modules
                 .iter()
                 .map(|(&id, config)| {
+                    let module = module_registry.get_expect(id);
+                    let mut api_map: BTreeMap<u32, u32> = BTreeMap::new();
+                    for endpoint in module.api_endpoints() {
+                        let minor = api_map.entry(endpoint.version.major).or_insert(0);
+                        *minor = (*minor).max(endpoint.version.minor);
+                    }
+                    let api = MultiApiVersion::try_from_iter(
+                        api_map
+                            .into_iter()
+                            .map(|(major, minor)| ApiVersion { major, minor }),
+                    )
+                    .expect("endpoints should have unique major versions within a module");
                     (
                         id,
-                        module_inits
-                            .get(&config.kind)
-                            .expect("missing module kind gen")
-                            .supported_api_versions(),
+                        SupportedModuleApiVersions {
+                            core_consensus: CORE_CONSENSUS_VERSION,
+                            module_consensus: config.version,
+                            api,
+                        },
                     )
                 })
                 .collect(),
@@ -849,5 +865,41 @@ impl ConfigGenParams {
                 .map(|peer| (*id, peer))
             })
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use fedimint_core::module::{ApiEndpoint, ApiVersion};
+    use fedimint_server_core::DynServerModule;
+
+    fn make_endpoint(major: u32, minor: u32) -> ApiEndpoint<DynServerModule> {
+        ApiEndpoint {
+            path: "/fake",
+            version: ApiVersion::new(major, minor),
+            handler: Box::new(|_, _, _| Box::pin(async { Ok(serde_json::Value::Null) })),
+        }
+    }
+
+    /// Confirms that the version derivation logic picks max(minor) per major.
+    #[test]
+    fn version_derived_from_endpoints_max_minor() {
+        let endpoints = vec![
+            make_endpoint(0, 1),
+            make_endpoint(0, 3), // highest minor for major 0
+            make_endpoint(0, 2),
+            make_endpoint(1, 0), // separate major
+        ];
+
+        let mut api_map: BTreeMap<u32, u32> = BTreeMap::new();
+        for ep in &endpoints {
+            let minor = api_map.entry(ep.version.major).or_insert(0);
+            *minor = (*minor).max(ep.version.minor);
+        }
+
+        assert_eq!(api_map[&0], 3, "max minor for major 0 should be 3");
+        assert_eq!(api_map[&1], 0, "max minor for major 1 should be 0");
     }
 }

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -198,7 +198,7 @@ pub async fn run(
         shutdown_receiver: shutdown_receiver.clone(),
         supported_api_versions: ServerConfig::supported_api_versions_summary(
             &cfg.consensus.modules,
-            &module_init_registry,
+            &module_registry,
         ),
         p2p_status_receivers,
         ci_status_receivers,

--- a/fedimintd/src/lib.rs
+++ b/fedimintd/src/lib.rs
@@ -315,15 +315,7 @@ pub async fn run(
         core_consensus = %CORE_CONSENSUS_VERSION,
         "Supported core consensus version",
     );
-    for (kind, module) in module_init_registry.iter() {
-        let supported = module.supported_api_versions();
-        debug!(
-            target: LOG_SERVER,
-            module = %kind,
-            supported = %supported,
-            "Supported module versions",
-        );
-    }
+
     let code_version_str = code_version_vendor_suffix.map_or_else(
         || fedimint_version.to_string(),
         |suffix| format!("{fedimint_version}+{suffix}"),

--- a/modules/fedimint-dummy-server/src/lib.rs
+++ b/modules/fedimint-dummy-server/src/lib.rs
@@ -14,8 +14,8 @@ use fedimint_core::core::ModuleInstanceId;
 use fedimint_core::db::{DatabaseTransaction, DatabaseVersion, IDatabaseTransactionOpsCoreTyped};
 use fedimint_core::module::audit::Audit;
 use fedimint_core::module::{
-    Amounts, ApiEndpoint, CORE_CONSENSUS_VERSION, CoreConsensusVersion, InputMeta,
-    ModuleConsensusVersion, ModuleInit, SupportedModuleApiVersions, TransactionItemAmounts,
+    Amounts, ApiEndpoint, CoreConsensusVersion, InputMeta, ModuleConsensusVersion, ModuleInit,
+    TransactionItemAmounts,
 };
 use fedimint_core::{Amount, InPoint, OutPoint, PeerId, push_db_pair_items};
 pub use fedimint_dummy_common as common;
@@ -96,17 +96,6 @@ impl ServerModuleInit for DummyInit {
     /// Returns the version of this module
     fn versions(&self, _core: CoreConsensusVersion) -> &[ModuleConsensusVersion] {
         &[MODULE_CONSENSUS_VERSION]
-    }
-
-    fn supported_api_versions(&self) -> SupportedModuleApiVersions {
-        SupportedModuleApiVersions::from_raw(
-            (CORE_CONSENSUS_VERSION.major, CORE_CONSENSUS_VERSION.minor),
-            (
-                MODULE_CONSENSUS_VERSION.major,
-                MODULE_CONSENSUS_VERSION.minor,
-            ),
-            &[(0, 0)],
-        )
     }
 
     /// Initialize the module

--- a/modules/fedimint-empty-server/src/lib.rs
+++ b/modules/fedimint-empty-server/src/lib.rs
@@ -14,8 +14,8 @@ use fedimint_core::core::ModuleInstanceId;
 use fedimint_core::db::{DatabaseTransaction, DatabaseVersion};
 use fedimint_core::module::audit::Audit;
 use fedimint_core::module::{
-    ApiEndpoint, CORE_CONSENSUS_VERSION, CoreConsensusVersion, InputMeta, ModuleConsensusVersion,
-    ModuleInit, SupportedModuleApiVersions, TransactionItemAmounts,
+    ApiEndpoint, CoreConsensusVersion, InputMeta, ModuleConsensusVersion, ModuleInit,
+    TransactionItemAmounts,
 };
 use fedimint_core::{InPoint, OutPoint, PeerId, push_db_pair_items};
 pub use fedimint_empty_common as common;
@@ -85,17 +85,6 @@ impl ServerModuleInit for EmptyInit {
     /// Returns the version of this module
     fn versions(&self, _core: CoreConsensusVersion) -> &[ModuleConsensusVersion] {
         &[MODULE_CONSENSUS_VERSION]
-    }
-
-    fn supported_api_versions(&self) -> SupportedModuleApiVersions {
-        SupportedModuleApiVersions::from_raw(
-            (CORE_CONSENSUS_VERSION.major, CORE_CONSENSUS_VERSION.minor),
-            (
-                MODULE_CONSENSUS_VERSION.major,
-                MODULE_CONSENSUS_VERSION.minor,
-            ),
-            &[(0, 0)],
-        )
     }
 
     /// Initialize the module

--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -21,9 +21,8 @@ use fedimint_core::encoding::btc::NetworkLegacyEncodingWrapper;
 use fedimint_core::envs::{FM_ENABLE_MODULE_LNV1_ENV, is_env_var_set_opt};
 use fedimint_core::module::audit::Audit;
 use fedimint_core::module::{
-    Amounts, ApiEndpoint, ApiEndpointContext, ApiVersion, CORE_CONSENSUS_VERSION,
-    CoreConsensusVersion, InputMeta, ModuleConsensusVersion, ModuleInit,
-    SupportedModuleApiVersions, TransactionItemAmounts, api_endpoint,
+    Amounts, ApiEndpoint, ApiEndpointContext, ApiVersion, CoreConsensusVersion, InputMeta,
+    ModuleConsensusVersion, ModuleInit, TransactionItemAmounts, api_endpoint,
 };
 use fedimint_core::secp256k1::{Message, PublicKey, SECP256K1};
 use fedimint_core::task::sleep;
@@ -203,17 +202,6 @@ impl ServerModuleInit for LightningInit {
 
     fn versions(&self, _core: CoreConsensusVersion) -> &[ModuleConsensusVersion] {
         &[MODULE_CONSENSUS_VERSION]
-    }
-
-    fn supported_api_versions(&self) -> SupportedModuleApiVersions {
-        SupportedModuleApiVersions::from_raw(
-            (CORE_CONSENSUS_VERSION.major, CORE_CONSENSUS_VERSION.minor),
-            (
-                MODULE_CONSENSUS_VERSION.major,
-                MODULE_CONSENSUS_VERSION.minor,
-            ),
-            &[(0, 1)],
-        )
     }
 
     fn is_enabled_by_default(&self) -> bool {

--- a/modules/fedimint-lnv2-server/src/lib.rs
+++ b/modules/fedimint-lnv2-server/src/lib.rs
@@ -24,9 +24,8 @@ use fedimint_core::encoding::Encodable;
 use fedimint_core::envs::{FM_ENABLE_MODULE_LNV2_ENV, is_env_var_set_opt};
 use fedimint_core::module::audit::Audit;
 use fedimint_core::module::{
-    Amounts, ApiEndpoint, ApiError, ApiVersion, CORE_CONSENSUS_VERSION, CoreConsensusVersion,
-    InputMeta, ModuleConsensusVersion, ModuleInit, SupportedModuleApiVersions,
-    TransactionItemAmounts, api_endpoint,
+    Amounts, ApiEndpoint, ApiError, ApiVersion, CoreConsensusVersion, InputMeta,
+    ModuleConsensusVersion, ModuleInit, TransactionItemAmounts, api_endpoint,
 };
 use fedimint_core::net::auth::check_auth;
 use fedimint_core::task::timeout;
@@ -222,17 +221,6 @@ impl ServerModuleInit for LightningInit {
 
     fn versions(&self, _core: CoreConsensusVersion) -> &[ModuleConsensusVersion] {
         &[MODULE_CONSENSUS_VERSION]
-    }
-
-    fn supported_api_versions(&self) -> SupportedModuleApiVersions {
-        SupportedModuleApiVersions::from_raw(
-            (CORE_CONSENSUS_VERSION.major, CORE_CONSENSUS_VERSION.minor),
-            (
-                MODULE_CONSENSUS_VERSION.major,
-                MODULE_CONSENSUS_VERSION.minor,
-            ),
-            &[(0, 0)],
-        )
     }
 
     fn is_enabled_by_default(&self) -> bool {

--- a/modules/fedimint-meta-server/src/lib.rs
+++ b/modules/fedimint-meta-server/src/lib.rs
@@ -27,9 +27,8 @@ use fedimint_core::db::{
 use fedimint_core::module::audit::Audit;
 use fedimint_core::module::serde_json::Value;
 use fedimint_core::module::{
-    ApiAuth, ApiEndpoint, ApiError, ApiVersion, CORE_CONSENSUS_VERSION, CoreConsensusVersion,
-    InputMeta, ModuleConsensusVersion, ModuleInit, SupportedModuleApiVersions,
-    TransactionItemAmounts, api_endpoint, serde_json,
+    ApiAuth, ApiEndpoint, ApiError, ApiVersion, CoreConsensusVersion, InputMeta,
+    ModuleConsensusVersion, ModuleInit, TransactionItemAmounts, api_endpoint, serde_json,
 };
 use fedimint_core::{InPoint, NumPeers, OutPoint, PeerId, push_db_pair_items};
 use fedimint_logging::LOG_MODULE_META;
@@ -128,17 +127,6 @@ impl ServerModuleInit for MetaInit {
     /// Returns the version of this module
     fn versions(&self, _core: CoreConsensusVersion) -> &[ModuleConsensusVersion] {
         &[MODULE_CONSENSUS_VERSION]
-    }
-
-    fn supported_api_versions(&self) -> SupportedModuleApiVersions {
-        SupportedModuleApiVersions::from_raw(
-            (CORE_CONSENSUS_VERSION.major, CORE_CONSENSUS_VERSION.minor),
-            (
-                MODULE_CONSENSUS_VERSION.major,
-                MODULE_CONSENSUS_VERSION.minor,
-            ),
-            &[(0, 0)],
-        )
     }
 
     /// Initialize the module

--- a/modules/fedimint-mint-server/src/lib.rs
+++ b/modules/fedimint-mint-server/src/lib.rs
@@ -24,9 +24,9 @@ use fedimint_core::encoding::Encodable;
 use fedimint_core::envs::{FM_ENABLE_MODULE_MINT_ENV, is_env_var_set_opt};
 use fedimint_core::module::audit::Audit;
 use fedimint_core::module::{
-    Amounts, ApiEndpoint, ApiError, ApiVersion, CORE_CONSENSUS_VERSION, CoreConsensusVersion,
-    InputMeta, ModuleConsensusVersion, ModuleInit, SerdeModuleEncodingBase64,
-    SupportedModuleApiVersions, TransactionItemAmounts, api_endpoint,
+    Amounts, ApiEndpoint, ApiError, ApiVersion, CoreConsensusVersion, InputMeta,
+    ModuleConsensusVersion, ModuleInit, SerdeModuleEncodingBase64, TransactionItemAmounts,
+    api_endpoint,
 };
 use fedimint_core::{
     Amount, InPoint, NumPeersExt, OutPoint, PeerId, Tiered, TieredMulti, apply,
@@ -176,17 +176,6 @@ impl ServerModuleInit for MintInit {
 
     fn versions(&self, _core: CoreConsensusVersion) -> &[ModuleConsensusVersion] {
         &[MODULE_CONSENSUS_VERSION]
-    }
-
-    fn supported_api_versions(&self) -> SupportedModuleApiVersions {
-        SupportedModuleApiVersions::from_raw(
-            (CORE_CONSENSUS_VERSION.major, CORE_CONSENSUS_VERSION.minor),
-            (
-                MODULE_CONSENSUS_VERSION.major,
-                MODULE_CONSENSUS_VERSION.minor,
-            ),
-            &[(0, 1)],
-        )
     }
 
     fn is_enabled_by_default(&self) -> bool {

--- a/modules/fedimint-mintv2-server/src/lib.rs
+++ b/modules/fedimint-mintv2-server/src/lib.rs
@@ -22,9 +22,8 @@ use fedimint_core::encoding::Encodable;
 use fedimint_core::envs::{FM_ENABLE_MODULE_MINTV2_ENV, is_env_var_set_opt};
 use fedimint_core::module::audit::Audit;
 use fedimint_core::module::{
-    AmountUnit, Amounts, ApiEndpoint, ApiError, ApiVersion, CORE_CONSENSUS_VERSION,
-    CoreConsensusVersion, InputMeta, ModuleConsensusVersion, ModuleInit,
-    SupportedModuleApiVersions, TransactionItemAmounts, api_endpoint,
+    AmountUnit, Amounts, ApiEndpoint, ApiError, ApiVersion, CoreConsensusVersion, InputMeta,
+    ModuleConsensusVersion, ModuleInit, TransactionItemAmounts, api_endpoint,
 };
 use fedimint_core::{
     Amount, BitcoinHash, InPoint, NumPeers, NumPeersExt, OutPoint, PeerId, apply,
@@ -138,17 +137,6 @@ impl ServerModuleInit for MintInit {
 
     fn versions(&self, _core: CoreConsensusVersion) -> &[ModuleConsensusVersion] {
         &[MODULE_CONSENSUS_VERSION]
-    }
-
-    fn supported_api_versions(&self) -> SupportedModuleApiVersions {
-        SupportedModuleApiVersions::from_raw(
-            (CORE_CONSENSUS_VERSION.major, CORE_CONSENSUS_VERSION.minor),
-            (
-                MODULE_CONSENSUS_VERSION.major,
-                MODULE_CONSENSUS_VERSION.minor,
-            ),
-            &[(0, 1)],
-        )
     }
 
     fn is_enabled_by_default(&self) -> bool {

--- a/modules/fedimint-unknown-server/src/lib.rs
+++ b/modules/fedimint-unknown-server/src/lib.rs
@@ -14,8 +14,8 @@ use fedimint_core::core::ModuleInstanceId;
 use fedimint_core::db::{DatabaseTransaction, DatabaseVersion};
 use fedimint_core::module::audit::Audit;
 use fedimint_core::module::{
-    ApiEndpoint, CORE_CONSENSUS_VERSION, CoreConsensusVersion, InputMeta, ModuleConsensusVersion,
-    ModuleInit, SupportedModuleApiVersions, TransactionItemAmounts,
+    ApiEndpoint, CoreConsensusVersion, InputMeta, ModuleConsensusVersion, ModuleInit,
+    TransactionItemAmounts,
 };
 use fedimint_core::{InPoint, OutPoint, PeerId};
 use fedimint_server_core::config::PeerHandleOps;
@@ -59,17 +59,6 @@ impl ServerModuleInit for UnknownInit {
     /// Returns the version of this module
     fn versions(&self, _core: CoreConsensusVersion) -> &[ModuleConsensusVersion] {
         &[MODULE_CONSENSUS_VERSION]
-    }
-
-    fn supported_api_versions(&self) -> SupportedModuleApiVersions {
-        SupportedModuleApiVersions::from_raw(
-            (CORE_CONSENSUS_VERSION.major, CORE_CONSENSUS_VERSION.minor),
-            (
-                MODULE_CONSENSUS_VERSION.major,
-                MODULE_CONSENSUS_VERSION.minor,
-            ),
-            &[(0, 0)],
-        )
     }
 
     /// Initialize the module

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -60,9 +60,8 @@ use fedimint_core::envs::{
 };
 use fedimint_core::module::audit::Audit;
 use fedimint_core::module::{
-    Amounts, ApiEndpoint, ApiError, ApiRequestErased, ApiVersion, CORE_CONSENSUS_VERSION,
-    CoreConsensusVersion, InputMeta, ModuleConsensusVersion, ModuleInit,
-    SupportedModuleApiVersions, TransactionItemAmounts, api_endpoint,
+    Amounts, ApiEndpoint, ApiError, ApiRequestErased, ApiVersion, CoreConsensusVersion, InputMeta,
+    ModuleConsensusVersion, ModuleInit, TransactionItemAmounts, api_endpoint,
 };
 use fedimint_core::net::auth::check_auth;
 use fedimint_core::task::TaskGroup;
@@ -318,17 +317,6 @@ impl ServerModuleInit for WalletInit {
 
     fn versions(&self, _core: CoreConsensusVersion) -> &[ModuleConsensusVersion] {
         &[MODULE_CONSENSUS_VERSION]
-    }
-
-    fn supported_api_versions(&self) -> SupportedModuleApiVersions {
-        SupportedModuleApiVersions::from_raw(
-            (CORE_CONSENSUS_VERSION.major, CORE_CONSENSUS_VERSION.minor),
-            (
-                MODULE_CONSENSUS_VERSION.major,
-                MODULE_CONSENSUS_VERSION.minor,
-            ),
-            &[(0, 2)],
-        )
     }
 
     fn is_enabled_by_default(&self) -> bool {

--- a/modules/fedimint-walletv2-server/src/lib.rs
+++ b/modules/fedimint-walletv2-server/src/lib.rs
@@ -43,9 +43,8 @@ use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::envs::{FM_ENABLE_MODULE_WALLETV2_ENV, is_env_var_set_opt};
 use fedimint_core::module::audit::Audit;
 use fedimint_core::module::{
-    Amounts, ApiEndpoint, ApiVersion, CORE_CONSENSUS_VERSION, CoreConsensusVersion, InputMeta,
-    ModuleConsensusVersion, ModuleInit, SupportedModuleApiVersions, TransactionItemAmounts,
-    api_endpoint,
+    Amounts, ApiEndpoint, ApiVersion, CoreConsensusVersion, InputMeta, ModuleConsensusVersion,
+    ModuleInit, TransactionItemAmounts, api_endpoint,
 };
 #[cfg(not(target_family = "wasm"))]
 use fedimint_core::task::TaskGroup;
@@ -265,17 +264,6 @@ impl ServerModuleInit for WalletInit {
 
     fn versions(&self, _core: CoreConsensusVersion) -> &[ModuleConsensusVersion] {
         &[MODULE_CONSENSUS_VERSION]
-    }
-
-    fn supported_api_versions(&self) -> SupportedModuleApiVersions {
-        SupportedModuleApiVersions::from_raw(
-            (CORE_CONSENSUS_VERSION.major, CORE_CONSENSUS_VERSION.minor),
-            (
-                MODULE_CONSENSUS_VERSION.major,
-                MODULE_CONSENSUS_VERSION.minor,
-            ),
-            &[(0, 1)],
-        )
     }
 
     fn is_enabled_by_default(&self) -> bool {


### PR DESCRIPTION
Instead of requiring each ServerModuleInit to manually declare its
supported API versions (which is easy to forget when adding new
endpoints), derive them automatically from the module's api_endpoints().

The version introduced in each api_endpoint! macro call is now stored
on ApiEndpoint as a `version` field (previously it was only used as a
compile-time type check). supported_api_versions_summary now iterates
the live module's endpoints and computes max(minor) per major version.

Removes the supported_api_versions() method from ServerModuleInit and
IServerModuleInit traits, and its manual implementation from all 10
server modules.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"

Closes #6650

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
