### PR TITLE
fix(ci): fix merge queue flakes and backport cancellations

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -3,10 +3,12 @@ on:
   pull_request_target:
     # Run on merge (close) or if label is added after merging
     types: [closed, labeled]
-# Set concurrenty limit to a single backport workflow per branch
-# https://docs.github.com/en/actions/using-jobs/using-concurrency
+# Scope concurrency to the PR so that backport runs for different PRs don't
+# cancel each other.  (github.ref resolves to the base branch for
+# pull_request_target events, so the old group key was shared by all PRs
+# targeting the same branch.)
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 jobs:
   backport:

--- a/.github/workflows/ci-backwards-compatibility.yml
+++ b/.github/workflows/ci-backwards-compatibility.yml
@@ -38,6 +38,8 @@ jobs:
       - name: Prepare
         uses: ./.github/actions/prepare
       - uses: dpc/nix-installer-action@dpc/jj-vqymqvyntouw
+        with:
+          github-token: ${{ github.token }}
       - uses: cachix/cachix-action@v17
         with:
           name: fedimint

--- a/.github/workflows/ci-backwards-compatibility.yml
+++ b/.github/workflows/ci-backwards-compatibility.yml
@@ -31,7 +31,7 @@ jobs:
     if: github.repository == 'fedimint/fedimint'
     name: "Backwards-compatibility tests"
     runs-on: [self-hosted, linux, x64]
-    timeout-minutes: 60
+    timeout-minutes: 90
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -48,6 +48,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dpc/nix-installer-action@dpc/jj-vqymqvyntouw
+        with:
+          github-token: ${{ github.token }}
       - uses: cachix/cachix-action@v17
         with:
           name: fedimint
@@ -97,6 +99,8 @@ jobs:
         if: github.event_name != 'pull_request' || matrix.build-in-pr
 
       - uses: dpc/nix-installer-action@dpc/jj-vqymqvyntouw
+        with:
+          github-token: ${{ github.token }}
       - uses: cachix/cachix-action@v17
         if: github.event_name != 'pull_request' || matrix.build-in-pr
         with:
@@ -141,6 +145,8 @@ jobs:
         uses: ./.github/actions/prepare
 
       - uses: dpc/nix-installer-action@dpc/jj-vqymqvyntouw
+        with:
+          github-token: ${{ github.token }}
         if: github.event_name != 'pull_request' || matrix.build-in-pr
       - uses: cachix/cachix-action@v17
         if: github.event_name != 'pull_request' || matrix.build-in-pr
@@ -226,6 +232,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dpc/nix-installer-action@dpc/jj-vqymqvyntouw
+        with:
+          github-token: ${{ github.token }}
       - uses: cachix/cachix-action@v17
         with:
           name: fedimint
@@ -249,6 +257,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dpc/nix-installer-action@dpc/jj-vqymqvyntouw
+        with:
+          github-token: ${{ github.token }}
       - uses: cachix/cachix-action@v17
         with:
           name: fedimint
@@ -299,6 +309,8 @@ jobs:
         if: github.event_name != 'pull_request' || matrix.build-in-pr
 
       - uses: dpc/nix-installer-action@dpc/jj-vqymqvyntouw
+        with:
+          github-token: ${{ github.token }}
         if: github.event_name != 'pull_request' || matrix.build-in-pr
 
       - uses: cachix/cachix-action@v17
@@ -359,6 +371,8 @@ jobs:
       - uses: actions/checkout@v6
         if: github.event_name != 'pull_request' || matrix.platform.run_in_pr
       - uses: dpc/nix-installer-action@dpc/jj-vqymqvyntouw
+        with:
+          github-token: ${{ github.token }}
         if: github.event_name != 'pull_request' || matrix.platform.run_in_pr
       - uses: cachix/cachix-action@v17
         if: github.event_name != 'pull_request' || matrix.platform.run_in_pr
@@ -513,6 +527,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dpc/nix-installer-action@dpc/jj-vqymqvyntouw
+        with:
+          github-token: ${{ github.token }}
       - uses: cachix/cachix-action@v17
         with:
           name: fedimint

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dpc/nix-installer-action@dpc/jj-vqymqvyntouw
+        with:
+          github-token: ${{ github.token }}
       - uses: cachix/cachix-action@v17
         with:
           name: fedimint

--- a/.github/workflows/hourly-run.yml
+++ b/.github/workflows/hourly-run.yml
@@ -61,6 +61,8 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: dpc/nix-installer-action@dpc/jj-vqymqvyntouw
+        with:
+          github-token: ${{ github.token }}
 
       - uses: cachix/cachix-action@v17
         with:

--- a/.github/workflows/upgrade-tests.yml
+++ b/.github/workflows/upgrade-tests.yml
@@ -45,6 +45,8 @@ jobs:
       - name: Prepare
         uses: ./.github/actions/prepare
       - uses: dpc/nix-installer-action@dpc/jj-vqymqvyntouw
+        with:
+          github-token: ${{ github.token }}
       - uses: cachix/cachix-action@v17
         with:
           name: fedimint

--- a/devimint/src/util.rs
+++ b/devimint/src/util.rs
@@ -1019,7 +1019,13 @@ fn get_command_str_for_alias(aliases: &[&str], default: &[&str]) -> Vec<String> 
     // try to use one of the aliases if set
     for alias in aliases {
         if let Ok(cmd) = std::env::var(alias) {
-            return cmd.split_whitespace().map(ToOwned::to_owned).collect();
+            let parts: Vec<String> = cmd.split_whitespace().map(ToOwned::to_owned).collect();
+            assert!(
+                !parts.is_empty(),
+                "Environment variable {alias} is set to an empty/whitespace-only string — \
+                 it should either be unset or contain a valid command path"
+            );
+            return parts;
         }
     }
     // otherwise return the default value

--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -394,10 +394,13 @@ else
       # for dkg we need to use the fedimint-cli version that matches fedimintd
       if [ "$binary" == "fedimintd" ]; then
         var_name=$(nix_binary_version_var_name "fedimint-cli" "$version")
-        export "${var_name}=$(nix_build_binary_for_version "fedimint-cli" "$version")"
+        # NOTE: must separate from `export` — `export v=$(failing_cmd)` masks the failure
+        value=$(nix_build_binary_for_version "fedimint-cli" "$version")
+        export "${var_name}=$value"
       fi
       var_name=$(nix_binary_version_var_name "$binary" "$version")
-      export "${var_name}=$(nix_build_binary_for_version "$binary" "$version")"
+      value=$(nix_build_binary_for_version "$binary" "$version")
+      export "${var_name}=$value"
     done
   done
 


### PR DESCRIPTION
## Summary
- **Stop silently swallowing nix build failures** in backcompat tests — `export var=$(failing_cmd)` masks non-zero exit codes in bash, causing tests to run with empty binary paths and panic with a cryptic index-out-of-bounds error instead of failing early
- **Pass `github-token` to all `nix-installer-action` usages** so nix uses authenticated GitHub API requests (higher rate limit), avoiding the intermittent HTTP 504 errors that trigger the above issue on self-hosted runners
- **Scope backport workflow concurrency to PR number** instead of base branch — `github.ref` resolves to the base branch for `pull_request_target` events, so all backport runs for PRs targeting master shared one concurrency group and cancelled each other (e.g. #8470's backport was cancelled by #8489)

## Test plan
- [ ] Verify backwards-compatibility tests fail fast with a clear message if a nix build fails, instead of proceeding with broken environment
- [ ] Verify merge queue runs no longer hit GitHub API 504 errors during `nix build github:fedimint/fedimint/...`
- [ ] Verify merging two PRs with backport labels in quick succession both get their backport PRs created

🤖 Generated with [Claude Code](https://claude.com/claude-code)