### PR TITLE
 fix(test): lock bitcoin exclusively in peg_ins_that_are_unconfirmed_a… 

### DIFF
--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -1441,11 +1441,14 @@ impl Wallet {
         old_count: u32,
         new_count: u32,
     ) {
+        let sync_start = fedimint_core::time::now();
         info!(
             target: LOG_MODULE_WALLET,
             old_count,
             new_count,
-            blocks_to_go = new_count - old_count,
+            blocks_to_go = new_count
+                .checked_sub(old_count)
+                .expect("new_count must be >= old_count"),
             "New block count consensus, initiating sync",
         );
 
@@ -1454,6 +1457,7 @@ impl Wallet {
         self.wait_for_finality_confs_or_shutdown(new_count).await;
 
         for height in old_count..new_count {
+            let block_start = fedimint_core::time::now();
             info!(
                 target: LOG_MODULE_WALLET,
                 height,
@@ -1570,9 +1574,21 @@ impl Wallet {
                 target: LOG_MODULE_WALLET,
                 height,
                 ?block_hash,
+                duration = ?block_start.elapsed().unwrap_or_default(),
                 "Successfully processed block of height {height}",
             );
         }
+
+        info!(
+            target: LOG_MODULE_WALLET,
+            old_count,
+            new_count,
+            blocks_processed = new_count
+                .checked_sub(old_count)
+                .expect("new_count must be >= old_count"),
+            duration = ?sync_start.elapsed().unwrap_or_default(),
+            "Block count consensus sync complete",
+        );
     }
 
     /// Add a change UTXO to our spendable UTXO database after it was included

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -677,6 +677,7 @@ async fn peg_outs_must_wait_for_available_utxos() -> anyhow::Result<()> {
 async fn peg_ins_that_are_unconfirmed_are_rejected() -> anyhow::Result<()> {
     let fixtures = fixtures();
     let bitcoin = fixtures.bitcoin();
+    let bitcoin = bitcoin.lock_exclusive().await;
     let dyn_bitcoin_rpc = fixtures.server_bitcoin_rpc();
     let bitcoin_rpc_connection = fixtures.server_bitcoin_rpc();
     let db = MemDatabase::new().into_database();


### PR DESCRIPTION
See commits.

I personally suspect that this is not going to entirely solve the issue, that's why I'm adding more debugging info, so next time this flakes in the CI, we can judge the performance of processing blocks in the consensus.

See commit messages.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
