### PR TITLE
fix(test): skip channel close in gw_liquidity_test for gateway < 0.9.0

### DIFF
--- a/gateway/integration_tests/src/main.rs
+++ b/gateway/integration_tests/src/main.rs
@@ -14,7 +14,7 @@ use devimint::envs::FM_DATA_DIR_ENV;
 use devimint::external::{Bitcoind, Esplora};
 use devimint::federation::Federation;
 use devimint::util::{ProcessManager, almost_equal, poll, poll_with_timeout};
-use devimint::version_constants::{VERSION_0_8_2, VERSION_0_10_0_ALPHA};
+use devimint::version_constants::{VERSION_0_8_2, VERSION_0_9_0_ALPHA, VERSION_0_10_0_ALPHA};
 use devimint::{Gatewayd, LightningNode, cli, util};
 use fedimint_core::config::FederationId;
 use fedimint_core::time::now;
@@ -475,20 +475,27 @@ async fn liquidity_test() -> anyhow::Result<()> {
                 bitcoind.poll_get_transaction(txid).await?;
             }
 
-            info!(target: LOG_TEST, "Testing closing all channels...");
+            // Skip channel closing for gateways older than 0.9.0-alpha, since
+            // cooperative close can hang due to LND fee estimation in regtest
+            // (fixed by adding sats_per_vbyte in 0.9.0-alpha).
+            if gw_lnd.gatewayd_version >= *VERSION_0_9_0_ALPHA {
+                info!(target: LOG_TEST, "Testing closing all channels...");
 
-            // Gracefully close one of LND's channel's
-            let gw_ldk_pubkey = gw_ldk.client().lightning_pubkey().await?;
-            gw_lnd.client().close_channel(gw_ldk_pubkey, false).await?;
+                // Gracefully close one of LND's channel's
+                let gw_ldk_pubkey = gw_ldk.client().lightning_pubkey().await?;
+                gw_lnd.client().close_channel(gw_ldk_pubkey, false).await?;
 
-            // Force close LDK's channels
-            gw_ldk_second.client().close_all_channels(true).await?;
+                // Force close LDK's channels
+                gw_ldk_second.client().close_all_channels(true).await?;
 
-            // Verify none of the channels are active
-            for gw in gateways {
-                let channels = gw.client().list_channels().await?;
-                let active_channel = channels.into_iter().any(|chan| chan.is_active);
-                assert!(!active_channel);
+                // Verify none of the channels are active
+                for gw in gateways {
+                    let channels = gw.client().list_channels().await?;
+                    let active_channel = channels.into_iter().any(|chan| chan.is_active);
+                    assert!(!active_channel);
+                }
+            } else {
+                info!(target: LOG_TEST, "Skipping channel close test for gateway version < 0.9.0");
             }
 
             Ok(())


### PR DESCRIPTION
The gw_liquidity_test flakes when running backwards-compatibility tests with gateway v0.8.2. The test times out (360s) because the `close-channels-with-peer` CLI command hangs indefinitely.

Failing CI run: https://github.com/fedimint/fedimint/actions/runs/24584545845/job/71890671867

Root cause analysis:

1. The test calls `gw_ldk_second.close_all_channels(true)` requesting force close of all channels.

2. The devimint `close_channel` helper checks the gateway CLI version and only passes `--force` when `gateway_cli_version >= 0.9.0-alpha`. Since v0.8.2 < 0.9.0-alpha, the `--force` flag is NOT sent, downgrading the intended force close to a cooperative close.

3. Similarly, `--sats-per-vbyte` is not passed for versions < 0.10.0-alpha. The v0.8.2 LND close_channels_with_peer implementation uses `..Default::default()` which sets `sat_per_vbyte = 0`, causing LND to use its internal fee estimator.

4. As documented in commit 33c3f53734c ("feat: add sats per vbyte so that LND fee estimation doesnt cause it to hang"), LND's fee estimation can hang indefinitely in regtest/test environments when no explicit fee rate is provided.

5. When the LDK gateway initiates a cooperative close with the LND peer, the closing negotiation requires LND to propose a fee. LND's fee estimation hangs, stalling the cooperative close protocol. The test then exceeds the 360-second GNU parallel timeout and is killed.

The fix skips the channel closing section of gw_liquidity_test when the gateway version is < 0.9.0-alpha. This is safe because:
- Channel closing is fully tested with current gateway versions
- The v0.8.2 gateway lacks both the `--force` flag and the `sats_per_vbyte` fix, making cooperative close inherently unreliable in test environments
- The rest of the liquidity test (ecash, lightning payments, BOLT12 offers, onchain sends, peg-in/peg-out) still runs for old versions

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
