### PR TITLE
chore(ci): sample 25% of backcompat tests in PRs too

### DIFF
--- a/.github/workflows/ci-backwards-compatibility.yml
+++ b/.github/workflows/ci-backwards-compatibility.yml
@@ -57,6 +57,11 @@ jobs:
           else
             PERFIT_METRIC="aPuCAjrFT7uE5Oax_T4sMw"
             VERSIONS_TO_TEST="v0.10.0"
+            # PRs only test one version (vs three in merge queue), but the
+            # full test matrix is still ~37 combos and takes ~23 min.
+            # Since the merge queue will re-run these tests anyway, sample
+            # 25% here too to keep PR feedback fast.
+            export FM_BACKCOMPAT_TEST_SAMPLE_PERCENT=25
           fi
 
           # the default tmp dir is too long (/home/ubuntu/actions-runner/_work/_temp/)


### PR DESCRIPTION
The backcompat CI job takes ~23 minutes on PRs even though it only tests a single version (v0.10.0), because the full test matrix is still ~37 combos. Since the merge queue will re-run these tests anyway (also at 25% but across all three versions), there's no need to run the full matrix on every PR push. Sampling 25% here matches the merge queue strategy introduced in #8534 and keeps PR feedback fast.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
