### PR TITLE
fix(mint): avoid panic on duplicate blind nonce in recovery index

### DIFF
--- a/modules/fedimint-mint-server/src/lib.rs
+++ b/modules/fedimint-mint-server/src/lib.rs
@@ -493,7 +493,7 @@ async fn migrate_db_v2(mut ctx: ServerModuleDbMigrationFnContext<'_, Mint>) -> a
 
     for (blind_nonce, out_point) in blind_nonce_outpoints {
         ctx.dbtx()
-            .insert_new_entry(&RecoveryBlindNonceOutpointKey(blind_nonce), &out_point)
+            .insert_entry(&RecoveryBlindNonceOutpointKey(blind_nonce), &out_point)
             .await;
     }
 
@@ -666,7 +666,7 @@ impl ServerModule for Mint {
         )
         .await;
 
-        dbtx.insert_new_entry(
+        dbtx.insert_entry(
             &RecoveryBlindNonceOutpointKey(output.blind_nonce),
             &out_point,
         )


### PR DESCRIPTION
## Summary

The `RecoveryBlindNonceOutpointKey → OutPoint` index in `fedimint-mint-server` was being populated with `insert_new_entry` in two places, both of which panic the guardian on a duplicate blind nonce:

- `migrate_db_v2` backfill (`modules/fedimint-mint-server/src/lib.rs:494-498`) — walks module history on first v0.11 start and builds the index from every `ModuleHistoryItem::Output`.
- Live `process_output` path (`modules/fedimint-mint-server/src/lib.rs:669-673`).


🤖 Generated with [Claude Code](https://claude.com/claude-code)