### PR TITLE
add mint recovery integration test

### DIFF
--- a/modules/fedimint-mint-tests/src/bin/mint-module-tests.rs
+++ b/modules/fedimint-mint-tests/src/bin/mint-module-tests.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use clap::Parser;
 use devimint::cmd;
 use devimint::federation::Federation;
+use devimint::util::almost_equal;
 use fedimint_logging::LOG_DEVIMINT;
 use rand::Rng;
 use tracing::info;
@@ -9,6 +10,8 @@ use tracing::info;
 #[derive(Debug, Parser)]
 enum Cmd {
     Restore,
+    RecoveryV1,
+    RecoveryV2,
     Sanity,
 }
 
@@ -16,6 +19,8 @@ enum Cmd {
 async fn main() -> anyhow::Result<()> {
     match Cmd::parse() {
         Cmd::Restore => restore().await,
+        Cmd::RecoveryV1 => mint_recovery_test().await,
+        Cmd::RecoveryV2 => mint_recovery_test().await,
         Cmd::Sanity => sanity().await,
     }
 }
@@ -119,6 +124,146 @@ pub async fn test_restore_gap_test(fed: &Federation) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Test that mint recovery works correctly in various scenarios.
+///
+/// The V1 variant should be run with `FM_FORCE_V1_MINT_RECOVERY=1` to
+/// force the legacy session-based recovery path which reissues recovered
+/// ecash.
+///
+/// Regression test for <https://github.com/fedimint/fedimint/issues/8004>
+async fn mint_recovery_test() -> anyhow::Result<()> {
+    devimint::run_devfed_test()
+        .call(|dev_fed, _process_mgr| async move {
+            let fed = dev_fed.fed().await?;
+
+            const PEGIN_SATS: u64 = 100_000;
+
+            info!(target: LOG_DEVIMINT, "### Test mint recovery with backup");
+            {
+                let client = fed.new_joined_client("mint-recovery-backup").await?;
+                fed.pegin_client(PEGIN_SATS, &client).await?;
+
+                let pre_balance = client.balance().await?;
+                info!(target: LOG_DEVIMINT, pre_balance, "Balance before backup");
+                assert!(pre_balance > 0);
+
+                // Upload backup so the federation stores spendable notes
+                cmd!(client, "backup").run().await?;
+
+                // Restore triggers recovery; with V1 this exercises the
+                // finalize_dbtx reissuance codepath
+                let restored = client
+                    .new_restored("mint-restored-with-backup", fed.invite_code()?)
+                    .await?;
+                cmd!(restored, "dev", "wait-complete").out_json().await?;
+
+                let post_balance = restored.balance().await?;
+                info!(target: LOG_DEVIMINT, post_balance, "Balance after recovery with backup");
+                almost_equal(pre_balance, post_balance, 100_000).unwrap();
+            }
+
+            info!(target: LOG_DEVIMINT, "### Test mint recovery without backup");
+            {
+                let client = fed.new_joined_client("mint-recovery-no-backup").await?;
+                fed.pegin_client(PEGIN_SATS, &client).await?;
+
+                let pre_balance = client.balance().await?;
+                assert!(pre_balance > 0);
+
+                // Restore without ever calling backup — recovery from history only
+                let restored = client
+                    .new_restored("mint-restored-no-backup", fed.invite_code()?)
+                    .await?;
+                cmd!(restored, "dev", "wait-complete").out_json().await?;
+
+                let post_balance = restored.balance().await?;
+                info!(target: LOG_DEVIMINT, post_balance, "Balance after recovery without backup");
+                almost_equal(pre_balance, post_balance, 100_000).unwrap();
+            }
+
+            info!(target: LOG_DEVIMINT, "### Test mint recovery after spend+reissue activity");
+            {
+                let client = fed
+                    .new_joined_client("mint-recovery-after-activity")
+                    .await?;
+                fed.pegin_client(PEGIN_SATS, &client).await?;
+
+                // Do several rounds of spend-to-self to churn note denominations
+                for i in 0..3 {
+                    let balance = client.balance().await?;
+                    let spend_amount = balance / 3;
+
+                    let notes = cmd!(client, "spend", spend_amount)
+                        .out_json()
+                        .await?
+                        .get("notes")
+                        .expect("Output didn't contain e-cash notes")
+                        .as_str()
+                        .unwrap()
+                        .to_owned();
+
+                    cmd!(client, "reissue", notes).out_json().await?;
+                    info!(target: LOG_DEVIMINT, i, spend_amount, "Spent and reissued to self");
+                }
+
+                let pre_balance = client.balance().await?;
+                info!(target: LOG_DEVIMINT, pre_balance, "Balance after activity");
+                assert!(pre_balance > 0);
+
+                cmd!(client, "backup").run().await?;
+
+                let restored = client
+                    .new_restored("mint-restored-after-activity", fed.invite_code()?)
+                    .await?;
+                cmd!(restored, "dev", "wait-complete").out_json().await?;
+
+                let post_balance = restored.balance().await?;
+                info!(target: LOG_DEVIMINT, post_balance, "Balance after recovery post-activity");
+                almost_equal(pre_balance, post_balance, 100_000).unwrap();
+            }
+
+            info!(target: LOG_DEVIMINT, "### Test mint recovery with post-backup activity");
+            {
+                let client = fed
+                    .new_joined_client("mint-recovery-post-backup")
+                    .await?;
+                fed.pegin_client(PEGIN_SATS, &client).await?;
+
+                // Backup while we still have the original notes
+                cmd!(client, "backup").run().await?;
+
+                // Spend and reissue after the backup — these note changes
+                // won't be in the backup, only in the federation history
+                let balance = client.balance().await?;
+                let spend_amount = balance / 2;
+                let notes = cmd!(client, "spend", spend_amount)
+                    .out_json()
+                    .await?
+                    .get("notes")
+                    .expect("Output didn't contain e-cash notes")
+                    .as_str()
+                    .unwrap()
+                    .to_owned();
+                cmd!(client, "reissue", notes).out_json().await?;
+
+                let pre_balance = client.balance().await?;
+                info!(target: LOG_DEVIMINT, pre_balance, "Balance after post-backup activity");
+
+                let restored = client
+                    .new_restored("mint-restored-post-backup", fed.invite_code()?)
+                    .await?;
+                cmd!(restored, "dev", "wait-complete").out_json().await?;
+
+                let post_balance = restored.balance().await?;
+                info!(target: LOG_DEVIMINT, post_balance, "Balance after recovery with post-backup activity");
+                almost_equal(pre_balance, post_balance, 100_000).unwrap();
+            }
+
+            Ok(())
+        })
+        .await
 }
 
 async fn sanity() -> anyhow::Result<()> {

--- a/modules/fedimint-mint-tests/src/bin/mint-module-tests.rs
+++ b/modules/fedimint-mint-tests/src/bin/mint-module-tests.rs
@@ -5,12 +5,16 @@ use devimint::federation::Federation;
 use devimint::util::almost_equal;
 use fedimint_logging::LOG_DEVIMINT;
 use rand::Rng;
+use tokio::try_join;
 use tracing::info;
 
 #[derive(Debug, Parser)]
 enum Cmd {
     Restore,
+    /// Mint recovery test. Run with `FM_FORCE_V1_MINT_RECOVERY=1` to force
+    /// V1 (session-based) recovery path.
     RecoveryV1,
+    /// Mint recovery test using default (V2 slice-based) recovery path.
     RecoveryV2,
     Sanity,
 }
@@ -138,132 +142,133 @@ async fn mint_recovery_test() -> anyhow::Result<()> {
         .call(|dev_fed, _process_mgr| async move {
             let fed = dev_fed.fed().await?;
 
-            const PEGIN_SATS: u64 = 100_000;
-
-            info!(target: LOG_DEVIMINT, "### Test mint recovery with backup");
-            {
-                let client = fed.new_joined_client("mint-recovery-backup").await?;
-                fed.pegin_client(PEGIN_SATS, &client).await?;
-
-                let pre_balance = client.balance().await?;
-                info!(target: LOG_DEVIMINT, pre_balance, "Balance before backup");
-                assert!(pre_balance > 0);
-
-                // Upload backup so the federation stores spendable notes
-                cmd!(client, "backup").run().await?;
-
-                // Restore triggers recovery; with V1 this exercises the
-                // finalize_dbtx reissuance codepath
-                let restored = client
-                    .new_restored("mint-restored-with-backup", fed.invite_code()?)
-                    .await?;
-                cmd!(restored, "dev", "wait-complete").out_json().await?;
-
-                let post_balance = restored.balance().await?;
-                info!(target: LOG_DEVIMINT, post_balance, "Balance after recovery with backup");
-                almost_equal(pre_balance, post_balance, 100_000).unwrap();
-            }
-
-            info!(target: LOG_DEVIMINT, "### Test mint recovery without backup");
-            {
-                let client = fed.new_joined_client("mint-recovery-no-backup").await?;
-                fed.pegin_client(PEGIN_SATS, &client).await?;
-
-                let pre_balance = client.balance().await?;
-                assert!(pre_balance > 0);
-
-                // Restore without ever calling backup — recovery from history only
-                let restored = client
-                    .new_restored("mint-restored-no-backup", fed.invite_code()?)
-                    .await?;
-                cmd!(restored, "dev", "wait-complete").out_json().await?;
-
-                let post_balance = restored.balance().await?;
-                info!(target: LOG_DEVIMINT, post_balance, "Balance after recovery without backup");
-                almost_equal(pre_balance, post_balance, 100_000).unwrap();
-            }
-
-            info!(target: LOG_DEVIMINT, "### Test mint recovery after spend+reissue activity");
-            {
-                let client = fed
-                    .new_joined_client("mint-recovery-after-activity")
-                    .await?;
-                fed.pegin_client(PEGIN_SATS, &client).await?;
-
-                // Do several rounds of spend-to-self to churn note denominations
-                for i in 0..3 {
-                    let balance = client.balance().await?;
-                    let spend_amount = balance / 3;
-
-                    let notes = cmd!(client, "spend", spend_amount)
-                        .out_json()
-                        .await?
-                        .get("notes")
-                        .expect("Output didn't contain e-cash notes")
-                        .as_str()
-                        .unwrap()
-                        .to_owned();
-
-                    cmd!(client, "reissue", notes).out_json().await?;
-                    info!(target: LOG_DEVIMINT, i, spend_amount, "Spent and reissued to self");
-                }
-
-                let pre_balance = client.balance().await?;
-                info!(target: LOG_DEVIMINT, pre_balance, "Balance after activity");
-                assert!(pre_balance > 0);
-
-                cmd!(client, "backup").run().await?;
-
-                let restored = client
-                    .new_restored("mint-restored-after-activity", fed.invite_code()?)
-                    .await?;
-                cmd!(restored, "dev", "wait-complete").out_json().await?;
-
-                let post_balance = restored.balance().await?;
-                info!(target: LOG_DEVIMINT, post_balance, "Balance after recovery post-activity");
-                almost_equal(pre_balance, post_balance, 100_000).unwrap();
-            }
-
-            info!(target: LOG_DEVIMINT, "### Test mint recovery with post-backup activity");
-            {
-                let client = fed
-                    .new_joined_client("mint-recovery-post-backup")
-                    .await?;
-                fed.pegin_client(PEGIN_SATS, &client).await?;
-
-                // Backup while we still have the original notes
-                cmd!(client, "backup").run().await?;
-
-                // Spend and reissue after the backup — these note changes
-                // won't be in the backup, only in the federation history
-                let balance = client.balance().await?;
-                let spend_amount = balance / 2;
-                let notes = cmd!(client, "spend", spend_amount)
-                    .out_json()
-                    .await?
-                    .get("notes")
-                    .expect("Output didn't contain e-cash notes")
-                    .as_str()
-                    .unwrap()
-                    .to_owned();
-                cmd!(client, "reissue", notes).out_json().await?;
-
-                let pre_balance = client.balance().await?;
-                info!(target: LOG_DEVIMINT, pre_balance, "Balance after post-backup activity");
-
-                let restored = client
-                    .new_restored("mint-restored-post-backup", fed.invite_code()?)
-                    .await?;
-                cmd!(restored, "dev", "wait-complete").out_json().await?;
-
-                let post_balance = restored.balance().await?;
-                info!(target: LOG_DEVIMINT, post_balance, "Balance after recovery with post-backup activity");
-                almost_equal(pre_balance, post_balance, 100_000).unwrap();
-            }
+            try_join!(
+                test_recovery_with_backup(fed),
+                test_recovery_without_backup(fed),
+                test_recovery_after_activity(fed),
+                test_recovery_with_post_backup_activity(fed),
+            )?;
 
             Ok(())
         })
         .await
+}
+
+const PEGIN_SATS: u64 = 1_000_000;
+
+async fn test_recovery_with_backup(fed: &Federation) -> Result<()> {
+    info!(target: LOG_DEVIMINT, "### Test mint recovery with backup");
+    let client = fed.new_joined_client("mint-recovery-backup").await?;
+    fed.pegin_client(PEGIN_SATS, &client).await?;
+
+    let pre_balance = client.balance().await?;
+    info!(target: LOG_DEVIMINT, pre_balance, "Balance before backup");
+    assert!(pre_balance > 0);
+
+    cmd!(client, "backup").run().await?;
+
+    let restored = client
+        .new_restored("mint-restored-with-backup", fed.invite_code()?)
+        .await?;
+    cmd!(restored, "dev", "wait-complete").out_json().await?;
+
+    let post_balance = restored.balance().await?;
+    info!(target: LOG_DEVIMINT, post_balance, "Balance after recovery with backup");
+    almost_equal(pre_balance, post_balance, 25_000).unwrap();
+    Ok(())
+}
+
+async fn test_recovery_without_backup(fed: &Federation) -> Result<()> {
+    info!(target: LOG_DEVIMINT, "### Test mint recovery without backup");
+    let client = fed.new_joined_client("mint-recovery-no-backup").await?;
+    fed.pegin_client(PEGIN_SATS, &client).await?;
+
+    let pre_balance = client.balance().await?;
+    assert!(pre_balance > 0);
+
+    let restored = client
+        .new_restored("mint-restored-no-backup", fed.invite_code()?)
+        .await?;
+    cmd!(restored, "dev", "wait-complete").out_json().await?;
+
+    let post_balance = restored.balance().await?;
+    info!(target: LOG_DEVIMINT, post_balance, "Balance after recovery without backup");
+    almost_equal(pre_balance, post_balance, 25_000).unwrap();
+    Ok(())
+}
+
+async fn test_recovery_after_activity(fed: &Federation) -> Result<()> {
+    info!(target: LOG_DEVIMINT, "### Test mint recovery after spend+reissue activity");
+    let client = fed
+        .new_joined_client("mint-recovery-after-activity")
+        .await?;
+    fed.pegin_client(PEGIN_SATS, &client).await?;
+
+    for i in 0..3 {
+        let balance = client.balance().await?;
+        let spend_amount = balance / 3;
+
+        let notes = cmd!(client, "spend", spend_amount)
+            .out_json()
+            .await?
+            .get("notes")
+            .expect("Output didn't contain e-cash notes")
+            .as_str()
+            .unwrap()
+            .to_owned();
+
+        cmd!(client, "reissue", notes).out_json().await?;
+        info!(target: LOG_DEVIMINT, i, spend_amount, "Spent and reissued to self");
+    }
+
+    let pre_balance = client.balance().await?;
+    info!(target: LOG_DEVIMINT, pre_balance, "Balance after activity");
+    assert!(pre_balance > 0);
+
+    cmd!(client, "backup").run().await?;
+
+    let restored = client
+        .new_restored("mint-restored-after-activity", fed.invite_code()?)
+        .await?;
+    cmd!(restored, "dev", "wait-complete").out_json().await?;
+
+    let post_balance = restored.balance().await?;
+    info!(target: LOG_DEVIMINT, post_balance, "Balance after recovery post-activity");
+    almost_equal(pre_balance, post_balance, 25_000).unwrap();
+    Ok(())
+}
+
+async fn test_recovery_with_post_backup_activity(fed: &Federation) -> Result<()> {
+    info!(target: LOG_DEVIMINT, "### Test mint recovery with post-backup activity");
+    let client = fed.new_joined_client("mint-recovery-post-backup").await?;
+    fed.pegin_client(PEGIN_SATS, &client).await?;
+
+    cmd!(client, "backup").run().await?;
+
+    let balance = client.balance().await?;
+    let spend_amount = balance / 2;
+    let notes = cmd!(client, "spend", spend_amount)
+        .out_json()
+        .await?
+        .get("notes")
+        .expect("Output didn't contain e-cash notes")
+        .as_str()
+        .unwrap()
+        .to_owned();
+    cmd!(client, "reissue", notes).out_json().await?;
+
+    let pre_balance = client.balance().await?;
+    info!(target: LOG_DEVIMINT, pre_balance, "Balance after post-backup activity");
+
+    let restored = client
+        .new_restored("mint-restored-post-backup", fed.invite_code()?)
+        .await?;
+    cmd!(restored, "dev", "wait-complete").out_json().await?;
+
+    let post_balance = restored.balance().await?;
+    info!(target: LOG_DEVIMINT, post_balance, "Balance after recovery with post-backup activity");
+    almost_equal(pre_balance, post_balance, 25_000).unwrap();
+    Ok(())
 }
 
 async fn sanity() -> anyhow::Result<()> {

--- a/scripts/tests/mint-recovery-test-v2.sh
+++ b/scripts/tests/mint-recovery-test-v2.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Runs mint recovery test using V2 (slice-based) recovery
+
+set -euo pipefail
+export RUST_LOG="${RUST_LOG:-info}"
+
+source scripts/_common.sh
+build_workspace
+add_target_dir_to_path
+make_fm_test_marker
+
+mint-module-tests recovery-v2

--- a/scripts/tests/mint-recovery-test.sh
+++ b/scripts/tests/mint-recovery-test.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Runs mint recovery test using V1 (session-based) recovery with reissuance
+
+set -euo pipefail
+export RUST_LOG="${RUST_LOG:-info}"
+export FM_FORCE_V1_MINT_RECOVERY=1
+
+source scripts/_common.sh
+build_workspace
+add_target_dir_to_path
+make_fm_test_marker
+
+mint-module-tests recovery-v1

--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -245,6 +245,16 @@ function wallet_recovery_2() {
 }
 export -f wallet_recovery_2
 
+function mint_recovery_v1() {
+  fm-run-test "${FUNCNAME[0]}" ./scripts/tests/mint-recovery-test.sh
+}
+export -f mint_recovery_v1
+
+function mint_recovery_v2() {
+  fm-run-test "${FUNCNAME[0]}" ./scripts/tests/mint-recovery-test-v2.sh
+}
+export -f mint_recovery_v2
+
 function devimint_cli_test() {
   fm-run-test "${FUNCNAME[0]}" ./scripts/tests/devimint-cli-test.sh
 }
@@ -466,6 +476,8 @@ tests_to_run_in_parallel+=(
   "circular_deposit"
   "wallet_recovery"
   "wallet_recovery_2"
+  "mint_recovery_v1"
+  "mint_recovery_v2"
   "recurringd_test"
   "large_setup_test"
 )


### PR DESCRIPTION

Add a regression test for https://github.com/fedimint/fedimint/issues/8004 that exercises the mint recovery codepath with backup reissuance and a mint module recovery test in general.

This reproduces #8004 (verified with a backport).

I'll be making some follows up on it soon.