### PR TITLE
fix(ci): fix cargo audit failure from new rustls-webpki advisories

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -31,6 +31,10 @@ ignore = [
   "RUSTSEC-2023-0089",
   # rustls-webpki CRL matching logic, pinned by iroh-relay 0.35.0 on 0.102.x with no patch available
   "RUSTSEC-2026-0049",
+  # rustls-webpki name constraint bugs, only exploitable via CA misissuance.
+  # 0.103.x fixed by cargo update; 0.102.x pinned by iroh 0.35.0 (no patch), 0.101.x pinned by ldk-node 0.6.1 (0.7.0 would fix)
+  "RUSTSEC-2026-0098",
+  "RUSTSEC-2026-0099",
 ]
 
 [output]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -945,7 +945,7 @@ dependencies = [
  "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "log",
  "prettyplease 0.2.35",
  "proc-macro2",
@@ -6291,7 +6291,7 @@ dependencies = [
  "ring",
  "rustls 0.23.28",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.12",
  "serde",
  "smallvec",
  "snafu",
@@ -6537,7 +6537,7 @@ dependencies = [
  "reqwest 0.12.22",
  "rustls 0.23.28",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.12",
  "serde",
  "sha1",
  "snafu",
@@ -6827,7 +6827,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.2",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -9431,7 +9431,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.12",
  "subtle",
  "zeroize",
 ]
@@ -9478,9 +9478,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -11762,7 +11762,7 @@ dependencies = [
  "paste",
  "pin-project",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.12",
  "socket2 0.6.1",
  "thiserror 2.0.18",
  "tokio",


### PR DESCRIPTION
## Summary
- **Bump `rustls-webpki` 0.103.10 → 0.103.12** (semver patch) to fix RUSTSEC-2026-0098 and RUSTSEC-2026-0099 for the main `rustls 0.23` stack
- **Ignore both advisories** for the remaining old versions pinned by transitive deps with no upstream patch:
  - `0.102.8`: pinned by `iroh 0.35.0` (no 0.35.1 exists; iroh jumped to 0.9x)
  - `0.101.7`: pinned by `ldk-node 0.6.1` via `rustls 0.21` (`ldk-node 0.7.0` would eliminate this chain)

Both advisories are X.509 name constraint validation bugs that require CA misissuance to exploit — low real-world risk.

## Test plan
- [x] `nix build .#ci.cargoAudit` passes locally with latest `advisory-db`

🤖 Generated with [Claude Code](https://claude.com/claude-code)