### PR TITLE
fix(ci): backport closure size limit increase to releases/v0.11

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -544,7 +544,7 @@ jobs:
               closure_size=$(nix path-info -rS --json .#$bin | nix run nixpkgs#jq '. | to_entries[] | select(.value.ultimate == true) | .value.narSize')
               >&2 echo "$bin's Nix closure size: $closure_size"
 
-              if [ 280000000 -lt $closure_size ]; then
+              if [ 300000000 -lt $closure_size ]; then
                 >&2 echo "$bin's Nix closure size seems too big: $closure_size"
                 exit 1
               fi


### PR DESCRIPTION
## Summary
- Backport of #8500 to `releases/v0.11`
- `gatewayd` Nix closure grew to ~288MB, exceeding the 280MB limit
- Bump limit from 280MB to 300MB
- Fixes https://github.com/fedimint/fedimint/actions/runs/24406214801/job/71290127956

## Test plan
- [ ] Verify release package CI jobs pass with the new limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)