### PR TITLE
fix(ci): backport s9pk Rust toolchain bump to releases/v0.11

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -781,11 +781,11 @@ jobs:
         run: |
           curl -fsSL https://deno.land/install.sh | sh
           echo "$HOME/.deno/bin" >> $GITHUB_PATH
-      # start-os v0.3.5.1 doesn't compile on newer Rust versions
+      # md-packer's ICU dependencies require rustc 1.86+
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: "1.85.1"
+          toolchain: "1.86.0"
       - name: Install cargo tools
         run: |
           # web-static-pack-packer 0.5.2 requires rustc 1.88+

--- a/.github/workflows/ci-start9-gatewayd.yml
+++ b/.github/workflows/ci-start9-gatewayd.yml
@@ -59,11 +59,11 @@ jobs:
         run: |
           curl -fsSL https://deno.land/install.sh | sh
           echo "$HOME/.deno/bin" >> $GITHUB_PATH
-      # start-os v0.3.5.1 doesn't compile on newer Rust versions
+      # md-packer's ICU dependencies require rustc 1.86+
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: "1.85.1"
+          toolchain: "1.86.0"
       - name: Install cargo tools
         run: |
           # web-static-pack-packer 0.5.2 requires rustc 1.88+


### PR DESCRIPTION
## Summary
- Backport of #8498 to `releases/v0.11`
- Bumps Rust toolchain from 1.85.1 to 1.86.0 in both s9pk build jobs
- `md-packer`'s ICU dependencies now require `rustc 1.86+`, causing the s9pk build to fail
- Fixes https://github.com/fedimint/fedimint/actions/runs/24398809754/job/71277502001

## Test plan
- [ ] Verify s9pk build job passes in CI with the new toolchain version

🤖 Generated with [Claude Code](https://claude.com/claude-code)