### PR TITLE
 chore(walletv2): add diagnostic logs for peg-in flow 

### DIFF
--- a/modules/fedimint-walletv2-client/src/lib.rs
+++ b/modules/fedimint-walletv2-client/src/lib.rs
@@ -60,7 +60,7 @@ use send_sm::{SendSMCommon, SendSMState, SendStateMachine};
 use serde::{Deserialize, Serialize};
 use strum::IntoEnumIterator as _;
 use thiserror::Error;
-use tracing::{info, warn};
+use tracing::{debug, warn};
 
 /// Number of output info entries to scan per batch.
 const SLICE_SIZE: u64 = 1000;
@@ -549,13 +549,12 @@ impl WalletClientModule {
             .output_info_slice(next_output_index, next_output_index + SLICE_SIZE)
             .await?;
 
-        info!(
-            target: LOG_CLIENT_MODULE_WALLETV2,
-            "Scanning for outputs..."
-        );
+        let returned_num = outputs.len();
+        let mut matched_num: usize = 0;
 
         for output in &outputs {
             if let Some(&address_index) = address_map.get(&output.script) {
+                matched_num += 1;
                 let next_address_index = valid_indices
                     .last()
                     .copied()
@@ -611,6 +610,15 @@ impl WalletClientModule {
 
             dbtx.commit_tx_result().await?;
         }
+
+        debug!(
+            target: LOG_CLIENT_MODULE_WALLETV2,
+            next_output_index,
+            returned_num,
+            matched_num,
+            valid_indices_num = valid_indices.len(),
+            "Scanning for outputs"
+        );
 
         Ok(!outputs.is_empty())
     }

--- a/modules/fedimint-walletv2-server/src/lib.rs
+++ b/modules/fedimint-walletv2-server/src/lib.rs
@@ -956,6 +956,16 @@ impl Wallet {
 
         assert!(old_consensus_block_count <= new_consensus_block_count);
 
+        debug!(
+            target: LOG_MODULE_WALLETV2,
+            %peer,
+            vote = block_count_vote,
+            old_consensus = old_consensus_block_count,
+            new_consensus = new_consensus_block_count,
+            advanced = new_consensus_block_count - old_consensus_block_count,
+            "Processed block count vote"
+        );
+
         // We do not sync blocks that predate the federation itself.
         if old_consensus_block_count == 0 {
             return Ok(());
@@ -994,6 +1004,9 @@ impl Wallet {
 
             let pks_hash = self.cfg.consensus.bitcoin_pks.consensus_hash();
 
+            let txs_num = block.txdata.len();
+            let mut potential_receives_num: usize = 0;
+
             for tx in block.txdata {
                 dbtx.remove_entry(&UnconfirmedTxKey(tx.compute_txid()))
                     .await;
@@ -1020,9 +1033,28 @@ impl Wallet {
 
                         dbtx.insert_new_entry(&OutputKey(index), &Output(outpoint, tx_out.clone()))
                             .await;
+
+                        debug!(
+                            target: LOG_MODULE_WALLETV2,
+                            output_index = index,
+                            %outpoint,
+                            value_sat = tx_out.value.to_sat(),
+                            height,
+                            "Recorded potential receive"
+                        );
+
+                        potential_receives_num += 1;
                     }
                 }
             }
+
+            debug!(
+                target: LOG_MODULE_WALLETV2,
+                height,
+                txs_num,
+                potential_receives_num,
+                "Scanned block"
+            );
         }
 
         Ok(())

--- a/scripts/dev/run-test/fm-run-test
+++ b/scripts/dev/run-test/fm-run-test
@@ -38,10 +38,14 @@ on_error() {
   echo "## FAILED $test_name$version_str:"
   echo "## OUT:"
   cat "$test_out_path"
-  echo
-  echo
-  echo "## LOG FEDIMINTD-0:"
-  { cat "$FM_RUN_TEST_TMPDIR"/devimint-*/logs/fedimintd-default-0.log | sed 's/^/fm0 /'; } || true
+  for fm_log in "$FM_RUN_TEST_TMPDIR"/devimint-*/logs/fedimintd-default-*.log; do
+    [ -e "$fm_log" ] || continue
+    fm_idx="$(basename "$fm_log" .log | sed 's/^fedimintd-default-//')"
+    echo
+    echo
+    echo "## LOG FEDIMINTD-${fm_idx}:"
+    sed "s/^/fm${fm_idx} /" "$fm_log" || true
+  done
   echo
   echo
   echo "## LOG LND GATEWAY:"


### PR DESCRIPTION
Helps diagnose flakes like the gw_liquidity_test_walletv2 failure
where two gateway clients spent 60s logging "Scanning for outputs..."
and we couldn't tell whether the federation was advancing
consensus_block_count, scanning the deposit's block, recording the
UTXO, or returning anything from output_info_slice.

Server (fedimint-walletv2-server):
- Log block-count vote handling on the non-redundant path: peer,
  vote, before/after consensus block count, advance delta. (Redundant
  votes stay silent — they're the common case.)
- Log per-block scan stats: height, txs_num, potential_receives_num.
- Info log when an output is recorded: output_index, outpoint, value,
  height — the exact event a peg-in poll is waiting for.

Client (fedimint-walletv2-client):
- Replace bare "Scanning for outputs..." with structured fields
  (next_output_index, returned_num, matched_num, valid_indices_num) so
  client polls can be tied to federation responses.

Failing CI run that motivated this: https://github.com/fedimint/fedimint/actions/runs/25175863110/job/73807652077

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
