### PR TITLE
chore: add WalletDescriptor to WalletClientConfig

### DIFF
--- a/modules/fedimint-walletv2-common/src/config.rs
+++ b/modules/fedimint-walletv2-common/src/config.rs
@@ -33,6 +33,8 @@ pub struct WalletConfigPrivate {
 pub struct WalletConfigConsensus {
     /// The public keys for the bitcoin multisig
     pub bitcoin_pks: BTreeMap<PeerId, PublicKey>,
+    /// The kind of descriptor the federation uses for the multisig.
+    pub descriptor: WalletDescriptor,
     /// Total vbytes of a pegout bitcoin transaction
     pub send_tx_vbytes: u64,
     /// Total vbytes of a pegin bitcoin transaction
@@ -105,6 +107,7 @@ impl WalletConfigConsensus {
 
         Self {
             bitcoin_pks,
+            descriptor: WalletDescriptor::Wsh,
             send_tx_vbytes: weight_to_vbytes(
                 tx_overhead_weight
                     + change_input_weight
@@ -201,10 +204,19 @@ fn test_fee_consensus() {
     );
 }
 
+/// Which kind of bitcoin descriptor the federation uses. Currently only `Wsh`
+/// is defined, we can expand in the future.
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize, Encodable, Decodable)]
+pub enum WalletDescriptor {
+    Wsh,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize, Encodable, Decodable)]
 pub struct WalletClientConfig {
     /// The public keys for the bitcoin multisig
     pub bitcoin_pks: BTreeMap<PeerId, PublicKey>,
+    /// The kind of descriptor the federation uses for the multisig.
+    pub descriptor: WalletDescriptor,
     /// Total vbytes of a pegout bitcoin transaction
     pub send_tx_vbytes: u64,
     /// Total vbytes of a pegin bitcoin transaction

--- a/modules/fedimint-walletv2-server/src/lib.rs
+++ b/modules/fedimint-walletv2-server/src/lib.rs
@@ -379,6 +379,7 @@ impl ServerModuleInit for WalletInit {
 
         Ok(WalletClientConfig {
             bitcoin_pks: config.bitcoin_pks,
+            descriptor: config.descriptor,
             send_tx_vbytes: config.send_tx_vbytes,
             receive_tx_vbytes: config.receive_tx_vbytes,
             feerate_base: config.feerate_base,


### PR DESCRIPTION
At some point in the future, I would like to upgrade Walletv2 to use Taproot in a backwards compatible way that doesn't break existing deployments.

Right now this is doable, but the main issue is that the client infers the descriptor based on the public keys that are in the `WalletClientConfig`. I think we should add an easily upgradable enum that contains the type of descriptor the federation is using, so that the client can use the correct descriptor.