### PR TITLE
chore: make jemalloc a feature in fedimintd and fedimint-cli

### DIFF
--- a/fedimint-cli/Cargo.toml
+++ b/fedimint-cli/Cargo.toml
@@ -13,7 +13,8 @@ version = { workspace = true }
 rustc-args = ["--cfg", "tokio_unstable"]
 
 [features]
-default = ["tor"]
+default = ["tor", "jemalloc"]
+jemalloc = ["dep:tikv-jemallocator", "fedimint-rocksdb/jemalloc"]
 tor = ["fedimint-client/tor", "fedimint-api-client/tor"]
 
 [[bin]]
@@ -62,7 +63,7 @@ tokio = { workspace = true, features = ["full", "tracing"] }
 tracing = { workspace = true }
 
 [target.'cfg(not(any(target_env = "msvc", target_os = "ios", target_os = "android")))'.dependencies]
-tikv-jemallocator = { workspace = true }
+tikv-jemallocator = { workspace = true, optional = true }
 
 [build-dependencies]
 fedimint-build = { workspace = true }

--- a/fedimint-cli/src/main.rs
+++ b/fedimint-cli/src/main.rs
@@ -1,9 +1,9 @@
 use fedimint_cli::FedimintCli;
 use fedimint_core::fedimint_build_code_version_env;
-#[cfg(not(any(target_env = "msvc", target_os = "ios", target_os = "android")))]
+#[cfg(feature = "jemalloc")]
 use tikv_jemallocator::Jemalloc;
 
-#[cfg(not(any(target_env = "msvc", target_os = "ios", target_os = "android")))]
+#[cfg(feature = "jemalloc")]
 #[global_allocator]
 // rocksdb suffers from memory fragmentation when using standard allocator
 static GLOBAL: Jemalloc = Jemalloc;

--- a/fedimint-rocksdb/Cargo.toml
+++ b/fedimint-rocksdb/Cargo.toml
@@ -11,6 +11,10 @@ version = { workspace = true }
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]
 
+[features]
+default = []
+jemalloc = ["rocksdb/jemalloc"]
+
 [lib]
 name = "fedimint_rocksdb"
 path = "src/lib.rs"
@@ -25,9 +29,6 @@ fedimint-logging = { workspace = true }
 futures = { workspace = true }
 rocksdb = { workspace = true }
 tracing = { workspace = true }
-
-[target.'cfg(not(any(target_env = "msvc", target_os = "ios", target_os = "android")))'.dependencies]
-rocksdb = { workspace = true, features = ["jemalloc"] }
 
 [target.'cfg(not(target_family="wasm"))'.dependencies]
 tokio = { workspace = true, features = [

--- a/fedimintd/Cargo.toml
+++ b/fedimintd/Cargo.toml
@@ -12,6 +12,10 @@ version = { workspace = true }
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]
 
+[features]
+default = ["jemalloc"]
+jemalloc = ["dep:tikv-jemallocator", "fedimint-rocksdb/jemalloc"]
+
 [[bin]]
 name = "fedimintd"
 path = "src/bin/main.rs"
@@ -52,7 +56,7 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 
 [target.'cfg(not(any(target_env = "msvc", target_os = "ios", target_os = "android")))'.dependencies]
-tikv-jemallocator = { workspace = true }
+tikv-jemallocator = { workspace = true, optional = true }
 
 [build-dependencies]
 fedimint-build = { workspace = true }

--- a/fedimintd/src/bin/main.rs
+++ b/fedimintd/src/bin/main.rs
@@ -1,10 +1,10 @@
 use std::convert::Infallible;
 
 use fedimint_core::fedimint_build_code_version_env;
-#[cfg(not(any(target_env = "msvc", target_os = "ios", target_os = "android")))]
+#[cfg(feature = "jemalloc")]
 use tikv_jemallocator::Jemalloc;
 
-#[cfg(not(any(target_env = "msvc", target_os = "ios", target_os = "android")))]
+#[cfg(feature = "jemalloc")]
 #[global_allocator]
 // rocksdb suffers from memory fragmentation when using standard allocator
 static GLOBAL: Jemalloc = Jemalloc;

--- a/fedimintd/src/lib.rs
+++ b/fedimintd/src/lib.rs
@@ -51,6 +51,11 @@ use fedimintd_envs::{
     FM_IROH_API_MAX_CONNECTIONS_ENV, FM_IROH_API_MAX_REQUESTS_PER_CONNECTION_ENV, FM_P2P_URL_ENV,
 };
 use futures::FutureExt as _;
+#[cfg(all(
+    not(feature = "jemalloc"),
+    not(any(target_env = "msvc", target_os = "ios", target_os = "android"))
+))]
+use tracing::warn;
 use tracing::{debug, error, info};
 
 use crate::metrics::APP_START_TS;
@@ -277,6 +282,16 @@ pub async fn run(
     tracing_builder.init().unwrap();
 
     info!("Starting fedimintd (version: {fedimint_version} version_hash: {code_version_hash})");
+
+    #[cfg(all(
+        not(feature = "jemalloc"),
+        not(any(target_env = "msvc", target_os = "ios", target_os = "android"))
+    ))]
+    warn!(
+        target: LOG_SERVER,
+        "fedimintd was built without the `jemalloc` feature. rocksdb is prone to memory \
+         fragmentation with the default allocator; consider rebuilding with `--features jemalloc`."
+    );
 
     let code_version_str = code_version_vendor_suffix.map_or_else(
         || fedimint_version.to_string(),

--- a/nix/flakebox.nix
+++ b/nix/flakebox.nix
@@ -384,6 +384,7 @@ in
         pname ? null,
         packages,
         mainProgram ? null,
+        features ? [ ],
         ...
       }@origArgs:
       let
@@ -391,6 +392,7 @@ in
           "mainProgram"
           "pname"
           "packages"
+          "features"
         ];
         pname =
           if builtins.hasAttr "pname" origArgs then
@@ -401,12 +403,20 @@ in
             null;
         # "--package x --package y" args passed to cargo
         pkgsArgs = lib.strings.concatStringsSep " " (builtins.map (name: "--package ${name}") packages);
+        # "--features pkg/feat --features pkg/feat" args passed to cargo
+        featuresArgs = lib.strings.concatStringsSep " " (builtins.map (f: "--features ${f}") features);
+        extraArgs = lib.strings.concatStringsSep " " (
+          builtins.filter (s: s != "") [
+            pkgsArgs
+            featuresArgs
+          ]
+        );
 
         deps = craneLib.buildDepsOnly (
           args
           // (lib.optionalAttrs (pname != null) { inherit pname; })
           // {
-            buildPhaseCargoCommand = "runLowPrio cargo build --profile $CARGO_PROFILE ${pkgsArgs}";
+            buildPhaseCargoCommand = "runLowPrio cargo build --profile $CARGO_PROFILE ${extraArgs}";
           }
         );
       in
@@ -417,7 +427,7 @@ in
           cargoArtifacts = deps;
           meta = { inherit mainProgram; };
           cargoBuildCommand = "runLowPrio bash ${./bin/cargo-with-memlimit.sh} build --profile $CARGO_PROFILE";
-          cargoExtraArgs = "${pkgsArgs}";
+          cargoExtraArgs = "${extraArgs}";
 
           # If the build contains `devimint`, wrap it in a script that will set
           # a correct `FM_DEVIMINT_STATIC_DATA_DIR`.
@@ -827,6 +837,13 @@ in
         "fedimint-cli"
         "fedimint-dbtool"
         "fedimint-recoverytool"
+      ];
+
+      # Cargo features can't be enabled by default conditionally on the target
+      # architecture, so we enable jemalloc here for the systems where it works.
+      features = lib.optionals (pkgs.stdenv.isLinux || pkgs.stdenv.isDarwin) [
+        "fedimintd/jemalloc"
+        "fedimint-cli/jemalloc"
       ];
     };
 


### PR DESCRIPTION
Previously, jemalloc was forced on for all consumers of fedimint-rocksdb via an unconditional `features = ["jemalloc"]` in a target-cfg dependency. That made it impossible for downstream crates (e.g. an ecash app embedding the client) to opt out, and on platforms where rocksdb's jemalloc feature fails to compile (msvc, ios, android) the only escape was to fork.

Move the opt-in to the binary crates that actually want jemalloc as the global allocator:

- fedimint-rocksdb: jemalloc is now an opt-in feature, off by default.
- fedimintd, fedimint-cli: expose a `jemalloc` feature, on by default, that pulls in `tikv-jemallocator` and `fedimint-rocksdb/jemalloc`. `tikv-jemallocator` stays target-gated to non-msvc/ios/android in `[target.'cfg(...)'.dependencies]`, so the feature is silently a no-op on those targets.
- main.rs in both binaries reduces to a plain `#[cfg(feature = "jemalloc")]`, with no architecture cfg in Rust code — the architecture allowlist lives in exactly one place (Cargo.toml's target-cfg block).

Cargo features cannot be enabled by default conditionally on the target architecture: `[features] default = [...]` is a single global list with no `cfg` syntax, and dependencies cannot activate features on their parent crate. The closest workarounds (a build.rs emitting a custom cfg, or a wrapper sub-crate exploiting target-conditional feature activation on a dep) all add complexity and lose the clean `--no-default-features` opt-out. Instead, the responsibility for "enable jemalloc by default on the right platforms" is pushed to the build system: nix/flakebox.nix now passes `--features fedimintd/jemalloc --features fedimint-cli/jemalloc` on Linux and Darwin.

If a user enables the feature on a target where it doesn't compile, that's on them — the failure mode is a clear compile error, not a silent fallback.

fedimintd also emits a startup `warn!` when built without the jemalloc feature on a target where it would historically have been on by default, pointing operators at `--features jemalloc`. (Skipped for fedimint-cli since allocator choice matters less for short-lived CLI invocations.)

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
