### PR TITLE
chore: make jemalloc a compile feature

### DIFF
--- a/fedimint-rocksdb/Cargo.toml
+++ b/fedimint-rocksdb/Cargo.toml
@@ -11,6 +11,10 @@ version = { workspace = true }
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]
 
+[features]
+default = ["jemalloc"]
+jemalloc = ["rocksdb/jemalloc"]
+
 [lib]
 name = "fedimint_rocksdb"
 path = "src/lib.rs"
@@ -25,9 +29,6 @@ fedimint-logging = { workspace = true }
 futures = { workspace = true }
 rocksdb = { workspace = true }
 tracing = { workspace = true }
-
-[target.'cfg(not(any(target_env = "msvc", target_os = "ios", target_os = "android")))'.dependencies]
-rocksdb = { workspace = true, features = ["jemalloc"] }
 
 [target.'cfg(not(target_family="wasm"))'.dependencies]
 tokio = { workspace = true, features = [


### PR DESCRIPTION
Rather than use jemalloc depending on the platform, this PR makes it a compile feature. I was hitting problems (segfault) integrating `v0.11.0-beta.1` into ecash app and ripping out jemalloc seemed to fix it.