### PR TITLE
refactor: add federation prefix to client-side logs

### DIFF
--- a/fedimint-client-module/src/module/init.rs
+++ b/fedimint-client-module/src/module/init.rs
@@ -12,12 +12,13 @@ use fedimint_core::config::FederationId;
 use fedimint_core::core::ModuleKind;
 use fedimint_core::db::{Database, DatabaseVersion};
 use fedimint_core::module::{ApiAuth, ApiVersion, CommonModuleInit, ModuleInit, MultiApiVersion};
-use fedimint_core::task::TaskGroup;
+use fedimint_core::task::{MaybeSend, ShuttingDownError, TaskGroup, TaskHandle};
 use fedimint_core::util::SafeUrl;
 use fedimint_core::{ChainId, NumPeers, apply, async_trait_maybe_send};
 use fedimint_derive_secret::DerivableSecret;
 use fedimint_logging::LOG_CLIENT;
-use tracing::warn;
+use tokio::sync::oneshot;
+use tracing::{Span, warn};
 
 use super::ClientContext;
 use super::recovery::RecoveryProgress;
@@ -61,6 +62,11 @@ where
     pub module_api: DynModuleApi,
     pub context: ClientContext<<C as ClientModuleInit>::Module>,
     pub task_group: TaskGroup,
+    /// Long-lived span carrying `fed_id`. Use [`Self::spawn_cancellable`] /
+    /// [`Self::spawn`] (or pass [`Self::client_span`] to
+    /// [`TaskGroup::spawn_cancellable_with_span`]) so log events from
+    /// background tasks carry the federation prefix.
+    pub client_span: Span,
     pub connector_registry: ConnectorRegistry,
     /// User-provided Bitcoin RPC client
     ///
@@ -141,6 +147,40 @@ where
         &self.task_group
     }
 
+    /// Long-lived span identifying this client (with `fed_id`).
+    pub fn client_span(&self) -> &Span {
+        &self.client_span
+    }
+
+    /// Spawn a cancellable task on the client's task group, parented to the
+    /// client's span so all events from the task carry `fed_id` (including
+    /// the lifecycle events emitted by [`TaskGroup`] itself).
+    pub fn spawn_cancellable<R>(
+        &self,
+        name: impl Into<String>,
+        future: impl std::future::Future<Output = R> + MaybeSend + 'static,
+    ) -> oneshot::Receiver<Result<R, ShuttingDownError>>
+    where
+        R: MaybeSend + 'static,
+    {
+        self.task_group
+            .spawn_cancellable_with_span(self.client_span.clone(), name, future)
+    }
+
+    /// Spawn a task on the client's task group, parented to the client's span.
+    pub fn spawn<Fut, R>(
+        &self,
+        name: impl Into<String>,
+        f: impl FnOnce(TaskHandle) -> Fut + MaybeSend + 'static,
+    ) -> oneshot::Receiver<R>
+    where
+        Fut: std::future::Future<Output = R> + MaybeSend + 'static,
+        R: MaybeSend + 'static,
+    {
+        self.task_group
+            .spawn_with_span(self.client_span.clone(), name, f)
+    }
+
     pub fn connector_registry(&self) -> &ConnectorRegistry {
         &self.connector_registry
     }
@@ -181,6 +221,8 @@ where
     pub context: ClientContext<<C as ClientModuleInit>::Module>,
     pub progress_tx: tokio::sync::watch::Sender<RecoveryProgress>,
     pub task_group: TaskGroup,
+    /// See [`ClientModuleInitArgs::client_span`].
+    pub client_span: Span,
     /// User-provided Bitcoin RPC client
     ///
     /// If set by the application using `ClientBuilder::with_bitcoind_rpc`,
@@ -218,6 +260,39 @@ where
 
     pub fn task_group(&self) -> &TaskGroup {
         &self.task_group
+    }
+
+    /// Long-lived span identifying this client (with `fed_id`).
+    pub fn client_span(&self) -> &Span {
+        &self.client_span
+    }
+
+    /// Spawn a cancellable task on the client's task group, parented to the
+    /// client's span so all events from the task carry `fed_id`.
+    pub fn spawn_cancellable<R>(
+        &self,
+        name: impl Into<String>,
+        future: impl std::future::Future<Output = R> + MaybeSend + 'static,
+    ) -> oneshot::Receiver<Result<R, ShuttingDownError>>
+    where
+        R: MaybeSend + 'static,
+    {
+        self.task_group
+            .spawn_cancellable_with_span(self.client_span.clone(), name, future)
+    }
+
+    /// Spawn a task on the client's task group, parented to the client's span.
+    pub fn spawn<Fut, R>(
+        &self,
+        name: impl Into<String>,
+        f: impl FnOnce(TaskHandle) -> Fut + MaybeSend + 'static,
+    ) -> oneshot::Receiver<R>
+    where
+        Fut: std::future::Future<Output = R> + MaybeSend + 'static,
+        R: MaybeSend + 'static,
+    {
+        self.task_group
+            .spawn_with_span(self.client_span.clone(), name, f)
     }
 
     pub fn core_api_version(&self) -> &ApiVersion {

--- a/fedimint-client/src/client.rs
+++ b/fedimint-client/src/client.rs
@@ -53,7 +53,9 @@ use fedimint_core::module::{
 };
 use fedimint_core::net::api_announcement::SignedApiAnnouncement;
 use fedimint_core::runtime::sleep;
-use fedimint_core::task::{Elapsed, MaybeSend, MaybeSync, TaskGroup};
+use fedimint_core::task::{
+    Elapsed, MaybeSend, MaybeSync, ShuttingDownError, TaskGroup, TaskHandle,
+};
 use fedimint_core::transaction::Transaction;
 use fedimint_core::util::backoff_util::custom_backoff;
 use fedimint_core::util::{
@@ -73,9 +75,9 @@ use futures::stream::FuturesUnordered;
 use futures::{Stream, StreamExt as _};
 use global_ctx::ModuleGlobalClientContext;
 use serde::{Deserialize, Serialize};
-use tokio::sync::{broadcast, watch};
+use tokio::sync::{broadcast, oneshot, watch};
 use tokio_stream::wrappers::WatchStream;
-use tracing::{debug, info, warn};
+use tracing::{Span, debug, info, warn};
 
 use crate::ClientBuilder;
 use crate::api_announcements::{ApiAnnouncementPrefix, get_api_urls};
@@ -149,6 +151,11 @@ pub struct Client {
     meta_service: Arc<MetaService>,
 
     task_group: TaskGroup,
+
+    /// Long-lived span attached to every task spawned via [`Client::spawn`] /
+    /// [`Client::spawn_cancellable`], so logs from background tasks carry the
+    /// federation prefix.
+    client_span: Span,
 
     /// Updates about client recovery progress
     client_recovery_progress_receiver:
@@ -227,19 +234,16 @@ impl Client {
 
         for peer_id in peers {
             let api = self.api.clone();
-            self.task_group.spawn_cancellable(
-                format!("federation-reconnect-once-{peer_id}"),
-                async move {
-                    if let Err(e) = api.get_peer_connection(peer_id).await {
-                        debug!(
-                            target: LOG_CLIENT_NET_API,
-                            %peer_id,
-                            err = %e.fmt_compact(),
-                            "Failed to connect to peer"
-                        );
-                    }
-                },
-            );
+            self.spawn_cancellable(format!("federation-reconnect-once-{peer_id}"), async move {
+                if let Err(e) = api.get_peer_connection(peer_id).await {
+                    debug!(
+                        target: LOG_CLIENT_NET_API,
+                        %peer_id,
+                        err = %e.fmt_compact(),
+                        "Failed to connect to peer"
+                    );
+                }
+            });
         }
     }
 
@@ -269,34 +273,76 @@ impl Client {
 
         for peer_id in peers {
             let api = self.api.clone();
-            self.task_group.spawn_cancellable(
-                format!("federation-reconnect-{peer_id}"),
-                async move {
-                    loop {
-                        match api.get_peer_connection(peer_id).await {
-                            Ok(conn) => {
-                                conn.await_disconnection().await;
-                            }
-                            Err(e) => {
-                                // Connection failed, backoff is handled inside
-                                // get_or_create_connection
-                                debug!(
-                                    target: LOG_CLIENT_NET_API,
-                                    %peer_id,
-                                    err = %e.fmt_compact(),
-                                    "Failed to connect to peer, will retry"
-                                );
-                            }
+            self.spawn_cancellable(format!("federation-reconnect-{peer_id}"), async move {
+                loop {
+                    match api.get_peer_connection(peer_id).await {
+                        Ok(conn) => {
+                            conn.await_disconnection().await;
+                        }
+                        Err(e) => {
+                            // Connection failed, backoff is handled inside
+                            // get_or_create_connection
+                            debug!(
+                                target: LOG_CLIENT_NET_API,
+                                %peer_id,
+                                err = %e.fmt_compact(),
+                                "Failed to connect to peer, will retry"
+                            );
                         }
                     }
-                },
-            );
+                }
+            });
         }
     }
 
     /// Get the [`TaskGroup`] that is tied to Client's lifetime.
     pub fn task_group(&self) -> &TaskGroup {
         &self.task_group
+    }
+
+    /// Construct the long-lived span attached to all tasks spawned by this
+    /// client.
+    ///
+    /// `parent: None` keeps the span tree shallow; `runtime::spawn` already
+    /// wraps each task in its own `spawn(task=…)` span, so log events from
+    /// these tasks carry both `task` and `fed_id`.
+    pub(crate) fn make_client_span(federation_id: FederationId) -> Span {
+        tracing::info_span!(
+            target: LOG_CLIENT,
+            parent: None,
+            "client",
+            fed_id = %federation_id.to_prefix(),
+        )
+    }
+
+    /// Spawn a cancellable task on the client's task group, instrumented with
+    /// the client's [`Span`] so all events from the task carry `fed_id`.
+    pub(crate) fn spawn_cancellable<R>(
+        &self,
+        name: impl Into<String>,
+        future: impl Future<Output = R> + MaybeSend + 'static,
+    ) -> oneshot::Receiver<Result<R, ShuttingDownError>>
+    where
+        R: MaybeSend + 'static,
+    {
+        self.task_group
+            .spawn_cancellable_with_span(self.client_span.clone(), name, future)
+    }
+
+    /// Spawn a task on the client's task group, parented to the client's
+    /// [`Span`] so all events from the task carry `fed_id` (including the
+    /// task lifecycle events emitted by [`TaskGroup`] itself).
+    pub(crate) fn spawn<Fut, R>(
+        &self,
+        name: impl Into<String>,
+        f: impl FnOnce(TaskHandle) -> Fut + MaybeSend + 'static,
+    ) -> oneshot::Receiver<R>
+    where
+        Fut: Future<Output = R> + MaybeSend + 'static,
+        R: MaybeSend + 'static,
+    {
+        self.task_group
+            .spawn_with_span(self.client_span.clone(), name, f)
     }
 
     /// Returns all registered Prometheus metrics encoded in text format.
@@ -392,11 +438,14 @@ impl Client {
     }
 
     pub fn start_executor(self: &Arc<Self>) {
-        debug!(
-            target: LOG_CLIENT,
-            "Starting fedimint client executor",
-        );
-        self.executor.start_executor(self.context_gen());
+        self.client_span.in_scope(|| {
+            debug!(
+                target: LOG_CLIENT,
+                "Starting fedimint client executor",
+            );
+        });
+        self.executor
+            .start_executor(self.context_gen(), self.client_span.clone());
     }
 
     pub fn federation_id(&self) -> FederationId {
@@ -1321,6 +1370,7 @@ impl Client {
             &self.api,
             &self.db,
             &self.task_group,
+            &self.client_span,
         )
         .await
     }
@@ -1330,13 +1380,14 @@ impl Client {
     ///
     /// This is a compromise, so we not have to wait for version discovery to
     /// complete every time a [`Client`] is being built.
-    async fn load_and_refresh_common_api_version_static(
+    pub(crate) async fn load_and_refresh_common_api_version_static(
         config: &ClientConfig,
         module_init: &ClientModuleInitRegistry,
         connectors: ConnectorRegistry,
         api: &DynGlobalApi,
         db: &Database,
         task_group: &TaskGroup,
+        client_span: &Span,
     ) -> anyhow::Result<ApiVersionSet> {
         if let Some(v) = db
             .begin_transaction_nc()
@@ -1344,20 +1395,24 @@ impl Client {
             .get_value(&CachedApiVersionSetKey)
             .await
         {
-            debug!(
-                target: LOG_CLIENT,
-                "Found existing cached common api versions"
-            );
+            client_span.in_scope(|| {
+                debug!(
+                    target: LOG_CLIENT,
+                    "Found existing cached common api versions"
+                );
+            });
             let config = config.clone();
             let client_module_init = module_init.clone();
             let api = api.clone();
             let db = db.clone();
             let task_group = task_group.clone();
+            let client_span_owned = client_span.clone();
             // Separate task group, because we actually don't want to be waiting for this to
             // finish, and it's just best effort.
-            task_group
-                .clone()
-                .spawn_cancellable("refresh_common_api_version_static", async move {
+            task_group.clone().spawn_cancellable_with_span(
+                client_span.clone(),
+                "refresh_common_api_version_static",
+                async move {
                     connectors.wait_for_initialized_connections().await;
 
                     if let Err(error) = Self::refresh_common_api_version_static(
@@ -1366,6 +1421,7 @@ impl Client {
                         &api,
                         &db,
                         task_group,
+                        &client_span_owned,
                         false,
                     )
                     .await
@@ -1375,7 +1431,8 @@ impl Client {
                             err = %error.fmt_compact_anyhow(), "Failed to discover common api versions"
                         );
                     }
-                });
+                },
+            );
 
             return Ok(v.0);
         }
@@ -1390,6 +1447,7 @@ impl Client {
             api,
             db,
             task_group.clone(),
+            client_span,
             true,
         )
         .await
@@ -1401,6 +1459,7 @@ impl Client {
         api: &DynGlobalApi,
         db: &Database,
         task_group: TaskGroup,
+        client_span: &Span,
         block_until_ok: bool,
     ) -> anyhow::Result<ApiVersionSet> {
         debug!(
@@ -1411,14 +1470,16 @@ impl Client {
         let (num_responses_sender, mut num_responses_receiver) = tokio::sync::watch::channel(0);
         let num_peers = NumPeers::from(config.global.api_endpoints.len());
 
-        task_group.spawn_cancellable("refresh peers api versions", {
+        task_group.spawn_cancellable_with_span(
+            client_span.clone(),
+            "refresh peers api versions",
             Client::fetch_common_api_versions_from_all_peers(
                 num_peers,
                 api.clone(),
                 db.clone(),
                 num_responses_sender,
-            )
-        });
+            ),
+        );
 
         let common_api_versions = loop {
             // Wait to collect enough answers before calculating a set of common api
@@ -1598,18 +1659,17 @@ impl Client {
             .iter_modules_id_kind()
             .map(|(id, kind)| (id, kind.to_string()))
             .collect();
-        self.task_group
-            .spawn("module recoveries", |_task_handle| async {
-                Self::run_module_recoveries_task(
-                    db,
-                    log_ordering_wakeup_tx,
-                    recovery_sender,
-                    module_recoveries,
-                    module_recovery_progress_receivers,
-                    module_kinds,
-                )
-                .await;
-            });
+        self.spawn("module recoveries", |_task_handle| async {
+            Self::run_module_recoveries_task(
+                db,
+                log_ordering_wakeup_tx,
+                recovery_sender,
+                module_recoveries,
+                module_recovery_progress_receivers,
+                module_kinds,
+            )
+            .await;
+        });
     }
 
     async fn run_module_recoveries_task(

--- a/fedimint-client/src/client/builder.rs
+++ b/fedimint-client/src/client/builder.rs
@@ -48,7 +48,7 @@ use fedimint_eventlog::{
 };
 use fedimint_logging::LOG_CLIENT;
 use tokio::sync::{broadcast, watch};
-use tracing::{debug, trace, warn};
+use tracing::{Span, debug, trace, warn};
 
 use super::handle::ClientHandle;
 use super::{Client, client_decoders};
@@ -652,6 +652,7 @@ impl ClientBuilder {
         };
 
         let task_group = TaskGroup::new();
+        let client_span = Client::make_client_span(fed_id);
 
         // Migrate the database before interacting with it in case any on-disk data
         // structures have changed.
@@ -694,6 +695,7 @@ impl ClientBuilder {
             &api,
             &db,
             &task_group,
+            &client_span,
         )
         .await
         .inspect_err(|err| {
@@ -705,31 +707,33 @@ impl ClientBuilder {
             modules: BTreeMap::new(),
         });
 
-        debug!(
-            target: LOG_CLIENT,
-            core = %common_api_versions.core,
-            "Negotiated core API version",
-        );
-        for (module_id, api_version) in &common_api_versions.modules {
-            let kind = config.modules.get(module_id).map(|m| m.kind());
-            let kind_str = kind
-                .as_ref()
-                .map(|k| k.to_string())
-                .unwrap_or_else(|| format!("unknown({module_id})"));
-            let supported = kind
-                .and_then(|k| self.module_inits.get(k))
-                .map(|m| m.supported_api_versions().to_string());
+        client_span.in_scope(|| {
             debug!(
                 target: LOG_CLIENT,
-                module = %kind_str,
-                api = %api_version,
-                supported = %supported.as_deref().unwrap_or("unknown"),
-                "Negotiated module API version",
+                core = %common_api_versions.core,
+                "Negotiated core API version",
             );
-        }
+            for (module_id, api_version) in &common_api_versions.modules {
+                let kind = config.modules.get(module_id).map(|m| m.kind());
+                let kind_str = kind
+                    .as_ref()
+                    .map(|k| k.to_string())
+                    .unwrap_or_else(|| format!("unknown({module_id})"));
+                let supported = kind
+                    .and_then(|k| self.module_inits.get(k))
+                    .map(|m| m.supported_api_versions().to_string());
+                debug!(
+                    target: LOG_CLIENT,
+                    module = %kind_str,
+                    api = %api_version,
+                    supported = %supported.as_deref().unwrap_or("unknown"),
+                    "Negotiated module API version",
+                );
+            }
+        });
 
         // Asynchronously refetch client config and compare with existing
-        Self::load_and_refresh_client_config_static(&config, &api, &db, &task_group);
+        Self::load_and_refresh_client_config_static(&config, &api, &db, &task_group, &client_span);
 
         // Try to cache chain_id if not already cached
         // This is best-effort - if the server doesn't support the endpoint yet, we'll
@@ -782,22 +786,26 @@ impl ClientBuilder {
             for (module_instance_id, module_config) in config.modules.clone() {
                 let kind = module_config.kind().clone();
                 let Some(module_init) = self.module_inits.get(&kind).cloned() else {
-                    debug!(
-                        target: LOG_CLIENT,
-                        kind=%kind,
-                        instance_id=%module_instance_id,
-                        "Module kind of instance not found in module gens, skipping");
+                    client_span.in_scope(|| {
+                        debug!(
+                            target: LOG_CLIENT,
+                            kind=%kind,
+                            instance_id=%module_instance_id,
+                            "Module kind of instance not found in module gens, skipping");
+                    });
                     continue;
                 };
 
                 let Some(&api_version) = common_api_versions.modules.get(&module_instance_id)
                 else {
-                    warn!(
-                        target: LOG_CLIENT,
-                        kind=%kind,
-                        instance_id=%module_instance_id,
-                        "Module kind of instance has incompatible api version, skipping"
-                    );
+                    client_span.in_scope(|| {
+                        warn!(
+                            target: LOG_CLIENT,
+                            kind=%kind,
+                            instance_id=%module_instance_id,
+                            "Module kind of instance has incompatible api version, skipping"
+                        );
+                    });
                     continue;
                 };
 
@@ -985,7 +993,7 @@ impl ClientBuilder {
             }
         }
 
-        let executor = {
+        let executor = client_span.in_scope(|| {
             let mut executor_builder = Executor::builder();
             executor_builder
                 .with_module(TRANSACTION_SUBMISSION_MODULE_INSTANCE, TxSubmissionContext);
@@ -1004,7 +1012,7 @@ impl ClientBuilder {
                 task_group.clone(),
                 log_ordering_wakeup_tx.clone(),
             )
-        };
+        });
 
         let recovery_receiver_init_val = module_recovery_progress_receivers
             .iter()
@@ -1034,6 +1042,7 @@ impl ClientBuilder {
             secp_ctx: Secp256k1::new(),
             root_secret,
             task_group,
+            client_span,
             operation_log: OperationLog::new(db.clone()),
             client_recovery_progress_receiver,
             meta_service: self.meta_service,
@@ -1042,63 +1051,55 @@ impl ClientBuilder {
             user_bitcoind_rpc,
             user_bitcoind_rpc_no_chain_id: self.bitcoind_rpc_no_chain_id_factory,
         });
-        client_inner
-            .task_group
-            .spawn_cancellable("MetaService::update_continuously", {
-                let client_inner = client_inner.clone();
-                async move {
-                    client_inner
-                        .meta_service
-                        .update_continuously(&client_inner)
-                        .await;
-                }
-            });
+        client_inner.spawn_cancellable("MetaService::update_continuously", {
+            let client_inner = client_inner.clone();
+            async move {
+                client_inner
+                    .meta_service
+                    .update_continuously(&client_inner)
+                    .await;
+            }
+        });
 
-        client_inner
-            .task_group
-            .spawn_cancellable("update-api-announcements", {
-                let client_inner = client_inner.clone();
-                async move {
-                    client_inner
-                        .connectors
-                        .wait_for_initialized_connections()
-                        .await;
-                    run_api_announcement_refresh_task(client_inner.clone()).await
-                }
-            });
+        client_inner.spawn_cancellable("update-api-announcements", {
+            let client_inner = client_inner.clone();
+            async move {
+                client_inner
+                    .connectors
+                    .wait_for_initialized_connections()
+                    .await;
+                run_api_announcement_refresh_task(client_inner.clone()).await
+            }
+        });
 
-        client_inner
-            .task_group
-            .spawn_cancellable("guardian metadata refresh task", {
-                let client_inner = client_inner.clone();
-                async move {
-                    client_inner
-                        .connectors
-                        .wait_for_initialized_connections()
-                        .await;
-                    run_guardian_metadata_refresh_task(client_inner.clone()).await
-                }
-            });
+        client_inner.spawn_cancellable("guardian metadata refresh task", {
+            let client_inner = client_inner.clone();
+            async move {
+                client_inner
+                    .connectors
+                    .wait_for_initialized_connections()
+                    .await;
+                run_guardian_metadata_refresh_task(client_inner.clone()).await
+            }
+        });
 
-        client_inner
-            .task_group
-            .spawn_cancellable("event log ordering task", {
-                let client_inner = client_inner.clone();
-                async move {
-                    client_inner
-                        .connectors
-                        .wait_for_initialized_connections()
-                        .await;
+        client_inner.spawn_cancellable("event log ordering task", {
+            let client_inner = client_inner.clone();
+            async move {
+                client_inner
+                    .connectors
+                    .wait_for_initialized_connections()
+                    .await;
 
-                    run_event_log_ordering_task(
-                        db.clone(),
-                        log_ordering_wakeup_rx,
-                        log_event_added_tx,
-                        log_event_added_transient_tx,
-                    )
-                    .await
-                }
-            });
+                run_event_log_ordering_task(
+                    db.clone(),
+                    log_ordering_wakeup_rx,
+                    log_event_added_tx,
+                    log_event_added_transient_tx,
+                )
+                .await
+            }
+        });
 
         // If chain_id is not cached yet, spawn a background task to fetch it
         // This handles the case where join/open happened before the server supported
@@ -1111,11 +1112,9 @@ impl ClientBuilder {
             .await
             .is_none()
         {
-            client_inner
-                .task_group
-                .spawn_cancellable("fetch-chain-id", {
-                    let client_inner = client_inner.clone();
-                    async move {
+            client_inner.spawn_cancellable("fetch-chain-id", {
+                let client_inner = client_inner.clone();
+                async move {
                         client_inner.api.wait_for_initialized_connections().await;
                         match client_inner.api.chain_id().await {
                             Ok(chain_id) => {
@@ -1234,6 +1233,7 @@ impl ClientBuilder {
         api: &DynGlobalApi,
         db: &Database,
         task_group: &TaskGroup,
+        client_span: &Span,
     ) {
         let config = config.clone();
         let api = api.clone();
@@ -1241,10 +1241,14 @@ impl ClientBuilder {
         let task_group = task_group.clone();
 
         // Spawn background task to refetch config
-        task_group.spawn_cancellable("refresh_client_config_static", async move {
-            api.wait_for_initialized_connections().await;
-            Self::refresh_client_config_static(&config, &api, &db).await;
-        });
+        task_group.spawn_cancellable_with_span(
+            client_span.clone(),
+            "refresh_client_config_static",
+            async move {
+                api.wait_for_initialized_connections().await;
+                Self::refresh_client_config_static(&config, &api, &db).await;
+            },
+        );
     }
 
     /// Wrapper that handles errors from config refresh with proper logging

--- a/fedimint-client/src/client/builder.rs
+++ b/fedimint-client/src/client/builder.rs
@@ -828,6 +828,7 @@ impl ClientBuilder {
                         let user_bitcoind_rpc = user_bitcoind_rpc.clone();
                         let user_bitcoind_rpc_no_chain_id =
                             self.bitcoind_rpc_no_chain_id_factory.clone();
+                        let client_span = client_span.clone();
                         (
                             Box::pin(async move {
                                 module_init
@@ -847,6 +848,7 @@ impl ClientBuilder {
                                         snapshot.as_ref().and_then(|s| s.modules.get(&module_instance_id)),
                                         progress_tx,
                                         task_group,
+                                        client_span,
                                         user_bitcoind_rpc,
                                         user_bitcoind_rpc_no_chain_id,
                                     )
@@ -946,6 +948,7 @@ impl ClientBuilder {
                                 api.clone(),
                                 self.admin_creds.as_ref().map(|cred| cred.auth.clone()),
                                 task_group.clone(),
+                                client_span.clone(),
                                 connectors.clone(),
                                 user_bitcoind_rpc.clone(),
                                 self.bitcoind_rpc_no_chain_id_factory.clone(),

--- a/fedimint-client/src/client/handle.rs
+++ b/fedimint-client/src/client/handle.rs
@@ -8,7 +8,7 @@ use fedimint_core::util::FmtCompactAnyhow as _;
 use fedimint_logging::LOG_CLIENT;
 #[cfg(not(target_family = "wasm"))]
 use tokio::runtime::{Handle as RuntimeHandle, RuntimeFlavor};
-use tracing::{debug, error, trace, warn};
+use tracing::{Instrument as _, debug, error, trace, warn};
 
 use super::Client;
 use crate::ClientBuilder;
@@ -59,33 +59,43 @@ impl ClientHandle {
             );
             return;
         };
+        let client_span = inner.client_span.clone();
         inner.executor.stop_executor();
         let db = inner.db.clone();
-        debug!(target: LOG_CLIENT, "Waiting for client task group to shut down");
+        client_span.in_scope(|| {
+            debug!(target: LOG_CLIENT, "Waiting for client task group to shut down");
+        });
         if let Err(err) = inner
             .task_group
             .clone()
             .shutdown_join_all(Some(Duration::from_secs(30)))
+            .instrument(client_span.clone())
             .await
         {
-            warn!(target: LOG_CLIENT, err = %err.fmt_compact_anyhow(), "Error waiting for client task group to shut down");
+            client_span.in_scope(|| {
+                warn!(target: LOG_CLIENT, err = %err.fmt_compact_anyhow(), "Error waiting for client task group to shut down");
+            });
         }
 
         let client_strong_count = Arc::strong_count(&inner);
-        debug!(target: LOG_CLIENT, "Dropping last handle to Client");
+        client_span.in_scope(|| {
+            debug!(target: LOG_CLIENT, "Dropping last handle to Client");
+        });
         // We are sure that no background tasks are running in the client anymore, so we
         // can drop the (usually) last inner reference.
         drop(inner);
 
-        if client_strong_count != 1 {
-            debug!(target: LOG_CLIENT, count = client_strong_count - 1, LOG_CLIENT, "External Client references remaining after last handle dropped");
-        }
+        client_span.in_scope(|| {
+            if client_strong_count != 1 {
+                debug!(target: LOG_CLIENT, count = client_strong_count - 1, LOG_CLIENT, "External Client references remaining after last handle dropped");
+            }
 
-        let db_strong_count = db.strong_count();
-        if db_strong_count != 1 {
-            debug!(target: LOG_CLIENT, count = db_strong_count - 1, "External DB references remaining after last handle dropped");
-        }
-        trace!(target: LOG_CLIENT, "Dropped last handle to Client");
+            let db_strong_count = db.strong_count();
+            if db_strong_count != 1 {
+                debug!(target: LOG_CLIENT, count = db_strong_count - 1, "External DB references remaining after last handle dropped");
+            }
+            trace!(target: LOG_CLIENT, "Dropped last handle to Client");
+        });
     }
 
     /// Restart the client
@@ -164,7 +174,13 @@ impl Drop for ClientHandle {
             return;
         }
 
-        debug!(target: LOG_CLIENT, "Shutting down the Client on last handle drop");
+        self.inner
+            .as_ref()
+            .expect("Must have inner client set")
+            .client_span
+            .in_scope(|| {
+                debug!(target: LOG_CLIENT, "Shutting down the Client on last handle drop");
+            });
         #[cfg(not(target_family = "wasm"))]
         runtime::block_in_place(|| {
             runtime::block_on(self.shutdown_inner());

--- a/fedimint-client/src/module_init.rs
+++ b/fedimint-client/src/module_init.rs
@@ -22,6 +22,7 @@ use fedimint_core::task::{MaybeSend, MaybeSync, TaskGroup};
 use fedimint_core::{NumPeers, apply, async_trait_maybe_send, dyn_newtype_define};
 use fedimint_derive_secret::DerivableSecret;
 use tokio::sync::watch;
+use tracing::Span;
 
 use crate::sm::notifier::Notifier;
 
@@ -56,6 +57,7 @@ pub trait IClientModuleInit: IDynCommonModuleInit + fmt::Debug + MaybeSend + May
         snapshot: Option<&DynModuleBackup>,
         progress_tx: watch::Sender<RecoveryProgress>,
         task_group: TaskGroup,
+        client_span: Span,
         user_bitcoind_rpc: Option<DynBitcoindRpc>,
         user_bitcoind_rpc_no_chain_id: Option<BitcoindRpcNoChainIdFactory>,
     ) -> anyhow::Result<()>;
@@ -76,6 +78,7 @@ pub trait IClientModuleInit: IDynCommonModuleInit + fmt::Debug + MaybeSend + May
         api: DynGlobalApi,
         admin_auth: Option<ApiAuth>,
         task_group: TaskGroup,
+        client_span: Span,
         connector_registry: ConnectorRegistry,
         user_bitcoind_rpc: Option<DynBitcoindRpc>,
         user_bitcoind_rpc_no_chain_id: Option<BitcoindRpcNoChainIdFactory>,
@@ -126,6 +129,7 @@ where
         snapshot: Option<&DynModuleBackup>,
         progress_tx: watch::Sender<RecoveryProgress>,
         task_group: TaskGroup,
+        client_span: Span,
         user_bitcoind_rpc: Option<DynBitcoindRpc>,
         user_bitcoind_rpc_no_chain_id: Option<BitcoindRpcNoChainIdFactory>,
     ) -> anyhow::Result<()> {
@@ -160,6 +164,7 @@ where
                 ),
                 progress_tx,
                 task_group,
+                client_span,
                 user_bitcoind_rpc,
                 user_bitcoind_rpc_no_chain_id,
             },
@@ -184,6 +189,7 @@ where
         api: DynGlobalApi,
         admin_auth: Option<ApiAuth>,
         task_group: TaskGroup,
+        client_span: Span,
         connector_registry: ConnectorRegistry,
         user_bitcoind_rpc: Option<DynBitcoindRpc>,
         user_bitcoind_rpc_no_chain_id: Option<BitcoindRpcNoChainIdFactory>,
@@ -211,6 +217,7 @@ where
                     module_db,
                 ),
                 task_group,
+                client_span,
                 connector_registry,
                 user_bitcoind_rpc,
                 user_bitcoind_rpc_no_chain_id,

--- a/fedimint-client/src/sm/executor.rs
+++ b/fedimint-client/src/sm/executor.rs
@@ -383,7 +383,7 @@ impl Executor {
     ///
     /// ## Panics
     /// If called more than once.
-    pub fn start_executor(&self, context_gen: ContextGen) {
+    pub fn start_executor(&self, context_gen: ContextGen, client_span: tracing::Span) {
         let Some((shutdown_receiver, sm_update_rx)) = self
             .inner
             .state
@@ -395,37 +395,41 @@ impl Executor {
         };
 
         let task_runner_inner = self.inner.clone();
-        let _handle = self.inner.client_task_group.spawn("sm-executor", |task_handle| async move {
-            let executor_runner = task_runner_inner.run(context_gen, sm_update_rx);
-            let task_group_shutdown_rx = task_handle.make_shutdown_rx();
-            select! {
-                () = task_group_shutdown_rx => {
-                    debug!(
-                        target: LOG_CLIENT_REACTOR,
-                        "Shutting down state machine executor runner due to task group shutdown signal"
-                    );
-                },
-                shutdown_happened_sender = shutdown_receiver => {
-                    match shutdown_happened_sender {
-                        Ok(()) => {
-                            debug!(
-                                target: LOG_CLIENT_REACTOR,
-                                "Shutting down state machine executor runner due to explicit shutdown signal"
-                            );
-                        },
-                        Err(_) => {
-                            warn!(
-                                target: LOG_CLIENT_REACTOR,
-                                "Shutting down state machine executor runner because the shutdown signal channel was closed (the executor object was dropped)"
-                            );
+        let _handle = self.inner.client_task_group.spawn_with_span(
+            client_span,
+            "sm-executor",
+            |task_handle| async move {
+                let executor_runner = task_runner_inner.run(context_gen, sm_update_rx);
+                let task_group_shutdown_rx = task_handle.make_shutdown_rx();
+                select! {
+                    () = task_group_shutdown_rx => {
+                        debug!(
+                            target: LOG_CLIENT_REACTOR,
+                            "Shutting down state machine executor runner due to task group shutdown signal"
+                        );
+                    },
+                    shutdown_happened_sender = shutdown_receiver => {
+                        match shutdown_happened_sender {
+                            Ok(()) => {
+                                debug!(
+                                    target: LOG_CLIENT_REACTOR,
+                                    "Shutting down state machine executor runner due to explicit shutdown signal"
+                                );
+                            },
+                            Err(_) => {
+                                warn!(
+                                    target: LOG_CLIENT_REACTOR,
+                                    "Shutting down state machine executor runner because the shutdown signal channel was closed (the executor object was dropped)"
+                                );
+                            }
                         }
-                    }
-                },
-                () = executor_runner => {
-                    error!(target: LOG_CLIENT_REACTOR, "State machine executor runner exited unexpectedly!");
-                },
-            };
-        });
+                    },
+                    () = executor_runner => {
+                        error!(target: LOG_CLIENT_REACTOR, "State machine executor runner exited unexpectedly!");
+                    },
+                };
+            },
+        );
     }
 
     /// Stops the background task that runs the state machines.

--- a/fedimint-client/src/sm/executor/tests.rs
+++ b/fedimint-client/src/sm/executor/tests.rs
@@ -144,7 +144,10 @@ fn get_executor() -> (Executor, Sender<u64>, Database) {
         TaskGroup::new(),
         log_ordering_wakeup_tx,
     );
-    executor.start_executor(Arc::new(|_, _| DynGlobalClientContext::new_fake()));
+    executor.start_executor(
+        Arc::new(|_, _| DynGlobalClientContext::new_fake()),
+        tracing::Span::none(),
+    );
 
     info!(
         target: LOG_CLIENT_REACTOR,

--- a/fedimint-core/src/runtime.rs
+++ b/fedimint-core/src/runtime.rs
@@ -6,7 +6,7 @@ use std::future::Future;
 use fedimint_logging::LOG_RUNTIME;
 pub use n0_future::task::{JoinError, JoinHandle};
 pub use n0_future::time::{Duration, Elapsed, Instant, sleep, sleep_until, timeout};
-use tracing::Instrument;
+use tracing::{Instrument, Span};
 
 use crate::task::MaybeSend;
 
@@ -16,6 +16,20 @@ where
     T: MaybeSend + 'static,
 {
     let span = tracing::debug_span!(target: LOG_RUNTIME, parent: None, "spawn", task = name);
+    n0_future::task::spawn(future.instrument(span))
+}
+
+/// Like [`spawn`] but with an explicit parent span.
+///
+/// Events from the spawned future inherit fields from `parent` (e.g. `fed_id`
+/// from the client span), including the lifecycle events emitted by
+/// [`crate::task::TaskGroup`] around the user future.
+pub fn spawn_with_span<F, T>(parent: &Span, name: &str, future: F) -> JoinHandle<T>
+where
+    F: Future<Output = T> + 'static + MaybeSend,
+    T: MaybeSend + 'static,
+{
+    let span = tracing::debug_span!(target: LOG_RUNTIME, parent: parent, "spawn", task = name);
     n0_future::task::spawn(future.instrument(span))
 }
 

--- a/fedimint-core/src/task.rs
+++ b/fedimint-core/src/task.rs
@@ -19,7 +19,7 @@ use inner::TaskGroupInner;
 use scopeguard::defer;
 use thiserror::Error;
 use tokio::sync::{oneshot, watch};
-use tracing::{debug, info, trace};
+use tracing::{Span, debug, info, trace};
 
 use crate::runtime;
 // TODO: stop using `task::*`, and use `runtime::*` in the code
@@ -142,7 +142,7 @@ impl TaskGroup {
         Fut: Future<Output = R> + MaybeSend + 'static,
         R: MaybeSend + 'static,
     {
-        self.spawn_inner(name, f, false)
+        self.spawn_inner(name, f, false, None)
     }
 
     /// This is a version of [`Self::spawn`] that uses less noisy logging level
@@ -157,7 +157,23 @@ impl TaskGroup {
         Fut: Future<Output = R> + MaybeSend + 'static,
         R: MaybeSend + 'static,
     {
-        self.spawn_inner(name, f, true)
+        self.spawn_inner(name, f, true, None)
+    }
+
+    /// Like [`Self::spawn`] but the spawn span (and the lifecycle events the
+    /// task group emits around the user future) is parented to `parent_span`,
+    /// so events inherit fields from it (e.g. `fed_id`).
+    pub fn spawn_with_span<Fut, R>(
+        &self,
+        parent_span: Span,
+        name: impl Into<String>,
+        f: impl FnOnce(TaskHandle) -> Fut + MaybeSend + 'static,
+    ) -> oneshot::Receiver<R>
+    where
+        Fut: Future<Output = R> + MaybeSend + 'static,
+        R: MaybeSend + 'static,
+    {
+        self.spawn_inner(name, f, false, Some(parent_span))
     }
 
     fn spawn_inner<Fut, R>(
@@ -165,6 +181,7 @@ impl TaskGroup {
         name: impl Into<String>,
         f: impl FnOnce(TaskHandle) -> Fut + MaybeSend + 'static,
         quiet: bool,
+        parent_span: Option<Span>,
     ) -> oneshot::Receiver<R>
     where
         Fut: Future<Output = R> + MaybeSend + 'static,
@@ -184,49 +201,51 @@ impl TaskGroup {
             .lock()
             .expect("Locking failed")
             .insert_with_key(move |task_key| {
-                (
-                    name.clone(),
-                    crate::runtime::spawn(&name, {
-                        let name = name.clone();
-                        async move {
-                            defer! {
-                                // Panic or normal completion, it means the task
-                                // is complete, and does not need to be shutdown
-                                // via join handle. This prevents buildup of task
-                                // handles.
-                                if handle
-                                    .inner
-                                    .active_tasks_join_handles
-                                    .lock()
-                                    .expect("Locking failed")
-                                    .remove(task_key)
-                                    .is_none() {
-                                        trace!(target: LOG_TASK, %name, "Task already canceled");
-                                    }
-                            }
-                            // Unfortunately log levels need to be static
-                            if quiet {
-                                trace!(target: LOG_TASK, %name, "Starting task");
-                            } else {
-                                debug!(target: LOG_TASK, %name, "Starting task");
-                            }
-                            let r = f(handle.clone()).await;
-                            guard.completed = true;
-
-                            if quiet {
-                                trace!(target: LOG_TASK, %name, "Finished task");
-                            } else {
-                                debug!(target: LOG_TASK, %name, "Finished task");
-                            }
-                            // if receiver is not interested, just drop the message
-                            let _ = tx.send(r);
-
-                            // NOTE: Since this is a `async move` the guard will not get moved
-                            // if it's not moved inside the body. Weird.
-                            drop(guard);
+                let task_future = {
+                    let name = name.clone();
+                    async move {
+                        defer! {
+                            // Panic or normal completion, it means the task
+                            // is complete, and does not need to be shutdown
+                            // via join handle. This prevents buildup of task
+                            // handles.
+                            if handle
+                                .inner
+                                .active_tasks_join_handles
+                                .lock()
+                                .expect("Locking failed")
+                                .remove(task_key)
+                                .is_none() {
+                                    trace!(target: LOG_TASK, %name, "Task already canceled");
+                                }
                         }
-                    }),
-                )
+                        // Unfortunately log levels need to be static
+                        if quiet {
+                            trace!(target: LOG_TASK, %name, "Starting task");
+                        } else {
+                            debug!(target: LOG_TASK, %name, "Starting task");
+                        }
+                        let r = f(handle.clone()).await;
+                        guard.completed = true;
+
+                        if quiet {
+                            trace!(target: LOG_TASK, %name, "Finished task");
+                        } else {
+                            debug!(target: LOG_TASK, %name, "Finished task");
+                        }
+                        // if receiver is not interested, just drop the message
+                        let _ = tx.send(r);
+
+                        // NOTE: Since this is a `async move` the guard will not get moved
+                        // if it's not moved inside the body. Weird.
+                        drop(guard);
+                    }
+                };
+                let join_handle = match parent_span.as_ref() {
+                    Some(parent) => crate::runtime::spawn_with_span(parent, &name, task_future),
+                    None => crate::runtime::spawn(&name, task_future),
+                };
+                (name, join_handle)
             });
 
         rx
@@ -243,6 +262,27 @@ impl TaskGroup {
         R: MaybeSend + 'static,
     {
         self.spawn(name, |handle| async move {
+            let value = handle.cancel_on_shutdown(future).await;
+            if value.is_err() {
+                // name will part of span
+                debug!(target: LOG_TASK, "task cancelled on shutdown");
+            }
+            value
+        })
+    }
+
+    /// Like [`Self::spawn_cancellable`] but with an explicit parent span — see
+    /// [`Self::spawn_with_span`].
+    pub fn spawn_cancellable_with_span<R>(
+        &self,
+        parent_span: Span,
+        name: impl Into<String>,
+        future: impl Future<Output = R> + MaybeSend + 'static,
+    ) -> oneshot::Receiver<Result<R, ShuttingDownError>>
+    where
+        R: MaybeSend + 'static,
+    {
+        self.spawn_with_span(parent_span, name, |handle| async move {
             let value = handle.cancel_on_shutdown(future).await;
             if value.is_err() {
                 // name will part of span

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -719,7 +719,7 @@ impl LightningClientModule {
         let secp = Secp256k1::new();
 
         let new_recurring_payment_code = Arc::new(Notify::new());
-        args.task_group().spawn_cancellable(
+        args.spawn_cancellable(
             "Recurring payment sync",
             Self::scan_recurring_payment_code_invoices(
                 args.context(),

--- a/modules/fedimint-lnv2-client/src/lib.rs
+++ b/modules/fedimint-lnv2-client/src/lib.rs
@@ -279,6 +279,7 @@ impl ClientModuleInit for LightningClientInit {
             self.custom_meta_fn.clone(),
             args.admin_auth().cloned(),
             args.task_group(),
+            args.client_span(),
         ))
     }
 
@@ -378,6 +379,7 @@ impl LightningClientModule {
         custom_meta_fn: Arc<dyn Fn() -> Value + Send + Sync>,
         admin_auth: Option<ApiAuth>,
         task_group: &TaskGroup,
+        client_span: &tracing::Span,
     ) -> Self {
         let module = Self {
             federation_id,
@@ -395,21 +397,25 @@ impl LightningClientModule {
             admin_auth,
         };
 
-        module.spawn_receive_lnurl_task(custom_meta_fn, task_group);
+        module.spawn_receive_lnurl_task(custom_meta_fn, task_group, client_span);
 
-        module.spawn_gateway_map_update_task(task_group);
+        module.spawn_gateway_map_update_task(task_group, client_span);
 
         module
     }
 
-    fn spawn_gateway_map_update_task(&self, task_group: &TaskGroup) {
+    fn spawn_gateway_map_update_task(&self, task_group: &TaskGroup, client_span: &tracing::Span) {
         let module = self.clone();
         let api = self.module_api.clone();
 
-        task_group.spawn_cancellable("gateway_map_update_task", async move {
-            api.wait_for_initialized_connections().await;
-            module.update_gateway_map().await;
-        });
+        task_group.spawn_cancellable_with_span(
+            client_span.clone(),
+            "gateway_map_update_task",
+            async move {
+                api.wait_for_initialized_connections().await;
+                module.update_gateway_map().await;
+            },
+        );
     }
 
     async fn update_gateway_map(&self) {
@@ -1098,16 +1104,21 @@ impl LightningClientModule {
         &self,
         custom_meta_fn: Arc<dyn Fn() -> Value + Send + Sync>,
         task_group: &TaskGroup,
+        client_span: &tracing::Span,
     ) {
         let module = self.clone();
         let api = self.module_api.clone();
 
-        task_group.spawn_cancellable("receive_lnurl_task", async move {
-            api.wait_for_initialized_connections().await;
-            loop {
-                module.receive_lnurl(custom_meta_fn()).await;
-            }
-        });
+        task_group.spawn_cancellable_with_span(
+            client_span.clone(),
+            "receive_lnurl_task",
+            async move {
+                api.wait_for_initialized_connections().await;
+                loop {
+                    module.receive_lnurl(custom_meta_fn()).await;
+                }
+            },
+        );
     }
 
     async fn receive_lnurl(&self, custom_meta: Value) {

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -355,6 +355,7 @@ impl ClientModuleInit for WalletClientInit {
             pegin_claimed_receiver,
             pegin_claimed_sender,
             task_group: args.task_group().clone(),
+            client_span: args.client_span().clone(),
             admin_auth: args.admin_auth().cloned(),
         })
     }
@@ -507,6 +508,7 @@ pub struct WalletClientModule {
     pegin_claimed_sender: watch::Sender<()>,
     pegin_claimed_receiver: watch::Receiver<()>,
     task_group: TaskGroup,
+    client_span: tracing::Span,
     admin_auth: Option<ApiAuth>,
 }
 
@@ -529,32 +531,36 @@ impl ClientModule for WalletClientModule {
     }
 
     async fn start(&self) {
-        self.task_group.spawn_cancellable("peg-in monitor", {
-            let client_ctx = self.client_ctx.clone();
-            let db = self.db.clone();
-            let btc_rpc = self.rpc.clone();
-            let module_api = self.module_api.clone();
-            let data = self.data.clone();
-            let pegin_claimed_sender = self.pegin_claimed_sender.clone();
-            let pegin_monitor_wakeup_receiver = self.pegin_monitor_wakeup_receiver.clone();
-            pegin_monitor::run_peg_in_monitor(
-                client_ctx,
-                db,
-                btc_rpc,
-                module_api,
-                data,
-                pegin_claimed_sender,
-                pegin_monitor_wakeup_receiver,
-            )
-        });
-
         self.task_group
-            .spawn_cancellable("supports-safe-deposit-version", {
+            .spawn_cancellable_with_span(self.client_span.clone(), "peg-in monitor", {
+                let client_ctx = self.client_ctx.clone();
+                let db = self.db.clone();
+                let btc_rpc = self.rpc.clone();
+                let module_api = self.module_api.clone();
+                let data = self.data.clone();
+                let pegin_claimed_sender = self.pegin_claimed_sender.clone();
+                let pegin_monitor_wakeup_receiver = self.pegin_monitor_wakeup_receiver.clone();
+                pegin_monitor::run_peg_in_monitor(
+                    client_ctx,
+                    db,
+                    btc_rpc,
+                    module_api,
+                    data,
+                    pegin_claimed_sender,
+                    pegin_monitor_wakeup_receiver,
+                )
+            });
+
+        self.task_group.spawn_cancellable_with_span(
+            self.client_span.clone(),
+            "supports-safe-deposit-version",
+            {
                 let db = self.db.clone();
                 let module_api = self.module_api.clone();
 
                 poll_supports_safe_deposit_version(db, module_api)
-            });
+            },
+        );
     }
 
     fn supports_backup(&self) -> bool {

--- a/modules/fedimint-walletv2-client/src/lib.rs
+++ b/modules/fedimint-walletv2-client/src/lib.rs
@@ -193,7 +193,7 @@ impl ClientModuleInit for WalletClientInit {
             module_api: args.module_api().clone(),
         };
 
-        module.spawn_output_scanner(args.task_group());
+        module.spawn_output_scanner(args.task_group(), args.client_span());
 
         Ok(module)
     }
@@ -491,10 +491,10 @@ impl WalletClientModule {
         (operation_id, range.txid())
     }
 
-    fn spawn_output_scanner(&self, task_group: &TaskGroup) {
+    fn spawn_output_scanner(&self, task_group: &TaskGroup, client_span: &tracing::Span) {
         let module = self.clone();
 
-        task_group.spawn_cancellable("output-scanner", async move {
+        task_group.spawn_cancellable_with_span(client_span.clone(), "output-scanner", async move {
             let mut dbtx = module.db.begin_transaction().await;
 
             if dbtx


### PR DESCRIPTION
In a multi-client application, it's often hard to debug thing when multiple clients are involved and their messages intertwined. These changes add an extra span with federation id prefix for the client, to make it possible to tell which logging statement is for which federation.
<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
