### PR TITLE
fix(mint): warn on duplicate blind nonce in recovery index

### DIFF
--- a/modules/fedimint-mint-server/src/lib.rs
+++ b/modules/fedimint-mint-server/src/lib.rs
@@ -492,9 +492,18 @@ async fn migrate_db_v2(mut ctx: ServerModuleDbMigrationFnContext<'_, Mint>) -> a
     }
 
     for (blind_nonce, out_point) in blind_nonce_outpoints {
-        ctx.dbtx()
+        if ctx
+            .dbtx()
             .insert_entry(&RecoveryBlindNonceOutpointKey(blind_nonce), &out_point)
-            .await;
+            .await
+            .is_some()
+        {
+            warn!(
+                target: LOG_MODULE_MINT,
+                bnonce = ?blind_nonce,
+                "Recovery blind nonce outpoint overwritten; duplicate blind nonce in outputs"
+            );
+        }
     }
 
     Ok(())
@@ -666,11 +675,20 @@ impl ServerModule for Mint {
         )
         .await;
 
-        dbtx.insert_entry(
-            &RecoveryBlindNonceOutpointKey(output.blind_nonce),
-            &out_point,
-        )
-        .await;
+        if dbtx
+            .insert_entry(
+                &RecoveryBlindNonceOutpointKey(output.blind_nonce),
+                &out_point,
+            )
+            .await
+            .is_some()
+        {
+            warn!(
+                target: LOG_MODULE_MINT,
+                bnonce = ?output.blind_nonce,
+                "Recovery blind nonce outpoint overwritten; duplicate blind nonce in outputs"
+            );
+        }
 
         let amount = output.amount;
         let fee = self.cfg.consensus.fee_consensus.fee(amount);


### PR DESCRIPTION
Follow-up to #8533 (a9068911434) which switched `insert_new_entry` to `insert_entry` to avoid panics on duplicate blind nonces.

The `insert_entry` return value was silently discarded in both the `migrate_db_v2` backfill and the live `process_output` path. Add a `warn!` log when a duplicate is detected, consistent with the existing `BlindNonceKey` duplicate warning nearby.

This seems useful just for information purposes - e.g. something else going on wrong around.

See: https://github.com/fedimint/fedimint/pull/8533#discussion_r2104009498

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
