### PR TITLE
fix(recurringdv2): drop double slash in LNURL verify URL

### DIFF
--- a/fedimint-recurringdv2/src/main.rs
+++ b/fedimint-recurringdv2/src/main.rs
@@ -162,7 +162,11 @@ async fn invoice(
 
     Json(LnurlResponse::Ok(InvoiceResponse {
         pr: invoice.clone(),
-        verify: Some(format!("{}/verify/{}", gateway, invoice.payment_hash())),
+        verify: Some(format!(
+            "{}/verify/{}",
+            gateway.to_string().trim_end_matches('/'),
+            invoice.payment_hash()
+        )),
     }))
 }
 


### PR DESCRIPTION
## Summary
- `SafeUrl`'s `Display` impl renders with a trailing `/`, so the `verify` field in the LNURL `InvoiceResponse` came out as `https://gw.example.com//verify/<hash>`.
- Drop the redundant leading slash in the `format!` so the URL is well-formed.