### PR TITLE
feat(devimint): add process visibility and kill subcommand

### DIFF
--- a/devimint/src/cli.rs
+++ b/devimint/src/cli.rs
@@ -128,6 +128,11 @@ pub enum Cmd {
 pub enum RpcCmd {
     Wait,
     Env,
+    /// Send SIGTERM to a named daemon using its PID file.
+    Kill {
+        /// Process name, e.g. "fedimintd-default-0", "bitcoind", "gatewayd-lnd"
+        name: String,
+    },
 }
 
 pub async fn setup(arg: CommonArgs) -> Result<(ProcessManager, TaskGroup)> {
@@ -447,6 +452,71 @@ fn devimint_static_data_dir() -> ffi::OsString {
     )
 }
 
+/// Whether the process currently running as `pid` still matches the given
+/// expected basename and start time recorded when it was spawned.
+///
+/// A basename match alone isn't enough to tell apart different instances of
+/// the same binary (e.g. several `fedimintd`s in one federation), so this
+/// also compares start time — a PID recycled from a dead instance onto a
+/// live one of the same binary would fail this check. `Ok(false)` covers
+/// both "no such process" and "a different process reused this pid".
+///
+/// `Err` means the check itself failed (e.g. `ps` could not be run) —
+/// callers must not treat that as "gone", or a tooling hiccup would orphan
+/// a live daemon.
+async fn pid_identity_matches(
+    pid: i32,
+    expected_basename: &str,
+    expected_start_time: &str,
+) -> Result<bool> {
+    let Some(running_basename) = crate::util::running_program_basename(pid as u32).await? else {
+        return Ok(false);
+    };
+    let Some(running_start_time) = crate::util::process_start_time(pid as u32).await? else {
+        return Ok(false);
+    };
+    Ok(running_basename == expected_basename && running_start_time == expected_start_time)
+}
+
+/// Whether the process is a zombie: already dead, just not yet reaped by
+/// its parent (the long-running devimint that spawned it).
+async fn is_zombie(pid: i32) -> bool {
+    let Ok(output) = tokio::process::Command::new("ps")
+        .args(["-o", "stat=", "-p", &pid.to_string()])
+        .output()
+        .await
+    else {
+        return false;
+    };
+    String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .starts_with('Z')
+}
+
+/// Polls `pid` until it's gone — or is a zombie, which signals can never
+/// change from here — or `timeout` elapses. Returns whether it exited.
+///
+/// Uses a flat interval rather than the shared `backoff_util::custom_backoff`
+/// helper: that's built for retrying operations of unknown duration where
+/// growing the delay avoids hammering a remote service, but here exit is
+/// usually near-instant and we want fast, consistent detection of it, not an
+/// escalating delay before the next check.
+async fn wait_for_pid_exit(pid_t: nix::unistd::Pid, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    while nix::sys::signal::kill(pid_t, None).is_ok() {
+        // `kill(pid, 0)` succeeds for zombies: the daemon is dead, its
+        // parent just hasn't reaped it yet, so don't keep waiting on it.
+        if is_zombie(pid_t.as_raw()).await {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        fedimint_core::runtime::sleep(Duration::from_millis(100)).await;
+    }
+    true
+}
+
 pub async fn rpc_command(rpc: RpcCmd, common: CommonArgs) -> Result<()> {
     fedimint_logging::TracingSetup::default().init()?;
     match rpc {
@@ -500,6 +570,116 @@ pub async fn rpc_command(rpc: RpcCmd, common: CommonArgs) -> Result<()> {
                 write_overwrite_async(env_file, env_string).await?;
             }
 
+            Ok(())
+        }
+        RpcCmd::Kill { name } => {
+            let pid_file = common.test_dir().join("logs").join(format!("{name}.pid"));
+            let pid_file_contents = fs::read_to_string(&pid_file)
+                .await
+                .with_context(|| format!("No PID file for '{name}' — is it running?"))?;
+            let mut lines = pid_file_contents.lines();
+            let pid: i32 = lines
+                .next()
+                .with_context(|| format!("Empty PID file for '{name}'"))?
+                .trim()
+                .parse()
+                .with_context(|| format!("Invalid PID in file for '{name}'"))?;
+            let expected_program = lines.next().unwrap_or_default();
+            let expected_start_time = lines.next().unwrap_or_default();
+            ensure!(
+                !expected_program.is_empty() && !expected_start_time.is_empty(),
+                "PID file for '{name}' doesn't record enough identity info to \
+                 safely verify (stale or old-format file?) — refusing to guess. \
+                 Remove it manually if you're sure it's safe."
+            );
+            let expected_basename = Path::new(expected_program).file_name().map_or_else(
+                || expected_program.to_owned(),
+                |s| s.to_string_lossy().into_owned(),
+            );
+
+            // A stale PID file (daemon already exited, PID recycled by the OS)
+            // could otherwise cause us to signal an unrelated process, so
+            // confirm the running process is still the very same instance we
+            // spawned (basename + start time) before signaling it. If it's
+            // gone (or the pid now belongs to something else), the daemon is
+            // already dead: clean up the stale PID file and succeed, so
+            // `kill` is idempotent.
+            if !pid_identity_matches(pid, &expected_basename, expected_start_time).await? {
+                let _ = fs::remove_file(&pid_file).await;
+                println!("'{name}' (pid {pid}) is not running anymore; removed stale PID file");
+                return Ok(());
+            }
+
+            let pid_t = nix::unistd::Pid::from_raw(pid);
+            nix::sys::signal::kill(pid_t, nix::sys::signal::Signal::SIGTERM)
+                .with_context(|| format!("Failed to send SIGTERM to '{name}' (pid {pid})"))?;
+
+            // Wait for the process to actually exit, escalating to SIGKILL if
+            // it doesn't within a grace period. Re-verify identity right
+            // before the SIGKILL too: the original process may have already
+            // exited during the wait, letting the OS hand `pid` to an
+            // unrelated process in the meantime. Only remove the PID file
+            // once exit is actually confirmed (or the pid is confirmed to no
+            // longer be ours anyway) — otherwise a still-running daemon
+            // (e.g. one stuck in uninterruptible I/O, immune to SIGKILL until
+            // it unblocks) would silently become untracked.
+            let mut exited = wait_for_pid_exit(pid_t, Duration::from_secs(5)).await;
+            let mut sigkilled = false;
+            if !exited {
+                match pid_identity_matches(pid, &expected_basename, expected_start_time).await {
+                    Ok(true) => {
+                        sigkilled = true;
+                        let _ = nix::sys::signal::kill(pid_t, nix::sys::signal::Signal::SIGKILL);
+                        exited = wait_for_pid_exit(pid_t, Duration::from_secs(5)).await;
+                    }
+                    Ok(false) => {
+                        warn!(
+                            target: LOG_DEVIMINT,
+                            %name, pid,
+                            "pid no longer matches the expected process after the \
+                             SIGTERM wait; not escalating to SIGKILL (likely \
+                             already exited and the pid was reused)"
+                        );
+                        // Not our process either way, so the PID file is stale
+                        // regardless of whether *something* is still running.
+                        exited = true;
+                    }
+                    Err(err) => {
+                        // Couldn't verify: don't SIGKILL what we can't
+                        // identify, and keep the PID file so a live daemon
+                        // isn't orphaned by a tooling failure.
+                        warn!(
+                            target: LOG_DEVIMINT,
+                            %name, pid, err = %err.fmt_compact_anyhow(),
+                            "could not re-verify process identity after the \
+                             SIGTERM wait; not escalating to SIGKILL"
+                        );
+                    }
+                }
+            }
+
+            if exited {
+                let _ = fs::remove_file(&pid_file).await;
+                if sigkilled {
+                    println!(
+                        "'{name}' (pid {pid}) didn't respond to SIGTERM within 5s; \
+                         sent SIGKILL"
+                    );
+                } else {
+                    println!("Sent SIGTERM to '{name}' (pid {pid})");
+                }
+            } else {
+                let signals_sent = if sigkilled {
+                    "SIGTERM and SIGKILL"
+                } else {
+                    "SIGTERM"
+                };
+                println!(
+                    "Sent {signals_sent} to '{name}' (pid {pid}), but it still \
+                     appears to be running — leaving its PID file in place so \
+                     it isn't lost track of."
+                );
+            }
             Ok(())
         }
     }

--- a/devimint/src/util.rs
+++ b/devimint/src/util.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::ffi::OsStr;
 use std::future::Future;
 use std::ops::ControlFlow;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::Arc;
 use std::time::Duration;
@@ -18,15 +18,15 @@ use fedimint_core::envs::{
 use fedimint_core::module::ApiAuth;
 use fedimint_core::task::{self};
 use fedimint_core::time::now;
-use fedimint_core::util::FmtCompactAnyhow as _;
 use fedimint_core::util::backoff_util::custom_backoff;
+use fedimint_core::util::{FmtCompactAnyhow as _, write_overwrite_async};
 use fedimint_logging::LOG_DEVIMINT;
 use semver::Version;
 use serde::de::DeserializeOwned;
 use tokio::fs::OpenOptions;
 use tokio::process::Child;
 use tokio::sync::Mutex;
-use tracing::debug;
+use tracing::{debug, info};
 
 use crate::envs::{
     FM_BACKWARDS_COMPATIBILITY_TEST_ENV, FM_BITCOIN_CLI_BASE_EXECUTABLE_ENV,
@@ -93,6 +93,7 @@ impl ProcessHandle {
 pub struct ProcessHandleInner {
     name: String,
     child: Option<Child>,
+    pid_file: Option<PathBuf>,
 }
 
 impl ProcessHandleInner {
@@ -117,6 +118,12 @@ impl ProcessHandleInner {
 
             process_reaper::kill_process(&child);
             process_reaper::reap_killed_processes();
+        }
+
+        // Best-effort: avoid leaving a stale PID file behind that could later
+        // be misread as still belonging to a since-recycled PID.
+        if let Some(pid_file) = self.pid_file.take() {
+            let _ = std::fs::remove_file(pid_file);
         }
     }
 
@@ -149,6 +156,11 @@ impl ProcessHandleInner {
 impl Drop for ProcessHandleInner {
     fn drop(&mut self) {
         if self.child.is_none() {
+            // Already reaped via `await_terminated`; still clean up the PID
+            // file so a stale entry doesn't accumulate.
+            if let Some(pid_file) = self.pid_file.take() {
+                let _ = std::fs::remove_file(pid_file);
+            }
             return;
         }
 
@@ -166,18 +178,19 @@ impl ProcessManager {
         Self { globals }
     }
 
-    /// Logs to $FM_LOGS_DIR/{name}.{out,err}
+    /// Logs to $FM_LOGS_DIR/{name}.log
     pub async fn spawn_daemon(&self, name: &str, mut cmd: Command) -> Result<ProcessHandle> {
         // Reap any recently killed processes so their resources
         // (ports, file locks) are fully released before we bind new ones.
         process_reaper::reap_killed_processes();
         debug!(target: LOG_DEVIMINT, %name, "Spawning daemon");
         let logs_dir = env::var(FM_LOGS_DIR_ENV)?;
-        let path = format!("{logs_dir}/{name}.log");
+        let log_path = format!("{logs_dir}/{name}.log");
+
         let log = OpenOptions::new()
             .append(true)
             .create(true)
-            .open(path)
+            .open(&log_path)
             .await?
             .into_std()
             .await;
@@ -188,17 +201,119 @@ impl ProcessManager {
             .cmd
             .spawn()
             .with_context(|| format!("Could not spawn: {name}"))?;
+
+        let pid = child.id().expect("pid available immediately after spawn");
+        // Redact env vars that look like secrets (key material, passwords,
+        // tokens): this is printed to stdout and written to the tracing log,
+        // both of which can end up in shared/CI output.
+        let cmd_str = cmd.command_pasteable(true);
+
+        println!("# Started {name} (pid {pid})\n{cmd_str}");
+        info!(target: LOG_DEVIMINT, %name, pid, cmd = %cmd_str, "Spawned daemon");
+
+        let pid_path = PathBuf::from(format!("{logs_dir}/{name}.pid"));
+        // Record the process's observed executable basename and start time
+        // alongside the PID so `devimint kill` can confirm it's still the
+        // very same process instance before signaling a possibly stale
+        // (recycled) PID. Probe the running process for its basename rather
+        // than trusting argv[0]: for symlinked or wrapped commands the two
+        // differ, and the kill-time check probes the running process.
+        let write_pid_file = async {
+            let program = running_program_basename(pid)
+                .await?
+                .with_context(|| format!("Process {pid} exited immediately after spawn"))?;
+            let start_time = process_start_time(pid)
+                .await?
+                .with_context(|| format!("Process {pid} exited immediately after spawn"))?;
+            write_overwrite_async(&pid_path, format!("{pid}\n{program}\n{start_time}\n")).await?;
+            Ok::<(), anyhow::Error>(())
+        };
+        if let Err(err) = write_pid_file.await {
+            // Don't leave an unmanaged process running if we can't record its PID.
+            process_reaper::kill_process(&child);
+            process_reaper::reap_killed_processes();
+            return Err(err).with_context(|| format!("Could not write PID file for: {name}"));
+        }
+
         let handle = ProcessHandle(Arc::new(Mutex::new(ProcessHandleInner {
             name: name.to_owned(),
             child: Some(child),
+            pid_file: Some(pid_path),
         })));
         Ok(handle)
     }
 }
 
+/// The wall-clock start time of the process currently running as `pid`, as
+/// reported by `ps -o lstart=`.
+///
+/// A basename match alone (e.g. "this pid is running `fedimintd`") isn't
+/// enough to identify *which* spawned instance a PID belongs to — a
+/// federation runs several `fedimintd`s side by side, so a PID recycled from
+/// one dead guardian could get reused by another live one. Pairing the
+/// basename with the process's start time is enough in practice to tell
+/// instances apart, since exact PID reuse landing in the same second is
+/// vanishingly unlikely.
+///
+/// Returns `Ok(None)` if no process with that pid exists; `Err` only if
+/// `ps` itself could not be run, so callers can tell "process is gone"
+/// apart from "we couldn't check".
+pub(crate) async fn process_start_time(pid: u32) -> Result<Option<String>> {
+    let output = tokio::process::Command::new("ps")
+        .args(["-o", "lstart=", "-p", &pid.to_string()])
+        .output()
+        .await
+        .context("Failed to run `ps` to read process start time")?;
+    let start_time = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+    Ok((!start_time.is_empty()).then_some(start_time))
+}
+
+/// Best-effort identity of the executable currently running as `pid`, as a
+/// basename.
+///
+/// Prefers `/proc/{pid}/exe` on Linux, since it's the kernel-resolved path
+/// to the actual binary and can't be spoofed via argv\[0\]; falls back to
+/// `ps -o comm=` elsewhere (e.g. macOS, which has no `/proc`).
+///
+/// Used both when spawning (to record the identity in the PID file) and by
+/// `devimint kill` (to verify it), so the two sides always compare values
+/// obtained the same way.
+///
+/// Returns `Ok(None)` if no process with that pid exists; `Err` only if the
+/// identity could not be determined (e.g. `ps` failed to run).
+pub(crate) async fn running_program_basename(pid: u32) -> Result<Option<String>> {
+    #[cfg(target_os = "linux")]
+    if let Ok(target) = std::fs::read_link(format!("/proc/{pid}/exe"))
+        && let Some(name) = target.file_name()
+    {
+        let name = name.to_string_lossy();
+        // The kernel appends " (deleted)" when the binary on disk was
+        // replaced after the process started (e.g. `cargo build` while the
+        // daemon is running) — it's still the same process, so strip it.
+        return Ok(Some(
+            name.strip_suffix(" (deleted)").unwrap_or(&name).to_owned(),
+        ));
+    }
+
+    let output = tokio::process::Command::new("ps")
+        .args(["-o", "comm=", "-p", &pid.to_string()])
+        .output()
+        .await
+        .context("Failed to run `ps` to verify process identity")?;
+    let comm = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+    if comm.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(Path::new(&comm).file_name().map_or_else(
+        || comm.clone(),
+        |s| s.to_string_lossy().into_owned(),
+    )))
+}
+
 pub struct Command {
     pub cmd: tokio::process::Command,
     pub args_debug: Vec<String>,
+    pub env_debug: Vec<(String, String)>,
 }
 
 impl Command {
@@ -221,6 +336,10 @@ impl Command {
         K: AsRef<OsStr>,
         V: AsRef<OsStr>,
     {
+        self.env_debug.push((
+            key.as_ref().to_string_lossy().into_owned(),
+            val.as_ref().to_string_lossy().into_owned(),
+        ));
         self.cmd.env(key, val);
         self
     }
@@ -231,7 +350,14 @@ impl Command {
         K: AsRef<OsStr>,
         V: AsRef<OsStr>,
     {
-        self.cmd.envs(env);
+        let pairs: Vec<(K, V)> = env.into_iter().collect();
+        for (k, v) in &pairs {
+            self.env_debug.push((
+                k.as_ref().to_string_lossy().into_owned(),
+                v.as_ref().to_string_lossy().into_owned(),
+            ));
+        }
+        self.cmd.envs(pairs);
         self
     }
 
@@ -251,6 +377,91 @@ impl Command {
             .map(|x| x.replace(' ', "␣"))
             .collect::<Vec<_>>()
             .join(" ")
+    }
+
+    /// Format the command as a bash-pasteable string with env vars and
+    /// single-quoted args so it can be copied and run directly in a shell.
+    ///
+    /// If `redact_secrets` is set, values of env vars whose key looks like it
+    /// holds key material or a credential (e.g. contains "secret",
+    /// "password", "token") are replaced with a placeholder. Use this when
+    /// the output may end up in stdout or logs that aren't strictly private
+    /// (e.g. shared CI output).
+    pub fn command_pasteable(&self, redact_secrets: bool) -> String {
+        fn single_quote(s: &str) -> String {
+            format!("'{}'", s.replace('\'', "'\\''"))
+        }
+        fn looks_like_secret(key: &str) -> bool {
+            // Strip `_`/`-` separators before matching so all naming styles
+            // hit the same patterns: `API_KEY`/`--api-key` → "apikey",
+            // `FM_BITCOIN_RPC_PASS` → contains "pass". Over-redacting the
+            // occasional false positive is fine for a dev-tool log; leaking
+            // a credential to CI output is not.
+            let key: String = key
+                .to_ascii_lowercase()
+                .chars()
+                .filter(|c| !matches!(c, '_' | '-'))
+                .collect();
+            [
+                "secret", "pass", "token", "apikey", "macaroon", "mnemonic", "seed",
+            ]
+            .iter()
+            .any(|pat| key.contains(pat))
+        }
+        let env_part = self
+            .env_debug
+            .iter()
+            .map(|(k, v)| {
+                let v = if redact_secrets && looks_like_secret(k) {
+                    "<redacted>"
+                } else {
+                    v.as_str()
+                };
+                format!("{}={}", k, single_quote(v))
+            })
+            .collect::<Vec<_>>()
+            .join(" ");
+
+        // Redact secrets passed as CLI args too, in both the `--flag=value`
+        // and separate `--flag value` forms (e.g. bitcoind/gatewayd
+        // `-rpcpassword`). This assumes secrets are always attached to a
+        // flag whose name looks sensitive — a bare positional value with no
+        // flag and no recognizable keyword in the value itself (e.g. a raw
+        // opaque token passed with no `--flag`) would slip through
+        // unredacted. No current daemon spawned by this tool passes secrets
+        // that way; if one does in the future, give it a named flag.
+        let mut args_part_tokens: Vec<String> = Vec::with_capacity(self.args_debug.len());
+        let mut redact_next_value = false;
+        for arg in &self.args_debug {
+            if redact_secrets && redact_next_value {
+                args_part_tokens.push(single_quote("<redacted>"));
+                redact_next_value = false;
+                continue;
+            }
+            if redact_secrets {
+                if let Some((flag, value)) = arg.split_once('=') {
+                    // Check the value too, not just the flag name: a flag
+                    // that doesn't itself look secret (e.g. `--config`) can
+                    // still carry a secret in its value (e.g. a nested
+                    // `rpcpassword=...` assignment).
+                    if looks_like_secret(flag) || looks_like_secret(value) {
+                        args_part_tokens.push(single_quote(&format!("{flag}=<redacted>")));
+                        continue;
+                    }
+                } else if looks_like_secret(arg) {
+                    args_part_tokens.push(single_quote(arg));
+                    redact_next_value = true;
+                    continue;
+                }
+            }
+            args_part_tokens.push(single_quote(arg));
+        }
+        let args_part = args_part_tokens.join(" ");
+        if env_part.is_empty() {
+            args_part
+        } else {
+            format!("{env_part} {args_part}")
+        }
     }
 
     /// Run the command and get its output as string.
@@ -539,6 +750,7 @@ impl ToCmdExt for &'_ str {
         Command {
             cmd: tokio::process::Command::new(self),
             args_debug: vec![self.to_owned()],
+            env_debug: vec![],
         }
     }
 }
@@ -987,6 +1199,7 @@ fn to_command(cli: Vec<String>) -> Command {
     Command {
         cmd,
         args_debug: cli,
+        env_debug: vec![],
     }
 }
 


### PR DESCRIPTION
feat(devimint): add process visibility and kill subcommand

When a daemon is spawned, devimint now prints its PID and the full
bash-pasteable run command (with env vars and single-quoted args) to
stdout and the tracing log. A PID file is also written to
$FM_LOGS_DIR/{name}.pid for each daemon.

This allows developers to:
- See exactly what command started each process
- Retrieve the run command from logs to manually restart a killed daemon
- Kill a specific named daemon without affecting others

A new `devimint kill <name>` subcommand sends SIGTERM to a named
daemon by reading its PID file, leaving all other daemons running.

To retrieve a daemon's run command from logs:
`grep "fedimintd-default-0" $FM_LOGS_DIR/devimint.log | sed 's/\x1B\[[0-9;]*m//g'`

Replace fedimintd-default-0 with whichever daemon you want — bitcoind, gatewayd-lnd, etc.

## Example workflow:
  ### Kill a specific guardian
  `devimint kill fedimintd-default-0`

  ### Retrieve and re-run its command to restart it
` eval $(grep "fedimintd-default-0" $FM_LOGS_DIR/devimint.log | sed 's/\x1B\[[0-9;]*m//g' | sed 's/.*cmd=//') `

Closes #2274


<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
