### PR TITLE
feat: expose meta consensus value via WASM client RPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3873,6 +3873,7 @@ dependencies = [
  "fedimint-core",
  "fedimint-logging",
  "fedimint-meta-common",
+ "futures",
  "serde",
  "serde_json",
  "strum 0.27.1",

--- a/fedimint-client-rpc/src/lib.rs
+++ b/fedimint-client-rpc/src/lib.rs
@@ -19,7 +19,7 @@ use fedimint_core::util::{BoxFuture, BoxStream};
 use fedimint_core::{Amount, TieredCounts, impl_db_record};
 use fedimint_derive_secret::{ChildId, DerivableSecret};
 use fedimint_ln_client::{LightningClientInit, LightningClientModule};
-use fedimint_meta_client::MetaClientInit;
+use fedimint_meta_client::{MetaClientInit, MetaClientModule};
 use fedimint_mint_client::{MintClientInit, MintClientModule, OOBNotes};
 use fedimint_wallet_client::{WalletClientInit, WalletClientModule};
 use futures::StreamExt;
@@ -365,6 +365,13 @@ impl RpcGlobalState {
                         .get_first_module::<WalletClientModule>()?
                         .inner();
                     let mut stream = wallet.handle_rpc(method, payload).await;
+                    while let Some(item) = stream.next().await {
+                        yield item?;
+                    }
+                }
+                "meta" => {
+                    let meta = client.get_first_module::<MetaClientModule>()?.inner();
+                    let mut stream = meta.handle_rpc(method, payload).await;
                     while let Some(item) = stream.next().await {
                         yield item?;
                     }

--- a/modules/fedimint-meta-client/Cargo.toml
+++ b/modules/fedimint-meta-client/Cargo.toml
@@ -29,6 +29,7 @@ fedimint-client-module = { workspace = true }
 fedimint-core = { workspace = true }
 fedimint-logging = { workspace = true }
 fedimint-meta-common = { workspace = true }
+futures = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 strum = { workspace = true }

--- a/modules/fedimint-meta-client/src/lib.rs
+++ b/modules/fedimint-meta-client/src/lib.rs
@@ -11,6 +11,7 @@ pub mod states;
 use std::collections::BTreeMap;
 use std::time::Duration;
 
+use anyhow::Context as _;
 use api::MetaFederationApi;
 use common::{KIND, MetaConsensusValue, MetaKey, MetaValue};
 use db::DbKeyPrefix;
@@ -28,11 +29,14 @@ use fedimint_core::module::{
     Amounts, ApiAuth, ApiVersion, ModuleCommon, ModuleInit, MultiApiVersion,
 };
 use fedimint_core::util::backoff_util::FibonacciBackoff;
-use fedimint_core::util::{backoff_util, retry};
+use fedimint_core::util::{BoxStream, backoff_util, retry};
 use fedimint_core::{PeerId, apply, async_trait_maybe_send};
 use fedimint_logging::LOG_CLIENT_MODULE_META;
 pub use fedimint_meta_common as common;
 use fedimint_meta_common::{DEFAULT_META_KEY, MetaCommonInit, MetaModuleTypes};
+use futures::stream;
+use serde::Deserialize;
+use serde_json::json;
 use states::MetaStateMachine;
 use strum::IntoEnumIterator;
 use tracing::{debug, warn};
@@ -98,6 +102,29 @@ impl MetaClientModule {
     }
 }
 
+#[derive(Debug, Deserialize)]
+struct GetConsensusValueRequest {
+    key: MetaKey,
+}
+
+fn format_rpc_consensus_value_response(
+    maybe_consensus_value: Option<MetaConsensusValue>,
+) -> anyhow::Result<serde_json::Value> {
+    Ok(match maybe_consensus_value {
+        Some(MetaConsensusValue { revision, value }) => {
+            let value = value
+                .to_json_lossy()
+                .context("deserializing consensus value as json")?;
+
+            json!({
+                "revision": revision,
+                "value": value,
+            })
+        }
+        None => serde_json::Value::Null,
+    })
+}
+
 /// Data needed by the state machine
 #[derive(Debug, Clone)]
 pub struct MetaClientContext {
@@ -137,6 +164,23 @@ impl ClientModule for MetaClientModule {
         _output: &<Self::Common as ModuleCommon>::Output,
     ) -> Option<Amounts> {
         unreachable!()
+    }
+
+    async fn handle_rpc(
+        &self,
+        method: String,
+        request: serde_json::Value,
+    ) -> BoxStream<'_, anyhow::Result<serde_json::Value>> {
+        Box::pin(stream::once(async move {
+            match method.as_str() {
+                "get_consensus_value" => {
+                    let req: GetConsensusValueRequest = serde_json::from_value(request)?;
+                    let maybe_consensus_value = self.get_consensus_value(req.key).await?;
+                    format_rpc_consensus_value_response(maybe_consensus_value)
+                }
+                _ => Err(anyhow::format_err!("Unknown method: {method}")),
+            }
+        }))
     }
 
     #[cfg(feature = "cli")]
@@ -277,5 +321,40 @@ async fn get_meta_module_value(
             }
         }
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use fedimint_meta_common::MetaValue;
+    use serde_json::json;
+
+    use super::{MetaConsensusValue, format_rpc_consensus_value_response};
+
+    #[test]
+    fn formats_consensus_value_as_json() {
+        let response = format_rpc_consensus_value_response(Some(MetaConsensusValue {
+            revision: 7,
+            value: MetaValue::from(br#"{"welcome_message":"hello"}"#.as_slice()),
+        }))
+        .expect("valid json meta value should format");
+
+        assert_eq!(
+            response,
+            json!({
+                "revision": 7,
+                "value": {
+                    "welcome_message": "hello",
+                },
+            })
+        );
+    }
+
+    #[test]
+    fn formats_missing_consensus_value_as_null() {
+        let response =
+            format_rpc_consensus_value_response(None).expect("null response should format");
+
+        assert_eq!(response, serde_json::Value::Null);
     }
 }


### PR DESCRIPTION
Added Meta module support to the client RPC path so opened clients can call meta.get_consensus_value. This is intended for the Fedimint SDK, which will use it to read federation metadata through the existing WASM/client RPC flow.

The RPC dispatcher now routes module = "meta" to MetaClientModule, and the meta client implements a minimal read-only handle_rpc for get_consensus_value. The response is returned as { revision, value }, with the stored meta blob decoded as JSON instead of exposed as the raw hex-encoded MetaValue. CLI formatting stays separate so future CLI output changes do not affect the RPC/WASM API.