### PR TITLE
feat(client): add finalize_and_submit_transaction_dbtx

### DIFF
--- a/fedimint-client-module/src/module/mod.rs
+++ b/fedimint-client-module/src/module/mod.rs
@@ -65,6 +65,15 @@ pub trait ClientContextIface: MaybeSend + MaybeSync {
         tx_builder: TransactionBuilder,
     ) -> anyhow::Result<OutPointRange>;
 
+    async fn finalize_and_submit_transaction_dbtx(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        operation_id: OperationId,
+        operation_type: &str,
+        operation_meta_gen: Box<maybe_add_send_sync!(dyn Fn(OutPointRange) -> serde_json::Value)>,
+        tx_builder: TransactionBuilder,
+    ) -> anyhow::Result<OutPointRange>;
+
     // TODO: unify
     async fn finalize_and_submit_transaction_inner(
         &self,
@@ -361,6 +370,32 @@ where
         self.client
             .get()
             .finalize_and_submit_transaction(
+                operation_id,
+                operation_type,
+                Box::new(move |out_point_range| {
+                    serde_json::to_value(operation_meta_gen(out_point_range)).expect("Can't fail")
+                }),
+                tx_builder,
+            )
+            .await
+    }
+
+    pub async fn finalize_and_submit_transaction_dbtx<F, Meta>(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        operation_id: OperationId,
+        operation_type: &str,
+        operation_meta_gen: F,
+        tx_builder: TransactionBuilder,
+    ) -> anyhow::Result<OutPointRange>
+    where
+        F: Fn(OutPointRange) -> Meta + MaybeSend + MaybeSync + 'static,
+        Meta: serde::Serialize + MaybeSend,
+    {
+        self.client
+            .get()
+            .finalize_and_submit_transaction_dbtx(
+                &mut dbtx.global_dbtx(self.global_dbtx_access_token),
                 operation_id,
                 operation_type,
                 Box::new(move |out_point_range| {

--- a/fedimint-client/src/client.rs
+++ b/fedimint-client/src/client.rs
@@ -703,24 +703,14 @@ impl Client {
                     let tx_builder = tx_builder.clone();
                     let operation_meta_gen = operation_meta_gen.clone();
                     Box::pin(async move {
-                        if Client::operation_exists_dbtx(dbtx, operation_id).await {
-                            bail!("There already exists an operation with id {operation_id:?}")
-                        }
-
-                        let out_point_range = self
-                            .finalize_and_submit_transaction_inner(dbtx, operation_id, tx_builder)
-                            .await?;
-
-                        self.operation_log()
-                            .add_operation_log_entry_dbtx(
-                                dbtx,
-                                operation_id,
-                                &operation_type,
-                                operation_meta_gen(out_point_range),
-                            )
-                            .await;
-
-                        Ok(out_point_range)
+                        self.finalize_and_submit_transaction_dbtx(
+                            dbtx,
+                            operation_id,
+                            &operation_type,
+                            operation_meta_gen,
+                            tx_builder,
+                        )
+                        .await
                     })
                 },
                 Some(100), // TODO: handle what happens after 100 retries
@@ -737,6 +727,40 @@ impl Client {
                 "Failed to commit tx submission dbtx after {attempts} attempts: {last_error}"
             ),
         }
+    }
+
+    /// See [`Self::finalize_and_submit_transaction`], just inside a database
+    /// transaction.
+    pub async fn finalize_and_submit_transaction_dbtx<F, M>(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        operation_id: OperationId,
+        operation_type: &str,
+        operation_meta_gen: F,
+        tx_builder: TransactionBuilder,
+    ) -> anyhow::Result<OutPointRange>
+    where
+        F: FnOnce(OutPointRange) -> M + MaybeSend,
+        M: serde::Serialize + MaybeSend,
+    {
+        if Client::operation_exists_dbtx(dbtx, operation_id).await {
+            bail!("There already exists an operation with id {operation_id:?}")
+        }
+
+        let out_point_range = self
+            .finalize_and_submit_transaction_inner(dbtx, operation_id, tx_builder)
+            .await?;
+
+        self.operation_log()
+            .add_operation_log_entry_dbtx(
+                dbtx,
+                operation_id,
+                operation_type,
+                operation_meta_gen(out_point_range),
+            )
+            .await;
+
+        Ok(out_point_range)
     }
 
     async fn finalize_and_submit_transaction_inner(
@@ -2209,6 +2233,25 @@ impl ClientContextIface for Client {
             operation_id,
             operation_type,
             // |out_point_range| operation_meta_gen(out_point_range),
+            &operation_meta_gen,
+            tx_builder,
+        )
+        .await
+    }
+
+    async fn finalize_and_submit_transaction_dbtx(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        operation_id: OperationId,
+        operation_type: &str,
+        operation_meta_gen: Box<maybe_add_send_sync!(dyn Fn(OutPointRange) -> serde_json::Value)>,
+        tx_builder: TransactionBuilder,
+    ) -> anyhow::Result<OutPointRange> {
+        Client::finalize_and_submit_transaction_dbtx(
+            self,
+            dbtx,
+            operation_id,
+            operation_type,
             &operation_meta_gen,
             tx_builder,
         )


### PR DESCRIPTION
## Summary

  Add `*_dbtx` variants for transaction finalization/submission across the exposed client APIs so callers can compose transaction submission atomically with other database work.

  Specifically:
  - add `Client::finalize_and_submit_transaction_dbtx`
  - expose the same capability via `ClientContextIface`
  - add a module-facing `ClientModule::finalize_and_submit_transaction_dbtx` helper

  Keep the existing `finalize_and_submit_transaction` methods as autocommit convenience wrappers.

  ## Motivation

  `finalize_and_submit_transaction` previously managed its own database transaction internally. That made it difficult for callers to make transaction finalization/submission atomic with surrounding database changes.

  This change exposes the composed behavior as a public `*_dbtx` API without widening the lower-level `_inner` helper, which remains internal.

  ## Notes

  This follows the existing client API pattern used elsewhere in the codebase:
  - public convenience wrapper
  - public `*_dbtx` variant for atomic composition
  - private/internal `_inner` helper for lower-level mechanics

  ## Testing

  - `just format`
  - `cargo check -p fedimint-client -p fedimint-client-module`
  - `cargo test -p fedimint-client -p fedimint-client-module --lib`
