### PR TITLE
feat:implemented and added spend_exact_denominations_notes to rpc

### DIFF
--- a/fedimint-core/src/tiered_multi.rs
+++ b/fedimint-core/src/tiered_multi.rs
@@ -126,6 +126,11 @@ impl<T> TieredMulti<T> {
         #[cfg(debug_assertions)]
         self.iter().for_each(|(_, v)| debug_assert!(!v.is_empty()));
     }
+
+    /// Returns the number of items in the given amount `tier`
+    pub fn tier_count(&self, tier: Amount) -> usize {
+        self.0.get(tier).map_or(0, Vec::len)
+    }
 }
 
 impl<C> FromIterator<(Amount, C)> for TieredMulti<C> {

--- a/fedimint-core/src/tiered_multi.rs
+++ b/fedimint-core/src/tiered_multi.rs
@@ -275,8 +275,12 @@ impl Decodable for TieredCounts {
         Ok(Self(
             tiered_counts_u64
                 .into_iter()
-                .map(|(amount, count)| (amount, count as usize))
-                .collect(),
+                .map(|(amount, count)| {
+                    usize::try_from(count)
+                        .map(|c| (amount, c))
+                        .map_err(DecodeError::from_err)
+                })
+                .collect::<Result<_, _>>()?,
         ))
     }
 }

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -19,6 +19,8 @@ mod input;
 mod oob;
 /// State machines for mint outputs
 pub mod output;
+/// State machines for spending notes with exact denominations
+pub mod spend_exact;
 
 pub mod events;
 
@@ -115,6 +117,7 @@ use crate::oob::{MintOOBStateMachine, MintOOBStates};
 use crate::output::{
     MintOutputCommon, MintOutputStateMachine, MintOutputStates, NoteIssuanceRequest,
 };
+use crate::spend_exact::SpendExactStateMachine;
 
 const MINT_E_CASH_TYPE_CHILD_ID: ChildId = ChildId(0);
 
@@ -523,6 +526,18 @@ pub enum SpendOOBState {
     Refunded,
 }
 
+/// The high-level state of a spend exact operation started with
+/// [`MintClientModule::spend_notes_with_exact_denominations`].
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub enum SpendExactState {
+    /// We need to reissue notes to get the exact denominations
+    Reissuing,
+    /// We have exact notes available and the operation completed immediately
+    Success(TieredMulti<SpendableNote>),
+    /// Some error happened and the operation failed
+    Failed(String),
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MintOperationMeta {
     pub variant: MintOperationMetaVariant,
@@ -550,6 +565,10 @@ pub enum MintOperationMetaVariant {
     SpendOOB {
         requested_amount: Amount,
         oob_notes: OOBNotes,
+    },
+    SpendExact {
+        requested_denominations: TieredCounts,
+        change_outpoints: Option<OutPointRange>,
     },
 }
 
@@ -1260,7 +1279,7 @@ impl MintClientModule {
             dbtx,
             &SelectNotesWithAtleastAmount,
             min_amount,
-            self.cfg.fee_consensus.clone(),
+            self.cfg.fee_consensus,
         )
         .await?;
 
@@ -1866,7 +1885,8 @@ impl MintClientModule {
 
                 (txid, out_points)
             }
-            MintOperationMetaVariant::SpendOOB { .. } => bail!("Operation is not a reissuance"),
+            MintOperationMetaVariant::SpendOOB { .. }
+            | MintOperationMetaVariant::SpendExact { .. } => bail!("Operation is not a reissuance"),
         };
 
         let client_ctx = self.client_ctx.clone();
@@ -2668,6 +2688,7 @@ pub enum MintClientStateMachines {
     Output(MintOutputStateMachine),
     Input(MintInputStateMachine),
     OOB(MintOOBStateMachine),
+    SpendExact(SpendExactStateMachine),
     // Removed in https://github.com/fedimint/fedimint/pull/4035 , now ignored
     Restore(MintRestoreStateMachine),
 }
@@ -2707,6 +2728,12 @@ impl State for MintClientStateMachines {
                     MintClientStateMachines::OOB
                 )
             }
+            MintClientStateMachines::SpendExact(spend_exact_state) => {
+                sm_enum_variant_translation!(
+                    spend_exact_state.transitions(context, global_context),
+                    MintClientStateMachines::SpendExact
+                )
+            }
             MintClientStateMachines::Restore(_) => {
                 sm_enum_variant_translation!(vec![], MintClientStateMachines::Restore)
             }
@@ -2718,6 +2745,9 @@ impl State for MintClientStateMachines {
             MintClientStateMachines::Output(issuance_state) => issuance_state.operation_id(),
             MintClientStateMachines::Input(redemption_state) => redemption_state.operation_id(),
             MintClientStateMachines::OOB(oob_state) => oob_state.operation_id(),
+            MintClientStateMachines::SpendExact(spend_exact_state) => {
+                spend_exact_state.operation_id()
+            }
             MintClientStateMachines::Restore(r) => r.operation_id,
         }
     }

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -1199,6 +1199,36 @@ impl ClientModule for MintClientModule {
                     let note_counts = self.get_note_counts_by_denomination(&mut dbtx).await;
                     yield serde_json::to_value(note_counts)?;
                 }
+                "spend_notes_with_exact_denominations" => {
+                    let req: SpendNotesWithExactDenominationsRequest =
+                        serde_json::from_value(request)?;
+
+                    let mut tiered_counts = TieredCounts::default();
+                    for msat in &req.denominations_msat {
+                        tiered_counts.inc(Amount::from_msats(*msat), 1);
+                    }
+
+                    let operation_id = self
+                        .spend_notes_with_exact_denominations(
+                            tiered_counts,
+                            req.try_cancel_after,
+                            req.extra_meta,
+                        )
+                        .await?;
+
+                    yield serde_json::to_value(operation_id)?;
+                }
+                "subscribe_spend_exact_notes" => {
+                    let req: SubscribeSpendExactNotesRequest =
+                        serde_json::from_value(request)?;
+                    let stream = self
+                        .subscribe_spend_exact_notes(req.operation_id, req.include_invite)
+                        .await?;
+
+                    for await state in stream {
+                        yield serde_json::to_value(state?)?;
+                    }
+                }
                 _ => {
                     Err(anyhow::format_err!("Unknown method: {method}"))?;
                     unreachable!()
@@ -1250,6 +1280,19 @@ struct TryCancelSpendNotesRequest {
 #[derive(Deserialize)]
 struct SubscribeSpendNotesRequest {
     operation_id: OperationId,
+}
+
+#[derive(Deserialize)]
+struct SpendNotesWithExactDenominationsRequest {
+    denominations_msat: Vec<u64>,
+    try_cancel_after: Duration,
+    extra_meta: serde_json::Value,
+}
+
+#[derive(Deserialize)]
+struct SubscribeSpendExactNotesRequest {
+    operation_id: OperationId,
+    include_invite: bool,
 }
 
 #[derive(Deserialize)]
@@ -1690,6 +1733,44 @@ impl MintClientModule {
             .into_iter_items()
             .map(|(amt, snote)| Ok((amt, snote.decode()?)))
             .collect::<anyhow::Result<TieredMulti<_>>>()
+    }
+    pub async fn subscribe_spend_exact_notes(
+        &self,
+        operation_id: OperationId,
+        include_invite: bool,
+    ) -> anyhow::Result<impl futures::Stream<Item = anyhow::Result<String>> + '_> {
+        let sub = self
+            .subscribe_spend_notes_with_exact_denominations(operation_id)
+            .await?;
+
+        let federation_id_prefix = self.federation_id.to_prefix();
+        let invite_code = if include_invite {
+            Some(self.client_ctx.get_invite_code().await)
+        } else {
+            None
+        };
+
+        Ok(async_stream::try_stream! {
+            let mut stream = sub.into_stream();
+            while let Some(state) = stream.next().await {
+                match state {
+                    SpendExactState::Success(notes) => {
+                        let token = match &invite_code {
+                            Some(ic) => OOBNotes::new_with_invite(notes, ic).to_string(),
+                            None => OOBNotes::new(federation_id_prefix, notes).to_string(),
+                        };
+                        yield token;
+                    }
+                    SpendExactState::Failed(e) => {
+                        Err(anyhow::anyhow!("spend_exact failed: {e}"))?;
+                        unreachable!()
+                    }
+                    SpendExactState::Reissuing => {
+                        // Reissuance in progress
+                    }
+                }
+            }
+        })
     }
 
     async fn get_all_spendable_notes(
@@ -2688,9 +2769,9 @@ pub enum MintClientStateMachines {
     Output(MintOutputStateMachine),
     Input(MintInputStateMachine),
     OOB(MintOOBStateMachine),
-    SpendExact(SpendExactStateMachine),
     // Removed in https://github.com/fedimint/fedimint/pull/4035 , now ignored
     Restore(MintRestoreStateMachine),
+    SpendExact(SpendExactStateMachine),
 }
 
 impl IntoDynInstance for MintClientStateMachines {
@@ -2757,6 +2838,7 @@ impl State for MintClientStateMachines {
             MintClientStateMachines::Output(s) => s.fmt_visualization(f, indent),
             MintClientStateMachines::Input(s) => s.fmt_visualization(f, indent),
             MintClientStateMachines::OOB(s) => s.fmt_visualization(f, indent),
+            MintClientStateMachines::SpendExact(s) => s.fmt_visualization(f, indent),
             MintClientStateMachines::Restore(_) => write!(f, "{indent}{self:?}"),
         }
     }

--- a/modules/fedimint-mint-client/src/output.rs
+++ b/modules/fedimint-mint-client/src/output.rs
@@ -9,9 +9,9 @@ use fedimint_api_client::api::{
     VERSION_THAT_INTRODUCED_AWAIT_OUTPUTS_OUTCOMES, deserialize_outcome,
 };
 use fedimint_api_client::query::FilterMapThreshold;
-use fedimint_client_module::DynGlobalClientContext;
 use fedimint_client_module::module::{ClientContext, OutPointRange};
 use fedimint_client_module::sm::{ClientSMDatabaseTransaction, State, StateTransition};
+use fedimint_client_module::{ClientModule, DynGlobalClientContext};
 use fedimint_core::core::{Decoder, OperationId};
 use fedimint_core::db::IDatabaseTransactionOpsCoreTyped;
 use fedimint_core::encoding::{Decodable, Encodable};
@@ -767,32 +767,11 @@ impl MintOutputStatesCreatedMulti {
             panic!("Unexpected prior state")
         };
 
-        let mut spendable_notes: Vec<(Amount, SpendableNote)> = vec![];
-
-        // Note verification is relatively slow and CPU-bound, so parallelize them
-        blinded_signature_shares
-            .into_par_iter()
-            .map(|(out_idx, blinded_signature_shares)| {
-                let agg_blind_signature = aggregate_signature_shares(
-                    &blinded_signature_shares
-                        .into_iter()
-                        .map(|(peer, share)| (peer.to_usize() as u64, share))
-                        .collect(),
-                );
-
-                // this implies that the mint client config's public keys are inconsistent
-                let (amount, issuance_request) =
-                    created.issuance_requests.get(&out_idx).expect("Must have");
-
-                let amount_key = tbs_pks.tier(amount).expect("Must have keys for any amount");
-
-                let spendable_note = issuance_request.finalize(agg_blind_signature);
-
-                assert!(spendable_note.note().verify(*amount_key), "We checked all signature shares in the trigger future, so the combined signature has to be valid");
-
-                (*amount, spendable_note)
-            })
-            .collect_into_vec(&mut spendable_notes);
+        let spendable_notes = par_finalize_notes(
+            &tbs_pks,
+            blinded_signature_shares,
+            &created.issuance_requests,
+        );
 
         for (amount, spendable_note) in spendable_notes {
             debug!(target: LOG_CLIENT_MODULE_MINT, amount = %amount, note=%spendable_note, "Adding new note from transaction output");
@@ -953,4 +932,90 @@ impl NoteIssuanceRequest {
     pub fn spend_key(&self) -> &Keypair {
         &self.spend_key
     }
+}
+
+impl MintClientContext {
+    #[allow(dead_code)]
+    pub(crate) async fn await_note_signature_shares(
+        &self,
+        out_point: OutPoint,
+        denomination: Amount,
+        note_issuance_request: &NoteIssuanceRequest,
+    ) -> BTreeMap<PeerId, BlindedSignatureShare> {
+        let global_api = self.client_ctx.global_api();
+
+        let decoder = <MintClientModule as ClientModule>::decoder();
+        let tbs_pks = self.peer_tbs_pks.clone();
+        let num_peers = global_api.all_peers().to_num_peers();
+        let blinded_message = note_issuance_request.blinded_message();
+
+        global_api
+            .request_with_strategy_retry(
+                // this query collects a threshold of 2f + 1 valid blind signature shares
+                FilterMapThreshold::new(
+                    move |peer, outcome| {
+                        verify_blind_share(
+                            peer,
+                            &outcome,
+                            denomination,
+                            blinded_message,
+                            &decoder,
+                            &tbs_pks,
+                        )
+                        .map_err(ServerError::InvalidResponse)
+                    },
+                    num_peers,
+                ),
+                AWAIT_OUTPUT_OUTCOME_ENDPOINT.to_owned(),
+                ApiRequestErased::new(out_point),
+            )
+            .await
+    }
+}
+
+/// Creates spendable e-cash notes from the blind signature shares and their
+/// issuance requests.
+///
+/// Since this is a CPU-heavy operation it is parallelized.
+pub(crate) fn par_finalize_notes(
+    tbs_pks: &Tiered<AggregatePublicKey>,
+    // out_idx, denomination, blind signature shares
+    blind_sig_shares: Vec<(u64, BTreeMap<PeerId, BlindedSignatureShare>)>,
+    // out_idx -> issuance request
+    issuance_requests: &BTreeMap<u64, (Amount, NoteIssuanceRequest)>,
+) -> Vec<(Amount, SpendableNote)> {
+    assert_eq!(
+        blind_sig_shares.len(),
+        issuance_requests.len(),
+        "We should have the same number of blind signatures as issuance requests"
+    );
+
+    let mut spendable_notes: Vec<(Amount, SpendableNote)> = vec![];
+
+    // Note verification is relatively slow and CPU-bound, so parallelize them
+    blind_sig_shares
+        .into_par_iter()
+        .map(|(out_idx, blinded_signature_shares)| {
+            let agg_blind_signature = aggregate_signature_shares(
+                &blinded_signature_shares
+                    .into_iter()
+                    .map(|(peer, share)| (peer.to_usize() as u64, share))
+                    .collect(),
+            );
+
+            // this implies that the mint client config's public keys are inconsistent
+            let (amount, issuance_request) =
+                issuance_requests.get(&out_idx).expect("Must have");
+
+            let amount_key = tbs_pks.tier(amount).expect("Must have keys for any amount");
+
+            let spendable_note = issuance_request.finalize(agg_blind_signature);
+
+            assert!(spendable_note.note().verify(*amount_key), "We checked all signature shares in the trigger future, so the combined signature has to be valid");
+
+            (*amount, spendable_note)
+        })
+        .collect_into_vec(&mut spendable_notes);
+
+    spendable_notes
 }

--- a/modules/fedimint-mint-client/src/output.rs
+++ b/modules/fedimint-mint-client/src/output.rs
@@ -935,7 +935,6 @@ impl NoteIssuanceRequest {
 }
 
 impl MintClientContext {
-    #[allow(dead_code)]
     pub(crate) async fn await_note_signature_shares(
         &self,
         out_point: OutPoint,

--- a/modules/fedimint-mint-client/src/spend_exact.rs
+++ b/modules/fedimint-mint-client/src/spend_exact.rs
@@ -1,0 +1,490 @@
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use anyhow::{bail, ensure};
+use async_stream::stream;
+use fedimint_client_module::module::OutPointRange;
+use fedimint_client_module::oplog::UpdateStreamOrOutcome;
+use fedimint_client_module::sm::{State, StateTransition};
+use fedimint_client_module::transaction::{
+    ClientOutput, ClientOutputBundle, ClientOutputSM, TransactionBuilder,
+};
+use fedimint_client_module::{ClientModule, DynGlobalClientContext};
+use fedimint_core::core::OperationId;
+use fedimint_core::db::AutocommitError;
+use fedimint_core::encoding::{Decodable, Encodable};
+use fedimint_core::module::{Amounts, CommonModuleInit};
+use fedimint_core::util::FmtCompactAnyhow;
+use fedimint_core::{Amount, TieredCounts, TieredMulti, apply, async_trait_maybe_send};
+use fedimint_logging::LOG_CLIENT_MODULE_MINT;
+use fedimint_mint_common::config::FeeConsensus;
+use fedimint_mint_common::{MintCommonInit, MintOutput};
+use futures::{StreamExt, pin_mut, stream};
+use serde::Serialize;
+use tokio::pin;
+use tracing::{debug, error, trace};
+
+use crate::output::{NoteIssuanceRequest, par_finalize_notes};
+use crate::{
+    MintClientContext, MintClientModule, MintClientStateMachines, MintOperationMeta,
+    MintOperationMetaVariant, NotesSelector, SpendExactState, SpendableNote,
+};
+
+impl MintClientModule {
+    /// Spend notes with exact denominations. The function takes a `TieredMulti`
+    /// argument specifying exactly how many notes per denomination to return.
+    ///
+    /// The function spawns a state machine that either finishes immediately if
+    /// the correct notes are already available, or starts a reissuance process
+    /// to get the exact denominations. The resulting notes are returned via
+    /// the [`Self::subscribe_spend_notes_with_exact_denominations`] function's
+    /// final success state.
+    ///
+    /// *Note that other than [`Self::spend_notes_with_selector`] this function
+    /// does not keep track of the notes. If you don't use them they are "lost"
+    /// (can always be recovered from operation, but someone needs to do that).*
+    #[allow(clippy::too_many_lines)]
+    pub async fn spend_notes_with_exact_denominations<M: Serialize>(
+        &self,
+        requested_denominations: TieredCounts,
+        extra_meta: M,
+    ) -> anyhow::Result<OperationId> {
+        ensure!(
+            !requested_denominations.is_empty(),
+            "Cannot request zero notes"
+        );
+
+        let extra_meta = serde_json::to_value(extra_meta).expect(
+            "MintClientModule::spend_notes_with_exact_denominations extra_meta is serializable",
+        );
+
+        let operation_id = OperationId::new_random();
+
+        // If we already have the right denominations, return immediately
+        let spend_res: anyhow::Result<()> = self.client_ctx
+            .module_db()
+            .autocommit(
+                |dbtx, _| {
+                    let extra_meta = extra_meta.clone();
+                    let requested_denominations = requested_denominations.clone();
+                    Box::pin(async move {
+                        let available_notes = Self::select_notes(
+                            dbtx,
+                            &SelectNotesWithExactDenominations::new(requested_denominations.clone()),
+                            requested_denominations.total_amount(),
+                            self.cfg.fee_consensus
+                        ).await?;
+
+                        for (amount, note) in available_notes.iter_items() {
+                            trace!(target: LOG_CLIENT_MODULE_MINT, %amount, %note, "Spending note as exact denomination spend");
+                            MintClientModule::delete_spendable_note(&self.client_ctx, dbtx, amount, note).await;
+                        }
+
+                        self.client_ctx.manual_operation_start_dbtx(
+                            dbtx,
+                            operation_id,
+                            MintClientModule::kind().as_str(),
+                            MintOperationMeta {
+                                variant: MintOperationMetaVariant::SpendExact {
+                                    requested_denominations: requested_denominations.clone(),
+                                    change_outpoints: None,
+                                },
+                                amount: available_notes.total_amount(),
+                                extra_meta,
+                            },
+                            vec![
+                                self.client_ctx.make_dyn(MintClientStateMachines::SpendExact(
+                                    SpendExactStateMachine {
+                                        operation_id,
+                                        state: SpendExactStates::Created(SpendExactStateCreated::DenominationsAvailable(SpendExactStateSuccess {
+                                            notes: available_notes,
+                                        })),
+                                    },
+                                )),
+                            ]
+                        ).await?;
+                        Ok(())
+                    })
+                },
+                None,
+            )
+            .await
+            .map_err(|e| match e {
+                AutocommitError::ClosureError { error, .. } => error,
+                AutocommitError::CommitFailed { .. } => {
+                    panic!("Infinite retries exhausted")
+                }
+            });
+
+        match spend_res {
+            Ok(()) => {
+                debug!(target: LOG_CLIENT_MODULE_MINT, "Spend notes with exact denominations succeeded");
+                return Ok(operation_id);
+            }
+            Err(e) => {
+                debug!(target: LOG_CLIENT_MODULE_MINT, e=%e.fmt_compact_anyhow(), "Spend notes with exact denominations failed, trying reissuing");
+            }
+        }
+
+        // If we don't have the correct notes, try to reissue existing notes into the
+        // correct denominations
+        let transaction_builder = self
+            .client_ctx
+            .module_db()
+            .autocommit(
+                |dbtx, _| {
+                    let requested_denominations = requested_denominations.clone();
+                    Box::pin(async move {
+                        let mut outputs = Vec::with_capacity(requested_denominations.count_items());
+                        let mut note_issuance_requests =
+                            Vec::with_capacity(requested_denominations.count_items());
+                        for (amount, count) in requested_denominations.iter() {
+                            for _ in 0..count {
+                                let note_secret = self.new_note_secret(amount, dbtx).await;
+                                let (issuance_request, blind_nonce) =
+                                    NoteIssuanceRequest::new(&self.secp, &note_secret);
+                                outputs.push(ClientOutput {
+                                    output: MintOutput::new_v0(amount, blind_nonce),
+                                    amounts: Amounts::new_bitcoin(amount),
+                                });
+                                note_issuance_requests.push((amount, issuance_request));
+                            }
+                        }
+
+                        let output_bundle = ClientOutputBundle::new(
+                            outputs,
+                            vec![ClientOutputSM {
+                                state_machines: Arc::new(move |out_point_range: OutPointRange| {
+                                    assert_eq!(
+                                        out_point_range.count(),
+                                        note_issuance_requests.len()
+                                    );
+
+                                    let requested_notes_requests = note_issuance_requests
+                                        .clone()
+                                        .into_iter()
+                                        .zip(out_point_range)
+                                        .map(|((amount, request), out_point)| {
+                                            (out_point.out_idx, (amount, request))
+                                        })
+                                        .collect::<BTreeMap<_, _>>();
+
+                                    vec![MintClientStateMachines::SpendExact(
+                                        SpendExactStateMachine {
+                                            operation_id,
+                                            state: SpendExactStates::Created(
+                                                SpendExactStateCreated::NeedsReissuing(
+                                                    SpendExactStateReissuing {
+                                                        requested_notes_outpoints: out_point_range,
+                                                        requested_notes_requests,
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    )]
+                                }),
+                            }],
+                        );
+                        Result::<_, anyhow::Error>::Ok(
+                            TransactionBuilder::new()
+                                .with_outputs(self.client_ctx.make_client_outputs(output_bundle)),
+                        )
+                    })
+                },
+                None,
+            )
+            .await
+            .expect("Can't fail");
+
+        // FIXME: why can't I finalize and submit inside the DB transaction?
+        self.client_ctx
+            .finalize_and_submit_transaction(
+                operation_id,
+                MintCommonInit::KIND.as_str(),
+                move |change_range: OutPointRange| MintOperationMeta {
+                    variant: MintOperationMetaVariant::SpendExact {
+                        requested_denominations: requested_denominations.clone(),
+                        change_outpoints: Some(change_range),
+                    },
+                    amount: requested_denominations.total_amount(),
+                    extra_meta: extra_meta.clone(),
+                },
+                transaction_builder,
+            )
+            .await?;
+
+        Ok(operation_id)
+    }
+
+    /// Subscribe to updates on the progress of a spend exact operation started
+    /// with [`MintClientModule::spend_notes_with_exact_denominations`].
+    pub async fn subscribe_spend_notes_with_exact_denominations(
+        &self,
+        operation_id: OperationId,
+    ) -> anyhow::Result<UpdateStreamOrOutcome<SpendExactState>> {
+        let operation = self.mint_operation(operation_id).await?;
+
+        let MintOperationMetaVariant::SpendExact {
+            change_outpoints, ..
+        } = operation.meta::<MintOperationMeta>().variant
+        else {
+            bail!("Operation is not a spend exact operation");
+        };
+
+        let notifier = self.notifier.clone();
+        let ctx = self.client_ctx.clone();
+
+        Ok(self.client_ctx.outcome_or_updates(operation, operation_id, move || {
+            stream! {
+                let stream = notifier
+                    .subscribe(operation_id)
+                    .await
+                    .filter_map(|state| async {
+                        let MintClientStateMachines::SpendExact(state) = state else {
+                            return None;
+                        };
+                        Some(state)
+                    });
+
+                pin_mut!(stream);
+
+                while let Some(state) = stream.next().await {
+                    match state.state {
+                        SpendExactStates::Reissuing(_) => {
+                            yield SpendExactState::Reissuing;
+                        },
+                        SpendExactStates::Success(success) => {
+                            if let Some(change_outpoints) = &change_outpoints {
+                                trace!(target: LOG_CLIENT_MODULE_MINT, "Awaiting reissue-exact change: {:?}", change_outpoints);
+                                ctx.await_primary_module_outputs(
+                                    operation_id,
+                                    change_outpoints.into_iter().collect()
+                                ).await.expect("Must await outputs");
+                            } else {
+                                trace!(target: LOG_CLIENT_MODULE_MINT, "No reissue-exact change outpoints to await");
+                            }
+
+                            yield SpendExactState::Success(success.notes);
+                            break;
+                        },
+                        SpendExactStates::Failure(error) => {
+                            yield SpendExactState::Failed(error);
+                            break;
+                        }
+                        SpendExactStates::Created(_) => {
+                            // Will be followed by one of the other states immediately, no need to even consider it.
+                        }
+                    }
+                }
+            }
+        }))
+    }
+}
+
+struct SelectNotesWithExactDenominations(TieredCounts);
+
+impl SelectNotesWithExactDenominations {
+    pub fn new(requested_denominations: TieredCounts) -> Self {
+        assert!(
+            !requested_denominations.is_empty(),
+            "Cannot request zero notes"
+        );
+        Self(requested_denominations)
+    }
+}
+
+#[apply(async_trait_maybe_send!)]
+impl<Note: Send> NotesSelector<Note> for SelectNotesWithExactDenominations {
+    async fn select_notes(
+        &self,
+        #[cfg(not(target_family = "wasm"))] stream: impl futures::Stream<Item = (Amount, Note)> + Send,
+        #[cfg(target_family = "wasm")] stream: impl futures::Stream<Item = (Amount, Note)>,
+        requested_amount: Amount,
+        _fee_consensus: FeeConsensus,
+    ) -> anyhow::Result<TieredMulti<Note>> {
+        assert_eq!(self.0.total_amount(), requested_amount, "Amount mismatch");
+        let mut notes = TieredMulti::default();
+
+        pin!(stream);
+        while let Some((amount, note)) = stream.next().await {
+            if notes.tier_count(amount) < self.0.get(amount) {
+                notes.push(amount, note);
+            }
+        }
+
+        ensure!(
+            self.0 == notes.summary(),
+            "Could not select notes with exact denominations. Requested denominations: {:?}. Selected denominations: {:?}",
+            self.0,
+            notes.summary(),
+        );
+
+        Ok(notes)
+    }
+}
+
+/// State machine for spending notes with exact denominations
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
+pub struct SpendExactStateMachine {
+    pub operation_id: OperationId,
+    pub state: SpendExactStates,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
+pub enum SpendExactStates {
+    /// We can't spawn a final state machine due to SM executor limitations, so
+    /// we add the created step even though it's not really needed
+    Created(SpendExactStateCreated),
+    /// We're waiting for reissuance to complete
+    Reissuing(SpendExactStateReissuing),
+    /// Reissuance completed successfully
+    Success(SpendExactStateSuccess),
+    /// Transaction was rejected
+    Failure(String),
+}
+
+/// Intermediary state since we can't spawn a final state like `Success`. See
+/// [`SpendExactStates::Created`].
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
+pub enum SpendExactStateCreated {
+    NeedsReissuing(SpendExactStateReissuing),
+    DenominationsAvailable(SpendExactStateSuccess),
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
+pub struct SpendExactStateReissuing {
+    /// Notes that the user requested, these will be returned in the
+    /// [`SpendExactStateSuccess`] state
+    pub(crate) requested_notes_outpoints: OutPointRange,
+    /// `out_idx -> (denomination, issuance_request)`
+    pub(crate) requested_notes_requests: BTreeMap<u64, (Amount, NoteIssuanceRequest)>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
+pub struct SpendExactStateSuccess {
+    /// The final notes with exact denominations
+    pub notes: TieredMulti<SpendableNote>,
+}
+
+impl State for SpendExactStateMachine {
+    type ModuleContext = MintClientContext;
+
+    fn transitions(
+        &self,
+        context: &Self::ModuleContext,
+        global_context: &DynGlobalClientContext,
+    ) -> Vec<StateTransition<Self>> {
+        match &self.state {
+            SpendExactStates::Created(_) => {
+                vec![StateTransition::new(
+                    std::future::ready(()),
+                    move |_dbtx, (), old_state: SpendExactStateMachine| {
+                        Box::pin(async move {
+                            let new_state = match old_state.state {
+                                SpendExactStates::Created(
+                                    SpendExactStateCreated::DenominationsAvailable(success),
+                                ) => SpendExactStates::Success(success),
+                                SpendExactStates::Created(
+                                    SpendExactStateCreated::NeedsReissuing(reissuing),
+                                ) => SpendExactStates::Reissuing(reissuing),
+                                _ => panic!("Invalid previous state"),
+                            };
+                            SpendExactStateMachine {
+                                operation_id: old_state.operation_id,
+                                state: new_state,
+                            }
+                        })
+                    },
+                )]
+            }
+            SpendExactStates::Reissuing(reissuing) => {
+                reissuing.transitions(self.operation_id, context, global_context)
+            }
+            SpendExactStates::Success(_) | SpendExactStates::Failure(_) => vec![],
+        }
+    }
+
+    fn operation_id(&self) -> OperationId {
+        self.operation_id
+    }
+}
+
+impl SpendExactStateReissuing {
+    fn transitions(
+        &self,
+        operation_id: OperationId,
+        context: &MintClientContext,
+        global_context: &DynGlobalClientContext,
+    ) -> Vec<StateTransition<SpendExactStateMachine>> {
+        let global_context = global_context.clone();
+        let context_transition = context.clone();
+        let context_trigger = context.clone();
+        let txid = self.requested_notes_outpoints.txid;
+        let requested_notes_outpoints = self.requested_notes_outpoints;
+        let requested_notes_requests = self.requested_notes_requests.clone();
+        vec![StateTransition::new(
+            async move {
+                global_context.await_tx_accepted(txid).await?;
+
+                let blind_sig_shares = stream::iter(requested_notes_outpoints)
+                    .then(move |out_point| {
+                        let requested_notes_requests_inner = requested_notes_requests.clone();
+                        let context_inner = context_trigger.clone();
+                        async move {
+                            let (amount, request) = requested_notes_requests_inner
+                                .get(&out_point.out_idx)
+                                .expect("Outpoint should have a request");
+                            let shares = context_inner
+                                .await_note_signature_shares(out_point, *amount, request)
+                                .await;
+
+                            (out_point.out_idx, shares)
+                        }
+                    })
+                    .collect::<Vec<_>>()
+                    .await;
+
+                Result::<_, String>::Ok(blind_sig_shares)
+            },
+            move |_dbtx, result, old_state: SpendExactStateMachine| {
+                let context_inner = context_transition.clone();
+                Box::pin(async move {
+                    let SpendExactStates::Reissuing(SpendExactStateReissuing {
+                        requested_notes_requests,
+                        ..
+                    }) = &old_state.state
+                    else {
+                        panic!("Expected Reissuing state");
+                    };
+
+                    let blind_sig_shares = match result {
+                        Ok(shares) => shares,
+                        Err(e) => {
+                            error!("Failed to get blind signature shares: {e}");
+
+                            return SpendExactStateMachine {
+                                operation_id,
+                                state: SpendExactStates::Failure(format!(
+                                    "Failed to get blind signature shares: {e}"
+                                )),
+                            };
+                        }
+                    };
+
+                    let notes = par_finalize_notes(
+                        &context_inner.tbs_pks,
+                        blind_sig_shares,
+                        requested_notes_requests,
+                    )
+                    .into_iter()
+                    .collect();
+
+                    SpendExactStateMachine {
+                        operation_id,
+                        state: SpendExactStates::Success(SpendExactStateSuccess { notes }),
+                    }
+                })
+            },
+        )]
+    }
+}

--- a/modules/fedimint-mint-client/src/spend_exact.rs
+++ b/modules/fedimint-mint-client/src/spend_exact.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 use std::sync::Arc;
+use std::time::{Duration, SystemTime};
 
 use anyhow::{bail, ensure};
 use async_stream::stream;
@@ -47,6 +48,7 @@ impl MintClientModule {
     pub async fn spend_notes_with_exact_denominations<M: Serialize>(
         &self,
         requested_denominations: TieredCounts,
+        try_cancel_after: Duration,
         extra_meta: M,
     ) -> anyhow::Result<OperationId> {
         ensure!(
@@ -59,6 +61,7 @@ impl MintClientModule {
         );
 
         let operation_id = OperationId::new_random();
+        let timeout = fedimint_core::time::now() + try_cancel_after;
 
         // If we already have the right denominations, return immediately
         let spend_res: anyhow::Result<()> = self.client_ctx
@@ -177,6 +180,7 @@ impl MintClientModule {
                                                     SpendExactStateReissuing {
                                                         requested_notes_outpoints: out_point_range,
                                                         requested_notes_requests,
+                                                        timeout,
                                                     },
                                                 ),
                                             ),
@@ -256,10 +260,13 @@ impl MintClientModule {
                         SpendExactStates::Success(success) => {
                             if let Some(change_outpoints) = &change_outpoints {
                                 trace!(target: LOG_CLIENT_MODULE_MINT, "Awaiting reissue-exact change: {:?}", change_outpoints);
-                                ctx.await_primary_module_outputs(
+                                if let Err(e) = ctx.await_primary_module_outputs(
                                     operation_id,
                                     change_outpoints.into_iter().collect()
-                                ).await.expect("Must await outputs");
+                                ).await {
+                                    yield SpendExactState::Failed(e.to_string());
+                                    break;
+                                }
                             } else {
                                 trace!(target: LOG_CLIENT_MODULE_MINT, "No reissue-exact change outpoints to await");
                             }
@@ -310,6 +317,9 @@ impl<Note: Send> NotesSelector<Note> for SelectNotesWithExactDenominations {
             if notes.tier_count(amount) < self.0.get(amount) {
                 notes.push(amount, note);
             }
+            if notes.summary() == self.0 {
+                break;
+            }
         }
 
         ensure!(
@@ -358,6 +368,8 @@ pub struct SpendExactStateReissuing {
     pub(crate) requested_notes_outpoints: OutPointRange,
     /// `out_idx -> (denomination, issuance_request)`
     pub(crate) requested_notes_requests: BTreeMap<u64, (Amount, NoteIssuanceRequest)>,
+    /// How long before wallet tries to auto-cancel.
+    pub(crate) timeout: SystemTime,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
@@ -422,12 +434,29 @@ impl SpendExactStateReissuing {
         let txid = self.requested_notes_outpoints.txid;
         let requested_notes_outpoints = self.requested_notes_outpoints;
         let requested_notes_requests = self.requested_notes_requests.clone();
+        let timeout = self.timeout;
+
         vec![StateTransition::new(
             async move {
-                global_context.await_tx_accepted(txid).await?;
+                let tx_accepted_fut = global_context.await_tx_accepted(txid);
+
+                let timeout_fut = fedimint_core::runtime::sleep(
+                    timeout
+                        .duration_since(fedimint_core::time::now())
+                        .unwrap_or(Duration::ZERO),
+                );
+
+                tokio::select! {
+                    result = tx_accepted_fut => {
+                        result.map_err(|e| format!("Transaction not accepted: {e:?}"))?;
+                    }
+                    () = timeout_fut => {
+                        return Err("Timed out waiting for transaction acceptance".to_owned());
+                    }
+                }
 
                 let blind_sig_shares = stream::iter(requested_notes_outpoints)
-                    .then(move |out_point| {
+                    .map(move |out_point| {
                         let requested_notes_requests_inner = requested_notes_requests.clone();
                         let context_inner = context_trigger.clone();
                         async move {
@@ -441,6 +470,7 @@ impl SpendExactStateReissuing {
                             (out_point.out_idx, shares)
                         }
                     })
+                    .buffer_unordered(requested_notes_outpoints.count())
                     .collect::<Vec<_>>()
                     .await;
 
@@ -460,13 +490,10 @@ impl SpendExactStateReissuing {
                     let blind_sig_shares = match result {
                         Ok(shares) => shares,
                         Err(e) => {
-                            error!("Failed to get blind signature shares: {e}");
-
+                            error!("Failed spend exact reissuing: {e}");
                             return SpendExactStateMachine {
                                 operation_id,
-                                state: SpendExactStates::Failure(format!(
-                                    "Failed to get blind signature shares: {e}"
-                                )),
+                                state: SpendExactStates::Failure(e),
                             };
                         }
                     };

--- a/modules/fedimint-mint-common/src/config.rs
+++ b/modules/fedimint-mint-common/src/config.rs
@@ -62,7 +62,7 @@ plugin_types_trait_impl_config!(
     MintClientConfig
 );
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Encodable, Decodable)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Encodable, Decodable)]
 pub struct FeeConsensus {
     base: Amount,
     parts_per_million: u64,

--- a/modules/fedimint-mint-server/src/lib.rs
+++ b/modules/fedimint-mint-server/src/lib.rs
@@ -358,7 +358,7 @@ impl ServerModuleInit for MintInit {
 
         Ok(MintClientConfig {
             tbs_pks,
-            fee_consensus: config.fee_consensus.clone(),
+            fee_consensus: config.fee_consensus,
             peer_tbs_pks: config.peer_tbs_pks.clone(),
             max_notes_per_denomination: config.max_notes_per_denomination,
         })

--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -11,7 +11,7 @@ use fedimint_core::db::IDatabaseTransactionOpsCoreTyped;
 use fedimint_core::module::{AmountUnit, Amounts};
 use fedimint_core::task::sleep_in_test;
 use fedimint_core::util::NextOrPending;
-use fedimint_core::{Amount, TieredMulti, sats, secp256k1};
+use fedimint_core::{Amount, TieredCounts, TieredMulti, msats, sats, secp256k1};
 use fedimint_dummy_client::{DummyClientInit, DummyClientModule};
 use fedimint_dummy_server::DummyInit;
 use fedimint_logging::LOG_TEST;
@@ -19,7 +19,7 @@ use fedimint_mint_client::api::MintFederationApi;
 use fedimint_mint_client::client_db::{NextECashNoteIndexKey, NoteKey};
 use fedimint_mint_client::{
     MintClientInit, MintClientModule, Note, OOBNotes, ReissueExternalNotesState,
-    SelectNotesWithAtleastAmount, SelectNotesWithExactAmount, SpendOOBState,
+    SelectNotesWithAtleastAmount, SelectNotesWithExactAmount, SpendExactState, SpendOOBState,
     SpendableNoteUndecoded,
 };
 use fedimint_mint_common::{MintInput, MintInputV0, Nonce};
@@ -765,6 +765,39 @@ async fn repair_wallet() -> anyhow::Result<()> {
             initial_balance, new_balance,
             "Balance should remain unchanged after repair"
         );
+    }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn spend_exact() -> anyhow::Result<()> {
+    let fed = fixtures().new_fed_degraded().await;
+    let client = fed.new_client().await;
+    let client_dummy_module = client.get_first_module::<DummyClientModule>()?;
+    let (op, outpoint) = client_dummy_module.print_money(sats(1000)).await?;
+    client
+        .await_primary_bitcoin_module_output(op, outpoint)
+        .await?;
+
+    // The wallet won't have any denomination more than 3 times at this point, so if
+    // we can spend exactly 8msat 10 times the exact spend functionality is working.
+    let client_mint = client.get_first_module::<MintClientModule>()?;
+
+    for _ in 0..10 {
+        let operation_id = client_mint
+            .spend_notes_with_exact_denominations(TieredCounts::from_iter(vec![(msats(8), 1)]), ())
+            .await?;
+        let outcome = client_mint
+            .subscribe_spend_notes_with_exact_denominations(operation_id)
+            .await?
+            .await_outcome()
+            .await;
+        let Some(SpendExactState::Success(notes)) = outcome else {
+            panic!("Expected success, got: {outcome:?}");
+        };
+        assert_eq!(notes.total_amount(), msats(8));
+        assert_eq!(notes.count_items(), 1);
     }
 
     Ok(())

--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -774,11 +774,7 @@ async fn repair_wallet() -> anyhow::Result<()> {
 async fn spend_exact() -> anyhow::Result<()> {
     let fed = fixtures().new_fed_degraded().await;
     let client = fed.new_client().await;
-    let client_dummy_module = client.get_first_module::<DummyClientModule>()?;
-    let (op, outpoint) = client_dummy_module.print_money(sats(1000)).await?;
-    client
-        .await_primary_bitcoin_module_output(op, outpoint)
-        .await?;
+    issue_ecash(&client, sats(1000)).await?;
 
     // The wallet won't have any denomination more than 3 times at this point, so if
     // we can spend exactly 8msat 10 times the exact spend functionality is working.
@@ -786,13 +782,19 @@ async fn spend_exact() -> anyhow::Result<()> {
 
     for _ in 0..10 {
         let operation_id = client_mint
-            .spend_notes_with_exact_denominations(TieredCounts::from_iter(vec![(msats(8), 1)]), ())
+            .spend_notes_with_exact_denominations(
+                TieredCounts::from_iter(vec![(msats(8), 1)]),
+                Duration::from_secs(60),
+                (),
+            )
             .await?;
+
         let outcome = client_mint
             .subscribe_spend_notes_with_exact_denominations(operation_id)
             .await?
             .await_outcome()
             .await;
+
         let Some(SpendExactState::Success(notes)) = outcome else {
             panic!("Expected success, got: {outcome:?}");
         };


### PR DESCRIPTION
Have implemented `spend_notes_with_exact_denominations` to mint module for PaperEcash usage