### PR TITLE
fix(tests): poll for channel closure instead of asserting immediately

### DIFF
--- a/devimint/src/gatewayd.rs
+++ b/devimint/src/gatewayd.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::ops::ControlFlow;
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -336,7 +336,10 @@ impl<'a> GatewayClient {
         Ok(())
     }
 
-    pub async fn close_all_channels(&self, force: bool) -> Result<()> {
+    /// Send close requests for all channels without waiting for them to
+    /// become inactive. See [`Self::close_all_channels`] for a version
+    /// that polls until closure is confirmed.
+    pub async fn close_all_channels_no_wait(&self, force: bool) -> Result<()> {
         let channels = self.list_channels().await?;
 
         for chan in channels {
@@ -345,6 +348,33 @@ impl<'a> GatewayClient {
         }
 
         Ok(())
+    }
+
+    /// Close all channels and poll until none are active.
+    ///
+    /// Only waits for channels that existed at the time of the call, so
+    /// channels opened while polling are ignored.
+    pub async fn close_all_channels(&self, force: bool, timeout: Duration) -> Result<()> {
+        let channels = self.list_channels().await?;
+        let closing_peers: HashSet<_> = channels.iter().map(|chan| chan.remote_pubkey).collect();
+
+        for chan in channels {
+            self.close_channel(chan.remote_pubkey, force).await?;
+        }
+
+        poll_with_timeout("waiting for channels to close", timeout, || async {
+            let channels = self.list_channels().await.map_err(ControlFlow::Continue)?;
+            if channels
+                .iter()
+                .any(|chan| closing_peers.contains(&chan.remote_pubkey) && chan.is_active)
+            {
+                return Err(ControlFlow::Continue(anyhow::anyhow!(
+                    "Some channels are still active"
+                )));
+            }
+            Ok(())
+        })
+        .await
     }
 
     /// Open a channel with the gateway's lightning node, returning the funding

--- a/gateway/integration_tests/src/main.rs
+++ b/gateway/integration_tests/src/main.rs
@@ -475,25 +475,11 @@ async fn liquidity_test() -> anyhow::Result<()> {
             let gw_ldk_pubkey = gw_ldk.client().lightning_pubkey().await?;
             gw_lnd.client().close_channel(gw_ldk_pubkey, false).await?;
 
-            // Force close LDK's channels
-            gw_ldk_second.client().close_all_channels(true).await?;
-
-            // Verify none of the channels are active
+            // Force close remaining channels on every gateway and wait
             for gw in &gateways {
-                poll("waiting for channels to close", || async {
-                    let channels = gw
-                        .client()
-                        .list_channels()
-                        .await
-                        .map_err(ControlFlow::Continue)?;
-                    if channels.iter().any(|chan| chan.is_active) {
-                        return Err(ControlFlow::Continue(anyhow::anyhow!(
-                            "Some channels are still active"
-                        )));
-                    }
-                    Ok(())
-                })
-                .await?;
+                gw.client()
+                    .close_all_channels(true, Duration::from_secs(30))
+                    .await?;
             }
 
             Ok(())

--- a/gateway/integration_tests/src/main.rs
+++ b/gateway/integration_tests/src/main.rs
@@ -479,10 +479,21 @@ async fn liquidity_test() -> anyhow::Result<()> {
             gw_ldk_second.client().close_all_channels(true).await?;
 
             // Verify none of the channels are active
-            for gw in gateways {
-                let channels = gw.client().list_channels().await?;
-                let active_channel = channels.into_iter().any(|chan| chan.is_active);
-                assert!(!active_channel);
+            for gw in &gateways {
+                poll("waiting for channels to close", || async {
+                    let channels = gw
+                        .client()
+                        .list_channels()
+                        .await
+                        .map_err(ControlFlow::Continue)?;
+                    if channels.iter().any(|chan| chan.is_active) {
+                        return Err(ControlFlow::Continue(anyhow::anyhow!(
+                            "Some channels are still active"
+                        )));
+                    }
+                    Ok(())
+                })
+                .await?;
             }
 
             Ok(())


### PR DESCRIPTION
Channel close operations are asynchronous — the API returns before the channel is fully marked inactive. This caused a flaky assertion in gw_liquidity_test_mintv2. Use poll() to retry with backoff, matching the standard pattern used throughout the test suite.

Fix https://github.com/fedimint/fedimint/actions/runs/24548404990/job/71768764812?pr=8523

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
