### PR TITLE
fix(ci): use process substitution to prevent orphan daemons from bloc…

### DIFF
--- a/scripts/dev/run-test/fm-run-test
+++ b/scripts/dev/run-test/fm-run-test
@@ -76,18 +76,42 @@ FM_RUN_TEST_TIMEOUT_SOFT=${FM_RUN_TEST_TIMEOUT:-310}
 
 set +e
 
+# We use process substitution `> >(ts ...)` instead of a pipe `| ts ...` to
+# prevent orphan daemon processes from blocking the script indefinitely.
+#
+# The test command spawns daemon processes (fedimintd, bitcoind, etc.) via
+# devimint. Many of these daemons call setsid() to create new sessions/process
+# groups. When `timeout` fires, it sends signals to its child's process group,
+# but daemons in different groups survive as orphans.
+#
+# With a pipeline (`timeout ... "$@" 2>&1 | ts`), bash waits for ALL pipeline
+# components to finish. Orphan daemons inherit the pipe's write-end FD through
+# the fork chain. After timeout kills the main test and exits, the pipe's write
+# end stays open (held by orphans), so `ts` blocks on read() waiting for EOF.
+# Since bash waits for `ts`, the pipeline never completes: `exit_status=$?` is
+# never reached, the error handler never fires, and GNU parallel's hard timeout
+# eventually kills the entire job — with no diagnostic output.
+#
+# With process substitution (`timeout ... "$@" > >(ts ...) 2>&1`), bash only
+# waits for the main command (`command time ... timeout`), not for the `ts`
+# process inside `>(...)`. When timeout kills the test and exits, bash
+# immediately proceeds to capture exit_status — regardless of whether orphan
+# daemons are still holding the FIFO write end open and keeping `ts` alive in
+# the background. The error handler can run and print diagnostics within the
+# time budget before parallel's hard timeout.
 command time -q --format="$time_fmt" -o "$time_out_path" \
     timeout -k 10 "$FM_RUN_TEST_TIMEOUT_SOFT" \
-    "$@" 2>&1 | ts -i "%.S" | ts -s "%M:%S" > "$test_out_path"; exit_status=$?
+    "$@" > >(ts -i "%.S" | ts -s "%M:%S" > "$test_out_path") 2>&1; exit_status=$?
 
 set -e
 
 if [ $exit_status -ne 0 ]; then
     if grep -q "please upgrade to gatewayd" "$FM_RUN_TEST_TMPDIR"/devimint-*/logs/gatewayd-lnd.log 2>/dev/null; then
         echo "## RERUN $test_name$version_str - known old gatewayd bug."
+        # See comment above for why process substitution is used here.
         command time -q --format="$time_fmt" -o "$time_out_path" \
             timeout -k 10 "$FM_RUN_TEST_TIMEOUT_SOFT" \
-            "$@" 2>&1 | ts -i "%.S" | ts -s "%M:%S" > "$test_out_path"
+            "$@" > >(ts -i "%.S" | ts -s "%M:%S" > "$test_out_path") 2>&1
     else
       exit $exit_status
     fi


### PR DESCRIPTION
…king test output pipeline

When `timeout` kills a test, daemon processes that called setsid() survive in different process groups. With a pipe (`| ts`), these orphans hold the pipe's write-end FD open, blocking `ts` on read() indefinitely. Since bash waits for all pipeline components, the script hangs until parallel's hard timeout kills it — with no diagnostic output. Process substitution (`> >(ts ...)`) makes bash only wait for the main command, so exit_status is captured immediately and the error handler can run.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
