### PR TITLE
fix(ci): sample 25% of backcompat tests in merge queue to avoid timeout

### DIFF
--- a/.github/workflows/ci-backwards-compatibility.yml
+++ b/.github/workflows/ci-backwards-compatibility.yml
@@ -50,6 +50,10 @@ jobs:
           if [[ "${{ github.event_name }}" == "merge_group" ]]; then
             PERFIT_METRIC="90S3yoXDQ-SXB0UbXG4qHQ"
             VERSIONS_TO_TEST="v0.8.2 v0.9.1 v0.10.0"
+            # Run only a random sample of tests to keep merge queue fast.
+            # With multiple versions x multiple test combos, 25% still
+            # gives good coverage for catching version-specific regressions.
+            export FM_BACKCOMPAT_TEST_SAMPLE_PERCENT=25
           else
             PERFIT_METRIC="aPuCAjrFT7uE5Oax_T4sMw"
             VERSIONS_TO_TEST="v0.10.0"

--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -537,7 +537,15 @@ parallel_args+=(
 
 # --memfree to make sure tests have enough memory to run
 # --nice to let you browse twitter without lag while the tests are running
-echo "$parsed_test_commands" | shuf | if parallel \
+shuffled_test_commands=$(echo "$parsed_test_commands" | shuf)
+if [ -n "${FM_BACKCOMPAT_TEST_SAMPLE_PERCENT:-}" ]; then
+  total=$(echo "$shuffled_test_commands" | wc -l)
+  count=$(( (total * FM_BACKCOMPAT_TEST_SAMPLE_PERCENT + 99) / 100 ))
+  >&2 echo "## Sampling $count out of $total tests (${FM_BACKCOMPAT_TEST_SAMPLE_PERCENT}%)"
+  shuffled_test_commands=$(echo "$shuffled_test_commands" | head -n "$count" || true)
+fi
+
+echo "$shuffled_test_commands" | if parallel \
   "${parallel_args[@]}" ; then
   >&2 echo "All tests successful"
 else


### PR DESCRIPTION
The backwards-compatibility merge queue job keeps timing out at the 60-minute limit. For example:
https://github.com/fedimint/fedimint/actions/runs/24681820408/job/72180790253

All 639 tests passed, but the job took 60m46s — just over the limit — so GitHub cancelled it.

The full matrix runs 37 distinct tests × ~18 version/LNv2 combinations = 639 test invocations. With ~6.5 min of Nix/build setup overhead, the ~54 min of test execution leaves no margin.

Rather than bumping the timeout or reducing version coverage, this randomly samples 25% of the test list per run. Since the list is already shuffled, each merge queue entry exercises a different random subset. Over a handful of merges the full matrix still gets covered, while each individual run finishes in roughly a quarter of the test time.

The env var `FM_BACKCOMPAT_TEST_SAMPLE_PERCENT` is only set for merge queue runs. PR and push runs are unaffected.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
