### PR TITLE
feat: Optional Taproot Walletv2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4771,6 +4771,7 @@ dependencies = [
  "async-stream",
  "bitcoin",
  "bitcoincore-rpc",
+ "clap",
  "devimint",
  "fedimint-bitcoind",
  "fedimint-client",

--- a/fedimint-api-client/src/api/global_api/with_cache.rs
+++ b/fedimint-api-client/src/api/global_api/with_cache.rs
@@ -390,6 +390,7 @@ where
         disable_base_fees: Option<bool>,
         enabled_modules: Option<BTreeSet<ModuleKind>>,
         federation_size: Option<u32>,
+        use_taproot: Option<bool>,
         auth: ApiAuth,
     ) -> FederationResult<String> {
         self.request_admin(
@@ -400,6 +401,7 @@ where
                 disable_base_fees,
                 enabled_modules,
                 federation_size,
+                use_taproot,
             }),
             auth,
         )

--- a/fedimint-api-client/src/api/mod.rs
+++ b/fedimint-api-client/src/api/mod.rs
@@ -500,6 +500,7 @@ pub trait IGlobalFederationApi: IRawFederationApi {
 
     async fn setup_status(&self, auth: ApiAuth) -> FederationResult<SetupStatus>;
 
+    #[allow(clippy::too_many_arguments)]
     async fn set_local_params(
         &self,
         name: String,
@@ -507,6 +508,7 @@ pub trait IGlobalFederationApi: IRawFederationApi {
         disable_base_fees: Option<bool>,
         enabled_modules: Option<BTreeSet<ModuleKind>>,
         federation_size: Option<u32>,
+        use_taproot: Option<bool>,
         auth: ApiAuth,
     ) -> FederationResult<String>;
 

--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -1422,6 +1422,7 @@ impl FedimintCli {
                         None,
                         None,
                         *federation_size,
+                        None,
                         cli.auth()?,
                     )
                     .await?;

--- a/fedimint-core/src/admin_client.rs
+++ b/fedimint-core/src/admin_client.rs
@@ -55,6 +55,9 @@ pub struct SetLocalParamsRequest {
     /// Total number of guardians (including the one who sets this), set by the
     /// leader
     pub federation_size: Option<u32>,
+    /// Whether walletv2 should use Taproot, set by the leader
+    #[serde(default)]
+    pub use_taproot: Option<bool>,
 }
 
 /// Archive of all the guardian config files that can be used to recover a lost

--- a/fedimint-core/src/envs.rs
+++ b/fedimint-core/src/envs.rs
@@ -31,6 +31,9 @@ pub const FM_ENABLE_MODULE_WALLETV2_ENV: &str = "FM_ENABLE_MODULE_WALLETV2";
 /// Disable mint base fees for testing and development environments
 pub const FM_DISABLE_BASE_FEES_ENV: &str = "FM_DISABLE_BASE_FEES";
 
+/// Use taproot based wallet instead of segwit
+pub const FM_USE_TAPROOT_WALLETV2_ENV: &str = "FM_USE_TAPROOT_WALLETV2";
+
 /// Print sensitive secrets without redacting them. Use only for debugging.
 pub const FM_DEBUG_SHOW_SECRETS_ENV: &str = "FM_DEBUG_SHOW_SECRETS";
 

--- a/fedimint-core/src/setup_code.rs
+++ b/fedimint-core/src/setup_code.rs
@@ -23,6 +23,10 @@ pub struct PeerSetupCode {
     /// Total number of guardians (including the one who sets this), set by the
     /// leader
     pub federation_size: Option<u32>,
+    /// Whether the walletv2 module should use Taproot instead of SegWit v0.
+    /// Set by the leader. `None` means the value was not configured by this
+    /// peer; `Some(false)` is the default used by existing federations.
+    pub use_taproot: Option<bool>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Encodable, Decodable, Serialize)]

--- a/fedimint-server-core/src/init.rs
+++ b/fedimint-server-core/src/init.rs
@@ -51,6 +51,11 @@ pub struct ConfigGenModuleArgs {
     pub network: Network,
     /// Whether to disable base fees for this federation
     pub disable_base_fees: bool,
+    /// Whether the walletv2 module should use a Taproot (P2TR + Schnorr)
+    /// multisig instead of the default SegWit v0 (P2WSH + ECDSA) multisig.
+    /// Decided once by the lead guardian during federation setup; other
+    /// modules ignore this flag.
+    pub use_taproot: bool,
 }
 
 /// Interface for Module Generation

--- a/fedimint-server-core/src/setup_ui.rs
+++ b/fedimint-server-core/src/setup_ui.rs
@@ -33,6 +33,7 @@ pub trait ISetupApi {
     async fn reset_setup_codes(&self);
 
     /// Set local guardian parameters
+    #[allow(clippy::too_many_arguments)]
     async fn set_local_parameters(
         &self,
         auth: ApiAuth,
@@ -41,6 +42,7 @@ pub trait ISetupApi {
         disable_base_fees: Option<bool>,
         enabled_modules: Option<BTreeSet<ModuleKind>>,
         federation_size: Option<u32>,
+        use_taproot: Option<bool>,
     ) -> Result<String>;
 
     /// Add peer connection info
@@ -58,6 +60,9 @@ pub trait ISetupApi {
 
     /// Returns whether base fees are disabled, if set by any setup code
     async fn cfg_base_fees_disabled(&self) -> Option<bool>;
+
+    /// Returns whether walletv2 should use Taproot, if set by any setup code
+    async fn cfg_use_taproot(&self) -> Option<bool>;
 
     /// Returns the enabled modules, if set by any setup code
     async fn cfg_enabled_modules(&self) -> Option<BTreeSet<ModuleKind>>;

--- a/fedimint-server-ui/src/setup.rs
+++ b/fedimint-server-ui/src/setup.rs
@@ -39,6 +39,8 @@ pub(crate) struct SetupInput {
     pub enable_base_fees: bool,
     #[serde(default)] // list of enabled module kinds
     pub enabled_modules: Vec<String>,
+    #[serde(default)]
+    pub use_taproot: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -182,6 +184,17 @@ fn setup_form_content(
                 #modules-list:has(.form-check-input:not(:checked)) ~ #modules-warning {
                     display: block;
                 }
+
+                #taproot-section {
+                    display: none;
+                    opacity: 0;
+                    transition: opacity 0.3s ease-in;
+                }
+
+                #taproot-section.visible {
+                    display: block;
+                    opacity: 1;
+                }
                 "#
             }
 
@@ -280,9 +293,43 @@ fn setup_form_content(
                                     div id="modules-warning" class="alert alert-warning mt-2 mb-0" style="font-size: 0.875rem;" {
                                         "Only modify this if you know what you are doing. Disabled modules cannot be enabled later."
                                     }
+
+                                    div id="taproot-section" class="mt-3" {
+                                        div class="form-check" {
+                                            input type="checkbox" class="form-check-input"
+                                                id="use_taproot" name="use_taproot" value="true";
+
+                                            label class="form-check-label" for="use_taproot" {
+                                                "Use Taproot (SegWit v1) for on-chain wallet"
+                                                span class="badge bg-warning text-dark ms-2" { "experimental" }
+                                            }
+                                        }
+                                    }
                                 }
                             }
                         }
+                    }
+
+                    script {
+                        (PreEscaped(r#"
+                        (function() {
+                            var clickCount = 0;
+                            var clickTimer = null;
+                            var btn = document.querySelector('#modulesAccordion .accordion-button');
+                            if (btn) {
+                                btn.addEventListener('click', function() {
+                                    clickCount++;
+                                    clearTimeout(clickTimer);
+                                    clickTimer = setTimeout(function() { clickCount = 0; }, 2000);
+                                    if (clickCount >= 7) {
+                                        var el = document.getElementById('taproot-section');
+                                        if (el) { el.classList.add('visible'); }
+                                        clickCount = 0;
+                                    }
+                                });
+                            }
+                        })();
+                        "#))
                     }
                 }
             }
@@ -365,6 +412,12 @@ async fn setup_submit(
         None
     };
 
+    let use_taproot = if input.is_lead && input.use_taproot {
+        Some(true)
+    } else {
+        None
+    };
+
     match state
         .api
         .set_local_parameters(
@@ -374,6 +427,7 @@ async fn setup_submit(
             disable_base_fees,
             enabled_modules,
             federation_size,
+            use_taproot,
         )
         .await
     {

--- a/fedimint-server/src/config/mod.rs
+++ b/fedimint-server/src/config/mod.rs
@@ -250,6 +250,8 @@ pub struct ConfigGenParams {
     pub enabled_modules: BTreeSet<ModuleKind>,
     /// Bitcoin network for this federation
     pub network: bitcoin::Network,
+    /// Whether walletv2 should use a Taproot multisig instead of SegWit v0
+    pub use_taproot: bool,
 }
 
 impl ServerConfigConsensus {
@@ -497,6 +499,7 @@ impl ServerConfig {
         let args = ConfigGenModuleArgs {
             network: peer0.network,
             disable_base_fees: peer0.disable_base_fees,
+            use_taproot: peer0.use_taproot,
         };
 
         // Use legacy module ordering for backwards compatibility tests
@@ -651,6 +654,7 @@ impl ServerConfig {
         let args = ConfigGenModuleArgs {
             network: params.network,
             disable_base_fees: params.disable_base_fees,
+            use_taproot: params.use_taproot,
         };
 
         // Use legacy module ordering for backwards compatibility tests

--- a/fedimint-server/src/config/setup.rs
+++ b/fedimint-server/src/config/setup.rs
@@ -17,7 +17,7 @@ use fedimint_core::endpoint_constants::{
 };
 use fedimint_core::envs::{
     FM_DISABLE_BASE_FEES_ENV, FM_IROH_API_SECRET_KEY_OVERRIDE_ENV,
-    FM_IROH_P2P_SECRET_KEY_OVERRIDE_ENV, is_env_var_set,
+    FM_IROH_P2P_SECRET_KEY_OVERRIDE_ENV, FM_USE_TAPROOT_WALLETV2_ENV, is_env_var_set,
 };
 use fedimint_core::module::{
     ApiAuth, ApiEndpoint, ApiEndpointContext, ApiError, ApiRequestErased, ApiVersion, api_endpoint,
@@ -70,6 +70,8 @@ pub struct LocalParams {
     /// Total number of guardians (including the one who sets this), set by the
     /// leader
     federation_size: Option<u32>,
+    /// Whether walletv2 should use Taproot, set by the leader
+    use_taproot: Option<bool>,
 }
 
 impl LocalParams {
@@ -81,6 +83,7 @@ impl LocalParams {
             disable_base_fees: self.disable_base_fees,
             enabled_modules: self.enabled_modules.clone(),
             federation_size: self.federation_size,
+            use_taproot: self.use_taproot,
         }
     }
 }
@@ -176,6 +179,7 @@ impl ISetupApi for SetupApi {
         disable_base_fees: Option<bool>,
         enabled_modules: Option<BTreeSet<ModuleKind>>,
         federation_size: Option<u32>,
+        use_taproot: Option<bool>,
     ) -> anyhow::Result<String> {
         if let Some(existing_local_parameters) = self.state.lock().await.local_params.clone()
             && existing_local_parameters.auth.as_str() == auth.as_str()
@@ -184,6 +188,7 @@ impl ISetupApi for SetupApi {
             && existing_local_parameters.disable_base_fees == disable_base_fees
             && existing_local_parameters.enabled_modules == enabled_modules
             && existing_local_parameters.federation_size == federation_size
+            && existing_local_parameters.use_taproot == use_taproot
         {
             return Ok(base32::encode_prefixed(
                 FEDIMINT_PREFIX,
@@ -254,6 +259,7 @@ impl ISetupApi for SetupApi {
                 disable_base_fees,
                 enabled_modules,
                 federation_size,
+                use_taproot,
             }
         } else {
             let (tls_cert, tls_key) =
@@ -283,6 +289,7 @@ impl ISetupApi for SetupApi {
                 disable_base_fees,
                 enabled_modules,
                 federation_size,
+                use_taproot,
             }
         };
 
@@ -336,6 +343,18 @@ impl ISetupApi for SetupApi {
             ensure!(
                 info.disable_base_fees.is_none(),
                 "Base fees setting has already been configured to disabled={disable_base_fees}"
+            );
+        }
+
+        if let Some(use_taproot) = state
+            .setup_codes
+            .iter()
+            .chain(once(&local_params.setup_code()))
+            .find_map(|info| info.use_taproot)
+        {
+            ensure!(
+                info.use_taproot.is_none(),
+                "Taproot wallet setting has already been configured to use_taproot={use_taproot}"
             );
         }
 
@@ -409,6 +428,12 @@ impl ISetupApi for SetupApi {
             .find_map(|info| info.disable_base_fees)
             .unwrap_or(is_env_var_set(FM_DISABLE_BASE_FEES_ENV));
 
+        let use_taproot = state
+            .setup_codes
+            .iter()
+            .find_map(|info| info.use_taproot)
+            .unwrap_or(is_env_var_set(FM_USE_TAPROOT_WALLETV2_ENV));
+
         let enabled_modules = state
             .setup_codes
             .iter()
@@ -438,6 +463,7 @@ impl ISetupApi for SetupApi {
             disable_base_fees,
             enabled_modules,
             network: self.settings.network,
+            use_taproot,
         };
 
         self.sender
@@ -476,6 +502,16 @@ impl ISetupApi for SetupApi {
             .iter()
             .chain(local_setup_code.iter())
             .find_map(|info| info.disable_base_fees)
+    }
+
+    async fn cfg_use_taproot(&self) -> Option<bool> {
+        let state = self.state.lock().await;
+        let local_setup_code = state.local_params.as_ref().map(LocalParams::setup_code);
+        state
+            .setup_codes
+            .iter()
+            .chain(local_setup_code.iter())
+            .find_map(|info| info.use_taproot)
     }
 
     async fn cfg_enabled_modules(&self) -> Option<BTreeSet<ModuleKind>> {
@@ -531,7 +567,7 @@ pub fn server_endpoints() -> Vec<ApiEndpoint<SetupApi>> {
                     .request_auth()
                     .ok_or(ApiError::bad_request("Missing password".to_string()))?;
 
-                 config.set_local_parameters(auth, request.name, request.federation_name, request.disable_base_fees, request.enabled_modules, request.federation_size)
+                 config.set_local_parameters(auth, request.name, request.federation_name, request.disable_base_fees, request.enabled_modules, request.federation_size, request.use_taproot)
                     .await
                     .map_err(|e| ApiError::bad_request(e.to_string()))
             }

--- a/fedimint-testing-core/src/config.rs
+++ b/fedimint-testing-core/src/config.rs
@@ -61,6 +61,7 @@ pub fn local_config_gen_params(
                 disable_base_fees: Some(!enable_mint_fees),
                 enabled_modules: None,
                 federation_size: None,
+                use_taproot: None,
             };
             (*peer, params)
         })
@@ -80,6 +81,7 @@ pub fn local_config_gen_params(
                 disable_base_fees: !enable_mint_fees,
                 enabled_modules: enabled_modules.clone(),
                 network: bitcoin::Network::Regtest,
+                use_taproot: false,
             };
             Ok((*peer, params))
         })

--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -1344,6 +1344,7 @@ mod tests {
         let args = fedimint_server_core::ConfigGenModuleArgs {
             network: Network::Regtest,
             disable_base_fees: false,
+            use_taproot: false,
         };
         let server_cfg = ServerModuleInit::trusted_dealer_gen(&LightningInit, &peers, &args);
 

--- a/modules/fedimint-mint-server/src/test.rs
+++ b/modules/fedimint-mint-server/src/test.rs
@@ -19,6 +19,7 @@ fn build_configs() -> (Vec<ServerModuleConfig>, ClientModuleConfig) {
     let args = ConfigGenModuleArgs {
         network: bitcoin::Network::Regtest,
         disable_base_fees: false,
+        use_taproot: false,
     };
     let mint_cfg = MintInit.trusted_dealer_gen(&peers, &args);
     let client_cfg = ClientModuleConfig::from_typed(

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -1136,6 +1136,7 @@ fn build_wallet_server_configs() -> anyhow::Result<(
     let args = fedimint_server_core::ConfigGenModuleArgs {
         network: bitcoin::Network::Regtest,
         disable_base_fees: false,
+        use_taproot: false,
     };
     let wallet_cfg =
         fedimint_server::core::ServerModuleInit::trusted_dealer_gen(&WalletInit, &peers, &args);

--- a/modules/fedimint-walletv2-client/src/lib.rs
+++ b/modules/fedimint-walletv2-client/src/lib.rs
@@ -48,10 +48,10 @@ use fedimint_core::task::{TaskGroup, block_in_place, sleep};
 use fedimint_core::{Amount, OutPoint, TransactionId, apply, async_trait_maybe_send};
 use fedimint_derive_secret::{ChildId, DerivableSecret};
 use fedimint_logging::LOG_CLIENT_MODULE_WALLETV2;
-use fedimint_walletv2_common::config::WalletClientConfig;
+use fedimint_walletv2_common::config::{WalletClientConfig, WalletDescriptor};
 use fedimint_walletv2_common::{
     KIND, StandardScript, TxInfo, WalletCommonInit, WalletInput, WalletInputV0, WalletModuleTypes,
-    WalletOutput, WalletOutputV0, descriptor, is_potential_receive,
+    WalletOutput, WalletOutputV0, descriptor, descriptor_tr, is_potential_receive,
 };
 use futures::StreamExt;
 use receive_sm::{ReceiveSMCommon, ReceiveSMState, ReceiveStateMachine};
@@ -391,11 +391,15 @@ impl WalletClientModule {
     }
 
     fn derive_address(&self, index: u64) -> Address {
-        descriptor(
-            &self.cfg.bitcoin_pks,
-            &self.derive_tweak(index).public_key().consensus_hash(),
-        )
-        .address(self.cfg.network)
+        let tweak = self.derive_tweak(index).public_key().consensus_hash();
+        match self.cfg.descriptor {
+            WalletDescriptor::Wsh => {
+                descriptor(&self.cfg.bitcoin_pks, &tweak).address(self.cfg.network)
+            }
+            WalletDescriptor::Tr => {
+                descriptor_tr(&self.cfg.bitcoin_pks, &tweak).address(self.cfg.network)
+            }
+        }
     }
 
     fn derive_tweak(&self, index: u64) -> Keypair {

--- a/modules/fedimint-walletv2-common/src/config.rs
+++ b/modules/fedimint-walletv2-common/src/config.rs
@@ -8,7 +8,7 @@ use fedimint_core::{Amount, PeerId, plugin_types_trait_impl_config, weight_to_vb
 use secp256k1::{PublicKey, SecretKey};
 use serde::{Deserialize, Serialize};
 
-use crate::{WalletCommonInit, descriptor};
+use crate::{WalletCommonInit, descriptor, descriptor_tr};
 
 plugin_types_trait_impl_config!(
     WalletCommonInit,
@@ -78,6 +78,7 @@ impl WalletConfigConsensus {
         bitcoin_pks: BTreeMap<PeerId, PublicKey>,
         fee_consensus: FeeConsensus,
         network: Network,
+        use_taproot: bool,
     ) -> Self {
         let tx_overhead_weight = 4 * 4 // nVersion
             + 1 // SegWit marker
@@ -86,10 +87,23 @@ impl WalletConfigConsensus {
             + 4 // up to 2 outputs
             + 4 * 4; // nLockTime
 
-        let change_witness_weight = descriptor(&bitcoin_pks, &sha256::Hash::all_zeros())
-            .max_weight_to_satisfy()
-            .expect("Cannot satisfy the change descriptor.")
-            .to_wu();
+        let change_witness_weight = if use_taproot {
+            descriptor_tr(&bitcoin_pks, &sha256::Hash::all_zeros())
+                .max_weight_to_satisfy()
+                .expect("Cannot satisfy the taproot change descriptor.")
+                .to_wu()
+        } else {
+            descriptor(&bitcoin_pks, &sha256::Hash::all_zeros())
+                .max_weight_to_satisfy()
+                .expect("Cannot satisfy the change descriptor.")
+                .to_wu()
+        };
+
+        let descriptor = if use_taproot {
+            WalletDescriptor::Tr
+        } else {
+            WalletDescriptor::Wsh
+        };
 
         let change_input_weight = 32 * 4 // txid
             + 4 * 4 // vout
@@ -107,7 +121,7 @@ impl WalletConfigConsensus {
 
         Self {
             bitcoin_pks,
-            descriptor: WalletDescriptor::Wsh,
+            descriptor,
             send_tx_vbytes: weight_to_vbytes(
                 tx_overhead_weight
                     + change_input_weight
@@ -209,6 +223,7 @@ fn test_fee_consensus() {
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize, Encodable, Decodable)]
 pub enum WalletDescriptor {
     Wsh,
+    Tr,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize, Encodable, Decodable)]

--- a/modules/fedimint-walletv2-common/src/lib.rs
+++ b/modules/fedimint-walletv2-common/src/lib.rs
@@ -6,6 +6,7 @@
 #![allow(clippy::return_self_not_must_use)]
 
 use std::collections::BTreeMap;
+use std::sync::Arc;
 use std::time::Duration;
 
 use bitcoin::hashes::{Hash, hash160, sha256};
@@ -18,9 +19,10 @@ use fedimint_core::module::{CommonModuleInit, ModuleCommon, ModuleConsensusVersi
 use fedimint_core::{
     NumPeersExt, PeerId, extensible_associated_module_type, plugin_types_trait_impl_common,
 };
-use miniscript::descriptor::Wsh;
+use miniscript::descriptor::{TapTree, Tr, Wsh};
+use miniscript::{Miniscript, Tap, Terminal, Threshold};
 use secp256k1::ecdsa::Signature;
-use secp256k1::{PublicKey, Scalar, XOnlyPublicKey};
+use secp256k1::{PublicKey, Scalar, XOnlyPublicKey, schnorr};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -29,7 +31,7 @@ pub mod endpoint_constants;
 
 pub const KIND: ModuleKind = ModuleKind::from_static_str("walletv2");
 
-pub const MODULE_CONSENSUS_VERSION: ModuleConsensusVersion = ModuleConsensusVersion::new(1, 0);
+pub const MODULE_CONSENSUS_VERSION: ModuleConsensusVersion = ModuleConsensusVersion::new(1, 1);
 
 /// Returns a sleep duration of 1 second in test environments or 60 seconds in
 /// production. Used for polling intervals where faster feedback is needed
@@ -58,6 +60,54 @@ pub fn tweak_public_key(pk: &PublicKey, tweak: &sha256::Hash) -> PublicKey {
         &Scalar::from_be_bytes(tweak.to_byte_array()).expect("Hash is within field order"),
     )
     .expect("Failed to tweak bitcoin public key")
+}
+
+/// Provably unspendable x-only public key (BIP-341 NUMS point from the
+/// BIP-341 spec). Used as the internal key in our Taproot descriptor so
+/// that key-path spending is impossible — only the script path may be
+/// used.
+pub fn nums_point() -> XOnlyPublicKey {
+    XOnlyPublicKey::from_slice(&[
+        0x50, 0x92, 0x9b, 0x74, 0xc1, 0xa0, 0x49, 0x54, 0xb7, 0x8b, 0x4b, 0x60, 0x35, 0xe9, 0x7a,
+        0x5e, 0x07, 0x8a, 0x5a, 0x0f, 0x28, 0xec, 0x96, 0xd5, 0x47, 0xbf, 0xee, 0x9a, 0xce, 0x80,
+        0x3a, 0xc0,
+    ])
+    .expect("Valid x-only public key")
+}
+
+pub fn tweak_xonly_public_key(pk: &XOnlyPublicKey, tweak: &sha256::Hash) -> XOnlyPublicKey {
+    let full_pk = PublicKey::from_x_only_public_key(*pk, secp256k1::Parity::Even);
+    let tweaked = full_pk
+        .add_exp_tweak(
+            secp256k1::SECP256K1,
+            &Scalar::from_be_bytes(tweak.to_byte_array()).expect("Hash is within field order"),
+        )
+        .expect("Failed to tweak bitcoin public key");
+    tweaked.x_only_public_key().0
+}
+
+/// Build the federation's Taproot multi-`a` descriptor for the given tweak.
+///
+/// The internal key is a provably unspendable BIP-341 NUMS point so the
+/// only way to spend is via the script path. The script path commits to a
+/// `multi_a` of the guardians' tweaked x-only keys.
+pub fn descriptor_tr(
+    pks: &BTreeMap<PeerId, PublicKey>,
+    tweak: &sha256::Hash,
+) -> Tr<XOnlyPublicKey> {
+    let threshold = pks.to_num_peers().threshold();
+    let mut tweaked: Vec<XOnlyPublicKey> = pks
+        .values()
+        .map(|pk| tweak_xonly_public_key(&pk.x_only_public_key().0, tweak))
+        .collect();
+    tweaked.sort();
+
+    let thresh = Threshold::new(threshold, tweaked).expect("Failed to create multi_a threshold");
+    let ms = Miniscript::<XOnlyPublicKey, Tap>::from_ast(Terminal::MultiA(thresh))
+        .expect("Failed to create multi_a miniscript");
+    let tree = TapTree::Leaf(Arc::new(ms));
+
+    Tr::new(nums_point(), Some(tree)).expect("Failed to construct Tr descriptor")
 }
 
 /// Returns true if the script pubkey potentially belongs to the federation.
@@ -136,6 +186,7 @@ pub enum WalletConsensusItem {
     BlockCount(u64),
     Feerate(Option<u64>),
     Signatures(Txid, Vec<Signature>),
+    SchnorrSignatures(Txid, Vec<schnorr::Signature>),
     #[encodable_default]
     Default {
         variant: u64,
@@ -154,6 +205,9 @@ impl std::fmt::Display for WalletConsensusItem {
             }
             WalletConsensusItem::Signatures(..) => {
                 write!(f, "Wallet Signatures")
+            }
+            WalletConsensusItem::SchnorrSignatures(..) => {
+                write!(f, "Wallet Schnorr Signatures")
             }
             WalletConsensusItem::Default { variant, .. } => {
                 write!(f, "Unknown Wallet CI variant={variant}")

--- a/modules/fedimint-walletv2-server/src/db.rs
+++ b/modules/fedimint-walletv2-server/src/db.rs
@@ -3,6 +3,7 @@ use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::{PeerId, impl_db_lookup, impl_db_record};
 use fedimint_walletv2_common::TxInfo;
 use secp256k1::ecdsa::Signature;
+use secp256k1::schnorr;
 use serde::Serialize;
 use strum_macros::EnumIter;
 
@@ -21,6 +22,7 @@ pub enum DbKeyPrefix {
     Signatures = 0x37,
     UnconfirmedTx = 0x38,
     FederationWallet = 0x39,
+    SchnorrSignatures = 0x3a,
 }
 
 impl std::fmt::Display for DbKeyPrefix {
@@ -137,6 +139,31 @@ impl_db_record!(
 impl_db_lookup!(key = SignaturesKey, query_prefix = SignaturesTxidPrefix);
 
 impl_db_lookup!(key = SignaturesKey, query_prefix = SignaturesPrefix);
+
+#[derive(Clone, Debug, Encodable, Decodable, Serialize)]
+pub struct SchnorrSignaturesKey(pub Txid, pub PeerId);
+
+#[derive(Clone, Debug, Encodable, Decodable)]
+pub struct SchnorrSignaturesTxidPrefix(pub Txid);
+
+#[derive(Clone, Debug, Encodable, Decodable)]
+pub struct SchnorrSignaturesPrefix;
+
+impl_db_record!(
+    key = SchnorrSignaturesKey,
+    value = Vec<schnorr::Signature>,
+    db_prefix = DbKeyPrefix::SchnorrSignatures,
+);
+
+impl_db_lookup!(
+    key = SchnorrSignaturesKey,
+    query_prefix = SchnorrSignaturesTxidPrefix
+);
+
+impl_db_lookup!(
+    key = SchnorrSignaturesKey,
+    query_prefix = SchnorrSignaturesPrefix
+);
 
 #[derive(Clone, Debug, Encodable, Decodable, Serialize)]
 pub struct UnconfirmedTxKey(pub Txid);

--- a/modules/fedimint-walletv2-server/src/lib.rs
+++ b/modules/fedimint-walletv2-server/src/lib.rs
@@ -11,6 +11,7 @@
 #![allow(clippy::too_many_lines)]
 
 pub mod db;
+mod taproot;
 
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -63,7 +64,7 @@ use fedimint_server_core::{
 };
 pub use fedimint_walletv2_common as common;
 use fedimint_walletv2_common::config::{
-    FeeConsensus, WalletClientConfig, WalletConfig, WalletConfigPrivate,
+    FeeConsensus, WalletClientConfig, WalletConfig, WalletConfigPrivate, WalletDescriptor,
 };
 use fedimint_walletv2_common::endpoint_constants::{
     CONSENSUS_BLOCK_COUNT_ENDPOINT, CONSENSUS_FEERATE_ENDPOINT, FEDERATION_WALLET_ENDPOINT,
@@ -72,20 +73,21 @@ use fedimint_walletv2_common::endpoint_constants::{
 };
 use fedimint_walletv2_common::{
     FederationWallet, MODULE_CONSENSUS_VERSION, TxInfo, WalletInputError, WalletOutputError,
-    descriptor, is_potential_receive, tweak_public_key,
+    descriptor, is_potential_receive, tweak_public_key, tweak_xonly_public_key,
 };
 use futures::StreamExt;
 use miniscript::descriptor::Wsh;
 use rand::rngs::OsRng;
 use secp256k1::ecdsa::Signature;
-use secp256k1::{PublicKey, Scalar, SecretKey};
+use secp256k1::{PublicKey, Scalar, SecretKey, schnorr};
 use serde::{Deserialize, Serialize};
 use strum::IntoEnumIterator;
 use tracing::{debug, info};
 
 use crate::db::{
-    BlockCountVoteKey, BlockCountVotePrefix, FeeRateVoteKey, FeeRateVotePrefix, TxInfoKey,
-    TxInfoPrefix, UnconfirmedTxKey, UnconfirmedTxPrefix, UnsignedTxKey, UnsignedTxPrefix,
+    BlockCountVoteKey, BlockCountVotePrefix, FeeRateVoteKey, FeeRateVotePrefix,
+    SchnorrSignaturesPrefix, TxInfoKey, TxInfoPrefix, UnconfirmedTxKey, UnconfirmedTxPrefix,
+    UnsignedTxKey, UnsignedTxPrefix,
 };
 
 /// Number of confirmations required for a transaction to be considered as
@@ -232,6 +234,16 @@ impl ModuleInit for WalletInit {
                         "Wallet Signatures"
                     );
                 }
+                DbKeyPrefix::SchnorrSignatures => {
+                    push_db_pair_items!(
+                        dbtx,
+                        SchnorrSignaturesPrefix,
+                        SchnorrSignaturesKey,
+                        Vec<schnorr::Signature>,
+                        wallet,
+                        "Wallet Schnorr Signatures"
+                    );
+                }
                 DbKeyPrefix::UnconfirmedTx => {
                     push_db_pair_items!(
                         dbtx,
@@ -324,6 +336,7 @@ impl ServerModuleInit for WalletInit {
                         bitcoin_pks.clone(),
                         fee_consensus.clone(),
                         args.network,
+                        args.use_taproot,
                     ),
                 };
 
@@ -349,7 +362,12 @@ impl ServerModuleInit for WalletInit {
 
         let config = WalletConfig {
             private: WalletConfigPrivate { bitcoin_sk },
-            consensus: WalletConfigConsensus::new(bitcoin_pks, fee_consensus, args.network),
+            consensus: WalletConfigConsensus::new(
+                bitcoin_pks,
+                fee_consensus,
+                args.network,
+                args.use_taproot,
+            ),
         };
 
         Ok(config.to_erased())
@@ -409,20 +427,28 @@ impl ServerModule for Wallet {
         &'a self,
         dbtx: &mut DatabaseTransaction<'_>,
     ) -> Vec<WalletConsensusItem> {
+        let our_pk = self.cfg.private.bitcoin_sk.public_key(secp256k1::SECP256K1);
+
         let mut items = dbtx
             .find_by_prefix(&UnsignedTxPrefix)
             .await
-            .map(|(key, unsigned_tx)| {
-                let signatures = self.sign_tx(&unsigned_tx);
-
-                self.verify_signatures(
-                    &unsigned_tx,
-                    &signatures,
-                    self.cfg.private.bitcoin_sk.public_key(secp256k1::SECP256K1),
-                )
-                .expect("Our signatures failed verification against our private key");
-
-                WalletConsensusItem::Signatures(key.0, signatures)
+            .map(|(key, unsigned_tx)| match self.cfg.consensus.descriptor {
+                WalletDescriptor::Wsh => {
+                    let signatures = self.sign_tx(&unsigned_tx);
+                    self.verify_signatures(
+                        &unsigned_tx,
+                        &signatures,
+                        self.cfg.private.bitcoin_sk.public_key(secp256k1::SECP256K1),
+                    )
+                    .expect("Our signatures failed verification against our private key");
+                    WalletConsensusItem::Signatures(key.0, signatures)
+                }
+                WalletDescriptor::Tr => {
+                    let signatures = self.sign_tx_schnorr(&unsigned_tx);
+                    self.verify_signatures_schnorr(&unsigned_tx, &signatures, our_pk)
+                        .expect("Our signatures failed verification against our private key");
+                    WalletConsensusItem::SchnorrSignatures(key.0, signatures)
+                }
             })
             .collect::<Vec<WalletConsensusItem>>()
             .await;
@@ -475,7 +501,19 @@ impl ServerModule for Wallet {
                 Ok(())
             }
             WalletConsensusItem::Signatures(txid, signatures) => {
+                ensure!(
+                    self.cfg.consensus.descriptor == WalletDescriptor::Wsh,
+                    "Received ECDSA signature on a Taproot Federation"
+                );
                 self.process_signatures(dbtx, txid, signatures, peer).await
+            }
+            WalletConsensusItem::SchnorrSignatures(txid, signatures) => {
+                ensure!(
+                    self.cfg.consensus.descriptor == WalletDescriptor::Tr,
+                    "Received Schnorr Signature on a Segwit Federation"
+                );
+                self.process_signatures_schnorr(dbtx, txid, signatures, peer)
+                    .await
             }
             WalletConsensusItem::Default { variant, .. } => Err(anyhow!(
                 "Received wallet consensus item with unknown variant {variant}"
@@ -504,9 +542,7 @@ impl ServerModule for Wallet {
             .await
             .ok_or(WalletInputError::UnknownOutputIndex)?;
 
-        let tweaked_pubkey = self
-            .descriptor(&input.tweak.consensus_hash())
-            .script_pubkey();
+        let tweaked_pubkey = self.script_pubkey_for(&input.tweak.consensus_hash());
 
         if tracked_output.script_pubkey != tweaked_pubkey {
             return Err(WalletInputError::WrongTweak);
@@ -558,7 +594,7 @@ impl ServerModule for Wallet {
                 ],
                 output: vec![TxOut {
                     value: change_value,
-                    script_pubkey: self.descriptor(&wallet.consensus_hash()).script_pubkey(),
+                    script_pubkey: self.script_pubkey_for(&wallet.consensus_hash()),
                 }],
             };
 
@@ -700,7 +736,7 @@ impl ServerModule for Wallet {
             output: vec![
                 TxOut {
                     value: change_value,
-                    script_pubkey: self.descriptor(&wallet.consensus_hash()).script_pubkey(),
+                    script_pubkey: self.script_pubkey_for(&wallet.consensus_hash()),
                 },
                 TxOut {
                     value: output.value,
@@ -1317,7 +1353,12 @@ impl Wallet {
         dbtx.find_by_range(OutputKey(start_index)..OutputKey(end_index))
             .await
             .filter_map(|entry| {
-                std::future::ready(entry.1.1.script_pubkey.is_p2wsh().then(|| OutputInfo {
+                let matches = if self.cfg.consensus.descriptor == WalletDescriptor::Tr {
+                    entry.1.1.script_pubkey.is_p2tr()
+                } else {
+                    entry.1.1.script_pubkey.is_p2wsh()
+                };
+                std::future::ready(matches.then(|| OutputInfo {
                     index: entry.0.0,
                     script: entry.1.1.script_pubkey,
                     value: entry.1.1.value,
@@ -1416,7 +1457,14 @@ impl Wallet {
             .consensus
             .bitcoin_pks
             .iter()
-            .map(|(peer, pk)| (*peer, tweak_public_key(pk, &wallet.tweak).to_string()))
+            .map(|(peer, pk)| {
+                let tweaked = if self.cfg.consensus.descriptor == WalletDescriptor::Tr {
+                    tweak_xonly_public_key(&pk.x_only_public_key().0, &wallet.tweak).to_string()
+                } else {
+                    tweak_public_key(pk, &wallet.tweak).to_string()
+                };
+                (*peer, tweaked)
+            })
             .collect();
 
         let tweak = &Scalar::from_be_bytes(wallet.tweak.to_byte_array())

--- a/modules/fedimint-walletv2-server/src/taproot.rs
+++ b/modules/fedimint-walletv2-server/src/taproot.rs
@@ -1,0 +1,229 @@
+use std::collections::BTreeMap;
+
+use anyhow::{Context, bail, ensure};
+use bitcoin::hashes::sha256;
+use bitcoin::sighash::{Prevouts, SighashCache};
+use bitcoin::taproot::LeafVersion;
+use bitcoin::{ScriptBuf, TapLeafHash, TxOut};
+use fedimint_core::db::{DatabaseTransaction, IDatabaseTransactionOpsCoreTyped};
+use fedimint_core::util::FmtCompactAnyhow;
+use fedimint_core::{BitcoinHash, NumPeersExt, PeerId};
+use fedimint_logging::LOG_MODULE_WALLETV2;
+use fedimint_walletv2_common::config::WalletDescriptor;
+use fedimint_walletv2_common::{descriptor_tr, tweak_xonly_public_key};
+use futures::StreamExt;
+use secp256k1::{Keypair, PublicKey, Scalar, XOnlyPublicKey, schnorr};
+use tracing::debug;
+
+use crate::db::{
+    SchnorrSignaturesKey, SchnorrSignaturesTxidPrefix, UnconfirmedTxKey, UnsignedTxKey,
+};
+use crate::{FederationTx, Wallet};
+
+impl Wallet {
+    pub(crate) fn script_pubkey_for(&self, tweak: &sha256::Hash) -> ScriptBuf {
+        match self.cfg.consensus.descriptor {
+            WalletDescriptor::Wsh => self.descriptor(tweak).script_pubkey(),
+            WalletDescriptor::Tr => {
+                descriptor_tr(&self.cfg.consensus.bitcoin_pks, tweak).script_pubkey()
+            }
+        }
+    }
+
+    pub(crate) async fn process_signatures_schnorr(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        txid: bitcoin::Txid,
+        signatures: Vec<schnorr::Signature>,
+        peer: PeerId,
+    ) -> anyhow::Result<()> {
+        let mut unsigned = dbtx
+            .get_value(&UnsignedTxKey(txid))
+            .await
+            .context("Unsigned transaction does not exist")?;
+
+        let pk = self
+            .cfg
+            .consensus
+            .bitcoin_pks
+            .get(&peer)
+            .expect("Failed to get public key of peer from config");
+
+        self.verify_signatures_schnorr(&unsigned, &signatures, *pk)?;
+
+        if dbtx
+            .insert_entry(&SchnorrSignaturesKey(txid, peer), &signatures)
+            .await
+            .is_some()
+        {
+            bail!("Already received valid signatures from this peer")
+        }
+
+        let signatures = dbtx
+            .find_by_prefix(&SchnorrSignaturesTxidPrefix(txid))
+            .await
+            .map(|(key, signatures)| (key.1, signatures))
+            .collect::<BTreeMap<PeerId, Vec<schnorr::Signature>>>()
+            .await;
+
+        if signatures.len() == self.cfg.consensus.bitcoin_pks.to_num_peers().threshold() {
+            dbtx.remove_entry(&UnsignedTxKey(txid)).await;
+
+            dbtx.remove_by_prefix(&SchnorrSignaturesTxidPrefix(txid))
+                .await;
+
+            self.finalize_tx_schnorr(&mut unsigned, &signatures);
+
+            dbtx.insert_new_entry(&UnconfirmedTxKey(txid), &unsigned)
+                .await;
+            if let Err(err) = self.btc_rpc.submit_transaction(unsigned.tx).await {
+                debug!(target: LOG_MODULE_WALLETV2, err = %err.fmt_compact_anyhow(), "Error broadcasting finalized transaction");
+            }
+        }
+        Ok(())
+    }
+
+    fn tap_leaf_hash(&self, tweak: &sha256::Hash) -> TapLeafHash {
+        let tr = descriptor_tr(&self.cfg.consensus.bitcoin_pks, tweak);
+        let (_, ms) = tr
+            .iter_scripts()
+            .next()
+            .expect("Taproot descriptor always has exactly one script leaf");
+        TapLeafHash::from_script(&ms.encode(), LeafVersion::TapScript)
+    }
+
+    fn build_prevouts(&self, unsigned_tx: &FederationTx) -> Vec<TxOut> {
+        unsigned_tx
+            .spent_tx_outs
+            .iter()
+            .map(|utxo| TxOut {
+                value: utxo.value,
+                script_pubkey: self.script_pubkey_for(&utxo.tweak),
+            })
+            .collect()
+    }
+
+    pub(crate) fn sign_tx_schnorr(&self, unsigned_tx: &FederationTx) -> Vec<schnorr::Signature> {
+        let prevouts = self.build_prevouts(unsigned_tx);
+        let mut sighash_cache = SighashCache::new(unsigned_tx.tx.clone());
+
+        unsigned_tx
+            .spent_tx_outs
+            .iter()
+            .enumerate()
+            .map(|(index, utxo)| {
+                let leaf_hash = self.tap_leaf_hash(&utxo.tweak);
+                let sighash = sighash_cache
+                    .taproot_script_spend_signature_hash(
+                        index,
+                        &Prevouts::All(&prevouts),
+                        leaf_hash,
+                        bitcoin::TapSighashType::Default,
+                    )
+                    .expect("Failed to compute taproot script spend sighash");
+
+                let scalar = &Scalar::from_be_bytes(utxo.tweak.to_byte_array())
+                    .expect("Hash is within field order");
+
+                let keypair =
+                    Keypair::from_secret_key(secp256k1::SECP256K1, &self.cfg.private.bitcoin_sk);
+                let tweaked_keypair = keypair
+                    .add_xonly_tweak(secp256k1::SECP256K1, scalar)
+                    .expect("Failed to tweak bitcoin keypair");
+                secp256k1::SECP256K1
+                    .sign_schnorr(&secp256k1::Message::from(sighash), &tweaked_keypair)
+            })
+            .collect()
+    }
+
+    pub(crate) fn verify_signatures_schnorr(
+        &self,
+        unsigned_tx: &FederationTx,
+        signatures: &[schnorr::Signature],
+        pk: PublicKey,
+    ) -> anyhow::Result<()> {
+        ensure!(
+            unsigned_tx.spent_tx_outs.len() == signatures.len(),
+            "Incorrect number of signatures"
+        );
+
+        let prevouts = self.build_prevouts(unsigned_tx);
+        let mut sighash_cache = SighashCache::new(unsigned_tx.tx.clone());
+
+        let xonly = pk.x_only_public_key().0;
+
+        for ((index, utxo), signature) in unsigned_tx
+            .spent_tx_outs
+            .iter()
+            .enumerate()
+            .zip(signatures.iter())
+        {
+            let leaf_hash = self.tap_leaf_hash(&utxo.tweak);
+
+            let sighash = sighash_cache
+                .taproot_script_spend_signature_hash(
+                    index,
+                    &Prevouts::All(&prevouts),
+                    leaf_hash,
+                    bitcoin::TapSighashType::Default,
+                )
+                .expect("Failed to compute taproot script spend sighash");
+
+            let pk = tweak_xonly_public_key(&xonly, &utxo.tweak);
+
+            secp256k1::SECP256K1.verify_schnorr(
+                signature,
+                &secp256k1::Message::from(sighash),
+                &pk,
+            )?;
+        }
+
+        Ok(())
+    }
+
+    fn finalize_tx_schnorr(
+        &self,
+        federation_tx: &mut FederationTx,
+        signatures: &BTreeMap<PeerId, Vec<schnorr::Signature>>,
+    ) {
+        assert_eq!(
+            federation_tx.spent_tx_outs.len(),
+            federation_tx.tx.input.len()
+        );
+
+        for (index, utxo) in federation_tx.spent_tx_outs.iter().enumerate() {
+            let leaf_hash = self.tap_leaf_hash(&utxo.tweak);
+
+            let satisfier: BTreeMap<(XOnlyPublicKey, TapLeafHash), bitcoin::taproot::Signature> =
+                signatures
+                    .iter()
+                    .map(|(peer, sigs)| {
+                        assert_eq!(sigs.len(), federation_tx.tx.input.len());
+
+                        let pk = self
+                            .cfg
+                            .consensus
+                            .bitcoin_pks
+                            .get(peer)
+                            .expect("Failed to get public key of peer from config")
+                            .x_only_public_key()
+                            .0;
+
+                        let pk = tweak_xonly_public_key(&pk, &utxo.tweak);
+
+                        (
+                            (pk, leaf_hash),
+                            bitcoin::taproot::Signature {
+                                signature: sigs[index],
+                                sighash_type: bitcoin::TapSighashType::Default,
+                            },
+                        )
+                    })
+                    .collect();
+
+            miniscript::Descriptor::Tr(descriptor_tr(&self.cfg.consensus.bitcoin_pks, &utxo.tweak))
+                .satisfy(&mut federation_tx.tx.input[index], satisfier)
+                .expect("Failed to satisfy descriptor");
+        }
+    }
+}

--- a/modules/fedimint-walletv2-tests/Cargo.toml
+++ b/modules/fedimint-walletv2-tests/Cargo.toml
@@ -22,6 +22,7 @@ anyhow = { workspace = true }
 async-stream = { workspace = true }
 bitcoin = { workspace = true }
 bitcoincore-rpc = { workspace = true }
+clap = { workspace = true }
 devimint = { workspace = true }
 fedimint-bitcoind = { workspace = true }
 fedimint-client = { workspace = true }

--- a/modules/fedimint-walletv2-tests/bin/tests.rs
+++ b/modules/fedimint-walletv2-tests/bin/tests.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 use anyhow::ensure;
 use bitcoin::address::NetworkUnchecked;
 use bitcoin::{Address, Txid};
+use clap::Parser;
 use devimint::external::Bitcoind;
 use devimint::federation::Client;
 use devimint::version_constants::VERSION_0_11_0_ALPHA;
@@ -13,6 +14,13 @@ use serde::Deserialize;
 use tokio::task::JoinHandle;
 use tokio::try_join;
 use tracing::info;
+
+#[derive(Parser)]
+struct Opts {
+    /// Enable taproot support for walletv2
+    #[arg(long)]
+    taproot: bool,
+}
 
 /// Spawns a background task that mines a block every 100ms, simulating
 /// continuous block production. This prevents deadlocks where the federation's
@@ -139,8 +147,13 @@ async fn get_deposit_address(client: &Client) -> anyhow::Result<Address> {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    let opts = Opts::parse();
+
     // Enable walletv2 module instead of wallet v1
     unsafe { std::env::set_var("FM_ENABLE_MODULE_WALLETV2", "true") };
+    if opts.taproot {
+        unsafe { std::env::set_var("FM_USE_TAPROOT_WALLETV2", "true") };
+    }
     unsafe { std::env::set_var("FM_ENABLE_MODULE_WALLET", "false") };
 
     devimint::run_devfed_test()

--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -175,6 +175,11 @@ function walletv2_module() {
 }
 export -f walletv2_module
 
+function walletv2_module_taproot() {
+  fm-run-test "${FUNCNAME[0]}" env FM_OFFLINE_NODES=0 ./scripts/tests/walletv2-module-test.sh --taproot
+}
+export -f walletv2_module_taproot
+
 function mintv2_module_test() {
   # mintv2 tests don't support different versions, so we skip for backwards-compatibility tests
   if [ -z "${FM_BACKWARDS_COMPATIBILITY_TEST:-}" ]; then
@@ -448,6 +453,7 @@ tests_to_run_in_parallel+=(
   "lnv2_module_lnurl_pay"
   "lnv1_lnv2_swap"
   "walletv2_module"
+  "walletv2_module_taproot"
   "mintv2_module_test"
   "devimint_cli_test"
   "devimint_cli_test_single"

--- a/scripts/tests/walletv2-module-test.sh
+++ b/scripts/tests/walletv2-module-test.sh
@@ -8,4 +8,4 @@ source scripts/_common.sh
 build_workspace
 add_target_dir_to_path
 
-fedimint-walletv2-devimint-tests 
+fedimint-walletv2-devimint-tests "$@"


### PR DESCRIPTION
Builds on: https://github.com/fedimint/fedimint/pull/8490

Let's try this again :)

We recently closed https://github.com/fedimint/fedimint/pull/8382 which migrated Walletv2 to a Taproot wallet because it did not add too much additional benefit and we were close to a release. Now, I believe we can add it, but in a backwards compatible way that allows users to opt-in using Taproot at federation setup time.

 - No existing functionality has been changed. Existing Walletv2 federations with Segwit v0 continue to work and they can also still be set up.
 - All taproot logic is isolated in its own module, that is less than 250 lines of code. Very clean separation.
 - Only backwards incompatible change is the addition of the `use_taproot` to the server and client configurations. This has been handled in the custom `Decodable` implementation. Everything else is just minimal additional logic.

Federation leader can enable Taproot in the UI. The setting is currently hidden: the user needs to open and close the Advanced section 7 times for the setting to even show up (similar to a dev mode in Android). This will allow us to make breaking changes to the taproot signing process, but still test out a Taproot wallet in the meantime.

Why do this now? Well, I believe that this is a necessary requirement for implementing FROST/ROAST. We will always need the fallback path for recovery, so we might as well implement it. From here, we can add FROST signing for a true Taproot wallet using the keyspend. But this is a first step.

Default advanced section:
<img width="870" height="1701" alt="image" src="https://github.com/user-attachments/assets/734046ca-f3fd-4132-afa4-60008b1cbfec" />

After clicking the arrow 7 times:
<img width="874" height="1755" alt="image" src="https://github.com/user-attachments/assets/3f3ab572-8be3-445f-b4c4-b908d293f0c5" />
