### PR TITLE
refactor(ci): make autoreview bot less verbose

### DIFF
--- a/.github/agents/review.md
+++ b/.github/agents/review.md
@@ -127,9 +127,9 @@ Schema:
 
 ```json
 {
-  "summary": "One paragraph describing what the PR does.",
-  "consensus_impact": "\"None\", or a description of what changed and why it is (or isn't) safe.",
   "verdict": "APPROVE or COMMENT",
+  "consensus_impact": "null, or a description of consensus implications that a human reviewer must evaluate.",
+  "reason": "null, or a short explanation of why the PR was not auto-approved (only when verdict is COMMENT and the reason is non-obvious).",
   "inline_comments": [
     {
       "path": "relative/path/to/file.rs",
@@ -138,8 +138,7 @@ Schema:
       "severity": "critical | warning | nit",
       "body": "Explanation of the issue."
     }
-  ],
-  "body": "Optional overall review body in markdown. Use this for high-level feedback that doesn't belong on a specific line."
+  ]
 }
 ```
 
@@ -148,7 +147,16 @@ Field details:
   and the PR does NOT touch consensus-critical paths. `COMMENT` — use for all
   other cases: consensus-critical PRs, PRs with issues found, or when unsure.
   Never block a PR.
-- **inline_comments**: Array of line-level comments. Can be empty.
+- **consensus_impact**: `null` if no consensus-critical code is affected. If
+  consensus-critical paths are touched, describe the specific implications a
+  human reviewer should evaluate. Do NOT write "None" — use `null`.
+- **reason**: `null` when approving, or when the inline comments already make
+  the reason obvious. Only set this to a short sentence when the verdict is
+  COMMENT and a human needs to understand what to focus on beyond the inline
+  comments (e.g. "touches consensus encoding", "diff was truncated").
+- **inline_comments**: Array of line-level comments. All findings — bugs, nits,
+  warnings — MUST go here as inline comments, not in a top-level summary.
+  Can be empty if the change is clean.
   - **path**: File path relative to repo root, as shown in the diff.
   - **line**: The line number in the diff to attach the comment to.
   - **side**: `RIGHT` for lines in the new version (additions, context on new
@@ -158,5 +166,10 @@ Field details:
     code smells or risky patterns, `nit` for style suggestions.
   - **body**: The comment text. Be specific and actionable. For critical/warning
     issues, explain what could go wrong.
-- **body**: Overall review comment. Summarize the review, mention consensus
-  impact if relevant. Can be empty string if inline comments cover everything.
+
+**Verbosity rules**: Be concise. Do NOT write a summary of what the PR does —
+the reviewer can read the diff. Do NOT restate findings in a top-level body
+that are already covered by inline comments. The top-level review comment
+should be minimal or empty; only include information a human reviewer needs
+that cannot be expressed as an inline comment (consensus implications, reasons
+for withholding approval).

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -286,32 +286,38 @@ jobs:
             VERDICT="COMMENT"
           fi
 
-          # Build the overall review body from JSON fields
-          SUMMARY=$(jq -r '.summary // ""' < /tmp/review.json)
-          CONSENSUS_IMPACT=$(jq -r '.consensus_impact // "None"' < /tmp/review.json)
-          BODY=$(jq -r '.body // ""' < /tmp/review.json)
+          # Build a minimal review body — only show information a human needs
+          CONSENSUS_IMPACT=$(jq -r '.consensus_impact // ""' < /tmp/review.json)
+          REASON=$(jq -r '.reason // ""' < /tmp/review.json)
 
-          {
-            echo "## Summary"
-            echo "$SUMMARY"
-            echo ""
-            echo "## Consensus Impact"
-            echo "$CONSENSUS_IMPACT"
-            if [ -n "$BODY" ]; then
-              echo ""
-              echo "$BODY"
-            fi
-            if [ "$IS_CONSENSUS" = "true" ] && [ "$VERDICT" = "COMMENT" ]; then
-              echo ""
-              echo "---"
-              echo "*Auto-approval is disabled for PRs touching consensus-critical code. A human reviewer must approve this PR.*"
-            fi
-            if [ "$TRUNCATED" = "true" ]; then
-              echo ""
-              echo "---"
-              echo "*The diff was too large for complete automated review. A human reviewer should verify the full changeset.*"
-            fi
-          } > /tmp/review_body.txt
+          # Treat JSON null as empty
+          [ "$CONSENSUS_IMPACT" = "null" ] && CONSENSUS_IMPACT=""
+          [ "$REASON" = "null" ] && REASON=""
+
+          BODY_PARTS=()
+
+          if [ -n "$CONSENSUS_IMPACT" ]; then
+            BODY_PARTS+=("**Consensus impact:** $CONSENSUS_IMPACT")
+          fi
+
+          if [ -n "$REASON" ]; then
+            BODY_PARTS+=("$REASON")
+          fi
+
+          if [ "$IS_CONSENSUS" = "true" ] && [ "$VERDICT" = "COMMENT" ]; then
+            BODY_PARTS+=("*Auto-approval is disabled for PRs touching consensus-critical code. A human reviewer must approve this PR.*")
+          fi
+
+          if [ "$TRUNCATED" = "true" ]; then
+            BODY_PARTS+=("*The diff was too large for complete automated review. A human reviewer should verify the full changeset.*")
+          fi
+
+          # Join parts with blank lines, or use a minimal default
+          if [ ${#BODY_PARTS[@]} -gt 0 ]; then
+            printf '%s\n\n' "${BODY_PARTS[@]}" | sed '$ d' > /tmp/review_body.txt
+          else
+            echo "LGTM" > /tmp/review_body.txt
+          fi
 
           # Check if there are inline comments
           INLINE_COUNT=$(jq '.inline_comments | length' < /tmp/review.json)


### PR DESCRIPTION
## Summary
- Remove summary and free-form body from review output; top-level comment now only shows consensus impact or non-approval reasons when significant
- All findings (bugs, nits, warnings) go into inline comments instead of a top-level summary
- Clean approvals just say "LGTM"

## Test plan
- [ ] Trigger a review on a non-consensus PR and verify the top-level comment is minimal
- [ ] Trigger a review on a consensus-critical PR and verify consensus impact is shown
- [ ] Verify inline comments still appear correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)