### PR TITLE
chore(audit): ignore RUSTSEC-2026-0118 and RUSTSEC-2026-0119 (hickory…

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -39,6 +39,10 @@ ignore = [
   "RUSTSEC-2026-0099",
   # rustls-webpki CRL parsing panic; fixed in 0.103.13 (updated). 0.101.x/0.102.x have no backport and remain pinned via fedimint-ldk-node/iroh 0.35.0
   "RUSTSEC-2026-0104",
+  # hickory-proto DNSSEC NSEC3 closest-encloser unbounded loop; only reachable with DNSSEC validation (dnssec-ring/dnssec-aws-lc-rs), which we do not enable. Fix is in 0.26.1; transitive via iroh, can't update yet.
+  "RUSTSEC-2026-0118",
+  # hickory-proto O(n²) name compression on message encoding; only affects encoding large DNS messages, which we do not do (we are a resolver consumer). Fix is in 0.26.1; transitive via iroh, can't update yet.
+  "RUSTSEC-2026-0119",
 ]
 
 [output]


### PR DESCRIPTION
…-proto)

Both advisories affect hickory-proto 0.25.2 (transitive via iroh) with fixes only in 0.26.1, which we cannot update to yet.

- RUSTSEC-2026-0118: DNSSEC NSEC3 closest-encloser unbounded loop — only reachable when DNSSEC validation is enabled via the dnssec-ring/dnssec-aws-lc-rs features, which we do not enable.
- RUSTSEC-2026-0119: O(n²) name compression on message encoding — only affects code that encodes large DNS messages; we are a resolver consumer.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
