### PR TITLE
feat: add connection type to `connection_status_stream`

### DIFF
--- a/fedimint-api-client/src/api/global_api/with_cache.rs
+++ b/fedimint-api-client/src/api/global_api/with_cache.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use anyhow::{anyhow, format_err};
 use bitcoin::secp256k1;
-use fedimint_connectors::{DynGuaridianConnection, ServerResult};
+use fedimint_connectors::{DynGuaridianConnection, PeerStatus, ServerResult};
 use fedimint_core::admin_client::{GuardianConfigBackup, SetLocalParamsRequest, SetupStatus};
 use fedimint_core::backup::{BackupStatistics, ClientBackupSnapshot};
 use fedimint_core::core::backup::SignedBackupRequest;
@@ -241,7 +241,7 @@ where
         self.inner.request_raw(peer_id, method, params).await
     }
 
-    fn connection_status_stream(&self) -> BoxStream<'static, BTreeMap<PeerId, bool>> {
+    fn connection_status_stream(&self) -> BoxStream<'static, BTreeMap<PeerId, PeerStatus>> {
         self.inner.connection_status_stream()
     }
 

--- a/fedimint-api-client/src/api/global_api/with_request_hook.rs
+++ b/fedimint-api-client/src/api/global_api/with_request_hook.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
-use fedimint_connectors::{DynGuaridianConnection, ServerResult};
+use fedimint_connectors::{DynGuaridianConnection, PeerStatus, ServerResult};
 use fedimint_core::core::ModuleInstanceId;
 use fedimint_core::module::ApiRequestErased;
 use fedimint_core::task::{MaybeSend, MaybeSync};
@@ -87,7 +87,7 @@ impl IRawFederationApi for RawFederationApiWithRequestHook {
         self.inner.request_raw(peer_id, method, params).await
     }
 
-    fn connection_status_stream(&self) -> BoxStream<'static, BTreeMap<PeerId, bool>> {
+    fn connection_status_stream(&self) -> BoxStream<'static, BTreeMap<PeerId, PeerStatus>> {
         self.inner.connection_status_stream()
     }
 

--- a/fedimint-api-client/src/api/mod.rs
+++ b/fedimint-api-client/src/api/mod.rs
@@ -14,7 +14,8 @@ pub use error::{FederationError, OutputOutcomeError};
 pub use fedimint_connectors::ServerResult;
 pub use fedimint_connectors::error::ServerError;
 use fedimint_connectors::{
-    ConnectionPool, ConnectorRegistry, DynGuaridianConnection, IGuardianConnection, PeerStatus,
+    ConnectionPool, Connectivity, ConnectorRegistry, DynGuaridianConnection, IGuardianConnection,
+    PeerStatus,
 };
 use fedimint_core::admin_client::{GuardianConfigBackup, ServerStatusLegacy, SetupStatus};
 use fedimint_core::backup::{BackupStatistics, ClientBackupSnapshot};
@@ -101,13 +102,16 @@ pub trait IRawFederationApi: Debug + MaybeSend + MaybeSync {
         params: &ApiRequestErased,
     ) -> ServerResult<Value>;
 
-    /// Returns a stream of connection status for each peer
+    /// Returns a stream of connection status for each peer.
     ///
     /// The stream emits a new value whenever the set of active connections in
     /// the pool changes. Each peer's entry is [`PeerStatus::Disconnected`] if
-    /// there is no active pooled connection, or
-    /// [`PeerStatus::Connected`] carrying the current
-    /// [`fedimint_connectors::Connectivity`] otherwise.
+    /// there is no active pooled connection, or [`PeerStatus::Connected`]
+    /// carrying the current [`fedimint_connectors::Connectivity`] otherwise.
+    /// If the pool reports the peer as active but the underlying connector no
+    /// longer has a known path for it (a disconnection racing the pool
+    /// update), the peer is reported as [`PeerStatus::Disconnected`] — the
+    /// next emission will confirm.
     ///
     /// Note: the stream does not tick on transport-level path changes (for
     /// example iroh hole-punching from relay to direct) on an existing
@@ -789,7 +793,18 @@ impl IRawFederationApi for FederationApi {
                     .iter()
                     .map(|(peer_id, url)| {
                         let status = if active_urls.contains(url) {
-                            PeerStatus::Connected(pool.connectivity(url))
+                            // The active-set snapshot and the per-connector
+                            // path state are separate sources of truth, so a
+                            // disconnection can race between them. If we saw
+                            // the url as active but the connector no longer
+                            // reports a known path, treat the race as
+                            // "disconnection won" and report Disconnected
+                            // for a consistent view — the next stream tick
+                            // will confirm.
+                            match pool.connectivity(url) {
+                                Connectivity::Unknown => PeerStatus::Disconnected,
+                                connectivity => PeerStatus::Connected(connectivity),
+                            }
                         } else {
                             PeerStatus::Disconnected
                         };

--- a/fedimint-api-client/src/api/mod.rs
+++ b/fedimint-api-client/src/api/mod.rs
@@ -104,19 +104,18 @@ pub trait IRawFederationApi: Debug + MaybeSend + MaybeSync {
 
     /// Returns a stream of connection status for each peer.
     ///
-    /// The stream emits a new value whenever the set of active connections in
-    /// the pool changes. Each peer's entry is [`PeerStatus::Disconnected`] if
-    /// there is no active pooled connection, or [`PeerStatus::Connected`]
-    /// carrying the current [`fedimint_connectors::Connectivity`] otherwise.
-    /// If the pool reports the peer as active but the underlying connector no
-    /// longer has a known path for it (a disconnection racing the pool
-    /// update), the peer is reported as [`PeerStatus::Disconnected`] — the
-    /// next emission will confirm.
+    /// The stream emits a new value whenever either the set of active
+    /// connections in the pool changes, or a connector observes a
+    /// transport-level path change on an existing connection (e.g. an iroh
+    /// connection upgrading from relay to direct).
     ///
-    /// Note: the stream does not tick on transport-level path changes (for
-    /// example iroh hole-punching from relay to direct) on an existing
-    /// connection — the carried [`fedimint_connectors::Connectivity`] only
-    /// refreshes when the pool membership itself changes.
+    /// Each peer's entry is [`PeerStatus::Disconnected`] if there is no
+    /// active pooled connection, or [`PeerStatus::Connected`] carrying the
+    /// current [`fedimint_connectors::Connectivity`] otherwise. If the pool
+    /// reports the peer as active but the underlying connector no longer
+    /// has a known path for it (a disconnection racing the pool update),
+    /// the peer is reported as [`PeerStatus::Disconnected`] — the next
+    /// emission will confirm.
     fn connection_status_stream(&self) -> BoxStream<'static, BTreeMap<PeerId, PeerStatus>>;
     /// Wait for some connections being initialized
     ///
@@ -786,9 +785,21 @@ impl IRawFederationApi for FederationApi {
     fn connection_status_stream(&self) -> BoxStream<'static, BTreeMap<PeerId, PeerStatus>> {
         let peers = self.peers.clone();
         let pool = self.connection_pool.clone();
+        let active_rx = self.connection_pool.get_active_connection_receiver();
 
-        WatchStream::new(self.connection_pool.get_active_connection_receiver())
-            .map(move |active_urls| {
+        // Tick on either (a) a change to the set of active pooled
+        // connections, or (b) a transport-level path change reported by
+        // the underlying connectors (e.g. iroh relay → direct). Both
+        // streams emit their current value immediately on subscription,
+        // so consumers see a snapshot right away.
+        let membership_ticks = WatchStream::new(active_rx.clone()).map(|_| ());
+        let path_change_ticks =
+            WatchStream::new(self.connection_pool.connectivity_change_notifier()).map(|_| ());
+        let ticks = futures::stream::select(membership_ticks, path_change_ticks);
+
+        ticks
+            .map(move |()| {
+                let active_urls = active_rx.borrow().clone();
                 peers
                     .iter()
                     .map(|(peer_id, url)| {

--- a/fedimint-api-client/src/api/mod.rs
+++ b/fedimint-api-client/src/api/mod.rs
@@ -14,7 +14,7 @@ pub use error::{FederationError, OutputOutcomeError};
 pub use fedimint_connectors::ServerResult;
 pub use fedimint_connectors::error::ServerError;
 use fedimint_connectors::{
-    ConnectionPool, ConnectorRegistry, DynGuaridianConnection, IGuardianConnection,
+    ConnectionPool, ConnectorRegistry, DynGuaridianConnection, IGuardianConnection, PeerStatus,
 };
 use fedimint_core::admin_client::{GuardianConfigBackup, ServerStatusLegacy, SetupStatus};
 use fedimint_core::backup::{BackupStatistics, ClientBackupSnapshot};
@@ -103,8 +103,17 @@ pub trait IRawFederationApi: Debug + MaybeSend + MaybeSync {
 
     /// Returns a stream of connection status for each peer
     ///
-    /// The stream emits a new value whenever the connection status changes.
-    fn connection_status_stream(&self) -> BoxStream<'static, BTreeMap<PeerId, bool>>;
+    /// The stream emits a new value whenever the set of active connections in
+    /// the pool changes. Each peer's entry is [`PeerStatus::Disconnected`] if
+    /// there is no active pooled connection, or
+    /// [`PeerStatus::Connected`] carrying the current
+    /// [`fedimint_connectors::Connectivity`] otherwise.
+    ///
+    /// Note: the stream does not tick on transport-level path changes (for
+    /// example iroh hole-punching from relay to direct) on an existing
+    /// connection — the carried [`fedimint_connectors::Connectivity`] only
+    /// refreshes when the pool membership itself changes.
+    fn connection_status_stream(&self) -> BoxStream<'static, BTreeMap<PeerId, PeerStatus>>;
     /// Wait for some connections being initialized
     ///
     /// This is useful to avoid initializing networking by
@@ -770,14 +779,22 @@ impl IRawFederationApi for FederationApi {
         self.request(peer_id, method, params.clone()).await
     }
 
-    fn connection_status_stream(&self) -> BoxStream<'static, BTreeMap<PeerId, bool>> {
+    fn connection_status_stream(&self) -> BoxStream<'static, BTreeMap<PeerId, PeerStatus>> {
         let peers = self.peers.clone();
+        let pool = self.connection_pool.clone();
 
         WatchStream::new(self.connection_pool.get_active_connection_receiver())
             .map(move |active_urls| {
                 peers
                     .iter()
-                    .map(|(peer_id, url)| (*peer_id, active_urls.contains(url)))
+                    .map(|(peer_id, url)| {
+                        let status = if active_urls.contains(url) {
+                            PeerStatus::Connected(pool.connectivity(url))
+                        } else {
+                            PeerStatus::Disconnected
+                        };
+                        (*peer_id, status)
+                    })
                     .collect()
             })
             .boxed()

--- a/fedimint-client-module/src/api.rs
+++ b/fedimint-client-module/src/api.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::string::ToString;
 
 use fedimint_api_client::api::{DynModuleApi, IRawFederationApi, ServerResult};
-use fedimint_connectors::DynGuaridianConnection;
+use fedimint_connectors::{DynGuaridianConnection, PeerStatus};
 use fedimint_core::core::ModuleInstanceId;
 use fedimint_core::db::{Database, DatabaseTransaction};
 use fedimint_core::module::ApiRequestErased;
@@ -166,7 +166,7 @@ where
         res
     }
 
-    fn connection_status_stream(&self) -> BoxStream<'static, BTreeMap<PeerId, bool>> {
+    fn connection_status_stream(&self) -> BoxStream<'static, BTreeMap<PeerId, PeerStatus>> {
         self.inner.connection_status_stream()
     }
 

--- a/fedimint-client/src/client.rs
+++ b/fedimint-client/src/client.rs
@@ -33,7 +33,7 @@ use fedimint_client_module::{
     AddStateMachinesResult, ClientModuleInstance, GetInviteCodeRequest, ModuleGlobalContextGen,
     ModuleRecoveryCompleted, TransactionUpdates, TxCreatedEvent,
 };
-use fedimint_connectors::ConnectorRegistry;
+use fedimint_connectors::{ConnectorRegistry, PeerStatus};
 use fedimint_core::config::{
     ClientConfig, FederationId, GlobalClientConfig, JsonClientConfig, ModuleInitRegistry,
 };
@@ -211,7 +211,7 @@ impl Client {
 
     /// Returns a stream that emits the current connection status of all peers
     /// whenever any peer's status changes. Emits initial state immediately.
-    pub fn connection_status_stream(&self) -> impl Stream<Item = BTreeMap<PeerId, bool>> {
+    pub fn connection_status_stream(&self) -> impl Stream<Item = BTreeMap<PeerId, PeerStatus>> {
         self.api.connection_status_stream()
     }
 

--- a/fedimint-connectors/src/http.rs
+++ b/fedimint-connectors/src/http.rs
@@ -8,7 +8,8 @@ use serde_json::Value;
 
 use crate::error::ServerError;
 use crate::{
-    DynGatewayConnection, DynGuaridianConnection, IConnection, IGatewayConnection, ServerResult,
+    Connectivity, DynGatewayConnection, DynGuaridianConnection, IConnection, IGatewayConnection,
+    ServerResult,
 };
 
 #[derive(Clone, Debug, Default)]
@@ -35,6 +36,10 @@ impl crate::Connector for HttpConnector {
         };
 
         Ok(IGatewayConnection::into_dyn(http_connection))
+    }
+
+    fn connectivity(&self, _url: &SafeUrl) -> Connectivity {
+        Connectivity::Direct
     }
 }
 

--- a/fedimint-connectors/src/iroh.rs
+++ b/fedimint-connectors/src/iroh.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 use std::fmt;
 use std::pin::Pin;
 use std::str::FromStr;
+use std::sync::Arc;
 
 use anyhow::{Context, bail};
 use async_trait::async_trait;
@@ -37,6 +38,7 @@ use iroh_base::ticket::NodeTicket;
 use iroh_next::Watcher as _;
 use reqwest::{Method, StatusCode};
 use serde_json::Value;
+use tokio::sync::watch;
 use tracing::{debug, trace, warn};
 
 use super::{DynGuaridianConnection, IGuardianConnection, ServerError, ServerResult};
@@ -53,6 +55,12 @@ pub(crate) struct IrohConnector {
     /// This is useful for testing, or forcing non-default network
     /// connectivity.
     connection_overrides: BTreeMap<NodeId, NodeAddr>,
+
+    /// Registry-owned signal bumped whenever any per-connection monitoring
+    /// task observes a transport-level path change (e.g. iroh relay →
+    /// direct). Consumers of [`crate::ConnectorRegistry`] subscribe via
+    /// [`crate::ConnectorRegistry::connectivity_change_notifier`].
+    path_change: Arc<watch::Sender<u64>>,
 }
 
 impl fmt::Debug for IrohConnector {
@@ -72,10 +80,13 @@ impl IrohConnector {
         iroh_dns: Option<SafeUrl>,
         iroh_enable_dht: bool,
         iroh_enable_next: bool,
+        path_change: Arc<watch::Sender<u64>>,
     ) -> anyhow::Result<Self> {
         const FM_IROH_CONNECT_OVERRIDES_ENV: &str = "FM_IROH_CONNECT_OVERRIDES";
         const FM_GW_IROH_CONNECT_OVERRIDES_ENV: &str = "FM_GW_IROH_CONNECT_OVERRIDES";
-        let mut s = Self::new_no_overrides(iroh_dns, iroh_enable_dht, iroh_enable_next).await?;
+        let mut s =
+            Self::new_no_overrides(iroh_dns, iroh_enable_dht, iroh_enable_next, path_change)
+                .await?;
 
         for (k, v) in parse_kv_list_from_env::<_, NodeTicket>(FM_IROH_CONNECT_OVERRIDES_ENV)? {
             s = s.with_connection_override(k, v.into());
@@ -93,6 +104,7 @@ impl IrohConnector {
         iroh_dns: Option<SafeUrl>,
         iroh_enable_dht: bool,
         iroh_enable_next: bool,
+        path_change: Arc<watch::Sender<u64>>,
     ) -> anyhow::Result<Self> {
         let endpoint_stable = Box::pin({
             let iroh_dns = iroh_dns.clone();
@@ -204,6 +216,7 @@ impl IrohConnector {
             stable: endpoint_stable,
             next: endpoint_next,
             connection_overrides: BTreeMap::new(),
+            path_change,
         })
     }
 
@@ -318,7 +331,11 @@ impl crate::Connector for IrohConnector {
                 .await?;
 
             #[cfg(not(target_family = "wasm"))]
-            Self::spawn_connection_monitoring_stable(&self.stable, node_id);
+            Self::spawn_connection_monitoring_stable(
+                &self.stable,
+                node_id,
+                self.path_change.clone(),
+            );
 
             Ok(IGatewayConnection::into_dyn(conn))
         } else {
@@ -345,7 +362,11 @@ impl crate::Connector for IrohConnector {
 
 impl IrohConnector {
     #[cfg(not(target_family = "wasm"))]
-    fn spawn_connection_monitoring_stable(endpoint: &Endpoint, node_id: NodeId) {
+    fn spawn_connection_monitoring_stable(
+        endpoint: &Endpoint,
+        node_id: NodeId,
+        path_change: Arc<watch::Sender<u64>>,
+    ) {
         if let Ok(mut conn_type_watcher) = endpoint.conn_type(node_id) {
             #[allow(clippy::let_underscore_future)]
             let _ = spawn("iroh connection (stable)", async move {
@@ -354,6 +375,7 @@ impl IrohConnector {
                 }
                 while let Ok(event) = conn_type_watcher.updated().await {
                     debug!(target: LOG_NET_IROH, %node_id, type = %event, "Connection type (changed)");
+                    path_change.send_modify(|c| *c = c.wrapping_add(1));
                 }
             });
         }
@@ -363,6 +385,7 @@ impl IrohConnector {
     fn spawn_connection_monitoring_next(
         endpoint: &iroh_next::Endpoint,
         node_addr: &iroh_next::NodeAddr,
+        path_change: Arc<watch::Sender<u64>>,
     ) {
         if let Some(mut conn_type_watcher) = endpoint.conn_type(node_addr.node_id) {
             let node_id = node_addr.node_id;
@@ -373,6 +396,7 @@ impl IrohConnector {
                 }
                 while let Ok(event) = conn_type_watcher.updated().await {
                     debug!(target: LOG_NET_IROH, node_id = %node_id, %event, "Connection type changed");
+                    path_change.send_modify(|c| *c = c.wrapping_add(1));
                 }
             });
         }
@@ -393,7 +417,11 @@ impl IrohConnector {
 
                 #[cfg(not(target_family = "wasm"))]
                 if conn.is_ok() {
-                    Self::spawn_connection_monitoring_stable(&self.stable, node_id);
+                    Self::spawn_connection_monitoring_stable(
+                        &self.stable,
+                        node_id,
+                        self.path_change.clone(),
+                    );
                 }
                 conn
             }
@@ -424,7 +452,11 @@ impl IrohConnector {
 
                 #[cfg(not(target_family = "wasm"))]
                 if conn.is_ok() {
-                    Self::spawn_connection_monitoring_next(&endpoint_next, &node_addr);
+                    Self::spawn_connection_monitoring_next(
+                        &endpoint_next,
+                        &node_addr,
+                        self.path_change.clone(),
+                    );
                 }
 
                 conn

--- a/fedimint-connectors/src/iroh.rs
+++ b/fedimint-connectors/src/iroh.rs
@@ -40,7 +40,7 @@ use serde_json::Value;
 use tracing::{debug, trace, warn};
 
 use super::{DynGuaridianConnection, IGuardianConnection, ServerError, ServerResult};
-use crate::{DynGatewayConnection, IConnection, IGatewayConnection};
+use crate::{Connectivity, DynGatewayConnection, IConnection, IGatewayConnection};
 
 #[derive(Clone)]
 pub(crate) struct IrohConnector {
@@ -324,6 +324,21 @@ impl crate::Connector for IrohConnector {
         } else {
             let conn = self.stable.connect(node_id, FEDIMINT_GATEWAY_ALPN).await?;
             Ok(IGatewayConnection::into_dyn(conn))
+        }
+    }
+
+    fn connectivity(&self, url: &SafeUrl) -> Connectivity {
+        let Ok(node_id) = Self::node_id_from_url(url) else {
+            return Connectivity::Unknown;
+        };
+        let Ok(watcher) = self.stable.conn_type(node_id) else {
+            return Connectivity::Unknown;
+        };
+        match watcher.get() {
+            Ok(iroh::endpoint::ConnectionType::Direct(_)) => Connectivity::Direct,
+            Ok(iroh::endpoint::ConnectionType::Relay(_)) => Connectivity::Relay,
+            Ok(iroh::endpoint::ConnectionType::Mixed(..)) => Connectivity::Mixed,
+            Ok(iroh::endpoint::ConnectionType::None) | Err(_) => Connectivity::Unknown,
         }
     }
 }

--- a/fedimint-connectors/src/lib.rs
+++ b/fedimint-connectors/src/lib.rs
@@ -508,13 +508,7 @@ pub trait Connector: Send + Sync + 'static + Debug {
     async fn connect_gateway(&self, url: &SafeUrl) -> anyhow::Result<DynGatewayConnection>;
 
     /// Report how a connection to `url` is currently reaching its peer.
-    ///
-    /// Defaults to [`Connectivity::Direct`] for transports without a relay
-    /// or anonymization concept. Iroh and Tor impls override this.
-    fn connectivity(&self, url: &SafeUrl) -> Connectivity {
-        let _ = url;
-        Connectivity::Direct
-    }
+    fn connectivity(&self, url: &SafeUrl) -> Connectivity;
 }
 
 /// How a connection is currently reaching its peer.

--- a/fedimint-connectors/src/lib.rs
+++ b/fedimint-connectors/src/lib.rs
@@ -473,6 +473,27 @@ impl ConnectorRegistry {
 
         result
     }
+
+    /// Report how a connection to `url` is currently reaching its peer.
+    ///
+    /// Returns [`Connectivity::Unknown`] if no connector for the url's scheme
+    /// is registered, or if the matching connector has not been initialized
+    /// yet (i.e. no connection attempt has been made).
+    pub fn connectivity(&self, url: &SafeUrl) -> Connectivity {
+        let url = match self.inner.connection_overrides.get(url) {
+            Some(replacement) => replacement,
+            None => url,
+        };
+
+        let Some((_, connector_cell)) = self.inner.connectors_lazy.get(url.scheme()) else {
+            return Connectivity::Unknown;
+        };
+
+        match connector_cell.get() {
+            Some(connector) => connector.connectivity(url),
+            None => Connectivity::Unknown,
+        }
+    }
 }
 pub type DynConnector = Arc<dyn Connector>;
 
@@ -485,6 +506,44 @@ pub trait Connector: Send + Sync + 'static + Debug {
     ) -> ServerResult<DynGuaridianConnection>;
 
     async fn connect_gateway(&self, url: &SafeUrl) -> anyhow::Result<DynGatewayConnection>;
+
+    /// Report how a connection to `url` is currently reaching its peer.
+    ///
+    /// Defaults to [`Connectivity::Direct`] for transports without a relay
+    /// or anonymization concept. Iroh and Tor impls override this.
+    fn connectivity(&self, url: &SafeUrl) -> Connectivity {
+        let _ = url;
+        Connectivity::Direct
+    }
+}
+
+/// How a connection is currently reaching its peer.
+///
+/// Transports without a relay concept (WS, HTTP) are always
+/// [`Connectivity::Direct`]. Tor-routed connections report
+/// [`Connectivity::Tor`]. Iroh connections may be [`Connectivity::Direct`]
+/// (peer-to-peer), [`Connectivity::Relay`] (routed through a relay
+/// server), or [`Connectivity::Mixed`] (both paths active); for Iroh this
+/// can change at runtime as hole-punching succeeds or falls back.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Connectivity {
+    Direct,
+    Relay,
+    Mixed,
+    Tor,
+    Unknown,
+}
+
+/// Per-peer connection state reported by the federation API.
+///
+/// [`PeerStatus::Connected`] carries the current [`Connectivity`] of the
+/// active connection; for Iroh this reflects the path at the moment of the
+/// emission and may be stale until the next pool-level change (relay→direct
+/// upgrades on an existing connection are not yet streamed).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PeerStatus {
+    Disconnected,
+    Connected(Connectivity),
 }
 
 /// Generic connection trait shared between [`IGuardianConnection`] and
@@ -698,6 +757,11 @@ impl<T: IConnection + ?Sized> ConnectionPool<T> {
 
     pub async fn wait_for_initialized_connections(&self) {
         self.connectors.wait_for_initialized_connections().await
+    }
+
+    /// Report how a connection to `url` is currently reaching its peer.
+    pub fn connectivity(&self, url: &SafeUrl) -> Connectivity {
+        self.connectors.connectivity(url)
     }
 }
 

--- a/fedimint-connectors/src/lib.rs
+++ b/fedimint-connectors/src/lib.rs
@@ -74,6 +74,11 @@ impl ConnectorRegistryBuilder {
         let mut connectors_lazy: BTreeMap<String, (ConnectorInitFn, OnceCell<DynConnector>)> =
             BTreeMap::new();
 
+        // Eagerly created so consumers can subscribe before the Iroh
+        // connector is lazily initialized. Only Iroh bumps it today
+        // (on transport-level path changes like relay → direct).
+        let path_change = Arc::new(watch::channel(0u64).0);
+
         // WS connector init function
         let builder_ws = self.clone();
         let ws_connector_init = Arc::new(move || {
@@ -86,12 +91,14 @@ impl ConnectorRegistryBuilder {
 
         // Iroh connector init function
         let builder_iroh = self.clone();
+        let path_change_iroh = path_change.clone();
         connectors_lazy.insert(
             "iroh".into(),
             (
                 Arc::new(move || {
                     let builder = builder_iroh.clone();
-                    Box::pin(async move { builder.build_iroh_connector().await })
+                    let path_change = path_change_iroh.clone();
+                    Box::pin(async move { builder.build_iroh_connector(path_change).await })
                         as Pin<Box<dyn Future<Output = anyhow::Result<DynConnector>> + Send>>
                 }),
                 OnceCell::new(),
@@ -119,18 +126,27 @@ impl ConnectorRegistryBuilder {
                 connectors_lazy,
                 connection_overrides: self.connection_overrides,
                 initialized: SetOnce::new(),
+                path_change,
             }
             .into(),
         })
     }
 
-    pub async fn build_iroh_connector(&self) -> anyhow::Result<DynConnector> {
+    pub async fn build_iroh_connector(
+        &self,
+        path_change: Arc<watch::Sender<u64>>,
+    ) -> anyhow::Result<DynConnector> {
         if !self.iroh_enable {
             bail!("Iroh connector not enabled");
         }
         Ok(Arc::new(
-            iroh::IrohConnector::new(self.iroh_dns.clone(), self.iroh_pkarr_dht, self.iroh_next)
-                .await?,
+            iroh::IrohConnector::new(
+                self.iroh_dns.clone(),
+                self.iroh_pkarr_dht,
+                self.iroh_next,
+                path_change,
+            )
+            .await?,
         ) as DynConnector)
     }
 
@@ -221,6 +237,9 @@ struct ConnectorRegistryInner {
     /// This is used for functionality that wants to avoid making
     /// network connections if nothing else did network request.
     initialized: tokio::sync::SetOnce<()>,
+    /// Ticks whenever a connector observes a transport-level path change
+    /// (e.g. iroh relay → direct). Only Iroh bumps this today.
+    path_change: Arc<watch::Sender<u64>>,
 }
 
 /// A set of available connectivity protocols a client can use to make
@@ -494,6 +513,18 @@ impl ConnectorRegistry {
             None => Connectivity::Unknown,
         }
     }
+
+    /// Subscribe to transport-level connectivity changes across all
+    /// connectors managed by this registry.
+    ///
+    /// The receiver ticks whenever a connector observes a path change on
+    /// an existing connection (for example an iroh connection upgrading
+    /// from relay to direct). The carried `u64` is an opaque counter —
+    /// consumers should treat each update as a "re-read connectivity"
+    /// signal.
+    pub fn connectivity_change_notifier(&self) -> watch::Receiver<u64> {
+        self.inner.path_change.subscribe()
+    }
 }
 pub type DynConnector = Arc<dyn Connector>;
 
@@ -756,6 +787,12 @@ impl<T: IConnection + ?Sized> ConnectionPool<T> {
     /// Report how a connection to `url` is currently reaching its peer.
     pub fn connectivity(&self, url: &SafeUrl) -> Connectivity {
         self.connectors.connectivity(url)
+    }
+
+    /// Subscribe to transport-level connectivity changes observed by
+    /// the connectors underlying this pool.
+    pub fn connectivity_change_notifier(&self) -> watch::Receiver<u64> {
+        self.connectors.connectivity_change_notifier()
     }
 }
 

--- a/fedimint-connectors/src/tor.rs
+++ b/fedimint-connectors/src/tor.rs
@@ -13,7 +13,7 @@ use tokio_rustls::rustls::{ClientConfig as TlsClientConfig, RootCertStore};
 use tracing::debug;
 
 use super::{Connector, DynGuaridianConnection};
-use crate::{DynGatewayConnection, IGuardianConnection as _, ServerError};
+use crate::{Connectivity, DynGatewayConnection, IGuardianConnection as _, ServerError};
 
 #[derive(Clone)]
 pub struct TorConnector {
@@ -182,5 +182,9 @@ impl Connector for TorConnector {
 
     async fn connect_gateway(&self, _url: &SafeUrl) -> anyhow::Result<DynGatewayConnection> {
         Err(anyhow!("Unsupported transport method"))
+    }
+
+    fn connectivity(&self, _url: &SafeUrl) -> Connectivity {
+        Connectivity::Tor
     }
 }

--- a/fedimint-connectors/src/ws.rs
+++ b/fedimint-connectors/src/ws.rs
@@ -23,8 +23,8 @@ pub type JsonRpcResult<T> = Result<T, JsonRpcClientError>;
 
 use super::Connector;
 use crate::{
-    DynGatewayConnection, DynGuaridianConnection, IConnection, IGuardianConnection, ServerError,
-    ServerResult,
+    Connectivity, DynGatewayConnection, DynGuaridianConnection, IConnection, IGuardianConnection,
+    ServerError, ServerResult,
 };
 
 #[derive(Debug, Clone)]
@@ -131,6 +131,10 @@ impl Connector for WebsocketConnector {
 
     async fn connect_gateway(&self, _url: &SafeUrl) -> anyhow::Result<DynGatewayConnection> {
         Err(anyhow!("Unsupported transport method"))
+    }
+
+    fn connectivity(&self, _url: &SafeUrl) -> Connectivity {
+        Connectivity::Direct
     }
 }
 


### PR DESCRIPTION
In Ecash App, I would like to expose the `Connectivity` type (relayed, direct, mixed, etc) instead of just showing if the client is connected to the guardian. We already do this on the guardian dashboard, I think it would be cool to expose it in the client as well.