### PR TITLE
ci: add 'opened' trigger to Claude review workflow

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -5,7 +5,7 @@ on:
   # Safety: we checkout the base branch (trusted) and only fetch the PR
   # diff as text — no untrusted code is checked out or executed.
   pull_request_target:
-    types: [ready_for_review, synchronize]
+    types: [opened, ready_for_review, synchronize]
 
 # One review per PR at a time
 concurrency:


### PR DESCRIPTION
## Summary
- Adds `opened` to the `pull_request_target` types so PRs created as non-draft also trigger the review
- Without this, `ready_for_review` only fires on draft→ready transitions

## Test plan
- [ ] Merge this, then push a commit to #8485 to trigger via `synchronize`

🤖 Generated with [Claude Code](https://claude.com/claude-code)