### PR TITLE
chore: compile-in jemalloc profiling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -335,7 +335,7 @@ tempfile = "3.20.0"
 test-log = { version = "0.2", features = ["trace"], default-features = false }
 thiserror = "2.0.18"
 threshold_crypto = { version = "0.2.1", package = "fedimint-threshold-crypto" }
-tikv-jemallocator = "0.6"
+tikv-jemallocator = { version = "0.6", features = ["profiling"] }
 time = "0.3.41"
 tokio = "1.48.0"
 tokio-rustls = { version = "0.26.4", features = ["aws_lc_rs"] }


### PR DESCRIPTION
This has neglible runtime cost, if not actually
enabled at runtime, and allows investigating
memory usage on real production workloads.

After enabling at runtime with:

```
MALLOC_CONF=prof:true,prof_prefix:/tmp/jeprof,lg_prof_interval:25
```

you can get memory profiling snapshot and figure out what is allocating how much memory.
<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
