### PR TITLE
feat(fedimintd): surface module env vars in --help output

### DIFF
--- a/fedimint-server-core/src/init.rs
+++ b/fedimint-server-core/src/init.rs
@@ -29,6 +29,18 @@ use crate::migration::{
 };
 use crate::{DynServerModule, ServerModule};
 
+/// Documentation for an environment variable used by a server module.
+///
+/// Modules return a list of these from
+/// [`ServerModuleInit::get_documented_env_vars`] so that `fedimintd --help`
+/// can surface all available env-var knobs to operators.
+pub struct EnvVarDoc {
+    /// The environment variable name (e.g. `"FM_ENABLE_MODULE_WALLET"`).
+    pub name: &'static str,
+    /// A short human-readable description shown in `--help`.
+    pub description: &'static str,
+}
+
 /// Arguments passed to modules during config generation
 ///
 /// This replaces the per-module GenParams approach with a unified struct
@@ -99,6 +111,9 @@ pub trait IServerModuleInit: IDynCommonModuleInit {
 
     /// Whether this module should be enabled by default in the setup UI
     fn is_enabled_by_default(&self) -> bool;
+
+    /// Returns documentation for every environment variable this module reads.
+    fn get_documented_env_vars(&self) -> Vec<EnvVarDoc>;
 }
 
 /// A type that can be used as module-shared value inside
@@ -235,6 +250,14 @@ pub trait ServerModuleInit: ModuleInit + Sized {
     fn is_enabled_by_default(&self) -> bool {
         true
     }
+
+    /// Returns documentation for every environment variable this module reads.
+    ///
+    /// The default implementation returns an empty list. Override this to
+    /// surface your module's env vars in `fedimintd --help`.
+    fn get_documented_env_vars(&self) -> Vec<EnvVarDoc> {
+        vec![]
+    }
 }
 
 #[apply(async_trait_maybe_send!)]
@@ -332,6 +355,10 @@ where
 
     fn is_enabled_by_default(&self) -> bool {
         <Self as ServerModuleInit>::is_enabled_by_default(self)
+    }
+
+    fn get_documented_env_vars(&self) -> Vec<EnvVarDoc> {
+        <Self as ServerModuleInit>::get_documented_env_vars(self)
     }
 }
 

--- a/fedimintd/src/lib.rs
+++ b/fedimintd/src/lib.rs
@@ -10,6 +10,7 @@ mod metrics;
 
 use std::convert::Infallible;
 use std::env;
+use std::fmt::Write as _;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::time::Duration;
@@ -272,7 +273,7 @@ pub async fn run(
         let mut module_env_help = String::from("\nModule environment variables:\n");
         for (_kind, module_init) in module_init_registry.iter() {
             for doc in module_init.get_documented_env_vars() {
-                module_env_help.push_str(&format!("  {:40}  {}\n", doc.name, doc.description));
+                let _ = writeln!(module_env_help, "  {:40}  {}", doc.name, doc.description);
             }
         }
         let matches = ServerOpts::command()

--- a/fedimintd/src/lib.rs
+++ b/fedimintd/src/lib.rs
@@ -16,7 +16,7 @@ use std::time::Duration;
 
 use anyhow::Context as _;
 use bitcoin::Network;
-use clap::{ArgGroup, Parser};
+use clap::{ArgGroup, CommandFactory, FromArgMatches, Parser};
 use fedimint_core::db::Database;
 use fedimint_core::envs::{
     FM_IROH_DNS_ENV, FM_IROH_RELAY_ENV, FM_USE_UNKNOWN_MODULE_ENV, is_env_var_set,
@@ -266,7 +266,21 @@ pub async fn run(
         .with_label_values(&[fedimint_version, code_version_hash])
         .set(fedimint_core::time::duration_since_epoch().as_secs() as i64);
 
-    let server_opts = ServerOpts::parse();
+    let server_opts = {
+        // Collect env vars from all registered modules and append them to the
+        // long-help text so operators can discover them via `fedimintd --help`.
+        let mut module_env_help = String::from("\nModule environment variables:\n");
+        for (_kind, module_init) in module_init_registry.iter() {
+            for doc in module_init.get_documented_env_vars() {
+                module_env_help.push_str(&format!("  {:40}  {}\n", doc.name, doc.description));
+            }
+        }
+        let matches = ServerOpts::command()
+            .after_long_help(module_env_help)
+            .get_matches();
+        ServerOpts::from_arg_matches(&matches)
+            .expect("clap arg matches must be valid after parsing")
+    };
 
     let mut tracing_builder = TracingSetup::default();
 

--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -60,7 +60,7 @@ use fedimint_logging::LOG_MODULE_LN;
 use fedimint_server_core::bitcoin_rpc::ServerBitcoinRpcMonitor;
 use fedimint_server_core::config::PeerHandleOps;
 use fedimint_server_core::{
-    ConfigGenModuleArgs, ServerModule, ServerModuleInit, ServerModuleInitArgs,
+    ConfigGenModuleArgs, EnvVarDoc, ServerModule, ServerModuleInit, ServerModuleInitArgs,
 };
 use futures::StreamExt;
 use metrics::{LN_CANCEL_OUTGOING_CONTRACTS, LN_FUNDED_CONTRACT_SATS, LN_INCOMING_OFFER};
@@ -218,6 +218,13 @@ impl ServerModuleInit for LightningInit {
 
     fn is_enabled_by_default(&self) -> bool {
         is_env_var_set_opt(FM_ENABLE_MODULE_LNV1_ENV).unwrap_or(true)
+    }
+
+    fn get_documented_env_vars(&self) -> Vec<EnvVarDoc> {
+        vec![EnvVarDoc {
+            name: FM_ENABLE_MODULE_LNV1_ENV,
+            description: "Set to 0/false to disable the LNv1 Lightning module. Enabled by default.",
+        }]
     }
 
     async fn init(&self, args: &ServerModuleInitArgs<Self>) -> anyhow::Result<Self::Module> {

--- a/modules/fedimint-lnv2-server/src/lib.rs
+++ b/modules/fedimint-lnv2-server/src/lib.rs
@@ -56,7 +56,7 @@ use fedimint_server_core::bitcoin_rpc::ServerBitcoinRpcMonitor;
 use fedimint_server_core::config::{PeerHandleOps, eval_poly_g1};
 use fedimint_server_core::migration::ServerModuleDbMigrationFn;
 use fedimint_server_core::{
-    ConfigGenModuleArgs, ServerModule, ServerModuleInit, ServerModuleInitArgs,
+    ConfigGenModuleArgs, EnvVarDoc, ServerModule, ServerModuleInit, ServerModuleInitArgs,
 };
 use futures::StreamExt;
 use group::Curve;
@@ -237,6 +237,13 @@ impl ServerModuleInit for LightningInit {
 
     fn is_enabled_by_default(&self) -> bool {
         is_env_var_set_opt(FM_ENABLE_MODULE_LNV2_ENV).unwrap_or(true)
+    }
+
+    fn get_documented_env_vars(&self) -> Vec<EnvVarDoc> {
+        vec![EnvVarDoc {
+            name: FM_ENABLE_MODULE_LNV2_ENV,
+            description: "Set to 0/false to disable the LNv2 Lightning module. Enabled by default.",
+        }]
     }
 
     async fn init(&self, args: &ServerModuleInitArgs<Self>) -> anyhow::Result<Self::Module> {

--- a/modules/fedimint-mint-server/src/lib.rs
+++ b/modules/fedimint-mint-server/src/lib.rs
@@ -49,7 +49,7 @@ use fedimint_server_core::migration::{
     ServerModuleDbMigrationFnContextExt as _,
 };
 use fedimint_server_core::{
-    ConfigGenModuleArgs, ServerModule, ServerModuleInit, ServerModuleInitArgs,
+    ConfigGenModuleArgs, EnvVarDoc, ServerModule, ServerModuleInit, ServerModuleInitArgs,
 };
 use futures::{FutureExt as _, StreamExt};
 use itertools::Itertools;
@@ -191,6 +191,13 @@ impl ServerModuleInit for MintInit {
 
     fn is_enabled_by_default(&self) -> bool {
         is_env_var_set_opt(FM_ENABLE_MODULE_MINT_ENV).unwrap_or(true)
+    }
+
+    fn get_documented_env_vars(&self) -> Vec<EnvVarDoc> {
+        vec![EnvVarDoc {
+            name: FM_ENABLE_MODULE_MINT_ENV,
+            description: "Set to 0/false to disable the mint (e-cash) module. Enabled by default.",
+        }]
     }
 
     async fn init(&self, args: &ServerModuleInitArgs<Self>) -> anyhow::Result<Self::Module> {

--- a/modules/fedimint-mintv2-server/src/lib.rs
+++ b/modules/fedimint-mintv2-server/src/lib.rs
@@ -46,7 +46,7 @@ use fedimint_mintv2_common::{
 use fedimint_server_core::config::{PeerHandleOps, eval_poly_g2};
 use fedimint_server_core::migration::ServerModuleDbMigrationFn;
 use fedimint_server_core::{
-    ConfigGenModuleArgs, ServerModule, ServerModuleInit, ServerModuleInitArgs,
+    ConfigGenModuleArgs, EnvVarDoc, ServerModule, ServerModuleInit, ServerModuleInitArgs,
 };
 use futures::StreamExt;
 use rand::SeedableRng;
@@ -153,6 +153,13 @@ impl ServerModuleInit for MintInit {
 
     fn is_enabled_by_default(&self) -> bool {
         is_env_var_set_opt(FM_ENABLE_MODULE_MINTV2_ENV).unwrap_or(false)
+    }
+
+    fn get_documented_env_vars(&self) -> Vec<EnvVarDoc> {
+        vec![EnvVarDoc {
+            name: FM_ENABLE_MODULE_MINTV2_ENV,
+            description: "Set to 1/true to enable the MintV2 module (experimental). Disabled by default.",
+        }]
     }
 
     async fn init(&self, args: &ServerModuleInitArgs<Self>) -> anyhow::Result<Self::Module> {

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -53,8 +53,10 @@ use fedimint_core::db::{
 use fedimint_core::encoding::btc::NetworkLegacyEncodingWrapper;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::envs::{
-    BitcoinRpcConfig, FM_ENABLE_MODULE_WALLET_ENV, is_automatic_consensus_version_voting_disabled,
-    is_env_var_set_opt, is_rbf_withdrawal_enabled, is_running_in_test_env,
+    BitcoinRpcConfig, FM_ENABLE_MODULE_WALLET_ENV,
+    FM_WALLET_DISABLE_AUTOMATIC_CONSENSUS_VERSION_VOTING_ENV, FM_WALLET_FEERATE_SOURCES_ENV,
+    is_automatic_consensus_version_voting_disabled, is_env_var_set_opt, is_rbf_withdrawal_enabled,
+    is_running_in_test_env,
 };
 use fedimint_core::module::audit::Audit;
 use fedimint_core::module::{
@@ -76,7 +78,7 @@ use fedimint_server_core::bitcoin_rpc::ServerBitcoinRpcMonitor;
 use fedimint_server_core::config::{PeerHandleOps, PeerHandleOpsExt};
 use fedimint_server_core::migration::ServerModuleDbMigrationFn;
 use fedimint_server_core::{
-    ConfigGenModuleArgs, ServerModule, ServerModuleInit, ServerModuleInitArgs,
+    ConfigGenModuleArgs, EnvVarDoc, ServerModule, ServerModuleInit, ServerModuleInitArgs,
 };
 pub use fedimint_wallet_common as common;
 use fedimint_wallet_common::config::{FeeConsensus, WalletClientConfig, WalletConfig};
@@ -331,6 +333,27 @@ impl ServerModuleInit for WalletInit {
 
     fn is_enabled_by_default(&self) -> bool {
         is_env_var_set_opt(FM_ENABLE_MODULE_WALLET_ENV).unwrap_or(true)
+    }
+
+    fn get_documented_env_vars(&self) -> Vec<EnvVarDoc> {
+        vec![
+            EnvVarDoc {
+                name: FM_ENABLE_MODULE_WALLET_ENV,
+                description: "Set to 0/false to disable the wallet (on-chain Bitcoin) module. Enabled by default.",
+            },
+            EnvVarDoc {
+                name: FM_WALLET_DISABLE_AUTOMATIC_CONSENSUS_VERSION_VOTING_ENV,
+                description: "Set to 1/true to disable automatic consensus version voting. Useful for testing and development.",
+            },
+            EnvVarDoc {
+                name: envs::FM_WALLET_FEERATE_MULTIPLIER_ENV,
+                description: "Multiplier applied to fee rate estimates (float, clamped 1.0–32.0). Defaults to 1.0.",
+            },
+            EnvVarDoc {
+                name: FM_WALLET_FEERATE_SOURCES_ENV,
+                description: "Semicolon-separated list of JSON API URLs (with optional `#<jq-filter>`) used as fee rate sources.",
+            },
+        ]
     }
 
     async fn init(&self, args: &ServerModuleInitArgs<Self>) -> anyhow::Result<Self::Module> {

--- a/modules/fedimint-walletv2-server/src/lib.rs
+++ b/modules/fedimint-walletv2-server/src/lib.rs
@@ -58,7 +58,7 @@ use fedimint_server_core::bitcoin_rpc::ServerBitcoinRpcMonitor;
 use fedimint_server_core::config::{PeerHandleOps, PeerHandleOpsExt};
 use fedimint_server_core::migration::ServerModuleDbMigrationFn;
 use fedimint_server_core::{
-    ConfigGenModuleArgs, ServerModule, ServerModuleInit, ServerModuleInitArgs,
+    ConfigGenModuleArgs, EnvVarDoc, ServerModule, ServerModuleInit, ServerModuleInitArgs,
 };
 pub use fedimint_walletv2_common as common;
 use fedimint_walletv2_common::config::{
@@ -279,6 +279,13 @@ impl ServerModuleInit for WalletInit {
 
     fn is_enabled_by_default(&self) -> bool {
         is_env_var_set_opt(FM_ENABLE_MODULE_WALLETV2_ENV).unwrap_or(false)
+    }
+
+    fn get_documented_env_vars(&self) -> Vec<EnvVarDoc> {
+        vec![EnvVarDoc {
+            name: FM_ENABLE_MODULE_WALLETV2_ENV,
+            description: "Set to 1/true to enable the WalletV2 module (experimental). Disabled by default.",
+        }]
     }
 
     async fn init(&self, args: &ServerModuleInitArgs<Self>) -> anyhow::Result<Self::Module> {


### PR DESCRIPTION
feat(fedimintd): surface module env vars in --help output

Add `EnvVarDoc` struct and `get_documented_env_vars()` to
`ServerModuleInit`/`IServerModuleInit` so modules can register the
environment variables they read. Implement it for wallet, mint, lnv1,
lnv2, mintv2, and walletv2 modules.

In `fedimintd`, collect the registered vars from the module registry
before parsing CLI args and append them as a formatted section to the
clap long-help output, making them discoverable via `fedimintd --help`.

Closes #1994

<img width="1054" height="168" alt="Screenshot 2026-04-09 at 15 35 22" src="https://github.com/user-attachments/assets/2e79d098-aeb4-4fee-a856-c314482493fe" />

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
