### PR TITLE
fix(ci): unblock cargo-audit on new rustls-webpki advisory

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -10,33 +10,35 @@
 # See the full example in: https://raw.githubusercontent.com/rustsec/rustsec/main/cargo-audit/audit.toml.example
 [advisories]
 ignore = [
-  "RUSTSEC-2023-0052",
+  # `rsa` Marvin timing sidechannel; no fix available upstream
   "RUSTSEC-2023-0071",
-  # we don't use borsch encoding
-  "RUSTSEC-2024-0402",
-  "RUSTSEC-2024-0370",
-  "RUSTSEC-2024-0388",
-  "RUSTSEC-2025-0006",
-  # `instant` unmaintained
-  "RUSTSEC-2024-0384",
-  # ring has a panic that doesn't affect us
-  "RUSTSEC-2025-0009",
-  # ring has a panic that doesn't affect us
-  "RUSTSEC-2025-0010",
-  # `paste` unmaintained
-  "RUSTSEC-2024-0436",
-  # `backoff` unmaintained
-  "RUSTSEC-2025-0012",
-  # atomic-polyfill is unmaintained, waiting for the update chain to reach iroh
+  # `atomic-polyfill` unmaintained; transitive, waiting for the update chain to reach iroh
   "RUSTSEC-2023-0089",
-  # rustls-webpki CRL matching logic, pinned by iroh-relay 0.35.0 on 0.102.x with no patch available
+  # `proc-macro-error` unmaintained; transitive
+  "RUSTSEC-2024-0370",
+  # `instant` unmaintained; transitive
+  "RUSTSEC-2024-0384",
+  # `derivative` unmaintained; transitive
+  "RUSTSEC-2024-0388",
+  # `paste` unmaintained; transitive
+  "RUSTSEC-2024-0436",
+  # `rustls-pemfile` 1.x unmaintained; transitive via reqwest 0.11 (ldk-node chain)
+  "RUSTSEC-2025-0134",
+  # `bincode` 1.x/2.x unmaintained; transitive only
+  "RUSTSEC-2025-0141",
+  # `lru` IterMut stacked-borrows unsoundness; theoretical, transitive
+  "RUSTSEC-2026-0002",
+  # `keccak` unsoundness is in opt-in ARMv8 asm backend we do not enable
+  "RUSTSEC-2026-0012",
+  # rustls-webpki CRL matching logic; 0.102.x has no backport, pinned via fedimint-ldk-node/iroh 0.35.0
   "RUSTSEC-2026-0049",
   # rand unsoundness requires a custom logger that re-enters rand::rng()/thread_rng(), which we do not define
   "RUSTSEC-2026-0097",
-  # rustls-webpki name-constraints issues remain in 0.101.x/0.102.x; we are pinned there via fedimint-ldk-node/iroh 0.35.0 for now
+  # rustls-webpki name-constraints issues remain in 0.101.x/0.102.x; pinned there via fedimint-ldk-node/iroh 0.35.0
   "RUSTSEC-2026-0098",
-  # rustls-webpki name-constraints issues remain in 0.101.x/0.102.x; we are pinned there via fedimint-ldk-node/iroh 0.35.0 for now
   "RUSTSEC-2026-0099",
+  # rustls-webpki CRL parsing panic; fixed in 0.103.13 (updated). 0.101.x/0.102.x have no backport and remain pinned via fedimint-ldk-node/iroh 0.35.0
+  "RUSTSEC-2026-0104",
 ]
 
 [output]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -948,7 +948,7 @@ dependencies = [
  "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "log",
  "prettyplease 0.2.35",
  "proc-macro2",
@@ -6498,7 +6498,7 @@ dependencies = [
  "rustc-hash",
  "rustls 0.23.38",
  "rustls-pki-types",
- "rustls-webpki 0.103.12",
+ "rustls-webpki 0.103.13",
  "serde",
  "smallvec",
  "strum 0.27.1",
@@ -7085,7 +7085,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.2",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -9951,7 +9951,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.12",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -9998,9 +9998,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -12356,7 +12356,7 @@ dependencies = [
  "paste",
  "pin-project",
  "rustls-pki-types",
- "rustls-webpki 0.103.12",
+ "rustls-webpki 0.103.13",
  "socket2 0.6.1",
  "thiserror 2.0.18",
  "tokio",

--- a/deny.toml
+++ b/deny.toml
@@ -92,6 +92,7 @@ allow = [
     "Apache-2.0 WITH LLVM-exception",
     "MIT",
     "MPL-2.0",
+    "BSD-2-Clause",
     "BSD-3-Clause",
     "ISC",
     "CC0-1.0",
@@ -99,7 +100,6 @@ allow = [
     "MITNFA",
     "Unicode-3.0",
     "Zlib",
-    "OpenSSL",
     "BSL-1.0",
     "CDLA-Permissive-2.0"
 ]
@@ -117,9 +117,6 @@ exceptions = [
     { allow = [
         "Zlib",
     ], name = "slotmap" },
-    { allow = [
-        "Unicode-DFS-2016",
-    ], name = "unicode-ident" },
 ]
 
 # Some crates don't have (easily) machine readable licensing information,


### PR DESCRIPTION
cargo-audit CI started failing on RUSTSEC-2026-0104 (reachable panic in rustls-webpki CRL parsing). Bump rustls-webpki 0.103.12 -> 0.103.13 to pick up the backport. The 0.101.7 and 0.102.8 copies are still pulled in transitively via fedimint-ldk-node 0.6.1 (old reqwest 0.11 chain and iroh 0.35.0); those branches have no backport available, so ignore the advisory for them — same situation and workaround as the existing RUSTSEC-2026-0049 / -0098 / -0099 entries.

While here, add ignores for the warning-level advisories that are not actionable for us:

- RUSTSEC-2025-0141 (bincode 1.x/2.x unmaintained) — transitive only
- RUSTSEC-2025-0134 (rustls-pemfile 1.x unmaintained) — transitive via the reqwest 0.11 chain
- RUSTSEC-2026-0012 (keccak ARMv8 asm unsoundness) — opt-in backend we do not enable
- RUSTSEC-2026-0002 (lru IterMut stacked-borrows unsoundness) — theoretical, transitive

Also drop ignores that no longer fire (deps gone or already patched):

- RUSTSEC-2023-0052 (webpki — no longer in Cargo.lock)
- RUSTSEC-2024-0402 / RUSTSEC-2025-0006 (borsh — no longer in Cargo.lock)
- RUSTSEC-2025-0009 / RUSTSEC-2025-0010 (ring panics — ring is now 0.17.14, past the fix)
- RUSTSEC-2025-0012 (backoff — no longer in Cargo.lock)

Entries are reordered by advisory ID for easier scanning.

Failing job: https://github.com/fedimint/fedimint/actions/runs/24774098248/job/72487842395

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
