### PR TITLE
chore: bump version to 0.12.0-alpha

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2204,7 +2204,7 @@ dependencies = [
 
 [[package]]
 name = "devimint"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -2697,7 +2697,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fedimint-aead"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "argon2",
@@ -2729,7 +2729,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-api-client"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2755,7 +2755,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-bip39"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "bip39",
  "fedimint-client",
@@ -2766,7 +2766,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-bitcoind"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2781,14 +2781,14 @@ dependencies = [
 
 [[package]]
 name = "fedimint-build"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "fedimint-cli"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2831,7 +2831,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2864,7 +2864,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client-module"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -2895,7 +2895,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client-rpc"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2923,7 +2923,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client-wasm"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2941,7 +2941,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-connectors"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "arti-client",
@@ -2976,7 +2976,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-core"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3042,7 +3042,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-cursed-redb"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3062,7 +3062,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-db-locked"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3074,7 +3074,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dbtool"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3110,7 +3110,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-derive"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
@@ -3120,7 +3120,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-derive-secret"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",
@@ -3132,11 +3132,11 @@ dependencies = [
 
 [[package]]
 name = "fedimint-docs"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 
 [[package]]
 name = "fedimint-dummy-client"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3158,7 +3158,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dummy-common"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -3168,7 +3168,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dummy-server"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3184,7 +3184,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-empty-client"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3201,7 +3201,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-empty-common"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -3211,7 +3211,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-empty-server"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3227,7 +3227,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-eventlog"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3245,7 +3245,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-fountain"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3257,7 +3257,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-fuzz"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "fedimint-core",
  "fedimint-ln-common",
@@ -3270,7 +3270,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-client"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "bcrypt",
@@ -3295,7 +3295,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-common"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -3312,7 +3312,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-server"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3393,7 +3393,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-server-db"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -3421,7 +3421,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-ui"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "async-trait",
  "axum 0.8.8",
@@ -3453,7 +3453,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gw-client"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3483,7 +3483,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gwv2-client"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3510,7 +3510,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-hkdf"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "bitcoin_hashes",
 ]
@@ -3558,7 +3558,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lightning"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3585,7 +3585,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-client"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3619,7 +3619,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-common"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3642,7 +3642,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-server"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3667,7 +3667,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-tests"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3696,7 +3696,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnurl"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "bech32",
  "lightning-invoice",
@@ -3708,7 +3708,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-client"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3740,7 +3740,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-common"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3760,7 +3760,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-server"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3784,7 +3784,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-tests"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3821,7 +3821,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-load-test-tool"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "clap",
@@ -3849,7 +3849,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-logging"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "console-subscriber",
@@ -3862,7 +3862,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-client"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3884,7 +3884,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-common"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -3898,7 +3898,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-server"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3917,7 +3917,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-tests"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "clap",
@@ -3931,7 +3931,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-metrics"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -3943,7 +3943,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-client"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3985,7 +3985,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-common"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",
@@ -3998,7 +3998,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-server"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4025,7 +4025,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-tests"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4059,7 +4059,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mintv2-client"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -4098,7 +4098,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mintv2-common"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",
@@ -4111,7 +4111,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mintv2-server"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4136,7 +4136,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mintv2-tests"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4169,7 +4169,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-portalloc"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "dirs",
@@ -4183,7 +4183,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-recoverytool"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -4206,7 +4206,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-recurringd"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -4235,7 +4235,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-recurringd-tests"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "devimint",
@@ -4249,7 +4249,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-recurringdv2"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -4270,7 +4270,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-rocksdb"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4287,7 +4287,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -4344,7 +4344,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server-bitcoin-rpc"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4360,7 +4360,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server-core"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4378,7 +4378,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server-tests"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "bitcoin",
  "fedimint-api-client",
@@ -4398,7 +4398,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server-ui"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4425,7 +4425,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-tbs"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "bls12_381",
  "criterion 0.5.1",
@@ -4440,7 +4440,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-testing"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4480,7 +4480,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-testing-core"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -4541,7 +4541,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-tpe"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "bitcoin_hashes",
  "bls12_381",
@@ -4555,7 +4555,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ui-common"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "axum 0.8.8",
  "axum-extra",
@@ -4567,7 +4567,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-unknown-common"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -4577,7 +4577,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-unknown-server"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4591,14 +4591,14 @@ dependencies = [
 
 [[package]]
 name = "fedimint-util-error"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "fedimint-wallet-client"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -4628,7 +4628,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-common"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -4644,7 +4644,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-server"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4671,7 +4671,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-tests"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4704,7 +4704,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-walletv2-client"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4731,7 +4731,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-walletv2-common"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -4744,7 +4744,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-walletv2-server"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4766,7 +4766,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-walletv2-tests"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4796,7 +4796,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wasm-tests"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "fedimint-client",
@@ -4817,7 +4817,7 @@ dependencies = [
 
 [[package]]
 name = "fedimintd"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -4854,7 +4854,7 @@ dependencies = [
 
 [[package]]
 name = "fedimintd-envs"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 
 [[package]]
 name = "ff"
@@ -5161,7 +5161,7 @@ dependencies = [
 
 [[package]]
 name = "gateway-tests"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ keywords = ["bitcoin", "lightning", "chaumian", "e-cash", "federated"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/fedimint/fedimint"
-version = "0.11.0-alpha"
+version = "0.12.0-alpha"
 
 [workspace.metadata]
 authors = ["The Fedimint Developers"]
@@ -167,7 +167,7 @@ criterion = "0.5.1"
 # We need to pin this arti's `curve25519-dalek` dependency, due to `https://rustsec.org/advisories/RUSTSEC-2024-0344` vulnerability
 # It's been updated by https://gitlab.torproject.org/tpo/core/arti/-/merge_requests/2211, should be removed in next release.
 curve25519-dalek = ">=4.1.3"
-devimint = { path = "./devimint", version = "=0.11.0-alpha" }
+devimint = { path = "./devimint", version = "=0.12.0-alpha" }
 dirs = "6.0.0"
 erased-serde = "0.4"
 esplora-client = { version = "0.12.3", default-features = false, features = [
@@ -177,70 +177,70 @@ esplora-client = { version = "0.12.3", default-features = false, features = [
 ] }
 tor-rtcompat = { version = "0.38.0", features = ["tokio", "rustls"] }
 
-fedimint-aead = { path = "./crypto/aead", version = "=0.11.0-alpha" }
-fedimint-api-client = { path = "./fedimint-api-client", version = "=0.11.0-alpha" }
-fedimint-bip39 = { path = "./fedimint-bip39", version = "=0.11.0-alpha" }
-fedimint-bitcoind = { path = "./fedimint-bitcoind", version = "=0.11.0-alpha" }
-fedimint-build = { path = "./fedimint-build", version = "=0.11.0-alpha" }
-fedimint-client = { path = "./fedimint-client", version = "=0.11.0-alpha" }
-fedimint-client-module = { path = "./fedimint-client-module", version = "=0.11.0-alpha" }
-fedimint-client-rpc = { path = "./fedimint-client-rpc", version = "=0.11.0-alpha" }
-fedimint-connectors = { path = "./fedimint-connectors", version = "=0.11.0-alpha" }
-fedimint-core = { path = "./fedimint-core", version = "=0.11.0-alpha" }
-fedimint-cursed-redb = { path = "./fedimint-cursed-redb", version = "=0.11.0-alpha" }
-fedimint-db-locked = { path = "./fedimint-db-locked", version = "=0.11.0-alpha" }
-fedimint-derive = { path = "./fedimint-derive", version = "=0.11.0-alpha" }
-fedimint-derive-secret = { path = "./crypto/derive-secret", version = "=0.11.0-alpha" }
-fedimint-dummy-client = { path = "./modules/fedimint-dummy-client", version = "=0.11.0-alpha" }
-fedimint-dummy-common = { path = "./modules/fedimint-dummy-common", version = "=0.11.0-alpha" }
-fedimint-dummy-server = { path = "./modules/fedimint-dummy-server", version = "=0.11.0-alpha" }
-fedimint-empty-common = { path = "./modules/fedimint-empty-common", version = "=0.11.0-alpha" }
-fedimint-eventlog = { path = "./fedimint-eventlog", version = "=0.11.0-alpha" }
-fedimint-gateway-common = { package = "fedimint-gateway-common", path = "./gateway/fedimint-gateway-common", version = "=0.11.0-alpha" }
-fedimint-gateway-server = { package = "fedimint-gateway-server", path = "./gateway/fedimint-gateway-server", version = "=0.11.0-alpha" }
-fedimint-gateway-server-db = { package = "fedimint-gateway-server-db", path = "./gateway/fedimint-gateway-server-db", version = "=0.11.0-alpha" }
-fedimint-gateway-ui = { package = "fedimint-gateway-ui", path = "./gateway/fedimint-gateway-ui", version = "=0.11.0-alpha" }
-fedimint-gw-client = { path = "./modules/fedimint-gw-client", version = "=0.11.0-alpha" }
-fedimint-gwv2-client = { path = "./modules/fedimint-gwv2-client", version = "=0.11.0-alpha" }
-fedimint-lightning = { package = "fedimint-lightning", path = "./gateway/fedimint-lightning", version = "=0.11.0-alpha" }
-fedimint-ln-client = { path = "./modules/fedimint-ln-client", version = "=0.11.0-alpha" }
-fedimint-ln-common = { path = "./modules/fedimint-ln-common", version = "=0.11.0-alpha" }
-fedimint-ln-server = { path = "./modules/fedimint-ln-server", version = "=0.11.0-alpha" }
-fedimint-lnurl = { path = "./fedimint-lnurl", version = "=0.11.0-alpha" }
-fedimint-lnv2-client = { path = "./modules/fedimint-lnv2-client", version = "=0.11.0-alpha" }
-fedimint-lnv2-common = { path = "./modules/fedimint-lnv2-common", version = "=0.11.0-alpha" }
-fedimint-lnv2-server = { path = "./modules/fedimint-lnv2-server", version = "=0.11.0-alpha" }
-fedimint-logging = { path = "./fedimint-logging", version = "=0.11.0-alpha" }
-fedimint-meta-client = { path = "./modules/fedimint-meta-client", version = "=0.11.0-alpha" }
-fedimint-meta-common = { path = "./modules/fedimint-meta-common", version = "=0.11.0-alpha" }
-fedimint-meta-server = { path = "./modules/fedimint-meta-server", version = "=0.11.0-alpha" }
-fedimint-metrics = { path = "./fedimint-metrics", version = "=0.11.0-alpha" }
-fedimint-mint-client = { path = "./modules/fedimint-mint-client", version = "=0.11.0-alpha" }
-fedimint-mint-common = { path = "./modules/fedimint-mint-common", version = "=0.11.0-alpha" }
-fedimint-mint-server = { path = "./modules/fedimint-mint-server", version = "=0.11.0-alpha" }
-fedimint-mintv2-client = { path = "./modules/fedimint-mintv2-client", version = "=0.11.0-alpha" }
-fedimint-mintv2-common = { path = "./modules/fedimint-mintv2-common", version = "=0.11.0-alpha" }
-fedimint-mintv2-server = { path = "./modules/fedimint-mintv2-server", version = "=0.11.0-alpha" }
-fedimint-portalloc = { path = "utils/portalloc", version = "=0.11.0-alpha" }
-fedimint-rocksdb = { path = "./fedimint-rocksdb", version = "=0.11.0-alpha" }
-fedimint-server = { path = "./fedimint-server", version = "=0.11.0-alpha" }
-fedimint-server-bitcoin-rpc = { path = "./fedimint-server-bitcoin-rpc", version = "=0.11.0-alpha" }
-fedimint-server-core = { path = "./fedimint-server-core", version = "=0.11.0-alpha" }
-fedimint-server-ui = { path = "./fedimint-server-ui", version = "=0.11.0-alpha" }
-fedimint-testing = { path = "./fedimint-testing", version = "=0.11.0-alpha" }
-fedimint-testing-core = { path = "./fedimint-testing-core", version = "=0.11.0-alpha" }
-fedimint-ui-common = { path = "./fedimint-ui-common", version = "=0.11.0-alpha" }
-fedimint-unknown-common = { path = "./modules/fedimint-unknown-common", version = "=0.11.0-alpha" }
-fedimint-unknown-server = { path = "./modules/fedimint-unknown-server", version = "=0.11.0-alpha" }
-fedimint-util-error = { path = "./fedimint-util-error", version = "=0.11.0-alpha" }
-fedimint-wallet-client = { path = "./modules/fedimint-wallet-client", version = "=0.11.0-alpha" }
-fedimint-wallet-common = { path = "./modules/fedimint-wallet-common", version = "=0.11.0-alpha" }
-fedimint-wallet-server = { path = "./modules/fedimint-wallet-server", version = "=0.11.0-alpha" }
-fedimint-walletv2-client = { path = "./modules/fedimint-walletv2-client", version = "=0.11.0-alpha" }
-fedimint-walletv2-common = { path = "./modules/fedimint-walletv2-common", version = "=0.11.0-alpha" }
-fedimint-walletv2-server = { path = "./modules/fedimint-walletv2-server", version = "=0.11.0-alpha" }
-fedimintd = { path = "./fedimintd", version = "=0.11.0-alpha" }
-fedimintd-envs = { path = "./fedimintd-envs", version = "=0.11.0-alpha" }
+fedimint-aead = { path = "./crypto/aead", version = "=0.12.0-alpha" }
+fedimint-api-client = { path = "./fedimint-api-client", version = "=0.12.0-alpha" }
+fedimint-bip39 = { path = "./fedimint-bip39", version = "=0.12.0-alpha" }
+fedimint-bitcoind = { path = "./fedimint-bitcoind", version = "=0.12.0-alpha" }
+fedimint-build = { path = "./fedimint-build", version = "=0.12.0-alpha" }
+fedimint-client = { path = "./fedimint-client", version = "=0.12.0-alpha" }
+fedimint-client-module = { path = "./fedimint-client-module", version = "=0.12.0-alpha" }
+fedimint-client-rpc = { path = "./fedimint-client-rpc", version = "=0.12.0-alpha" }
+fedimint-connectors = { path = "./fedimint-connectors", version = "=0.12.0-alpha" }
+fedimint-core = { path = "./fedimint-core", version = "=0.12.0-alpha" }
+fedimint-cursed-redb = { path = "./fedimint-cursed-redb", version = "=0.12.0-alpha" }
+fedimint-db-locked = { path = "./fedimint-db-locked", version = "=0.12.0-alpha" }
+fedimint-derive = { path = "./fedimint-derive", version = "=0.12.0-alpha" }
+fedimint-derive-secret = { path = "./crypto/derive-secret", version = "=0.12.0-alpha" }
+fedimint-dummy-client = { path = "./modules/fedimint-dummy-client", version = "=0.12.0-alpha" }
+fedimint-dummy-common = { path = "./modules/fedimint-dummy-common", version = "=0.12.0-alpha" }
+fedimint-dummy-server = { path = "./modules/fedimint-dummy-server", version = "=0.12.0-alpha" }
+fedimint-empty-common = { path = "./modules/fedimint-empty-common", version = "=0.12.0-alpha" }
+fedimint-eventlog = { path = "./fedimint-eventlog", version = "=0.12.0-alpha" }
+fedimint-gateway-common = { package = "fedimint-gateway-common", path = "./gateway/fedimint-gateway-common", version = "=0.12.0-alpha" }
+fedimint-gateway-server = { package = "fedimint-gateway-server", path = "./gateway/fedimint-gateway-server", version = "=0.12.0-alpha" }
+fedimint-gateway-server-db = { package = "fedimint-gateway-server-db", path = "./gateway/fedimint-gateway-server-db", version = "=0.12.0-alpha" }
+fedimint-gateway-ui = { package = "fedimint-gateway-ui", path = "./gateway/fedimint-gateway-ui", version = "=0.12.0-alpha" }
+fedimint-gw-client = { path = "./modules/fedimint-gw-client", version = "=0.12.0-alpha" }
+fedimint-gwv2-client = { path = "./modules/fedimint-gwv2-client", version = "=0.12.0-alpha" }
+fedimint-lightning = { package = "fedimint-lightning", path = "./gateway/fedimint-lightning", version = "=0.12.0-alpha" }
+fedimint-ln-client = { path = "./modules/fedimint-ln-client", version = "=0.12.0-alpha" }
+fedimint-ln-common = { path = "./modules/fedimint-ln-common", version = "=0.12.0-alpha" }
+fedimint-ln-server = { path = "./modules/fedimint-ln-server", version = "=0.12.0-alpha" }
+fedimint-lnurl = { path = "./fedimint-lnurl", version = "=0.12.0-alpha" }
+fedimint-lnv2-client = { path = "./modules/fedimint-lnv2-client", version = "=0.12.0-alpha" }
+fedimint-lnv2-common = { path = "./modules/fedimint-lnv2-common", version = "=0.12.0-alpha" }
+fedimint-lnv2-server = { path = "./modules/fedimint-lnv2-server", version = "=0.12.0-alpha" }
+fedimint-logging = { path = "./fedimint-logging", version = "=0.12.0-alpha" }
+fedimint-meta-client = { path = "./modules/fedimint-meta-client", version = "=0.12.0-alpha" }
+fedimint-meta-common = { path = "./modules/fedimint-meta-common", version = "=0.12.0-alpha" }
+fedimint-meta-server = { path = "./modules/fedimint-meta-server", version = "=0.12.0-alpha" }
+fedimint-metrics = { path = "./fedimint-metrics", version = "=0.12.0-alpha" }
+fedimint-mint-client = { path = "./modules/fedimint-mint-client", version = "=0.12.0-alpha" }
+fedimint-mint-common = { path = "./modules/fedimint-mint-common", version = "=0.12.0-alpha" }
+fedimint-mint-server = { path = "./modules/fedimint-mint-server", version = "=0.12.0-alpha" }
+fedimint-mintv2-client = { path = "./modules/fedimint-mintv2-client", version = "=0.12.0-alpha" }
+fedimint-mintv2-common = { path = "./modules/fedimint-mintv2-common", version = "=0.12.0-alpha" }
+fedimint-mintv2-server = { path = "./modules/fedimint-mintv2-server", version = "=0.12.0-alpha" }
+fedimint-portalloc = { path = "utils/portalloc", version = "=0.12.0-alpha" }
+fedimint-rocksdb = { path = "./fedimint-rocksdb", version = "=0.12.0-alpha" }
+fedimint-server = { path = "./fedimint-server", version = "=0.12.0-alpha" }
+fedimint-server-bitcoin-rpc = { path = "./fedimint-server-bitcoin-rpc", version = "=0.12.0-alpha" }
+fedimint-server-core = { path = "./fedimint-server-core", version = "=0.12.0-alpha" }
+fedimint-server-ui = { path = "./fedimint-server-ui", version = "=0.12.0-alpha" }
+fedimint-testing = { path = "./fedimint-testing", version = "=0.12.0-alpha" }
+fedimint-testing-core = { path = "./fedimint-testing-core", version = "=0.12.0-alpha" }
+fedimint-ui-common = { path = "./fedimint-ui-common", version = "=0.12.0-alpha" }
+fedimint-unknown-common = { path = "./modules/fedimint-unknown-common", version = "=0.12.0-alpha" }
+fedimint-unknown-server = { path = "./modules/fedimint-unknown-server", version = "=0.12.0-alpha" }
+fedimint-util-error = { path = "./fedimint-util-error", version = "=0.12.0-alpha" }
+fedimint-wallet-client = { path = "./modules/fedimint-wallet-client", version = "=0.12.0-alpha" }
+fedimint-wallet-common = { path = "./modules/fedimint-wallet-common", version = "=0.12.0-alpha" }
+fedimint-wallet-server = { path = "./modules/fedimint-wallet-server", version = "=0.12.0-alpha" }
+fedimint-walletv2-client = { path = "./modules/fedimint-walletv2-client", version = "=0.12.0-alpha" }
+fedimint-walletv2-common = { path = "./modules/fedimint-walletv2-common", version = "=0.12.0-alpha" }
+fedimint-walletv2-server = { path = "./modules/fedimint-walletv2-server", version = "=0.12.0-alpha" }
+fedimintd = { path = "./fedimintd", version = "=0.12.0-alpha" }
+fedimintd-envs = { path = "./fedimintd-envs", version = "=0.12.0-alpha" }
 ff = "0.13.1"
 fs-lock = "=0.1.10"
 fs2 = "0.4.3"
@@ -252,7 +252,7 @@ gloo-timers = "0.3.0"
 group = "0.13.0"
 hex = "0.4.3"
 hex-conservative = "1.0.0"
-hkdf = { package = "fedimint-hkdf", path = "./crypto/hkdf", version = "=0.11.0-alpha" }
+hkdf = { package = "fedimint-hkdf", path = "./crypto/hkdf", version = "=0.12.0-alpha" }
 honggfuzz = { version = "=0.5.55", default-features = false } # needs to be pinned to the same version `cargo-fuzz` binary uses
 hyper = "1.6"
 imbl = "5.0.0"
@@ -329,7 +329,7 @@ substring = "1.4.5"
 subtle = "2.6.1"
 syn = "2.0"
 tar = "0.4.45"
-tbs = { package = "fedimint-tbs", path = "./crypto/tbs", version = "=0.11.0-alpha" }
+tbs = { package = "fedimint-tbs", path = "./crypto/tbs", version = "=0.12.0-alpha" }
 tempfile = "3.20.0"
 test-log = { version = "0.2", features = ["trace"], default-features = false }
 thiserror = "2.0.18"
@@ -348,7 +348,7 @@ tonic_lnd = { version = "0.4.0", package = "fedimint-tonic-lnd", features = [
 ] }
 tower = { version = "0.4.13", default-features = false }
 tower-http = { version = "0.6.8", features = ["cors"] }
-tpe = { package = "fedimint-tpe", path = "./crypto/tpe", version = "=0.11.0-alpha" }
+tpe = { package = "fedimint-tpe", path = "./crypto/tpe", version = "=0.12.0-alpha" }
 tracing = "0.1.44"
 tracing-opentelemetry = "0.29.0"
 tracing-subscriber = "0.3.22"


### PR DESCRIPTION
## Summary
- Bump all workspace crate versions from `0.11.0-alpha` to `0.12.0-alpha`
- Update Start9 package files (Dockerfile, manifest.yaml, migrations.ts)

## Test plan
- [x] `cargo clippy` passes clean
- [x] `cargo check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)