### PR TITLE
fix(ci): set PERFIT_SERVER for daily fuzz workflow

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -6,6 +6,9 @@ on:
 
 name: Daily check
 
+env:
+  PERFIT_SERVER: https://perfit.dev.fedimint.org
+
 permissions:
   contents: read
 


### PR DESCRIPTION
The daily fuzz job was failing because perfit run requires --server, which other workflows provide via the top-level PERFIT_SERVER env var. Add the same env to daily.yml so the fuzz step can upload metrics.

Failing run: https://github.com/fedimint/fedimint/actions/runs/25069287134/job/73444858612

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
