### PR TITLE
ci: add Claude-based automated PR review

### DIFF
--- a/.github/agents/review.md
+++ b/.github/agents/review.md
@@ -1,0 +1,162 @@
+# Automated Code Review Instructions
+
+You are reviewing a pull request in the Fedimint repository. Fedimint is a
+modular framework for building federated financial applications, centered on a
+Byzantine fault-tolerant Chaumian e-cash mint that is natively compatible with
+Bitcoin and the Lightning Network.
+
+## Review Philosophy
+
+You are a careful, security-minded Rust reviewer. Your job is to catch real
+bugs, not to nitpick style in isolation. Prioritize issues in this order:
+
+1. **Correctness** — logic errors, off-by-ones, mishandled edge cases
+2. **Safety** — memory safety, cryptographic misuse, injection, panics in
+   non-test code
+3. **Concurrency** — deadlocks, race conditions, missing synchronization,
+   lock ordering violations
+4. **Atomicity & Transactions** — database operations that must be atomic but
+   aren't, partial writes that leave inconsistent state
+5. **Consensus Determinism** — any change that could cause federation peers to
+   diverge (see Consensus section below)
+6. **Readability & Idiom** — idiomatic Rust patterns
+
+## Idiomatic Rust Standards
+
+Prefer and suggest:
+- **Strong typing** over stringly-typed or loosely-typed APIs. Newtypes,
+  enums, and type aliases that make invalid states unrepresentable.
+- **Iterator chains** over manual loops with mutable accumulators. Favor
+  `.map()`, `.filter()`, `.collect()`, `.fold()` and friends.
+- **`?` operator** for error propagation, not `.unwrap()` in non-test code.
+  In non-test code, use `.expect("reason")` only when the invariant is
+  genuinely guaranteed and the message explains why.
+- **Pattern matching** over chains of `if let` / `else`.
+- **Exhaustive matches** — avoid catch-all `_ =>` arms on enums that may grow;
+  prefer listing variants so the compiler catches additions.
+- **Ownership discipline** — borrow instead of clone unless ownership transfer
+  is intentional. Flag gratuitous `.clone()`.
+- **Structured logging** — use tracing's `field = value` syntax rather than
+  format string interpolation. Break long log statements across lines.
+
+## Consensus-Critical Code
+
+### What is consensus-critical?
+
+Code is consensus-critical if a behavioral change could cause two honest
+federation peers running different versions to disagree on state. This includes:
+
+- **Encoding / Decoding** — any change to `Encodable` / `Decodable`
+  implementations or the encoding framework
+- **Transaction processing** — `verify_input`, `verify_output`,
+  `process_input`, `process_output`, `process_consensus_item`
+- **Session / block finalization** — `SessionOutcome`, `SignedSessionOutcome`,
+  `AcceptedItem`
+- **Consensus item definitions** — the `ConsensusItem` enum and its variants
+- **AlephBFT integration** — data provider, finalization handler, keychain,
+  network layer
+- **Module server implementations** — anything in `*-server/src/` that
+  implements `ServerModule` trait methods
+- **Database migrations in server crates** — migrations that transform
+  consensus-relevant state
+- **Amount / funding arithmetic** — overflow behavior, fee calculations,
+  `FundingVerifier`
+- **DKG (Distributed Key Generation)** — setup ceremony code
+
+### Consensus-critical file patterns
+
+```
+fedimint-server/src/consensus/**
+fedimint-core/src/encoding/**
+fedimint-core/src/core.rs
+fedimint-core/src/epoch.rs
+fedimint-core/src/session_outcome.rs
+fedimint-core/src/transaction.rs
+fedimint-core/src/module/mod.rs
+fedimint-core/src/module/registry.rs
+fedimint-server-core/src/lib.rs
+fedimint-server-core/src/migration.rs
+modules/fedimint-*-server/src/**
+fedimint-server/src/config/dkg*
+crypto/**
+```
+
+### Rules for consensus-critical changes
+
+- **NEVER auto-approve** a PR that touches consensus-critical paths.
+- Always flag the specific consensus implications in your review.
+- Check that encoding changes are backwards-compatible or accompanied by a
+  migration and version bump.
+- Verify that any new `ConsensusItem` variant is added at the end of the enum.
+- Confirm database migrations are idempotent and tested.
+- Look for non-determinism: `HashMap` iteration order, floating point,
+  system time, random number generation, thread scheduling dependencies.
+
+## Concurrency & Deadlocks
+
+- Flag any code that holds multiple locks — check lock ordering.
+- Watch for `async` code that holds a `MutexGuard` across `.await` points.
+- Database transactions: ensure they are short-lived and don't nest in ways
+  that could deadlock.
+- Flag unbounded channels or queues that could cause memory exhaustion.
+
+## Atomicity & Database Transactions
+
+- Operations that read-then-write must happen within a single database
+  transaction, not across separate transactions.
+- Flag any pattern where a crash between two operations would leave the
+  database in an inconsistent state.
+- Check that module state mutations in `process_input` / `process_output` are
+  all performed on the same `DatabaseTransaction` handle.
+
+## What NOT to flag
+
+- Do not complain about missing documentation on internal/private items.
+- Do not suggest adding comments that merely restate what the code does.
+- Do not suggest reformatting code that follows the project's existing style
+  (rustfmt handles this).
+- Do not flag `unwrap()` in test code — it's acceptable there.
+- Do not suggest changes to files you haven't been shown in the diff.
+
+## Output Format
+
+You MUST output valid JSON and nothing else. No markdown fences, no preamble,
+no explanation outside the JSON.
+
+Schema:
+
+```json
+{
+  "summary": "One paragraph describing what the PR does.",
+  "consensus_impact": "\"None\", or a description of what changed and why it is (or isn't) safe.",
+  "verdict": "APPROVE or COMMENT",
+  "inline_comments": [
+    {
+      "path": "relative/path/to/file.rs",
+      "line": 42,
+      "side": "RIGHT",
+      "severity": "critical | warning | nit",
+      "body": "Explanation of the issue."
+    }
+  ],
+  "body": "Optional overall review body in markdown. Use this for high-level feedback that doesn't belong on a specific line."
+}
+```
+
+Field details:
+- **verdict**: `APPROVE` — no critical or warning-level issues, change is safe,
+  and the PR does NOT touch consensus-critical paths. `COMMENT` — use for all
+  other cases: consensus-critical PRs, PRs with issues found, or when unsure.
+  Never block a PR.
+- **inline_comments**: Array of line-level comments. Can be empty.
+  - **path**: File path relative to repo root, as shown in the diff.
+  - **line**: The line number in the diff to attach the comment to.
+  - **side**: `RIGHT` for lines in the new version (additions, context on new
+    side), `LEFT` for lines in the old version (deletions). When in doubt, use
+    `RIGHT`.
+  - **severity**: `critical` for likely bugs or security issues, `warning` for
+    code smells or risky patterns, `nit` for style suggestions.
+  - **body**: The comment text. Be specific and actionable. For critical/warning
+    issues, explain what could go wrong.
+- **body**: Overall review comment. Summarize the review, mention consensus
+  impact if relevant. Can be empty string if inline comments cover everything.

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,345 @@
+name: "Claude PR Review"
+
+on:
+  # Use pull_request_target so secrets are available for fork PRs.
+  # Safety: we checkout the base branch (trusted) and only fetch the PR
+  # diff as text — no untrusted code is checked out or executed.
+  pull_request_target:
+    types: [ready_for_review, synchronize]
+
+# One review per PR at a time
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    if: github.repository == 'fedimint/fedimint' && github.event.pull_request.draft == false
+    name: Claude Code Review
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write
+    env:
+      GH_TOKEN: ${{ secrets.BACKPORT_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Checkout the base branch (trusted code only)
+          ref: ${{ github.event.pull_request.base.ref }}
+          fetch-depth: 0
+
+      - name: Fetch PR head
+        run: |
+          # Fetch the PR head commit without checking it out
+          git fetch origin "${{ github.event.pull_request.head.sha }}"
+
+      - name: Get changed files
+        id: changed
+        run: |
+          BASE_SHA=${{ github.event.pull_request.base.sha }}
+          HEAD_SHA=${{ github.event.pull_request.head.sha }}
+          FILES=$(git diff --name-only "$BASE_SHA"..."$HEAD_SHA")
+          echo "files<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$FILES" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+          # Check if any changed file matches consensus-critical patterns
+          CONSENSUS=false
+          while IFS= read -r file; do
+            case "$file" in
+              fedimint-server/src/consensus/*) CONSENSUS=true ;;
+              fedimint-core/src/encoding/*) CONSENSUS=true ;;
+              fedimint-core/src/core.rs) CONSENSUS=true ;;
+              fedimint-core/src/epoch.rs) CONSENSUS=true ;;
+              fedimint-core/src/session_outcome.rs) CONSENSUS=true ;;
+              fedimint-core/src/transaction.rs) CONSENSUS=true ;;
+              fedimint-core/src/module/mod.rs) CONSENSUS=true ;;
+              fedimint-core/src/module/registry.rs) CONSENSUS=true ;;
+              fedimint-server-core/src/lib.rs) CONSENSUS=true ;;
+              fedimint-server-core/src/migration.rs) CONSENSUS=true ;;
+              modules/fedimint-*-server/src/*) CONSENSUS=true ;;
+              fedimint-server/src/config/dkg*) CONSENSUS=true ;;
+              crypto/*) CONSENSUS=true ;;
+            esac
+          done <<< "$FILES"
+
+          echo "consensus=$CONSENSUS" >> "$GITHUB_OUTPUT"
+          echo "Consensus-critical: $CONSENSUS"
+
+      - name: Get diff for review
+        id: diff
+        run: |
+          BASE_SHA=${{ github.event.pull_request.base.sha }}
+          HEAD_SHA=${{ github.event.pull_request.head.sha }}
+
+          git diff "$BASE_SHA"..."$HEAD_SHA" > /tmp/pr_diff.patch
+
+          DIFF_SIZE=$(wc -c < /tmp/pr_diff.patch)
+          MAX_SIZE=200000
+          if [ "$DIFF_SIZE" -gt "$MAX_SIZE" ]; then
+            truncate -s "$MAX_SIZE" /tmp/pr_diff.patch
+            echo -e "\n\n... [diff truncated at ${MAX_SIZE} bytes, full diff is ${DIFF_SIZE} bytes] ..." >> /tmp/pr_diff.patch
+            echo "truncated=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "truncated=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install Claude Code
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Fetch prior AI reviews
+        id: prior
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+
+          # Determine the bot account login from the token
+          BOT_LOGIN=$(gh api user --jq '.login')
+
+          # Fetch all reviews on this PR by the bot account
+          PRIOR=$(gh api \
+            "repos/${{ github.repository }}/pulls/${PR_NUMBER}/reviews" \
+            --jq "[.[] | select(.user.login == \"${BOT_LOGIN}\") | {submitted_at, body, state}] | sort_by(.submitted_at)")
+
+          PRIOR_COUNT=$(echo "$PRIOR" | jq 'length')
+
+          if [ "$PRIOR_COUNT" -gt 0 ]; then
+            echo "has_prior=true" >> "$GITHUB_OUTPUT"
+            # Also grab inline comments from the bot
+            PRIOR_COMMENTS=$(gh api \
+              "repos/${{ github.repository }}/pulls/${PR_NUMBER}/comments" \
+              --jq "[.[] | select(.user.login == \"${BOT_LOGIN}\") | {path, line, side, body, created_at}] | sort_by(.created_at)")
+
+            {
+              echo "## Previous AI reviews on this PR"
+              echo ""
+              echo "Review bodies:"
+              echo '```json'
+              echo "$PRIOR"
+              echo '```'
+              echo ""
+              echo "Inline comments from previous reviews:"
+              echo '```json'
+              echo "$PRIOR_COMMENTS"
+              echo '```'
+            } > /tmp/prior_reviews.txt
+          else
+            echo "has_prior=false" >> "$GITHUB_OUTPUT"
+            echo "" > /tmp/prior_reviews.txt
+          fi
+
+      - name: Build review prompt
+        run: |
+          IS_CONSENSUS="${{ steps.changed.outputs.consensus }}"
+          TRUNCATED="${{ steps.diff.outputs.truncated }}"
+          HAS_PRIOR="${{ steps.prior.outputs.has_prior }}"
+
+          # Prepend the review instructions so Claude has them in context
+          cat .github/agents/review.md > /tmp/review_prompt.txt
+
+          # Include prior AI reviews if they exist
+          if [ "$HAS_PRIOR" = "true" ]; then
+            cat >> /tmp/review_prompt.txt <<'PRIOR_HEADER'
+
+          ---
+
+          The following are your previous reviews on this PR. Build on this context:
+          do not repeat points already made unless they are still unaddressed in the
+          current diff. Focus on what changed since your last review. If previous
+          issues have been fixed, acknowledge that briefly.
+          PRIOR_HEADER
+            cat /tmp/prior_reviews.txt >> /tmp/review_prompt.txt
+          fi
+
+          cat >> /tmp/review_prompt.txt <<'PROMPT_HEADER'
+
+          ---
+
+          Review the following pull request. Follow the review instructions above.
+          Output ONLY valid JSON matching the schema specified above. No other text.
+          PROMPT_HEADER
+
+          # PR metadata
+          cat >> /tmp/review_prompt.txt <<PROMPT_META
+
+          PR Title: ${{ github.event.pull_request.title }}
+          Consensus-critical files changed: ${IS_CONSENSUS}
+          PROMPT_META
+
+          # Conditional instructions
+          if [ "$IS_CONSENSUS" = "true" ]; then
+            cat >> /tmp/review_prompt.txt <<'EOF'
+
+          IMPORTANT: This PR touches CONSENSUS-CRITICAL code paths. You MUST NOT output APPROVE as your verdict. Use COMMENT to provide thorough feedback, paying special attention to determinism, encoding compatibility, and state divergence risks.
+          EOF
+          else
+            cat >> /tmp/review_prompt.txt <<'EOF'
+
+          If this is a straightforward, low-risk change (documentation, tests, CI config, simple refactors, dependency bumps) with no issues found, you may output APPROVE. For anything complex or uncertain, output COMMENT instead.
+          EOF
+          fi
+
+          if [ "$TRUNCATED" = "true" ]; then
+            cat >> /tmp/review_prompt.txt <<'EOF'
+
+          WARNING: The diff was truncated due to size. You are reviewing a partial diff. Do NOT approve — use COMMENT and note that the full diff was too large for automated review.
+          EOF
+          fi
+
+          # Append the diff
+          printf '\nDiff:\n' >> /tmp/review_prompt.txt
+          cat /tmp/pr_diff.patch >> /tmp/review_prompt.txt
+
+      - name: Run Claude review
+        id: claude-review
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          # Run Claude in print mode (non-interactive, stdout only)
+          # Allow up to 30 turns so it can explore the codebase for context
+          RAW=$(claude -p \
+            --model claude-sonnet-4-6 \
+            --max-turns 30 \
+            < /tmp/review_prompt.txt) || true
+
+          if [ -z "$RAW" ]; then
+            echo "Claude produced no output, skipping review"
+            echo "verdict=SKIP" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Extract JSON from the output (Claude may wrap it in markdown fences)
+          # Try to find a JSON block, fall back to treating the whole output as JSON
+          JSON=$(echo "$RAW" | sed -n '/^```json/,/^```$/p' | sed '1d;$d')
+          if [ -z "$JSON" ] || ! echo "$JSON" | jq . > /dev/null 2>&1; then
+            JSON=$(echo "$RAW" | sed -n '/^{/,/^}/p')
+          fi
+          if [ -z "$JSON" ] || ! echo "$JSON" | jq . > /dev/null 2>&1; then
+            # Last resort: try the raw output directly
+            JSON="$RAW"
+          fi
+
+          if ! echo "$JSON" | jq . > /dev/null 2>&1; then
+            echo "Failed to parse Claude output as JSON, posting raw output as comment"
+            echo "$RAW" > /tmp/review_body.txt
+            echo "verdict=COMMENT" >> "$GITHUB_OUTPUT"
+            echo "has_inline=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "$JSON" > /tmp/review.json
+
+          # Extract verdict
+          VERDICT=$(jq -r '.verdict // "COMMENT"' < /tmp/review.json)
+
+          # Never let AI block a PR
+          if [ "$VERDICT" = "REQUEST_CHANGES" ]; then
+            VERDICT="COMMENT"
+          fi
+
+          # Never approve consensus-critical PRs
+          IS_CONSENSUS="${{ steps.changed.outputs.consensus }}"
+          if [ "$IS_CONSENSUS" = "true" ] && [ "$VERDICT" = "APPROVE" ]; then
+            VERDICT="COMMENT"
+          fi
+
+          # Never approve truncated diffs
+          TRUNCATED="${{ steps.diff.outputs.truncated }}"
+          if [ "$TRUNCATED" = "true" ] && [ "$VERDICT" = "APPROVE" ]; then
+            VERDICT="COMMENT"
+          fi
+
+          # Build the overall review body from JSON fields
+          SUMMARY=$(jq -r '.summary // ""' < /tmp/review.json)
+          CONSENSUS_IMPACT=$(jq -r '.consensus_impact // "None"' < /tmp/review.json)
+          BODY=$(jq -r '.body // ""' < /tmp/review.json)
+
+          {
+            echo "## Summary"
+            echo "$SUMMARY"
+            echo ""
+            echo "## Consensus Impact"
+            echo "$CONSENSUS_IMPACT"
+            if [ -n "$BODY" ]; then
+              echo ""
+              echo "$BODY"
+            fi
+            if [ "$IS_CONSENSUS" = "true" ] && [ "$VERDICT" = "COMMENT" ]; then
+              echo ""
+              echo "---"
+              echo "*Auto-approval is disabled for PRs touching consensus-critical code. A human reviewer must approve this PR.*"
+            fi
+            if [ "$TRUNCATED" = "true" ]; then
+              echo ""
+              echo "---"
+              echo "*The diff was too large for complete automated review. A human reviewer should verify the full changeset.*"
+            fi
+          } > /tmp/review_body.txt
+
+          # Check if there are inline comments
+          INLINE_COUNT=$(jq '.inline_comments | length' < /tmp/review.json)
+          if [ "$INLINE_COUNT" -gt 0 ]; then
+            echo "has_inline=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_inline=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          echo "verdict=$VERDICT" >> "$GITHUB_OUTPUT"
+
+      - name: Submit review with inline comments
+        if: steps.claude-review.outputs.verdict != 'SKIP'
+        run: |
+          VERDICT="${{ steps.claude-review.outputs.verdict }}"
+          HAS_INLINE="${{ steps.claude-review.outputs.has_inline }}"
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          COMMIT_SHA="${{ github.event.pull_request.head.sha }}"
+
+          if [ "$VERDICT" = "APPROVE" ]; then
+            GH_EVENT="APPROVE"
+          else
+            GH_EVENT="COMMENT"
+          fi
+
+          if [ "$HAS_INLINE" = "true" ] && [ -f /tmp/review.json ]; then
+            # Build the review with inline comments via the GitHub API
+            # gh pr review doesn't support inline comments, so use the API directly
+            REVIEW_BODY=$(cat /tmp/review_body.txt)
+
+            # Build the comments array for the API
+            COMMENTS=$(jq -c '[.inline_comments[] | {
+              path: .path,
+              line: .line,
+              side: (.side // "RIGHT"),
+              body: (
+                (if .severity == "critical" then "**Critical**: "
+                 elif .severity == "warning" then "**Warning**: "
+                 else "**Nit**: "
+                 end) + .body
+              )
+            }]' < /tmp/review.json)
+
+            # Submit via GitHub REST API
+            jq -n \
+              --arg body "$REVIEW_BODY" \
+              --arg event "$GH_EVENT" \
+              --arg commit_id "$COMMIT_SHA" \
+              --argjson comments "$COMMENTS" \
+              '{
+                body: $body,
+                event: $event,
+                commit_id: $commit_id,
+                comments: $comments
+              }' | gh api \
+              "repos/${{ github.repository }}/pulls/${PR_NUMBER}/reviews" \
+              --method POST \
+              --input -
+          else
+            # No inline comments, use simple gh pr review
+            if [ "$VERDICT" = "APPROVE" ]; then
+              gh pr review "$PR_NUMBER" --approve --body-file /tmp/review_body.txt
+            else
+              gh pr review "$PR_NUMBER" --comment --body-file /tmp/review_body.txt
+            fi
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+Additional agent-specific instructions (e.g. for CI-driven code review) can be found in `.github/agents/`.
+
 ## Project Overview
 
 Fedimint is a modular framework for building federated financial applications. It provides a trust-minimized, censorship-resistant, and private alternative to centralized applications. The core implementation focuses on a federated Chaumian e-cash mint that's natively compatible with Bitcoin and the Lightning Network.


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that runs Claude Code to review PRs when they are marked as ready for review or updated with new commits
- Includes `.github/agents/review.md` with detailed review instructions covering consensus safety, idiomatic Rust, concurrency, atomicity, and determinism
- Never blocks PRs — only comments or approves. Never auto-approves consensus-critical changes. Feeds prior AI reviews into subsequent runs to avoid repetition.

## Details

**Trigger**: `ready_for_review` and `synchronize` (skips drafts)

**Consensus detection**: Pattern-matches changed files against known consensus-critical paths (consensus engine, encoding, module servers, DKG, crypto). When consensus code is touched, auto-approval is hard-blocked regardless of Claude's verdict.

**Output**: Structured JSON with inline comments posted to specific diff lines via the GitHub review API, plus an overall summary with consensus impact assessment.

**Secrets needed**:
- `ANTHROPIC_API_KEY` — for Claude API access
- `BACKPORT_TOKEN` — existing bot token, used to submit reviews

## Test plan
- [x] Add `CLAUDE_CODE_OAUTH_TOKEN` secret to the repo
- [x] Open a test PR touching non-consensus code, mark ready for review, verify Claude posts a review with inline comments
- [ ] Open a test PR touching consensus-critical code, verify it gets `COMMENT` verdict (not `APPROVE`)
- [ ] Push a follow-up commit to a reviewed PR, verify the re-review references prior feedback
- [ ] Verify draft PRs do not trigger the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)