### PR TITLE
fix(ci): move FEDIMINTD_TAG ARG before first FROM in s9pk Dockerfile

### DIFF
--- a/fedimint-startos/Dockerfile
+++ b/fedimint-startos/Dockerfile
@@ -1,3 +1,6 @@
+# ARG before any FROM so it's available in FROM instructions
+ARG FEDIMINTD_TAG=latest
+
 # Stage 1: Download yq in a full-featured image
 FROM alpine:latest AS downloader
 ARG TARGETARCH
@@ -11,7 +14,6 @@ RUN case "$TARGETARCH" in \
     chmod +x /tmp/yq
 
 # Stage 2: Main image
-ARG FEDIMINTD_TAG=latest
 FROM fedimint/fedimintd:${FEDIMINTD_TAG}
 
 # Copy yq from downloader stage


### PR DESCRIPTION
## Summary
- Moves `ARG FEDIMINTD_TAG=latest` before the first `FROM` in the s9pk Dockerfile so Docker treats it as a global ARG
- Fixes the s9pk build failing with `invalid reference format` because `${FEDIMINTD_TAG}` resolved to an empty string in the second `FROM` instruction
- Already pushed directly to `releases/v0.11` (aa2c0e00cbe)

## Context
Docker `ARG`s declared after a `FROM` are scoped to that build stage. Since `FEDIMINTD_TAG` was declared between the two `FROM` instructions, it was invisible to the second `FROM fedimint/fedimintd:${FEDIMINTD_TAG}`, causing the tag to resolve to empty and the build to fail.

## Test plan
- [ ] Verify the s9pk CI job passes on the next tagged release

🤖 Generated with [Claude Code](https://claude.com/claude-code)