### PR TITLE
chore: remove `VERSION_0_8_2-alpha` and `VERISON_0_9_0-alpha`

### DIFF
--- a/.github/workflows/ci-backwards-compatibility.yml
+++ b/.github/workflows/ci-backwards-compatibility.yml
@@ -49,7 +49,7 @@ jobs:
           # run a slimmed down back-compat test for PR push or each major version for merge queue
           if [[ "${{ github.event_name }}" == "merge_group" ]]; then
             PERFIT_METRIC="90S3yoXDQ-SXB0UbXG4qHQ"
-            VERSIONS_TO_TEST="v0.9.1 v0.10.0 v0.11.0"
+            VERSIONS_TO_TEST="v0.9.1 v0.10.0 v0.11.1"
             # Run only a random sample of tests to keep merge queue fast.
             # With multiple versions x multiple test combos, 25% still
             # gives good coverage for catching version-specific regressions.

--- a/.github/workflows/ci-backwards-compatibility.yml
+++ b/.github/workflows/ci-backwards-compatibility.yml
@@ -49,7 +49,7 @@ jobs:
           # run a slimmed down back-compat test for PR push or each major version for merge queue
           if [[ "${{ github.event_name }}" == "merge_group" ]]; then
             PERFIT_METRIC="90S3yoXDQ-SXB0UbXG4qHQ"
-            VERSIONS_TO_TEST="v0.8.2 v0.9.1 v0.10.0"
+            VERSIONS_TO_TEST="v0.9.1 v0.10.0 v0.11.0"
             # Run only a random sample of tests to keep merge queue fast.
             # With multiple versions x multiple test combos, 25% still
             # gives good coverage for catching version-specific regressions.

--- a/.github/workflows/upgrade-tests.yml
+++ b/.github/workflows/upgrade-tests.yml
@@ -56,7 +56,7 @@ jobs:
           # read versions from manually triggered workflows
           # default needed for cron or manual workflow without params
           VERSIONS="${{ github.event.inputs.versions }}"
-          VERSIONS=${VERSIONS:="v0.8.2 current, v0.9.1 current, v0.10.0 current"}
+          VERSIONS=${VERSIONS:="v0.9.1 current, v0.10.0 current, v0.11.0 current"}
 
           # if empty, defaults to all test kinds within script
           export TEST_KINDS="${{ github.event.inputs.test_kinds }}"

--- a/.github/workflows/upgrade-tests.yml
+++ b/.github/workflows/upgrade-tests.yml
@@ -56,7 +56,7 @@ jobs:
           # read versions from manually triggered workflows
           # default needed for cron or manual workflow without params
           VERSIONS="${{ github.event.inputs.versions }}"
-          VERSIONS=${VERSIONS:="v0.9.1 current, v0.10.0 current, v0.11.0 current"}
+          VERSIONS=${VERSIONS:="v0.9.1 current, v0.10.0 current, v0.11.1 current"}
 
           # if empty, defaults to all test kinds within script
           export TEST_KINDS="${{ github.event.inputs.test_kinds }}"

--- a/devimint/src/gatewayd.rs
+++ b/devimint/src/gatewayd.rs
@@ -35,9 +35,9 @@ use crate::envs::{
 };
 use crate::external::{Bitcoind, LightningNode};
 use crate::federation::Federation;
-use crate::util::{Command, ProcessHandle, ProcessManager, poll, poll_with_timeout, supports_lnv2};
+use crate::util::{Command, ProcessHandle, ProcessManager, poll, poll_with_timeout};
 use crate::vars::utf8;
-use crate::version_constants::{VERSION_0_9_0_ALPHA, VERSION_0_10_0_ALPHA, VERSION_0_11_0_ALPHA};
+use crate::version_constants::{VERSION_0_10_0_ALPHA, VERSION_0_11_0_ALPHA};
 
 #[derive(Debug, Clone)]
 pub struct GatewayClient {
@@ -302,7 +302,7 @@ impl<'a> GatewayClient {
 
     pub async fn close_channel(&self, remote_pubkey: PublicKey, force: bool) -> Result<()> {
         let gateway_cli_version = crate::util::GatewayCli::version_or_default().await;
-        let mut close_channel = if force && gateway_cli_version >= *VERSION_0_9_0_ALPHA {
+        let mut close_channel = if force {
             cmd!(
                 self,
                 "lightning",
@@ -403,14 +403,7 @@ impl<'a> GatewayClient {
     }
 
     pub async fn list_channels(&self) -> Result<Vec<ChannelInfo>> {
-        let gateway_cli_version = crate::util::GatewayCli::version_or_default().await;
-        let channels = if gateway_cli_version >= *VERSION_0_9_0_ALPHA {
-            cmd!(self, "lightning", "list-channels").out_json().await?
-        } else {
-            cmd!(self, "lightning", "list-active-channels")
-                .out_json()
-                .await?
-        };
+        let channels = cmd!(self, "lightning", "list-channels").out_json().await?;
 
         let channels = channels
             .as_array()
@@ -791,30 +784,9 @@ impl Gatewayd {
         ]);
 
         let gatewayd_version = crate::util::Gatewayd::version_or_default().await;
-        if gatewayd_version < *VERSION_0_9_0_ALPHA {
-            let mode = if supports_lnv2() {
-                "All"
-            } else {
-                info!(target: LOG_DEVIMINT, "LNv2 is not supported, running gatewayd in LNv1 mode");
-                "LNv1"
-            };
-            gateway_env.insert(
-                "FM_GATEWAY_LIGHTNING_MODULE_MODE".to_owned(),
-                mode.to_string(),
-            );
-        }
 
         if ln_type == LightningNodeType::Ldk {
             gateway_env.insert("FM_LDK_ALIAS".to_owned(), gw_name.clone());
-
-            // Prior to `v0.9.0`, only LDK could connect to bitcoind
-            if gatewayd_version < *VERSION_0_9_0_ALPHA {
-                let btc_rpc_port = process_mgr.globals.FM_PORT_BTC_RPC;
-                gateway_env.insert(
-                    "FM_LDK_BITCOIND_RPC_URL".to_owned(),
-                    format!("http://bitcoin:bitcoin@127.0.0.1:{btc_rpc_port}"),
-                );
-            }
         }
 
         let process = process_mgr
@@ -938,12 +910,6 @@ impl Gatewayd {
         unsafe { std::env::set_var("FM_GATEWAY_CLI_BASE_EXECUTABLE", gateway_cli_path) };
 
         let gatewayd_version = crate::util::Gatewayd::version_or_default().await;
-        if gatewayd_version < *VERSION_0_9_0_ALPHA && supports_lnv2() {
-            info!(target: LOG_DEVIMINT, "LNv2 is now supported, running in All mode");
-            // TODO: Audit that the environment access only happens in single-threaded code.
-            unsafe { std::env::set_var("FM_GATEWAY_LIGHTNING_MODULE_MODE", "All") };
-        }
-
         let new_ln = ln;
         let new_gw = Self::new(process_mgr, new_ln.clone(), self.gateway_index).await?;
         self.process = new_gw.process;

--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -20,7 +20,6 @@ use fedimint_core::util::{retry, write_overwrite_async};
 use fedimint_core::{Amount, PeerId};
 use fedimint_ln_client::LightningPaymentOutcome;
 use fedimint_ln_client::cli::LnInvoiceResponse;
-use fedimint_ln_server::common::LightningGatewayAnnouncement;
 use fedimint_ln_server::common::lightning_invoice::Bolt11Invoice;
 use fedimint_lnv2_client::FinalSendOperationState;
 use fedimint_logging::LOG_DEVIMINT;
@@ -37,9 +36,7 @@ use crate::cli::{CommonArgs, cleanup_on_exit, exec_user_command, setup};
 use crate::envs::{FM_DATA_DIR_ENV, FM_DEVIMINT_RUN_DEPRECATED_TESTS_ENV, FM_PASSWORD_ENV};
 use crate::federation::Client;
 use crate::util::{LoadTestTool, ProcessManager, almost_equal, poll};
-use crate::version_constants::{
-    VERSION_0_8_2, VERSION_0_9_0_ALPHA, VERSION_0_10_0_ALPHA, VERSION_0_11_0_ALPHA,
-};
+use crate::version_constants::{VERSION_0_10_0_ALPHA, VERSION_0_11_0_ALPHA};
 use crate::{DevFed, Gatewayd, LightningNode, Lnd, cmd, dev_fed};
 
 pub struct Stats {
@@ -799,38 +796,6 @@ pub async fn cli_tests(dev_fed: DevFed) -> Result<()> {
 
     // LND gateway tests
     info!("Testing LND gateway");
-
-    let gatewayd_version = crate::util::Gatewayd::version_or_default().await;
-    // Gatewayd did not support default fees before v0.8.2
-    // In order for the amount tests to pass, we need to reliably set the fees to
-    // 0,0.
-    if gatewayd_version < *VERSION_0_8_2 {
-        gw_lnd
-            .set_federation_routing_fee(fed_id.clone(), 0, 0)
-            .await?;
-
-        // Poll until the client has heard about the updated fees
-        poll("Waiting for LND GW fees to update", || async {
-            let gateways_val = cmd!(client, "list-gateways")
-                .out_json()
-                .await
-                .map_err(ControlFlow::Break)?;
-            let gateways =
-                serde_json::from_value::<Vec<LightningGatewayAnnouncement>>(gateways_val)
-                    .expect("Could not deserialize");
-            let fees = gateways
-                .first()
-                .expect("No gateway was registered")
-                .info
-                .fees;
-            if fees.base_msat == 0 && fees.proportional_millionths == 0 {
-                Ok(())
-            } else {
-                Err(ControlFlow::Continue(anyhow!("Fees have not been updated")))
-            }
-        })
-        .await?;
-    }
 
     // OUTGOING: fedimint-cli pays LDK via LND gateway
     if let Some(iroh_gw_id) = &iroh_lnd_id
@@ -1609,22 +1574,13 @@ async fn ln_pay(client: &Client, invoice: String, gw_id: String) -> anyhow::Resu
     let value = cmd!(client, "ln-pay", invoice, "--gateway-id", gw_id,)
         .out_json()
         .await?;
-    let fedimint_cli_version = crate::util::FedimintCli::version_or_default().await;
-    if fedimint_cli_version >= *VERSION_0_9_0_ALPHA {
-        let outcome = serde_json::from_value::<LightningPaymentOutcome>(value)
-            .expect("Could not deserialize Lightning payment outcome");
-        match outcome {
-            LightningPaymentOutcome::Success { preimage } => Ok(preimage),
-            LightningPaymentOutcome::Failure { error_message } => {
-                Err(anyhow!("Failed to pay lightning invoice: {error_message}"))
-            }
+    let outcome = serde_json::from_value::<LightningPaymentOutcome>(value)
+        .expect("Could not deserialize Lightning payment outcome");
+    match outcome {
+        LightningPaymentOutcome::Success { preimage } => Ok(preimage),
+        LightningPaymentOutcome::Failure { error_message } => {
+            Err(anyhow!("Failed to pay lightning invoice: {error_message}"))
         }
-    } else {
-        let operation_id = value["operation_id"]
-            .as_str()
-            .ok_or(anyhow!("Failed to pay invoice"))?
-            .to_string();
-        Ok(operation_id)
     }
 }
 
@@ -2187,19 +2143,6 @@ pub async fn test_client_config_change_detection(
 ) -> Result<()> {
     log_binary_versions().await?;
 
-    let fedimint_cli_version = crate::util::FedimintCli::version_or_default().await;
-    let fedimintd_version = crate::util::FedimintdCmd::version_or_default().await;
-
-    if fedimint_cli_version < *VERSION_0_9_0_ALPHA {
-        info!(target: LOG_DEVIMINT, "Skipping the test - fedimint-cli too old");
-        return Ok(());
-    }
-
-    if fedimintd_version < *VERSION_0_9_0_ALPHA {
-        info!(target: LOG_DEVIMINT, "Skipping the test - fedimintd too old");
-        return Ok(());
-    }
-
     let DevFed { mut fed, .. } = dev_fed;
     let peer_ids: Vec<_> = fed.member_ids().collect();
 
@@ -2525,19 +2468,6 @@ pub async fn test_guardian_password_change(
     process_mgr: &ProcessManager,
 ) -> Result<()> {
     log_binary_versions().await?;
-
-    let fedimint_cli_version = crate::util::FedimintCli::version_or_default().await;
-    let fedimintd_version = crate::util::FedimintdCmd::version_or_default().await;
-
-    if fedimint_cli_version < *VERSION_0_9_0_ALPHA {
-        info!(target: LOG_DEVIMINT, "Skipping the test - fedimint-cli too old");
-        return Ok(());
-    }
-
-    if fedimintd_version < *VERSION_0_9_0_ALPHA {
-        info!(target: LOG_DEVIMINT, "Skipping the test - fedimintd too old");
-        return Ok(());
-    }
 
     let DevFed { mut fed, .. } = dev_fed;
     fed.await_all_peers().await?;

--- a/devimint/src/version_constants.rs
+++ b/devimint/src/version_constants.rs
@@ -2,10 +2,6 @@ use std::sync::LazyLock;
 
 use semver::Version;
 
-pub static VERSION_0_8_2: LazyLock<Version> =
-    LazyLock::new(|| Version::parse("0.8.2").expect("version is parsable"));
-pub static VERSION_0_9_0_ALPHA: LazyLock<Version> =
-    LazyLock::new(|| Version::parse("0.9.0-alpha").expect("version is parsable"));
 pub static VERSION_0_10_0_ALPHA: LazyLock<Version> =
     LazyLock::new(|| Version::parse("0.10.0-alpha").expect("version is parsable"));
 pub static VERSION_0_11_0_ALPHA: LazyLock<Version> =

--- a/gateway/integration_tests/src/main.rs
+++ b/gateway/integration_tests/src/main.rs
@@ -14,7 +14,7 @@ use devimint::envs::FM_DATA_DIR_ENV;
 use devimint::external::{Bitcoind, Esplora};
 use devimint::federation::Federation;
 use devimint::util::{ProcessManager, almost_equal, poll, poll_with_timeout};
-use devimint::version_constants::{VERSION_0_8_2, VERSION_0_9_0_ALPHA, VERSION_0_10_0_ALPHA};
+use devimint::version_constants::VERSION_0_10_0_ALPHA;
 use devimint::{Gatewayd, LightningNode, cli, util};
 use fedimint_core::config::FederationId;
 use fedimint_core::time::now;
@@ -182,8 +182,6 @@ async fn config_test(gw_type: LightningNodeType) -> anyhow::Result<()> {
                 gw.client().connect_fed(invite_code).await.expect_err("Connecting to the same federation succeeded");
                 info!(target: LOG_TEST, "Verified that gateway couldn't connect to already connected federation");
 
-                let gatewayd_version = util::Gatewayd::version_or_default().await;
-
                 // Change the routing fees for a specific federation
                 let fed_id = dev_fed.fed().await?.calculate_federation_id();
                 gw.client().set_federation_routing_fee(fed_id.clone(), 20, 20000)
@@ -230,12 +228,8 @@ async fn config_test(gw_type: LightningNodeType) -> anyhow::Result<()> {
                 let new_invite_code = new_fed.invite_code()?;
                 gw.client().connect_fed(new_invite_code.clone()).await?;
 
-                let (default_base, default_ppm) = if gatewayd_version >= *VERSION_0_8_2 {
-                    (0, 0)
-                } else {
-                    // v0.8.0 and v0.8.1
-                    (2000, 3000)
-                };
+                let default_base = 0;
+                let default_ppm = 0;
 
                 let lightning_fee = gw.client().get_lightning_fee(new_fed_id.clone()).await?;
                 assert_eq!(
@@ -475,27 +469,20 @@ async fn liquidity_test() -> anyhow::Result<()> {
                 bitcoind.poll_get_transaction(txid).await?;
             }
 
-            // Skip channel closing for gateways older than 0.9.0-alpha, since
-            // cooperative close can hang due to LND fee estimation in regtest
-            // (fixed by adding sats_per_vbyte in 0.9.0-alpha).
-            if gw_lnd.gatewayd_version >= *VERSION_0_9_0_ALPHA {
-                info!(target: LOG_TEST, "Testing closing all channels...");
+            info!(target: LOG_TEST, "Testing closing all channels...");
 
-                // Gracefully close one of LND's channel's
-                let gw_ldk_pubkey = gw_ldk.client().lightning_pubkey().await?;
-                gw_lnd.client().close_channel(gw_ldk_pubkey, false).await?;
+            // Gracefully close one of LND's channel's
+            let gw_ldk_pubkey = gw_ldk.client().lightning_pubkey().await?;
+            gw_lnd.client().close_channel(gw_ldk_pubkey, false).await?;
 
-                // Force close LDK's channels
-                gw_ldk_second.client().close_all_channels(true).await?;
+            // Force close LDK's channels
+            gw_ldk_second.client().close_all_channels(true).await?;
 
-                // Verify none of the channels are active
-                for gw in gateways {
-                    let channels = gw.client().list_channels().await?;
-                    let active_channel = channels.into_iter().any(|chan| chan.is_active);
-                    assert!(!active_channel);
-                }
-            } else {
-                info!(target: LOG_TEST, "Skipping channel close test for gateway version < 0.9.0");
+            // Verify none of the channels are active
+            for gw in gateways {
+                let channels = gw.client().list_channels().await?;
+                let active_channel = channels.into_iter().any(|chan| chan.is_active);
+                assert!(!active_channel);
             }
 
             Ok(())

--- a/modules/fedimint-lnv2-tests/bin/swap_tests.rs
+++ b/modules/fedimint-lnv2-tests/bin/swap_tests.rs
@@ -1,5 +1,4 @@
 use devimint::federation::Client;
-use devimint::version_constants::VERSION_0_9_0_ALPHA;
 use devimint::{cmd, util};
 use fedimint_core::core::OperationId;
 use fedimint_lnv2_client::FinalSendOperationState;
@@ -27,15 +26,6 @@ async fn main() -> anyhow::Result<()> {
             federation.pegin_client(10_000, &client).await?;
 
             let gw_lnd = dev_fed.gw_lnd().await?;
-
-            let gatewayd_version = util::Gatewayd::version_or_default().await;
-            let gateway_cli_version = util::GatewayCli::version_or_default().await;
-
-            if gatewayd_version < *VERSION_0_9_0_ALPHA || gateway_cli_version < *VERSION_0_9_0_ALPHA
-            {
-                info!("Gateway version too old for swap tests, skipping");
-                return Ok(());
-            }
 
             info!("Pegging-in gateway...");
             federation.pegin_gateways(1_000_000, vec![gw_lnd]).await?;

--- a/modules/fedimint-lnv2-tests/bin/tests.rs
+++ b/modules/fedimint-lnv2-tests/bin/tests.rs
@@ -4,9 +4,7 @@ use clap::{Parser, Subcommand};
 use devimint::devfed::DevJitFed;
 use devimint::federation::Client;
 use devimint::util::almost_equal;
-use devimint::version_constants::{
-    VERSION_0_9_0_ALPHA, VERSION_0_10_0_ALPHA, VERSION_0_11_0_ALPHA,
-};
+use devimint::version_constants::{VERSION_0_10_0_ALPHA, VERSION_0_11_0_ALPHA};
 use devimint::{Gatewayd, cmd, util};
 use fedimint_core::core::OperationId;
 use fedimint_core::encoding::Encodable;
@@ -370,15 +368,9 @@ async fn test_payments(dev_fed: &DevJitFed) -> anyhow::Result<()> {
         .set_federation_transaction_fee(fed_id.clone(), 0, 0)
         .await?;
 
-    if util::FedimintdCmd::version_or_default().await >= *VERSION_0_9_0_ALPHA {
-        // Gateway pays: 1_000 msat LNv2 federation base fee. Gateway receives:
-        // 1_000_000 payment.
-        test_fees(fed_id, &client, gw_lnd, gw_ldk, 1_000_000 - 1_000).await?;
-    } else {
-        // Gateway pays: 1_000 msat LNv2 federation base fee, 100 msat LNv2 federation
-        // relative fee. Gateway receives: 1_000_000 payment.
-        test_fees(fed_id, &client, gw_lnd, gw_ldk, 1_000_000 - 1_000 - 100).await?;
-    }
+    // Gateway pays: 1_000 msat LNv2 federation base fee. Gateway receives:
+    // 1_000_000 payment.
+    test_fees(fed_id, &client, gw_lnd, gw_ldk, 1_000_000 - 1_000).await?;
 
     let online_peers: Vec<usize> = federation.members.keys().copied().collect();
 


### PR DESCRIPTION
Builds on: https://github.com/fedimint/fedimint/pull/8487

Bumps the backwards compat and upgrade tests and removes old stale logic.