### PR TITLE
test(lnv2): add LNURL recovery integration test

### DIFF
--- a/modules/fedimint-lnv2-tests/bin/tests.rs
+++ b/modules/fedimint-lnv2-tests/bin/tests.rs
@@ -599,6 +599,7 @@ async fn test_lnurl_recovery(dev_fed: &DevJitFed) -> anyhow::Result<()> {
     let recurringd = dev_fed.recurringdv2().await?.api_url().to_string();
 
     const LNURL_AMOUNT_MSAT: u64 = 500_000;
+    const LNURL_BALANCE_TOLERANCE_MSAT: u64 = 100_000;
 
     // ── Phase 1: Pre-recovery LNURL receives ──────────────────────────
 
@@ -616,7 +617,13 @@ async fn test_lnurl_recovery(dev_fed: &DevJitFed) -> anyhow::Result<()> {
         gw_lnd.client().pay_invoice(invoice).await?;
     }
 
-    while client.balance().await? < 3 * LNURL_AMOUNT_MSAT - 100_000 {
+    while almost_equal(
+        client.balance().await?,
+        3 * LNURL_AMOUNT_MSAT,
+        LNURL_BALANCE_TOLERANCE_MSAT,
+    )
+    .is_err()
+    {
         info!("Waiting for pre-recovery LNURL payments to settle...");
         cmd!(client, "dev", "wait", "1").out_json().await?;
     }
@@ -665,8 +672,13 @@ async fn test_lnurl_recovery(dev_fed: &DevJitFed) -> anyhow::Result<()> {
         gw_lnd.client().pay_invoice(invoice).await?;
     }
 
-    let expected_min = post_recovery_balance + 2 * LNURL_AMOUNT_MSAT - 100_000;
-    while restored.balance().await? < expected_min {
+    while almost_equal(
+        restored.balance().await?,
+        post_recovery_balance + 2 * LNURL_AMOUNT_MSAT,
+        LNURL_BALANCE_TOLERANCE_MSAT,
+    )
+    .is_err()
+    {
         info!("Waiting for post-recovery LNURL payments to settle...");
         cmd!(restored, "dev", "wait", "1").out_json().await?;
     }

--- a/modules/fedimint-lnv2-tests/bin/tests.rs
+++ b/modules/fedimint-lnv2-tests/bin/tests.rs
@@ -587,25 +587,12 @@ async fn test_lnurl_pay(dev_fed: &DevJitFed) -> anyhow::Result<()> {
 
 /// Tests LNURL receives after recovery from seed.
 ///
-/// Recovery restores funds via the mint module; the operation log and LNv2
-/// state are not recovered (the module uses `NoModuleBackup`). This test
-/// verifies that:
-/// 1. Balance is fully recovered
-/// 2. Old LNv2 operations do not appear in the restored client
-/// 3. New LNURL receives continue to work after recovery
+/// LNv2 uses `NoModuleBackup`, so recovery restores funds via the mint module
+/// but not the operation log or LNv2 state. Verifies:
+/// 1. Balance is fully recovered.
+/// 2. Payments to a pre-recovery LNURL are still claimed by the restored
+///    client.
 async fn test_lnurl_recovery(dev_fed: &DevJitFed) -> anyhow::Result<()> {
-    if util::FedimintCli::version_or_default().await < *VERSION_0_11_0_ALPHA {
-        return Ok(());
-    }
-
-    if util::FedimintdCmd::version_or_default().await < *VERSION_0_11_0_ALPHA {
-        return Ok(());
-    }
-
-    if util::Gatewayd::version_or_default().await < *VERSION_0_11_0_ALPHA {
-        return Ok(());
-    }
-
     let federation = dev_fed.fed().await?;
     let gw_lnd = dev_fed.gw_lnd().await?;
     let gw_ldk = dev_fed.gw_ldk().await?;
@@ -623,14 +610,12 @@ async fn test_lnurl_recovery(dev_fed: &DevJitFed) -> anyhow::Result<()> {
 
     let lnurl = generate_lnurl(&client, &recurringd, &gw_ldk.addr).await?;
 
-    // Pay 3 invoices to the LNURL (gw_lnd pays, gw_ldk receives)
     for i in 0..3 {
         info!("Paying LNURL invoice {}/3", i + 1);
         let (invoice, _verify_url) = fetch_invoice(lnurl.clone(), LNURL_AMOUNT_MSAT).await?;
         gw_lnd.client().pay_invoice(invoice).await?;
     }
 
-    // Wait for all 3 payments to be claimed
     while client.balance().await? < 3 * LNURL_AMOUNT_MSAT - 100_000 {
         info!("Waiting for pre-recovery LNURL payments to settle...");
         cmd!(client, "dev", "wait", "1").out_json().await?;
@@ -639,13 +624,12 @@ async fn test_lnurl_recovery(dev_fed: &DevJitFed) -> anyhow::Result<()> {
     let pre_recovery_balance = client.balance().await?;
     info!("Pre-recovery balance: {pre_recovery_balance} msats");
 
-    // Extract the mnemonic for recovery
     let mnemonic = cmd!(client, "print-secret").out_json().await?["secret"]
         .as_str()
         .expect("secret is a string")
         .to_owned();
 
-    // ── Phase 2: Recovery and state verification ──────────────────────
+    // ── Phase 2: Recovery ─────────────────────────────────────────────
 
     info!("Phase 2: Recovering client from seed");
 
@@ -661,52 +645,26 @@ async fn test_lnurl_recovery(dev_fed: &DevJitFed) -> anyhow::Result<()> {
     .run()
     .await?;
 
-    // Give the receive_lnurl background task time to sync the stream index
-    cmd!(restored, "dev", "wait", "1").out_json().await?;
+    while restored.balance().await? < pre_recovery_balance {
+        info!("Waiting for recovery to complete...");
+        cmd!(restored, "dev", "wait", "1").out_json().await?;
+    }
 
-    // Verify balance was recovered by the mint module
     let post_recovery_balance = restored.balance().await?;
     info!("Post-recovery balance: {post_recovery_balance} msats");
-    assert!(
-        post_recovery_balance >= pre_recovery_balance,
-        "Recovered balance {post_recovery_balance} should be >= pre-recovery balance {pre_recovery_balance}"
-    );
-
-    // Verify old LNv2 operations are not in the operation log
-    let operations = cmd!(restored, "list-operations", "--limit", "100")
-        .out_json()
-        .await?;
-    let lnv2_ops: Vec<_> = operations["operations"]
-        .as_array()
-        .expect("operations is an array")
-        .iter()
-        .filter(|op| op["operation_kind"].as_str() == Some("lnv2"))
-        .collect();
-    assert!(
-        lnv2_ops.is_empty(),
-        "Expected no LNv2 operations after recovery, found {}",
-        lnv2_ops.len()
-    );
-
-    info!("Recovery verified: balance restored, no stale LNv2 operations");
 
     // ── Phase 3: Post-recovery LNURL receives ─────────────────────────
 
-    info!("Phase 3: Testing new LNURL receives after recovery");
+    info!("Phase 3: Paying to the original LNURL; restored client must claim");
 
-    // Generate a fresh LNURL (re-registers with recurringd using same seed-derived
-    // key)
-    let restored_lnurl = generate_lnurl(&restored, &recurringd, &gw_ldk.addr).await?;
-
-    // Pay 2 invoices to the restored client's LNURL (gw_lnd pays, gw_ldk receives)
+    // Reuse the Phase 1 `lnurl` on purpose: this is what a third party would
+    // have saved pre-recovery, and it must still pay the restored client.
     for i in 0..2 {
-        info!("Paying post-recovery LNURL invoice {}/2", i + 1);
-        let (invoice, _verify_url) =
-            fetch_invoice(restored_lnurl.clone(), LNURL_AMOUNT_MSAT).await?;
+        info!("Paying pre-recovery LNURL invoice {}/2", i + 1);
+        let (invoice, _verify_url) = fetch_invoice(lnurl.clone(), LNURL_AMOUNT_MSAT).await?;
         gw_lnd.client().pay_invoice(invoice).await?;
     }
 
-    // Wait for balance to increase
     let expected_min = post_recovery_balance + 2 * LNURL_AMOUNT_MSAT - 100_000;
     while restored.balance().await? < expected_min {
         info!("Waiting for post-recovery LNURL payments to settle...");
@@ -716,7 +674,6 @@ async fn test_lnurl_recovery(dev_fed: &DevJitFed) -> anyhow::Result<()> {
     let final_balance = restored.balance().await?;
     info!("Final balance: {final_balance} msats");
 
-    // Verify new operations appeared in the operation log
     let operations = cmd!(restored, "list-operations", "--limit", "100")
         .out_json()
         .await?;

--- a/modules/fedimint-lnv2-tests/bin/tests.rs
+++ b/modules/fedimint-lnv2-tests/bin/tests.rs
@@ -58,6 +58,8 @@ enum Commands {
     Payments,
     /// Run LNURL pay tests
     LnurlPay,
+    /// Test LNURL receives after recovery from seed
+    LnurlRecovery,
 }
 
 #[tokio::main]
@@ -82,11 +84,16 @@ async fn main() -> anyhow::Result<()> {
                     pegin_gateways(&dev_fed).await?;
                     test_lnurl_pay(&dev_fed).await?;
                 }
+                Some(Commands::LnurlRecovery) => {
+                    pegin_gateways(&dev_fed).await?;
+                    test_lnurl_recovery(&dev_fed).await?;
+                }
                 None => {
                     // Run all tests if no subcommand is specified
                     test_gateway_registration(&dev_fed).await?;
                     test_payments(&dev_fed).await?;
                     test_lnurl_pay(&dev_fed).await?;
+                    test_lnurl_recovery(&dev_fed).await?;
                 }
             }
 
@@ -574,6 +581,161 @@ async fn test_lnurl_pay(dev_fed: &DevJitFed) -> anyhow::Result<()> {
     }
 
     info!("Client B successfully received funds via LNURL!");
+
+    Ok(())
+}
+
+/// Tests LNURL receives after recovery from seed.
+///
+/// Recovery restores funds via the mint module; the operation log and LNv2
+/// state are not recovered (the module uses `NoModuleBackup`). This test
+/// verifies that:
+/// 1. Balance is fully recovered
+/// 2. Old LNv2 operations do not appear in the restored client
+/// 3. New LNURL receives continue to work after recovery
+async fn test_lnurl_recovery(dev_fed: &DevJitFed) -> anyhow::Result<()> {
+    if util::FedimintCli::version_or_default().await < *VERSION_0_11_0_ALPHA {
+        return Ok(());
+    }
+
+    if util::FedimintdCmd::version_or_default().await < *VERSION_0_11_0_ALPHA {
+        return Ok(());
+    }
+
+    if util::Gatewayd::version_or_default().await < *VERSION_0_11_0_ALPHA {
+        return Ok(());
+    }
+
+    let federation = dev_fed.fed().await?;
+    let gw_lnd = dev_fed.gw_lnd().await?;
+    let gw_ldk = dev_fed.gw_ldk().await?;
+    let recurringd = dev_fed.recurringdv2().await?.api_url().to_string();
+
+    const LNURL_AMOUNT_MSAT: u64 = 500_000;
+
+    // ── Phase 1: Pre-recovery LNURL receives ──────────────────────────
+
+    info!("Phase 1: Creating client and receiving via LNURL before recovery");
+
+    let client = federation
+        .new_joined_client("lnv2-lnurl-recovery-original")
+        .await?;
+
+    let lnurl = generate_lnurl(&client, &recurringd, &gw_ldk.addr).await?;
+
+    // Pay 3 invoices to the LNURL (gw_lnd pays, gw_ldk receives)
+    for i in 0..3 {
+        info!("Paying LNURL invoice {}/3", i + 1);
+        let (invoice, _verify_url) = fetch_invoice(lnurl.clone(), LNURL_AMOUNT_MSAT).await?;
+        gw_lnd.client().pay_invoice(invoice).await?;
+    }
+
+    // Wait for all 3 payments to be claimed
+    while client.balance().await? < 3 * LNURL_AMOUNT_MSAT - 100_000 {
+        info!("Waiting for pre-recovery LNURL payments to settle...");
+        cmd!(client, "dev", "wait", "1").out_json().await?;
+    }
+
+    let pre_recovery_balance = client.balance().await?;
+    info!("Pre-recovery balance: {pre_recovery_balance} msats");
+
+    // Extract the mnemonic for recovery
+    let mnemonic = cmd!(client, "print-secret").out_json().await?["secret"]
+        .as_str()
+        .expect("secret is a string")
+        .to_owned();
+
+    // ── Phase 2: Recovery and state verification ──────────────────────
+
+    info!("Phase 2: Recovering client from seed");
+
+    let restored = Client::create("lnv2-lnurl-recovery-restored").await?;
+    cmd!(
+        restored,
+        "restore",
+        "--invite-code",
+        federation.invite_code()?,
+        "--mnemonic",
+        &mnemonic
+    )
+    .run()
+    .await?;
+
+    // Give the receive_lnurl background task time to sync the stream index
+    cmd!(restored, "dev", "wait", "1").out_json().await?;
+
+    // Verify balance was recovered by the mint module
+    let post_recovery_balance = restored.balance().await?;
+    info!("Post-recovery balance: {post_recovery_balance} msats");
+    assert!(
+        post_recovery_balance >= pre_recovery_balance,
+        "Recovered balance {post_recovery_balance} should be >= pre-recovery balance {pre_recovery_balance}"
+    );
+
+    // Verify old LNv2 operations are not in the operation log
+    let operations = cmd!(restored, "list-operations", "--limit", "100")
+        .out_json()
+        .await?;
+    let lnv2_ops: Vec<_> = operations["operations"]
+        .as_array()
+        .expect("operations is an array")
+        .iter()
+        .filter(|op| op["operation_kind"].as_str() == Some("lnv2"))
+        .collect();
+    assert!(
+        lnv2_ops.is_empty(),
+        "Expected no LNv2 operations after recovery, found {}",
+        lnv2_ops.len()
+    );
+
+    info!("Recovery verified: balance restored, no stale LNv2 operations");
+
+    // ── Phase 3: Post-recovery LNURL receives ─────────────────────────
+
+    info!("Phase 3: Testing new LNURL receives after recovery");
+
+    // Generate a fresh LNURL (re-registers with recurringd using same seed-derived
+    // key)
+    let restored_lnurl = generate_lnurl(&restored, &recurringd, &gw_ldk.addr).await?;
+
+    // Pay 2 invoices to the restored client's LNURL (gw_lnd pays, gw_ldk receives)
+    for i in 0..2 {
+        info!("Paying post-recovery LNURL invoice {}/2", i + 1);
+        let (invoice, _verify_url) =
+            fetch_invoice(restored_lnurl.clone(), LNURL_AMOUNT_MSAT).await?;
+        gw_lnd.client().pay_invoice(invoice).await?;
+    }
+
+    // Wait for balance to increase
+    let expected_min = pre_recovery_balance + 2 * LNURL_AMOUNT_MSAT - 100_000;
+    while restored.balance().await? < expected_min {
+        info!("Waiting for post-recovery LNURL payments to settle...");
+        cmd!(restored, "dev", "wait", "1").out_json().await?;
+    }
+
+    let final_balance = restored.balance().await?;
+    info!("Final balance: {final_balance} msats");
+
+    // Verify new operations appeared in the operation log
+    let operations = cmd!(restored, "list-operations", "--limit", "100")
+        .out_json()
+        .await?;
+    let lnv2_ops: Vec<_> = operations["operations"]
+        .as_array()
+        .expect("operations is an array")
+        .iter()
+        .filter(|op| op["operation_kind"].as_str() == Some("lnv2"))
+        .collect();
+    assert!(
+        lnv2_ops.len() >= 2,
+        "Expected at least 2 LNv2 operations after post-recovery receives, found {}",
+        lnv2_ops.len()
+    );
+
+    info!(
+        "LNURL recovery test passed: {} new operations, balance {final_balance} msats",
+        lnv2_ops.len()
+    );
 
     Ok(())
 }

--- a/modules/fedimint-lnv2-tests/bin/tests.rs
+++ b/modules/fedimint-lnv2-tests/bin/tests.rs
@@ -707,7 +707,7 @@ async fn test_lnurl_recovery(dev_fed: &DevJitFed) -> anyhow::Result<()> {
     }
 
     // Wait for balance to increase
-    let expected_min = pre_recovery_balance + 2 * LNURL_AMOUNT_MSAT - 100_000;
+    let expected_min = post_recovery_balance + 2 * LNURL_AMOUNT_MSAT - 100_000;
     while restored.balance().await? < expected_min {
         info!("Waiting for post-recovery LNURL payments to settle...");
         cmd!(restored, "dev", "wait", "1").out_json().await?;

--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -165,6 +165,11 @@ function lnv2_module_lnurl_pay() {
 }
 export -f lnv2_module_lnurl_pay
 
+function lnv2_module_lnurl_recovery() {
+  fm-run-test "${FUNCNAME[0]}" env FM_OFFLINE_NODES=0 ./scripts/tests/lnv2-module-test.sh lnurl-recovery
+}
+export -f lnv2_module_lnurl_recovery
+
 function lnv1_lnv2_swap() {
   fm-run-test "${FUNCNAME[0]}" env FM_OFFLINE_NODES=0 ./scripts/tests/lnv1-lnv2-swap-test.sh
 }
@@ -446,6 +451,7 @@ tests_to_run_in_parallel+=(
   "lnv2_module_payments"
   "lnv2_mintv2_walletv2_lightning_payments"
   "lnv2_module_lnurl_pay"
+  "lnv2_module_lnurl_recovery"
   "lnv1_lnv2_swap"
   "walletv2_module"
   "mintv2_module_test"


### PR DESCRIPTION
Ref. #8465 (partial — LNv2 only)

### Summary
- Adds integration test covering the three-phase scenario: LNURL receive → recover from seed → LNURL receive                                                                                               
- Pins the invariant that recovery restores funds via the mint module; the operation log and LNv2 state are not recovered
 - Wires the new subcommand into `test-ci-all.sh` so the parallel runner picks it 

### Test plan                                                                                          
  - [x] `./scripts/tests/lnv2-module-test.sh lnurl-recovery` passes locally
  - [x] Full LNv2 suite (`gateway-registration`, `payments`, `lnurl-pay`, `lnurl-recovery`,  `lnv1-lnv2-swap`) passes sequentially with no regressions
  - [x] `cargo fmt --all && cargo clippy --workspace --all-targets -- -D warnings` clean
