### PR TITLE
fix: increase gateway base port (pre-dkg)

### DIFF
--- a/justfile.fedimint.just
+++ b/justfile.fedimint.just
@@ -150,10 +150,10 @@ devimint-env-pre-dkg *PARAMS:
   @>&2 echo "fedimint-1 UI: http://localhost:2006"
   @>&2 echo "fedimint-2 UI: http://localhost:2010"
   @>&2 echo "fedimint-3 UI: http://localhost:2014"
-  @>&2 echo "gateway LND UI: http://localhost:8173"
-  @>&2 echo "gateway LDK UI: http://localhost:8175"
-  @>&2 echo "gateway LDK2 UI: http://localhost:8177"
-  env FM_FEDERATIONS_BASE_PORT=2000 FM_GATEWAY_BASE_PORT=8170 FM_PRE_DKG=true ./scripts/dev/devimint-env.sh {{PARAMS}}
+  @>&2 echo "gateway LND UI: http://localhost:8183"
+  @>&2 echo "gateway LDK UI: http://localhost:8185"
+  @>&2 echo "gateway LDK2 UI: http://localhost:8187"
+  env FM_FEDERATIONS_BASE_PORT=2000 FM_GATEWAY_BASE_PORT=8180 FM_PRE_DKG=true ./scripts/dev/devimint-env.sh {{PARAMS}}
 
 # Spawn devimint post-dkg on fixed port numbers (useful for UI work)
 devimint-env-post-dkg *PARAMS:
@@ -161,10 +161,10 @@ devimint-env-post-dkg *PARAMS:
   @>&2 echo "fedimint-1 UI: http://localhost:2006"
   @>&2 echo "fedimint-2 UI: http://localhost:2010"
   @>&2 echo "fedimint-3 UI: http://localhost:2014"
-  @>&2 echo "gateway LND UI: http://localhost:8173"
-  @>&2 echo "gateway LDK UI: http://localhost:8175"
-  @>&2 echo "gateway LDK2 UI: http://localhost:8177"
-  env FM_FEDERATIONS_BASE_PORT=2000 FM_GATEWAY_BASE_PORT=8170 ./scripts/dev/devimint-env.sh {{PARAMS}}
+  @>&2 echo "gateway LND UI: http://localhost:8183"
+  @>&2 echo "gateway LDK UI: http://localhost:8185"
+  @>&2 echo "gateway LDK2 UI: http://localhost:8187"
+  env FM_FEDERATIONS_BASE_PORT=2000 FM_GATEWAY_BASE_PORT=8180 ./scripts/dev/devimint-env.sh {{PARAMS}}
 
 devimint-env-tmux *PARAMS:
   ./scripts/dev/tmuxinator/run.sh {{PARAMS}}


### PR DESCRIPTION
The base gateway port conflicts the fedimintd's default port, which is a tad annoying for dev work if you're also running fedimintd signet instance.