### PR TITLE
fix: devimint opens channels in a circle

### DIFF
--- a/devimint/src/external.rs
+++ b/devimint/src/external.rs
@@ -713,13 +713,12 @@ pub async fn open_channels_between_gateways(
     )
     .await?;
 
-    // All unique pairs of gateways.
-    // For a list of gateways [A, B, C], this will produce [(A, B), (B, C)].
-    // Since the first gateway within each pair initiates the channel open,
-    // order within each pair needs to be enforced so that each Lightning node opens
-    // 1 channel.
+    // Cyclic pairs of gateways, so every node gets a channel with every other
+    // node for our typical 3-gateway setup. For a list [A, B, C] this produces
+    // [(A, B), (B, C), (C, A)]. The first gateway in each pair initiates the
+    // channel open, so each Lightning node opens exactly one channel.
     let gateway_pairs: Vec<(&NamedGateway, &NamedGateway)> =
-        gateways.iter().tuple_windows::<(_, _)>().collect();
+        gateways.iter().circular_tuple_windows::<(_, _)>().collect();
 
     info!(target: LOG_DEVIMINT, block_height = %block_height, "devimint current block");
     let sats_per_side = 5_000_000;

--- a/gateway/integration_tests/src/main.rs
+++ b/gateway/integration_tests/src/main.rs
@@ -431,13 +431,9 @@ async fn liquidity_test() -> anyhow::Result<()> {
             assert_eq!(lnd_transactions.len(), 0);
 
             info!(target: LOG_TEST, "Testing paying Bolt12 Offers...");
-            // TODO: investigate why the first BOLT12 payment attempt is expiring consistently
-            poll_with_timeout("First BOLT12 payment", Duration::from_secs(30), || async {
-                let offer_with_amount = gw_ldk_second.client().create_offer(Some(Amount::from_msats(10_000_000))).await.map_err(ControlFlow::Continue)?;
-                gw_ldk.client().pay_offer(offer_with_amount, None).await.map_err(ControlFlow::Continue)?;
-                assert!(get_transaction(gw_ldk_second, PaymentKind::Bolt12Offer, Amount::from_msats(10_000_000), PaymentStatus::Succeeded).await.is_some());
-                Ok(())
-            }).await?;
+            let offer_with_amount = gw_ldk_second.client().create_offer(Some(Amount::from_msats(10_000_000))).await?;
+            gw_ldk.client().pay_offer(offer_with_amount, None).await?;
+            assert!(get_transaction(gw_ldk_second, PaymentKind::Bolt12Offer, Amount::from_msats(10_000_000), PaymentStatus::Succeeded).await.is_some());
 
             let offer_without_amount = gw_ldk.client().create_offer(None).await?;
             gw_ldk_second.client().pay_offer(offer_without_amount.clone(), Some(Amount::from_msats(5_000_000))).await?;


### PR DESCRIPTION
Previously, we always opened channels linearly, which resulted in a channel graph that looks like this: `LDK2 -> LND -> LDK`.

This means that there was no direct channel between LDK2 and LDK. This was originally done intentionally, since a long time ago we had a bug with LNv1 that prevented LND from routing any payment correctly.

This bug has obviously been fixed for awhile, but we've kept the channel graph the same to cover this case. Unfortunately this has the downside of relying on gossip through LND for the LDK gateways channel graph to be updated. This caused the BOLT12 payments from LDK2 -> LDK to be very slow and cause flakiness.

Personally, I don't think it's worth keeping the channel topography. We should just open another channel like this: `LDK2 -> LND -> LDK -> LDK2`. This way, every node has a channel with every other node and we don't need to rely on gossip for the channel graph to be updated. I think it is very unlikely that the LND routing bug for LNv1 will regress.

On my machine, the test now runs in under a minute:

```
(nix:nix-shell-env) jumoell@asus:~/Projects/fedimint$ time ./scripts/tests/gateway-module-test.sh liquidity-test
Lowering IO priority with chrt -i 0 ionice -c 3
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.94s
2026-04-23T16:37:31.361476Z  INFO fm::devimint: Devimint data dir path=/tmp/nix-shell.T2YQ3c/devimint-641260-248
2026-04-23T16:37:31.373760Z  INFO devimint::tests: fedimint_cli_version="fedimint-cli 0.12.0-alpha"
2026-04-23T16:37:31.383879Z  INFO devimint::tests: fedimint_cli_version_hash="7b9921ec1ae40afb000000006801433ee5d2f712"
2026-04-23T16:37:31.390344Z  INFO devimint::tests: gateway_cli_version="fedimint-gateway-client 0.12.0-alpha"
2026-04-23T16:37:31.397890Z  INFO devimint::tests: gateway_cli_version_hash="7b9921ec1ae40afb000000006801433ee5d2f712"
2026-04-23T16:37:31.407886Z  INFO devimint::tests: fedimintd_version_hash="7b9921ec1ae40afb000000006801433ee5d2f712"
2026-04-23T16:37:31.419266Z  INFO devimint::tests: gatewayd_version_hash="7b9921ec1ae40afb000000006801433ee5d2f712"
2026-04-23T16:37:31.593416Z  INFO devimint::recurringdv2: Recurringdv2 started at 127.0.0.1:12030
2026-04-23T16:37:31.593458Z  INFO fm::devimint: Started recurringdv2 elapsed_ms=173
2026-04-23T16:37:31.606547Z  INFO devimint::recurringd: Recurringd started at 127.0.0.1:12029
2026-04-23T16:37:31.606604Z  INFO fm::devimint: Started recurringd elapsed_ms=187
2026-04-23T16:37:42.157953Z  INFO fm::devimint: Started bitcoind elapsed_ms=10738
2026-04-23T16:37:42.752331Z  INFO fm::devimint: Started ldk gateway 2 elapsed_ms=594
2026-04-23T16:37:42.786369Z  INFO fm::devimint: Started ldk gateway elapsed_ms=628
2026-04-23T16:37:42.899579Z  INFO fm::devimint: Started esplora elapsed_ms=741
2026-04-23T16:37:45.491726Z  INFO fm::devimint: Started lnd elapsed_ms=3333
2026-04-23T16:37:46.038476Z  INFO fm::devimint: Started lnd gateway elapsed_ms=546
2026-04-23T16:37:46.588770Z  INFO fm::devimint: Started federation elapsed_ms=4430
2026-04-23T16:37:47.016068Z  INFO fm::devimint: Connected recurringd to federation elapsed_ms=427
2026-04-23T16:37:47.135793Z  INFO fm::devimint: Connected ldk gateway 2 elapsed_ms=546
2026-04-23T16:37:47.197119Z  INFO fm::devimint: Connected ldk gateway elapsed_ms=608
2026-04-23T16:37:47.494874Z  INFO fm::devimint: Registered lnd gateway elapsed_ms=905
2026-04-23T16:37:48.962925Z  INFO fm::devimint: Generated federation epoch elapsed_ms=2374
2026-04-23T16:37:52.469324Z  INFO fm::devimint: Funding all gateway lightning nodes...
2026-04-23T16:37:53.854829Z  INFO fm::devimint: Gateway lightning nodes funded.
2026-04-23T16:37:56.196650Z  INFO fm::devimint: devimint current block block_height=122
2026-04-23T16:37:56.196692Z  INFO fm::devimint: Opening channel with 5000000 sats on each side... from=LDK2 to=LND
2026-04-23T16:37:57.050379Z  INFO fm::devimint: Opening channel with 5000000 sats on each side... from=LND to=LDK
2026-04-23T16:37:57.542040Z  INFO fm::devimint: Opening channel with 5000000 sats on each side... from=LDK to=LDK2
2026-04-23T16:38:02.820189Z  INFO fm::devimint: open_channels_between_gateways successful
2026-04-23T16:38:02.820234Z  INFO fm::devimint: Opened channels between gateways elapsed_ms=13857
2026-04-23T16:38:02.820445Z  INFO fm::test: Pegging-in gateways...
2026-04-23T16:38:02.862211Z  INFO devimint::federation: Pegging-in gateway funds amount=1000000 deposit_fees=1000
2026-04-23T16:38:08.517750Z  INFO fm::test: Testing ecash payments between gateways...
2026-04-23T16:38:08.517798Z  INFO fm::test: Testing ecash payment gw_send=lnd gw_receive=ldk
2026-04-23T16:38:09.764072Z  INFO fm::test: Testing ecash payment gw_send=ldk gw_receive=lnd
2026-04-23T16:38:10.788708Z  INFO fm::test: Testing payments between gateways...
2026-04-23T16:38:10.788748Z  INFO fm::test: Testing lightning payment gw_send=lnd gw_receive=ldk
2026-04-23T16:38:11.577353Z  INFO fm::test: Testing lightning payment gw_send=ldk gw_receive=lnd
2026-04-23T16:38:11.998360Z  INFO fm::test: Verifying list of transactions
2026-04-23T16:38:12.341265Z  INFO fm::test: Testing paying Bolt12 Offers...
2026-04-23T16:38:15.520696Z  INFO fm::test: Pegging-out gateways...
2026-04-23T16:38:15.520733Z  INFO devimint::federation: Pegging-out gateway funds amount=500000000
2026-04-23T16:38:20.309874Z  INFO fm::test: Testing only admin can send onchain...
2026-04-23T16:38:20.554314Z  INFO fm::test: Testing sending onchain...
2026-04-23T16:38:21.177359Z  INFO fm::test: Testing closing all channels...

real	0m54.158s
user	0m49.737s
sys	0m10.007s
```