### PR TITLE
chore(ci): add backend tests for walletv2 and mintv2 modules

### DIFF
--- a/scripts/tests/backend-test.sh
+++ b/scripts/tests/backend-test.sh
@@ -49,6 +49,18 @@ function run_tests() {
         ${TEST_ARGS_SERIALIZED} \
         -E 'package(fedimint-lnv2-tests)'
     fi
+    if [ -z "${FM_BITCOIND_TEST_ONLY:-}" ] || [ "${FM_BITCOIND_TEST_ONLY:-}" = "walletv2" ]; then
+      cargo nextest run --locked --workspace --all-targets \
+        ${CARGO_PROFILE:+--cargo-profile ${CARGO_PROFILE}} ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} \
+        ${TEST_ARGS_SERIALIZED} \
+        -E 'package(fedimint-walletv2-tests)'
+    fi
+    if [ -z "${FM_BITCOIND_TEST_ONLY:-}" ] || [ "${FM_BITCOIND_TEST_ONLY:-}" = "mintv2" ]; then
+      cargo nextest run --locked --workspace --all-targets \
+        ${CARGO_PROFILE:+--cargo-profile ${CARGO_PROFILE}} ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} \
+        ${TEST_ARGS_SERIALIZED} \
+        -E 'package(fedimint-mintv2-tests)'
+    fi
     >&2 echo "### Testing against bitcoind - complete"
   fi
 

--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -305,6 +305,22 @@ function bckn_bitcoind_lnv2() {
 }
 export -f bckn_bitcoind_lnv2
 
+function bckn_bitcoind_walletv2() {
+  # backend tests don't support different versions, so we skip for backwards-compatibility tests
+  if [ -z "${FM_BACKWARDS_COMPATIBILITY_TEST:-}" ]; then
+    fm-run-test "${FUNCNAME[0]}" env FM_TEST_ONLY=bitcoind FM_BITCOIND_TEST_ONLY=walletv2 ./scripts/tests/backend-test.sh
+  fi
+}
+export -f bckn_bitcoind_walletv2
+
+function bckn_bitcoind_mintv2() {
+  # backend tests don't support different versions, so we skip for backwards-compatibility tests
+  if [ -z "${FM_BACKWARDS_COMPATIBILITY_TEST:-}" ]; then
+    fm-run-test "${FUNCNAME[0]}" env FM_TEST_ONLY=bitcoind FM_BITCOIND_TEST_ONLY=mintv2 ./scripts/tests/backend-test.sh
+  fi
+}
+export -f bckn_bitcoind_mintv2
+
 function bckn_gw_client() {
   # backend tests don't support different versions, so we skip for backwards-compatibility tests
   if [ -z "${FM_BACKWARDS_COMPATIBILITY_TEST:-}" ]; then
@@ -408,6 +424,8 @@ tests_to_run_in_parallel+=(
   "bckn_bitcoind_wallet"
   "bckn_bitcoind_ln"
   "bckn_bitcoind_lnv2"
+  "bckn_bitcoind_walletv2"
+  "bckn_bitcoind_mintv2"
   "bckn_gw_client"
   "bckn_gw_not_client"
   "bckn_esplora"


### PR DESCRIPTION
## Summary
- Add `bckn_bitcoind_walletv2` and `bckn_bitcoind_mintv2` backend integration tests
- The v2 wallet and mint modules were missing backend tests unlike lnv2 which already had one

🤖 Generated with [Claude Code](https://claude.com/claude-code)