### PR TITLE
feat(wallet-client): bounded reuse of unused deposit addresses via `a…

### DIFF
--- a/fedimint-cli/src/client.rs
+++ b/fedimint-cli/src/client.rs
@@ -493,15 +493,15 @@ pub async fn handle_command(
                 target: LOG_CLIENT,
                 "Command deprecated. Use `fedimint-cli module wallet new-deposit-address` instead."
             );
-            let (operation_id, address, tweak_idx) = client
+            let deposit_address = client
                 .get_first_module::<WalletClientModule>()?
                 .allocate_deposit_address_expert_only(())
                 .await?;
             Ok(serde_json::json! {
                 {
-                    "address": address,
-                    "operation_id": operation_id,
-                    "idx": tweak_idx.0
+                    "address": deposit_address.address,
+                    "operation_id": deposit_address.operation_id,
+                    "idx": deposit_address.tweak_idx.0
                 }
             })
         }

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -1274,9 +1274,10 @@ impl Gateway {
         let client = self.select_client(payload.federation_id).await?;
 
         if let Ok(wallet_module) = client.value().get_first_module::<WalletClientModule>() {
-            let (_, address, _) = wallet_module
+            let address = wallet_module
                 .allocate_deposit_address_expert_only(())
-                .await?;
+                .await?
+                .address;
             Ok(address)
         } else if let Ok(wallet_module) = client
             .value()

--- a/modules/fedimint-wallet-client/src/cli.rs
+++ b/modules/fedimint-wallet-client/src/cli.rs
@@ -201,13 +201,12 @@ pub(crate) async fn handle_cli_command(
             serde_json::Value::Bool(true)
         }
         Opts::NewDepositAddress => {
-            let (operation_id, address, tweak_idx) =
-                module.allocate_deposit_address_expert_only(()).await?;
+            let deposit_address = module.allocate_deposit_address_expert_only(()).await?;
             serde_json::json! {
                 {
-                    "address": address,
-                    "operation_id": operation_id,
-                    "tweak_idx": tweak_idx.0
+                    "address": deposit_address.address,
+                    "operation_id": deposit_address.operation_id,
+                    "tweak_idx": deposit_address.tweak_idx.0
                 }
             }
         }

--- a/modules/fedimint-wallet-client/src/client_db.rs
+++ b/modules/fedimint-wallet-client/src/client_db.rs
@@ -20,6 +20,7 @@ pub enum DbKeyPrefix {
     RecoveryFinalized = 0x2f,
     RecoveryState = 0x30,
     SupportsSafeDeposit = 0x31,
+    PegInPoolCursor = 0x32,
     /// Prefixes between 0xb0..=0xcf shall all be considered allocated for
     /// historical and future external use
     ExternalReservedStart = 0xb0,
@@ -209,4 +210,19 @@ impl_db_record!(
 impl_db_lookup!(
     key = SupportsSafeDepositKey,
     query_prefix = SupportsSafeDepositPrefix
+);
+
+/// Round-robin cursor for
+/// [`crate::WalletClientModule::allocate_deposit_address_pooled`].
+///
+/// Stores the [`TweakIdx`] of the most recently reused unused address. The
+/// next reuse picks the smallest unused tweak with `tweak_idx > cursor`,
+/// wrapping back to the smallest unused tweak when none exists.
+#[derive(Clone, Debug, Encodable, Decodable, Serialize)]
+pub struct PegInPoolCursorKey;
+
+impl_db_record!(
+    key = PegInPoolCursorKey,
+    value = TweakIdx,
+    db_prefix = DbKeyPrefix::PegInPoolCursor,
 );

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -128,9 +128,9 @@ pub enum DepositStateV2 {
     Failed(String),
 }
 
-/// Deposit address already allocated by this client.
+/// Deposit address allocated by this client.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct PooledDepositAddress {
+pub struct DepositAddressInfo {
     pub operation_id: OperationId,
     pub address: Address,
     pub tweak_idx: TweakIdx,
@@ -145,16 +145,11 @@ pub struct PooledDepositAddress {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MaybeNewAddress {
     /// A new tweak/operation was created on this call.
-    NewAddress {
-        operation_id: OperationId,
-        address: Address,
-        tweak_idx: TweakIdx,
-    },
+    NewAddress(DepositAddressInfo),
     /// The unused-address gap is full. No new address was allocated.
-    TooManyUnusedAddresses {
-        /// Reusable unused addresses, ordered by `creation_time` ascending.
-        addresses: Vec<PooledDepositAddress>,
-    },
+    ///
+    /// Reusable unused addresses are ordered by `creation_time` ascending.
+    TooManyUnusedAddresses(Vec<DepositAddressInfo>),
 }
 
 /// Outcome of [`WalletClientModule::allocate_deposit_address_pooled`], so
@@ -803,7 +798,7 @@ impl WalletClientModule {
     async fn allocate_deposit_address_inner(
         &self,
         dbtx: &mut DatabaseTransaction<'_>,
-    ) -> (OperationId, Address, TweakIdx) {
+    ) -> DepositAddressInfo {
         dbtx.ensure_isolated().expect("Must be isolated db");
 
         let tweak_idx = get_next_peg_in_tweak_child_id(dbtx).await;
@@ -824,7 +819,11 @@ impl WalletClientModule {
         )
         .await;
 
-        (operation_id, address, tweak_idx)
+        DepositAddressInfo {
+            operation_id,
+            address,
+            tweak_idx,
+        }
     }
 
     /// Fetches the fees that would need to be paid to make the withdraw request
@@ -890,13 +889,16 @@ impl WalletClientModule {
     }
 
     pub async fn peg_in(&self, req: PegInRequest) -> anyhow::Result<PegInResponse> {
-        let (operation_id, address, _) = self.safe_allocate_deposit_address(req.extra_meta).await?;
+        let deposit_address = self.safe_allocate_deposit_address(req.extra_meta).await?;
 
         Ok(PegInResponse {
-            deposit_address: Address::from_script(&address.script_pubkey(), self.get_network())?
-                .as_unchecked()
-                .clone(),
-            operation_id,
+            deposit_address: Address::from_script(
+                &deposit_address.address.script_pubkey(),
+                self.get_network(),
+            )?
+            .as_unchecked()
+            .clone(),
+            operation_id: deposit_address.operation_id,
         })
     }
 
@@ -995,7 +997,7 @@ impl WalletClientModule {
     pub async fn safe_allocate_deposit_address<M>(
         &self,
         extra_meta: M,
-    ) -> anyhow::Result<(OperationId, Address, TweakIdx)>
+    ) -> anyhow::Result<DepositAddressInfo>
     where
         M: Serialize + MaybeSend + MaybeSync,
     {
@@ -1027,48 +1029,55 @@ impl WalletClientModule {
     pub async fn allocate_deposit_address_expert_only<M>(
         &self,
         extra_meta: M,
-    ) -> anyhow::Result<(OperationId, Address, TweakIdx)>
+    ) -> anyhow::Result<DepositAddressInfo>
     where
         M: Serialize + MaybeSend + MaybeSync,
     {
         let extra_meta_value =
             serde_json::to_value(extra_meta).expect("Failed to serialize extra meta");
-        let (operation_id, address, tweak_idx) = self
+        let deposit_address = self
             .db
             .autocommit(
                 move |dbtx, _| {
                     let extra_meta_value_inner = extra_meta_value.clone();
                     Box::pin(async move {
-                        let (operation_id, address, tweak_idx) = self
-                            .allocate_deposit_address_inner(dbtx)
-                            .await;
+                        let deposit_address = self.allocate_deposit_address_inner(dbtx).await;
 
-                        self.client_ctx.manual_operation_start_dbtx(
-                            dbtx,
-                            operation_id,
-                            WalletCommonInit::KIND.as_str(),
-                            WalletOperationMeta {
-                                variant: WalletOperationMetaVariant::Deposit {
-                                    address: address.clone().into_unchecked(),
-                                    tweak_idx: Some(tweak_idx),
-                                    expires_at: None,
+                        self.client_ctx
+                            .manual_operation_start_dbtx(
+                                dbtx,
+                                deposit_address.operation_id,
+                                WalletCommonInit::KIND.as_str(),
+                                WalletOperationMeta {
+                                    variant: WalletOperationMetaVariant::Deposit {
+                                        address: deposit_address.address.clone().into_unchecked(),
+                                        tweak_idx: Some(deposit_address.tweak_idx),
+                                        expires_at: None,
+                                    },
+                                    extra_meta: extra_meta_value_inner,
                                 },
-                                extra_meta: extra_meta_value_inner,
-                            },
-                            vec![]
-                        ).await?;
+                                vec![],
+                            )
+                            .await?;
 
-                        debug!(target: LOG_CLIENT_MODULE_WALLET, %tweak_idx, %address, "Derived a new deposit address");
+                        debug!(
+                            target: LOG_CLIENT_MODULE_WALLET,
+                            tweak_idx = %deposit_address.tweak_idx,
+                            address = %deposit_address.address,
+                            "Derived a new deposit address"
+                        );
 
                         // Begin watching the script address
-                        self.rpc.watch_script_history(&address.script_pubkey()).await?;
+                        self.rpc
+                            .watch_script_history(&deposit_address.address.script_pubkey())
+                            .await?;
 
                         let sender = self.pegin_monitor_wakeup_sender.clone();
                         dbtx.on_commit(move || {
                             sender.send_replace(());
                         });
 
-                        Ok((operation_id, address, tweak_idx))
+                        Ok(deposit_address)
                     })
                 },
                 Some(100),
@@ -1082,7 +1091,7 @@ impl WalletClientModule {
                 AutocommitError::ClosureError { error, .. } => error,
             })?;
 
-        Ok((operation_id, address, tweak_idx))
+        Ok(deposit_address)
     }
 
     /// Allocate a deposit address, bounding the gap of consecutive unused
@@ -1145,7 +1154,7 @@ impl WalletClientModule {
 
                                     debug_assert_eq!(operation_id, data.operation_id);
 
-                                    PooledDepositAddress {
+                                    DepositAddressInfo {
                                         operation_id,
                                         address,
                                         tweak_idx,
@@ -1154,22 +1163,21 @@ impl WalletClientModule {
                                 .collect();
 
                             return Ok::<_, anyhow::Error>(
-                                MaybeNewAddress::TooManyUnusedAddresses { addresses },
+                                MaybeNewAddress::TooManyUnusedAddresses(addresses),
                             );
                         }
 
-                        let (operation_id, address, tweak_idx) =
-                            self.allocate_deposit_address_inner(dbtx).await;
+                        let deposit_address = self.allocate_deposit_address_inner(dbtx).await;
 
                         self.client_ctx
                             .manual_operation_start_dbtx(
                                 dbtx,
-                                operation_id,
+                                deposit_address.operation_id,
                                 WalletCommonInit::KIND.as_str(),
                                 WalletOperationMeta {
                                     variant: WalletOperationMetaVariant::Deposit {
-                                        address: address.clone().into_unchecked(),
-                                        tweak_idx: Some(tweak_idx),
+                                        address: deposit_address.address.clone().into_unchecked(),
+                                        tweak_idx: Some(deposit_address.tweak_idx),
                                         expires_at: None,
                                     },
                                     extra_meta: extra_meta_value_inner,
@@ -1180,12 +1188,13 @@ impl WalletClientModule {
 
                         debug!(
                             target: LOG_CLIENT_MODULE_WALLET,
-                            %tweak_idx, %address,
+                            tweak_idx = %deposit_address.tweak_idx,
+                            address = %deposit_address.address,
                             "Derived a new pooled deposit address"
                         );
 
                         self.rpc
-                            .watch_script_history(&address.script_pubkey())
+                            .watch_script_history(&deposit_address.address.script_pubkey())
                             .await?;
 
                         let sender = self.pegin_monitor_wakeup_sender.clone();
@@ -1193,11 +1202,7 @@ impl WalletClientModule {
                             sender.send_replace(());
                         });
 
-                        Ok(MaybeNewAddress::NewAddress {
-                            operation_id,
-                            address,
-                            tweak_idx,
-                        })
+                        Ok(MaybeNewAddress::NewAddress(deposit_address))
                     })
                 },
                 Some(100),
@@ -1262,25 +1267,16 @@ impl WalletClientModule {
     pub async fn allocate_deposit_address_pooled(
         &self,
         max_gap_size: usize,
-    ) -> anyhow::Result<(OperationId, Address, TweakIdx, AllocateDepositOutcome)> {
+    ) -> anyhow::Result<(DepositAddressInfo, AllocateDepositOutcome)> {
         let stateless = self
             .allocate_deposit_address_pooled_stateless(max_gap_size)
             .await?;
 
         let reused_addresses = match stateless {
-            MaybeNewAddress::NewAddress {
-                operation_id,
-                address,
-                tweak_idx,
-            } => {
-                return Ok((
-                    operation_id,
-                    address,
-                    tweak_idx,
-                    AllocateDepositOutcome::Fresh,
-                ));
+            MaybeNewAddress::NewAddress(deposit_address) => {
+                return Ok((deposit_address, AllocateDepositOutcome::Fresh));
             }
-            MaybeNewAddress::TooManyUnusedAddresses { addresses } => addresses,
+            MaybeNewAddress::TooManyUnusedAddresses(addresses) => addresses,
         };
 
         let result = self
@@ -1300,6 +1296,7 @@ impl WalletClientModule {
                             .unwrap_or(0);
                         let reused_address = reused_addresses[pick_pos].clone();
 
+                        let existing_tweak_idx = reused_address.tweak_idx;
                         let existing = dbtx
                             .get_value(&PegInTweakIndexKey(reused_address.tweak_idx))
                             .await
@@ -1345,11 +1342,9 @@ impl WalletClientModule {
                         });
 
                         Ok::<_, anyhow::Error>((
-                            reused_address.operation_id,
-                            reused_address.address,
-                            reused_address.tweak_idx,
+                            reused_address,
                             AllocateDepositOutcome::Reused {
-                                original_tweak_idx: reused_address.tweak_idx,
+                                original_tweak_idx: existing_tweak_idx,
                             },
                         ))
                     })

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -81,8 +81,8 @@ use crate::api::WalletFederationApi;
 use crate::backup::{FEDERATION_RECOVER_MAX_GAP, RecoveryStateV2, WalletRecovery};
 use crate::client_db::{
     ClaimedPegInData, ClaimedPegInKey, ClaimedPegInPrefix, NextPegInTweakIndexKey,
-    PegInTweakIndexData, PegInTweakIndexPrefix, RecoveryFinalizedKey, RecoveryStateKey,
-    SupportsSafeDepositPrefix,
+    PegInPoolCursorKey, PegInTweakIndexData, PegInTweakIndexPrefix, RecoveryFinalizedKey,
+    RecoveryStateKey, SupportsSafeDepositPrefix,
 };
 use crate::deposit::DepositStateMachine;
 use crate::withdraw::{CreatedWithdrawState, WithdrawStateMachine, WithdrawStates};
@@ -126,6 +126,21 @@ pub enum DepositStateV2 {
         btc_out_point: bitcoin::OutPoint,
     },
     Failed(String),
+}
+
+/// Outcome of [`WalletClientModule::allocate_deposit_address_pooled`], so
+/// callers can decide whether to perform per-operation initialization (notes,
+/// fee bookkeeping, metadata writes) — for `Reused` returns, that work was
+/// already done at the time of the original `Fresh` allocation and must not be
+/// repeated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AllocateDepositOutcome {
+    /// A new tweak/operation was created on this call.
+    Fresh,
+    /// An existing unused address was returned. The carried `TweakIdx` is the
+    /// same as the one returned in the tuple and refers to the original
+    /// allocation; it's exposed here as well for explicit diagnostic use.
+    Reused { original_tweak_idx: TweakIdx },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
@@ -284,6 +299,11 @@ impl ModuleInit for WalletClientInit {
                         wallet_client_items,
                         "Supports Safe Deposit"
                     );
+                }
+                DbKeyPrefix::PegInPoolCursor => {
+                    if let Some(cursor) = dbtx.get_value(&PegInPoolCursorKey).await {
+                        wallet_client_items.insert("PegInPoolCursor".to_string(), Box::new(cursor));
+                    }
                 }
                 DbKeyPrefix::RecoveryState
                 | DbKeyPrefix::ExternalReservedStart
@@ -1034,6 +1054,191 @@ impl WalletClientModule {
             })?;
 
         Ok((operation_id, address, tweak_idx))
+    }
+
+    /// Allocate a deposit address, bounding the gap of consecutive unused
+    /// addresses past the last-used one.
+    ///
+    /// "Unused" here means `PegInTweakIndexData::claimed.is_empty()` — the
+    /// `pegin_monitor` has not yet successfully claimed any deposit on this
+    /// address. There is a small race window where a deposit has been
+    /// observed in the mempool / awaiting confirmations but not yet claimed,
+    /// in which case the address still looks unused. Reusing such an address
+    /// is benign in practice: `pegin_monitor` claims any number of deposits
+    /// per address.
+    ///
+    /// Let `gap` be the count of unused tweak indices strictly greater than
+    /// the highest used index (or the count of all allocated tweaks if none
+    /// have been used yet). Semantics:
+    ///   - If `gap >= max_gap_size` and there is at least one unused address to
+    ///     reuse, returns one of them (round-robin — see below) with
+    ///     [`AllocateDepositOutcome::Reused`].
+    ///   - Otherwise, allocates a new address (equivalent to
+    ///     [`Self::allocate_deposit_address_expert_only`]) and returns it with
+    ///     [`AllocateDepositOutcome::Fresh`].
+    ///
+    /// `max_gap_size == 0` therefore means "only allocate fresh when the
+    /// previous address was already used". The very first call still
+    /// allocates fresh because there are no addresses to reuse.
+    ///
+    /// `max_gap_size == usize::MAX` makes this method behave like
+    /// [`Self::allocate_deposit_address_expert_only`] — always `Fresh`.
+    ///
+    /// Selection policy when reusing: round-robin over unused addresses
+    /// ordered by `creation_time` ascending, with the cursor persisted
+    /// per-client in the wallet module's DB. The cursor stores the next
+    /// tweak index to consider; after picking idx X it advances to X+1, and
+    /// when no candidate has `tweak_idx >= cursor` it wraps to the
+    /// oldest-by-`creation_time` candidate. This gives the caller the
+    /// predictable "cycle through the unused addresses" behavior.
+    ///
+    /// On reuse the `creation_time` and check-schedule fields of the
+    /// underlying tweak entry are reset to "now", so `pegin_monitor`'s
+    /// age-proportional polling delay restarts from zero. Without this an
+    /// old entry would keep its long stale next-check delay and a user
+    /// sending to it could wait a long time before the client noticed.
+    ///
+    /// Caveats inherited from
+    /// [`Self::allocate_deposit_address_expert_only`] (40KB tx limit, future
+    /// minimum peg-in amount) apply equally to fresh and reused addresses.
+    #[allow(clippy::too_many_lines)]
+    pub async fn allocate_deposit_address_pooled(
+        &self,
+        max_gap_size: usize,
+    ) -> anyhow::Result<(OperationId, Address, TweakIdx, AllocateDepositOutcome)> {
+        let max_gap_size_u64 = u64::try_from(max_gap_size).unwrap_or(u64::MAX);
+        let extra_meta_value = serde_json::Value::Null;
+        let result = self
+            .db
+            .autocommit(
+                move |dbtx, _| {
+                    let extra_meta_value_inner = extra_meta_value.clone();
+                    Box::pin(async move {
+                        // Walk peg-in tweaks in descending order, taking
+                        // unused ones (`claimed.is_empty()`) until we hit a
+                        // used one. That gives us exactly the trailing gap
+                        // — `gap + 1` reads regardless of total tweak count.
+                        // No RPC and no separately-maintained `last_used`
+                        // index needed.
+                        let mut unused: Vec<(TweakIdx, PegInTweakIndexData)> = dbtx
+                            .find_by_prefix_sorted_descending(&PegInTweakIndexPrefix)
+                            .await
+                            .take_while(|(_, d)| std::future::ready(d.claimed.is_empty()))
+                            .map(|(k, v)| (k.0, v))
+                            .collect()
+                            .await;
+                        // Order by `creation_time` ascending for round-robin
+                        // selection (and stable wraparound after reuse
+                        // mutates `creation_time`).
+                        unused.sort_by_key(|(t, d)| (d.creation_time, *t));
+                        let gap = unused.len() as u64;
+
+                        if gap >= max_gap_size_u64 && !unused.is_empty() {
+                            let cursor = dbtx
+                                .get_value(&PegInPoolCursorKey)
+                                .await
+                                .unwrap_or(TweakIdx(0));
+
+                            let pick_pos =
+                                unused.iter().position(|(t, _)| *t >= cursor).unwrap_or(0);
+                            let (tweak_idx, existing) = unused.swap_remove(pick_pos);
+
+                            let (_script, address, _key, op_id) =
+                                self.data.derive_peg_in_script(tweak_idx);
+
+                            dbtx.insert_entry(&PegInPoolCursorKey, &tweak_idx.next())
+                                .await;
+
+                            // Reset the monitoring schedule so the reused
+                            // address gets checked as aggressively as a
+                            // freshly-allocated one. Without this, an old
+                            // entry would retain its `age/10` next-check
+                            // delay from `pegin_monitor`, meaning a user who
+                            // sends to a long-idle pool address could wait
+                            // hours before the client polls for the deposit.
+                            let now = fedimint_core::time::now();
+                            dbtx.insert_entry(
+                                &PegInTweakIndexKey(tweak_idx),
+                                &PegInTweakIndexData {
+                                    creation_time: now,
+                                    last_check_time: None,
+                                    next_check_time: Some(now),
+                                    operation_id: existing.operation_id,
+                                    claimed: existing.claimed,
+                                },
+                            )
+                            .await;
+
+                            let sender = self.pegin_monitor_wakeup_sender.clone();
+                            dbtx.on_commit(move || {
+                                sender.send_replace(());
+                            });
+
+                            return Ok::<_, anyhow::Error>((
+                                op_id,
+                                address,
+                                tweak_idx,
+                                AllocateDepositOutcome::Reused {
+                                    original_tweak_idx: tweak_idx,
+                                },
+                            ));
+                        }
+
+                        let (operation_id, address, tweak_idx) =
+                            self.allocate_deposit_address_inner(dbtx).await;
+
+                        self.client_ctx
+                            .manual_operation_start_dbtx(
+                                dbtx,
+                                operation_id,
+                                WalletCommonInit::KIND.as_str(),
+                                WalletOperationMeta {
+                                    variant: WalletOperationMetaVariant::Deposit {
+                                        address: address.clone().into_unchecked(),
+                                        tweak_idx: Some(tweak_idx),
+                                        expires_at: None,
+                                    },
+                                    extra_meta: extra_meta_value_inner,
+                                },
+                                vec![],
+                            )
+                            .await?;
+
+                        debug!(
+                            target: LOG_CLIENT_MODULE_WALLET,
+                            %tweak_idx, %address,
+                            "Derived a new pooled deposit address"
+                        );
+
+                        self.rpc
+                            .watch_script_history(&address.script_pubkey())
+                            .await?;
+
+                        let sender = self.pegin_monitor_wakeup_sender.clone();
+                        dbtx.on_commit(move || {
+                            sender.send_replace(());
+                        });
+
+                        Ok((
+                            operation_id,
+                            address,
+                            tweak_idx,
+                            AllocateDepositOutcome::Fresh,
+                        ))
+                    })
+                },
+                Some(100),
+            )
+            .await
+            .map_err(|e| match e {
+                AutocommitError::CommitFailed {
+                    last_error,
+                    attempts,
+                } => anyhow!("Failed to commit after {attempts} attempts: {last_error}"),
+                AutocommitError::ClosureError { error, .. } => error,
+            })?;
+
+        Ok(result)
     }
 
     /// Returns a stream of updates about an ongoing deposit operation created

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -128,6 +128,35 @@ pub enum DepositStateV2 {
     Failed(String),
 }
 
+/// Deposit address already allocated by this client.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PooledDepositAddress {
+    pub operation_id: OperationId,
+    pub address: Address,
+    pub tweak_idx: TweakIdx,
+}
+
+/// Result of [`WalletClientModule::allocate_deposit_address_pooled_stateless`].
+///
+/// Callers that need a custom address-picking strategy can use
+/// [`MaybeNewAddress::TooManyUnusedAddresses`] to see all currently reusable
+/// addresses instead of relying on this crate's round-robin policy.
+#[allow(clippy::enum_variant_names)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MaybeNewAddress {
+    /// A new tweak/operation was created on this call.
+    NewAddress {
+        operation_id: OperationId,
+        address: Address,
+        tweak_idx: TweakIdx,
+    },
+    /// The unused-address gap is full. No new address was allocated.
+    TooManyUnusedAddresses {
+        /// Reusable unused addresses, ordered by `creation_time` ascending.
+        addresses: Vec<PooledDepositAddress>,
+    },
+}
+
 /// Outcome of [`WalletClientModule::allocate_deposit_address_pooled`], so
 /// callers can decide whether to perform per-operation initialization (notes,
 /// fee bookkeeping, metadata writes) — for `Reused` returns, that work was
@@ -1057,7 +1086,7 @@ impl WalletClientModule {
     }
 
     /// Allocate a deposit address, bounding the gap of consecutive unused
-    /// addresses past the last-used one.
+    /// addresses past the last-used one, without selecting a reusable address.
     ///
     /// "Unused" here means `PegInTweakIndexData::claimed.is_empty()` — the
     /// `pegin_monitor` has not yet successfully claimed any deposit on this
@@ -1070,42 +1099,33 @@ impl WalletClientModule {
     /// Let `gap` be the count of unused tweak indices strictly greater than
     /// the highest used index (or the count of all allocated tweaks if none
     /// have been used yet). Semantics:
-    ///   - If `gap >= max_gap_size` and there is at least one unused address to
-    ///     reuse, returns one of them (round-robin — see below) with
-    ///     [`AllocateDepositOutcome::Reused`].
+    ///   - If `gap >= max_gap_size` and there is at least one unused address,
+    ///     returns all those addresses with
+    ///     [`MaybeNewAddress::TooManyUnusedAddresses`].
     ///   - Otherwise, allocates a new address (equivalent to
     ///     [`Self::allocate_deposit_address_expert_only`]) and returns it with
-    ///     [`AllocateDepositOutcome::Fresh`].
+    ///     [`MaybeNewAddress::NewAddress`].
     ///
     /// `max_gap_size == 0` therefore means "only allocate fresh when the
     /// previous address was already used". The very first call still
     /// allocates fresh because there are no addresses to reuse.
     ///
     /// `max_gap_size == usize::MAX` makes this method behave like
-    /// [`Self::allocate_deposit_address_expert_only`] — always `Fresh`.
+    /// [`Self::allocate_deposit_address_expert_only`] — always allocating a new
+    /// address.
     ///
-    /// Selection policy when reusing: round-robin over unused addresses
-    /// ordered by `creation_time` ascending, with the cursor persisted
-    /// per-client in the wallet module's DB. The cursor stores the next
-    /// tweak index to consider; after picking idx X it advances to X+1, and
-    /// when no candidate has `tweak_idx >= cursor` it wraps to the
-    /// oldest-by-`creation_time` candidate. This gives the caller the
-    /// predictable "cycle through the unused addresses" behavior.
-    ///
-    /// On reuse the `creation_time` and check-schedule fields of the
-    /// underlying tweak entry are reset to "now", so `pegin_monitor`'s
-    /// age-proportional polling delay restarts from zero. Without this an
-    /// old entry would keep its long stale next-check delay and a user
-    /// sending to it could wait a long time before the client noticed.
+    /// Reusable addresses are ordered by `creation_time` ascending. This lets
+    /// callers that need a custom selection strategy choose from all available
+    /// candidates.
     ///
     /// Caveats inherited from
     /// [`Self::allocate_deposit_address_expert_only`] (40KB tx limit, future
-    /// minimum peg-in amount) apply equally to fresh and reused addresses.
-    #[allow(clippy::too_many_lines)]
-    pub async fn allocate_deposit_address_pooled(
+    /// minimum peg-in amount) apply equally to newly allocated and reused
+    /// addresses.
+    pub async fn allocate_deposit_address_pooled_stateless(
         &self,
         max_gap_size: usize,
-    ) -> anyhow::Result<(OperationId, Address, TweakIdx, AllocateDepositOutcome)> {
+    ) -> anyhow::Result<MaybeNewAddress> {
         let max_gap_size_u64 = u64::try_from(max_gap_size).unwrap_or(u64::MAX);
         let extra_meta_value = serde_json::Value::Null;
         let result = self
@@ -1114,74 +1134,28 @@ impl WalletClientModule {
                 move |dbtx, _| {
                     let extra_meta_value_inner = extra_meta_value.clone();
                     Box::pin(async move {
-                        // Walk peg-in tweaks in descending order, taking
-                        // unused ones (`claimed.is_empty()`) until we hit a
-                        // used one. That gives us exactly the trailing gap
-                        // — `gap + 1` reads regardless of total tweak count.
-                        // No RPC and no separately-maintained `last_used`
-                        // index needed.
-                        let mut unused: Vec<(TweakIdx, PegInTweakIndexData)> = dbtx
-                            .find_by_prefix_sorted_descending(&PegInTweakIndexPrefix)
-                            .await
-                            .take_while(|(_, d)| std::future::ready(d.claimed.is_empty()))
-                            .map(|(k, v)| (k.0, v))
-                            .collect()
-                            .await;
-                        // Order by `creation_time` ascending for round-robin
-                        // selection (and stable wraparound after reuse
-                        // mutates `creation_time`).
-                        unused.sort_by_key(|(t, d)| (d.creation_time, *t));
-                        let gap = unused.len() as u64;
+                        let unused = self.unused_pooled_deposit_addresses(dbtx).await;
 
-                        if gap >= max_gap_size_u64 && !unused.is_empty() {
-                            let cursor = dbtx
-                                .get_value(&PegInPoolCursorKey)
-                                .await
-                                .unwrap_or(TweakIdx(0));
+                        if max_gap_size_u64 <= unused.len() as u64 && !unused.is_empty() {
+                            let addresses = unused
+                                .into_iter()
+                                .map(|(tweak_idx, data)| {
+                                    let (_script, address, _key, operation_id) =
+                                        self.data.derive_peg_in_script(tweak_idx);
 
-                            let pick_pos =
-                                unused.iter().position(|(t, _)| *t >= cursor).unwrap_or(0);
-                            let (tweak_idx, existing) = unused.swap_remove(pick_pos);
+                                    debug_assert_eq!(operation_id, data.operation_id);
 
-                            let (_script, address, _key, op_id) =
-                                self.data.derive_peg_in_script(tweak_idx);
+                                    PooledDepositAddress {
+                                        operation_id,
+                                        address,
+                                        tweak_idx,
+                                    }
+                                })
+                                .collect();
 
-                            dbtx.insert_entry(&PegInPoolCursorKey, &tweak_idx.next())
-                                .await;
-
-                            // Reset the monitoring schedule so the reused
-                            // address gets checked as aggressively as a
-                            // freshly-allocated one. Without this, an old
-                            // entry would retain its `age/10` next-check
-                            // delay from `pegin_monitor`, meaning a user who
-                            // sends to a long-idle pool address could wait
-                            // hours before the client polls for the deposit.
-                            let now = fedimint_core::time::now();
-                            dbtx.insert_entry(
-                                &PegInTweakIndexKey(tweak_idx),
-                                &PegInTweakIndexData {
-                                    creation_time: now,
-                                    last_check_time: None,
-                                    next_check_time: Some(now),
-                                    operation_id: existing.operation_id,
-                                    claimed: existing.claimed,
-                                },
-                            )
-                            .await;
-
-                            let sender = self.pegin_monitor_wakeup_sender.clone();
-                            dbtx.on_commit(move || {
-                                sender.send_replace(());
-                            });
-
-                            return Ok::<_, anyhow::Error>((
-                                op_id,
-                                address,
-                                tweak_idx,
-                                AllocateDepositOutcome::Reused {
-                                    original_tweak_idx: tweak_idx,
-                                },
-                            ));
+                            return Ok::<_, anyhow::Error>(
+                                MaybeNewAddress::TooManyUnusedAddresses { addresses },
+                            );
                         }
 
                         let (operation_id, address, tweak_idx) =
@@ -1219,11 +1193,164 @@ impl WalletClientModule {
                             sender.send_replace(());
                         });
 
-                        Ok((
+                        Ok(MaybeNewAddress::NewAddress {
                             operation_id,
                             address,
                             tweak_idx,
-                            AllocateDepositOutcome::Fresh,
+                        })
+                    })
+                },
+                Some(100),
+            )
+            .await
+            .map_err(|e| match e {
+                AutocommitError::CommitFailed {
+                    last_error,
+                    attempts,
+                } => anyhow!("Failed to commit after {attempts} attempts: {last_error}"),
+                AutocommitError::ClosureError { error, .. } => error,
+            })?;
+
+        Ok(result)
+    }
+
+    async fn unused_pooled_deposit_addresses(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+    ) -> Vec<(TweakIdx, PegInTweakIndexData)> {
+        // Walk peg-in tweaks in descending order, taking unused ones
+        // (`claimed.is_empty()`) until we hit a used one. That gives us exactly
+        // the trailing gap — `gap + 1` reads regardless of total tweak count.
+        // No RPC and no separately-maintained `last_used` index needed.
+        let mut unused: Vec<(TweakIdx, PegInTweakIndexData)> = dbtx
+            .find_by_prefix_sorted_descending(&PegInTweakIndexPrefix)
+            .await
+            .take_while(|(_, d)| std::future::ready(d.claimed.is_empty()))
+            .map(|(k, v)| (k.0, v))
+            .collect()
+            .await;
+
+        // Order by `creation_time` ascending for caller selection and stable
+        // wraparound after stateful reuse mutates `creation_time`.
+        unused.sort_by_key(|(t, d)| (d.creation_time, *t));
+        unused
+    }
+
+    /// Allocate a deposit address, bounding the gap of consecutive unused
+    /// addresses past the last-used one.
+    ///
+    /// This is a stateful wrapper over
+    /// [`Self::allocate_deposit_address_pooled_stateless`]. If the stateless
+    /// method returns [`MaybeNewAddress::TooManyUnusedAddresses`], this method
+    /// picks one of those addresses with a persisted round-robin cursor and
+    /// returns it with [`AllocateDepositOutcome::Reused`].
+    ///
+    /// Selection policy when reusing: round-robin over unused addresses
+    /// ordered by `creation_time` ascending, with the cursor persisted
+    /// per-client in the wallet module's DB. The cursor stores the next
+    /// tweak index to consider; after picking idx X it advances to X+1, and
+    /// when no candidate has `tweak_idx >= cursor` it wraps to the
+    /// oldest-by-`creation_time` candidate. This gives the caller the
+    /// predictable "cycle through the unused addresses" behavior.
+    ///
+    /// On reuse the `creation_time` and check-schedule fields of the
+    /// underlying tweak entry are reset to "now", so `pegin_monitor`'s
+    /// age-proportional polling delay restarts from zero. Without this an
+    /// old entry would keep its long stale next-check delay and a user
+    /// sending to it could wait a long time before the client noticed.
+    #[allow(clippy::too_many_lines)]
+    pub async fn allocate_deposit_address_pooled(
+        &self,
+        max_gap_size: usize,
+    ) -> anyhow::Result<(OperationId, Address, TweakIdx, AllocateDepositOutcome)> {
+        let stateless = self
+            .allocate_deposit_address_pooled_stateless(max_gap_size)
+            .await?;
+
+        let reused_addresses = match stateless {
+            MaybeNewAddress::NewAddress {
+                operation_id,
+                address,
+                tweak_idx,
+            } => {
+                return Ok((
+                    operation_id,
+                    address,
+                    tweak_idx,
+                    AllocateDepositOutcome::Fresh,
+                ));
+            }
+            MaybeNewAddress::TooManyUnusedAddresses { addresses } => addresses,
+        };
+
+        let result = self
+            .db
+            .autocommit(
+                move |dbtx, _| {
+                    let reused_addresses = reused_addresses.clone();
+                    Box::pin(async move {
+                        let cursor = dbtx
+                            .get_value(&PegInPoolCursorKey)
+                            .await
+                            .unwrap_or(TweakIdx(0));
+
+                        let pick_pos = reused_addresses
+                            .iter()
+                            .position(|a| cursor <= a.tweak_idx)
+                            .unwrap_or(0);
+                        let reused_address = reused_addresses[pick_pos].clone();
+
+                        let existing = dbtx
+                            .get_value(&PegInTweakIndexKey(reused_address.tweak_idx))
+                            .await
+                            .with_context(|| {
+                                format!(
+                                    "Pooled address disappeared while reusing {}",
+                                    reused_address.tweak_idx
+                                )
+                            })?;
+
+                        ensure!(
+                            existing.claimed.is_empty(),
+                            "Pooled address was used while reusing {}",
+                            reused_address.tweak_idx
+                        );
+
+                        dbtx.insert_entry(&PegInPoolCursorKey, &reused_address.tweak_idx.next())
+                            .await;
+
+                        // Reset the monitoring schedule so the reused address
+                        // gets checked as aggressively as a freshly-allocated
+                        // one. Without this, an old entry would retain its
+                        // `age/10` next-check delay from `pegin_monitor`,
+                        // meaning a user who sends to a long-idle pool address
+                        // could wait hours before the client polls for the
+                        // deposit.
+                        let now = fedimint_core::time::now();
+                        dbtx.insert_entry(
+                            &PegInTweakIndexKey(reused_address.tweak_idx),
+                            &PegInTweakIndexData {
+                                creation_time: now,
+                                last_check_time: None,
+                                next_check_time: Some(now),
+                                operation_id: existing.operation_id,
+                                claimed: existing.claimed,
+                            },
+                        )
+                        .await;
+
+                        let sender = self.pegin_monitor_wakeup_sender.clone();
+                        dbtx.on_commit(move || {
+                            sender.send_replace(());
+                        });
+
+                        Ok::<_, anyhow::Error>((
+                            reused_address.operation_id,
+                            reused_address.address,
+                            reused_address.tweak_idx,
+                            AllocateDepositOutcome::Reused {
+                                original_tweak_idx: reused_address.tweak_idx,
+                            },
                         ))
                     })
                 },

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -65,9 +65,11 @@ async fn peg_in<'a>(
     await_consensus_upgrade(client, fed).await?;
 
     let wallet_module = &client.get_first_module::<WalletClientModule>()?;
-    let (op, address, _) = wallet_module
+    let deposit_address = wallet_module
         .allocate_deposit_address_expert_only(())
         .await?;
+    let op = deposit_address.operation_id;
+    let address = deposit_address.address;
     info!(?address, "Peg-in address generated");
     let (_proof, tx) = bitcoin
         .send_and_mine_block(
@@ -231,9 +233,11 @@ async fn on_chain_peg_in_and_peg_out_happy_case() -> anyhow::Result<()> {
     await_consensus_upgrade(&client, &fed).await?;
 
     assert_eq!(client.get_balance_for_btc().await?, sats(0));
-    let (op, address, _) = wallet_module
+    let deposit_address = wallet_module
         .allocate_deposit_address_expert_only(())
         .await?;
+    let op = deposit_address.operation_id;
+    let address = deposit_address.address;
 
     // Test operation is created
     let operations = client
@@ -387,9 +391,12 @@ async fn on_chain_peg_in_detects_multiple() -> anyhow::Result<()> {
     await_consensus_upgrade(&client, &fed).await?;
 
     let wallet_module = &client.get_first_module::<WalletClientModule>()?;
-    let (op, address, tweak_idx) = wallet_module
+    let deposit_address = wallet_module
         .allocate_deposit_address_expert_only(())
         .await?;
+    let op = deposit_address.operation_id;
+    let address = deposit_address.address;
+    let tweak_idx = deposit_address.tweak_idx;
 
     // First peg-in
     {
@@ -839,9 +846,11 @@ async fn dust_deposits_are_ignored() -> anyhow::Result<()> {
     await_consensus_upgrade(&client, &fed).await?;
 
     assert_eq!(client.get_balance_for_btc().await?, sats(0));
-    let (op, address, _) = wallet_module
+    let deposit_address = wallet_module
         .allocate_deposit_address_expert_only(())
         .await?;
+    let op = deposit_address.operation_id;
+    let address = deposit_address.address;
 
     info!(?address, "Peg-in address generated");
     let (_proof, tx) = bitcoin
@@ -913,21 +922,21 @@ async fn allocate_deposit_address_pooled_zero_gap_reuses_until_used() -> anyhow:
     let wallet_module = client.get_first_module::<WalletClientModule>()?;
 
     // First call has nothing to reuse → Fresh.
-    let (_op, addr0, tweak_idx0, outcome0) =
-        wallet_module.allocate_deposit_address_pooled(0).await?;
+    let (deposit_address0, outcome0) = wallet_module.allocate_deposit_address_pooled(0).await?;
     assert_eq!(outcome0, AllocateDepositOutcome::Fresh);
+    let addr0 = deposit_address0.address;
+    let tweak_idx0 = deposit_address0.tweak_idx;
 
     // Subsequent calls keep returning the same address until a deposit lands
     // on it.
     for _ in 0..3 {
-        let (_op, addr, tweak_idx, outcome) =
-            wallet_module.allocate_deposit_address_pooled(0).await?;
+        let (deposit_address, outcome) = wallet_module.allocate_deposit_address_pooled(0).await?;
         assert_matches!(
             outcome,
             AllocateDepositOutcome::Reused { original_tweak_idx } if original_tweak_idx == tweak_idx0
         );
-        assert_eq!(addr, addr0);
-        assert_eq!(tweak_idx, tweak_idx0);
+        assert_eq!(deposit_address.address, addr0);
+        assert_eq!(deposit_address.tweak_idx, tweak_idx0);
     }
     Ok(())
 }
@@ -953,10 +962,9 @@ async fn allocate_deposit_address_pooled_caps_and_reuses_round_robin() -> anyhow
         fedimint_wallet_client::client_db::TweakIdx,
     )> = vec![];
     for _ in 0..GAP {
-        let (_op, addr, tweak_idx, outcome) =
-            wallet_module.allocate_deposit_address_pooled(GAP).await?;
+        let (deposit_address, outcome) = wallet_module.allocate_deposit_address_pooled(GAP).await?;
         assert_eq!(outcome, AllocateDepositOutcome::Fresh);
-        fresh.push((addr, tweak_idx));
+        fresh.push((deposit_address.address, deposit_address.tweak_idx));
     }
     let unique_addrs: HashSet<_> = fresh.iter().map(|(a, _)| a.script_pubkey()).collect();
     assert_eq!(unique_addrs.len(), GAP);
@@ -964,7 +972,7 @@ async fn allocate_deposit_address_pooled_caps_and_reuses_round_robin() -> anyhow
     let stateless = wallet_module
         .allocate_deposit_address_pooled_stateless(GAP)
         .await?;
-    let MaybeNewAddress::TooManyUnusedAddresses { addresses } = stateless else {
+    let MaybeNewAddress::TooManyUnusedAddresses(addresses) = stateless else {
         panic!("expected reusable addresses from stateless allocation");
     };
     assert_eq!(addresses.len(), GAP);
@@ -977,21 +985,19 @@ async fn allocate_deposit_address_pooled_caps_and_reuses_round_robin() -> anyhow
     // begins at TweakIdx(0) and advances to picked.next() each time, so the
     // cycle is [0, 1, 2, 3].
     for expected in &fresh {
-        let (_op, addr, tweak_idx, outcome) =
-            wallet_module.allocate_deposit_address_pooled(GAP).await?;
+        let (deposit_address, outcome) = wallet_module.allocate_deposit_address_pooled(GAP).await?;
         assert_matches!(
             outcome,
-            AllocateDepositOutcome::Reused { original_tweak_idx } if original_tweak_idx == tweak_idx
+            AllocateDepositOutcome::Reused { original_tweak_idx } if original_tweak_idx == expected.1
         );
-        assert_eq!(addr, expected.0);
-        assert_eq!(tweak_idx, expected.1);
+        assert_eq!(deposit_address.address, expected.0);
+        assert_eq!(deposit_address.tweak_idx, expected.1);
     }
 
     // After a full cycle, cursor wraps and we get the first entry again.
-    let (_op, addr, _tweak_idx, outcome) =
-        wallet_module.allocate_deposit_address_pooled(GAP).await?;
+    let (deposit_address, outcome) = wallet_module.allocate_deposit_address_pooled(GAP).await?;
     assert_matches!(outcome, AllocateDepositOutcome::Reused { .. });
-    assert_eq!(addr, fresh[0].0);
+    assert_eq!(deposit_address.address, fresh[0].0);
     Ok(())
 }
 
@@ -1013,10 +1019,9 @@ async fn allocate_deposit_address_pooled_used_address_shrinks_gap() -> anyhow::R
 
     let mut fresh = vec![];
     for _ in 0..GAP {
-        let (_op, addr, tweak_idx, outcome) =
-            wallet_module.allocate_deposit_address_pooled(GAP).await?;
+        let (deposit_address, outcome) = wallet_module.allocate_deposit_address_pooled(GAP).await?;
         assert_eq!(outcome, AllocateDepositOutcome::Fresh);
-        fresh.push((addr, tweak_idx));
+        fresh.push((deposit_address.address, deposit_address.tweak_idx));
     }
 
     // Send an on-chain deposit to the first address and drive it to a
@@ -1035,15 +1040,14 @@ async fn allocate_deposit_address_pooled_used_address_shrinks_gap() -> anyhow::R
     bitcoin.mine_blocks(finality_delay).await;
     wallet_module.await_num_deposits(used_tweak_idx, 1).await?;
 
-    let (_op, addr, _tweak_idx, outcome) =
-        wallet_module.allocate_deposit_address_pooled(GAP).await?;
+    let (deposit_address, outcome) = wallet_module.allocate_deposit_address_pooled(GAP).await?;
     assert_eq!(
         outcome,
         AllocateDepositOutcome::Fresh,
         "expected Fresh after deposit landed"
     );
     assert_ne!(
-        addr, used_addr,
+        deposit_address.address, used_addr,
         "fresh allocation must not collide with the used address"
     );
 

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -11,7 +11,7 @@ use fedimint_client::ClientHandleArc;
 use fedimint_client::secret::{PlainRootSecretStrategy, RootSecretStrategy};
 use fedimint_connectors::ConnectorRegistry;
 use fedimint_core::db::mem_impl::MemDatabase;
-use fedimint_core::db::{DatabaseTransaction, IRawDatabaseExt};
+use fedimint_core::db::{DatabaseTransaction, IDatabaseTransactionOpsCoreTyped, IRawDatabaseExt};
 use fedimint_core::module::{AmountUnit, serde_json};
 use fedimint_core::task::{TaskGroup, sleep_in_test};
 use fedimint_core::util::{BoxStream, NextOrPending, SafeUrl, retry};
@@ -928,16 +928,30 @@ async fn allocate_deposit_address_pooled_zero_gap_reuses_until_used() -> anyhow:
     let tweak_idx0 = deposit_address0.tweak_idx;
 
     // Subsequent calls keep returning the same address until a deposit lands
-    // on it.
+    // on it. Reuse must also keep pointing at the original operation instead
+    // of creating duplicate operation-log entries for the same address.
     for _ in 0..3 {
         let (deposit_address, outcome) = wallet_module.allocate_deposit_address_pooled(0).await?;
         assert_matches!(
             outcome,
             AllocateDepositOutcome::Reused { original_tweak_idx } if original_tweak_idx == tweak_idx0
         );
+        assert_eq!(deposit_address.operation_id, deposit_address0.operation_id);
         assert_eq!(deposit_address.address, addr0);
         assert_eq!(deposit_address.tweak_idx, tweak_idx0);
     }
+
+    let operations = client
+        .operation_log()
+        .paginate_operations_rev(10, None)
+        .await;
+    assert_eq!(
+        operations.len(),
+        1,
+        "reused addresses must not start new operations"
+    );
+    assert_eq!(operations[0].0.operation_id, deposit_address0.operation_id);
+
     Ok(())
 }
 
@@ -994,10 +1008,67 @@ async fn allocate_deposit_address_pooled_caps_and_reuses_round_robin() -> anyhow
         assert_eq!(deposit_address.tweak_idx, expected.1);
     }
 
-    // After a full cycle, cursor wraps and we get the first entry again.
+    // After a full cycle, cursor wraps to one of the reusable entries.
     let (deposit_address, outcome) = wallet_module.allocate_deposit_address_pooled(GAP).await?;
     assert_matches!(outcome, AllocateDepositOutcome::Reused { .. });
-    assert_eq!(deposit_address.address, fresh[0].0);
+    assert!(fresh.iter().any(|expected| {
+        expected.0 == deposit_address.address && expected.1 == deposit_address.tweak_idx
+    }));
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn allocate_deposit_address_pooled_reuse_resets_monitoring_schedule() -> anyhow::Result<()> {
+    let fixtures = fixtures();
+    let fed = fixtures.new_fed_degraded().await;
+    let client = fed.new_client().await;
+    let bitcoin = fixtures.bitcoin();
+    let bitcoin = bitcoin.lock_exclusive().await;
+    bitcoin.mine_blocks(10).await;
+    await_consensus_to_catch_up(&client, 1).await?;
+    await_consensus_upgrade(&client, &fed).await?;
+
+    let wallet_module = client.get_first_module::<WalletClientModule>()?;
+
+    let (original, outcome) = wallet_module.allocate_deposit_address_pooled(0).await?;
+    assert_eq!(outcome, AllocateDepositOutcome::Fresh);
+
+    let distant_past = fedimint_core::time::now() - Duration::from_secs(24 * 60 * 60);
+    {
+        let mut dbtx = wallet_module.db.begin_transaction().await;
+        let mut data = dbtx
+            .get_value(&fedimint_wallet_client::client_db::PegInTweakIndexKey(
+                original.tweak_idx,
+            ))
+            .await
+            .expect("allocated tweak must exist");
+        data.creation_time = distant_past;
+        data.last_check_time = Some(distant_past);
+        data.next_check_time = Some(distant_past + Duration::from_secs(60 * 60));
+        dbtx.insert_entry(
+            &fedimint_wallet_client::client_db::PegInTweakIndexKey(original.tweak_idx),
+            &data,
+        )
+        .await;
+        dbtx.commit_tx().await;
+    }
+
+    let (reused, outcome) = wallet_module.allocate_deposit_address_pooled(0).await?;
+    assert_matches!(
+        outcome,
+        AllocateDepositOutcome::Reused { original_tweak_idx } if original_tweak_idx == original.tweak_idx
+    );
+    assert_eq!(reused.operation_id, original.operation_id);
+    assert_eq!(reused.address, original.address);
+
+    let data = wallet_module
+        .get_pegin_tweak_idx(original.tweak_idx)
+        .await?;
+    assert!(distant_past < data.creation_time);
+    assert_eq!(data.last_check_time, None);
+    assert!(data.next_check_time.is_some());
+    assert!(distant_past < data.next_check_time.expect("next check time must be set"));
+
     Ok(())
 }
 

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -26,7 +26,9 @@ use fedimint_testing::federation::FederationTest;
 use fedimint_testing::fixtures::Fixtures;
 use fedimint_testing_core::config::API_AUTH;
 use fedimint_wallet_client::api::WalletFederationApi;
-use fedimint_wallet_client::{DepositStateV2, WalletClientInit, WalletClientModule, WithdrawState};
+use fedimint_wallet_client::{
+    AllocateDepositOutcome, DepositStateV2, WalletClientInit, WalletClientModule, WithdrawState,
+};
 use fedimint_wallet_common::config::WalletConfig;
 use fedimint_wallet_common::tweakable::Tweakable;
 use fedimint_wallet_common::txoproof::PegInProof;
@@ -897,6 +899,145 @@ async fn dust_deposits_are_ignored() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn allocate_deposit_address_pooled_zero_gap_reuses_until_used() -> anyhow::Result<()> {
+    let fixtures = fixtures();
+    let fed = fixtures.new_fed_degraded().await;
+    let client = fed.new_client().await;
+    let bitcoin = fixtures.bitcoin();
+    let bitcoin = bitcoin.lock_exclusive().await;
+    bitcoin.mine_blocks(10).await;
+    await_consensus_to_catch_up(&client, 1).await?;
+    await_consensus_upgrade(&client, &fed).await?;
+
+    let wallet_module = client.get_first_module::<WalletClientModule>()?;
+
+    // First call has nothing to reuse → Fresh.
+    let (_op, addr0, tweak_idx0, outcome0) =
+        wallet_module.allocate_deposit_address_pooled(0).await?;
+    assert_eq!(outcome0, AllocateDepositOutcome::Fresh);
+
+    // Subsequent calls keep returning the same address until a deposit lands
+    // on it.
+    for _ in 0..3 {
+        let (_op, addr, tweak_idx, outcome) =
+            wallet_module.allocate_deposit_address_pooled(0).await?;
+        assert_matches!(
+            outcome,
+            AllocateDepositOutcome::Reused { original_tweak_idx } if original_tweak_idx == tweak_idx0
+        );
+        assert_eq!(addr, addr0);
+        assert_eq!(tweak_idx, tweak_idx0);
+    }
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn allocate_deposit_address_pooled_caps_and_reuses_round_robin() -> anyhow::Result<()> {
+    let fixtures = fixtures();
+    let fed = fixtures.new_fed_degraded().await;
+    let client = fed.new_client().await;
+    let bitcoin = fixtures.bitcoin();
+    let bitcoin = bitcoin.lock_exclusive().await;
+    bitcoin.mine_blocks(10).await;
+    await_consensus_to_catch_up(&client, 1).await?;
+    await_consensus_upgrade(&client, &fed).await?;
+
+    let wallet_module = client.get_first_module::<WalletClientModule>()?;
+
+    const GAP: usize = 4;
+
+    // Fill the gap: every call should be Fresh and yield a distinct address.
+    let mut fresh: Vec<(
+        bitcoin::Address,
+        fedimint_wallet_client::client_db::TweakIdx,
+    )> = vec![];
+    for _ in 0..GAP {
+        let (_op, addr, tweak_idx, outcome) =
+            wallet_module.allocate_deposit_address_pooled(GAP).await?;
+        assert_eq!(outcome, AllocateDepositOutcome::Fresh);
+        fresh.push((addr, tweak_idx));
+    }
+    let unique_addrs: HashSet<_> = fresh.iter().map(|(a, _)| a.script_pubkey()).collect();
+    assert_eq!(unique_addrs.len(), GAP);
+
+    // Past the cap: round-robin reuse, starting from the oldest. Cursor
+    // begins at TweakIdx(0) and advances to picked.next() each time, so the
+    // cycle is [0, 1, 2, 3].
+    for expected in &fresh {
+        let (_op, addr, tweak_idx, outcome) =
+            wallet_module.allocate_deposit_address_pooled(GAP).await?;
+        assert_matches!(
+            outcome,
+            AllocateDepositOutcome::Reused { original_tweak_idx } if original_tweak_idx == tweak_idx
+        );
+        assert_eq!(addr, expected.0);
+        assert_eq!(tweak_idx, expected.1);
+    }
+
+    // After a full cycle, cursor wraps and we get the first entry again.
+    let (_op, addr, _tweak_idx, outcome) =
+        wallet_module.allocate_deposit_address_pooled(GAP).await?;
+    assert_matches!(outcome, AllocateDepositOutcome::Reused { .. });
+    assert_eq!(addr, fresh[0].0);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn allocate_deposit_address_pooled_used_address_shrinks_gap() -> anyhow::Result<()> {
+    let fixtures = fixtures();
+    let fed = fixtures.new_fed_degraded().await;
+    let client = fed.new_client().await;
+    let bitcoin = fixtures.bitcoin();
+    let bitcoin = bitcoin.lock_exclusive().await;
+    let finality_delay = 10;
+    bitcoin.mine_blocks(finality_delay).await;
+    await_consensus_to_catch_up(&client, 1).await?;
+    await_consensus_upgrade(&client, &fed).await?;
+
+    let wallet_module = client.get_first_module::<WalletClientModule>()?;
+
+    const GAP: usize = 3;
+
+    let mut fresh = vec![];
+    for _ in 0..GAP {
+        let (_op, addr, tweak_idx, outcome) =
+            wallet_module.allocate_deposit_address_pooled(GAP).await?;
+        assert_eq!(outcome, AllocateDepositOutcome::Fresh);
+        fresh.push((addr, tweak_idx));
+    }
+
+    // Send an on-chain deposit to the first address and drive it to a
+    // claimed state — that's what flips `PegInTweakIndexData::claimed` from
+    // empty to non-empty in the DB, which is what shrinks the gap. The gap
+    // (count of unused with idx > last_used) drops from GAP=3 to 2, so the
+    // next call should allocate Fresh again.
+    let (used_addr, used_tweak_idx) = fresh[0].clone();
+    let _ = bitcoin
+        .send_and_mine_block(
+            &used_addr,
+            bsats(PEG_IN_AMOUNT_SATS)
+                + bsats(wallet_module.get_fee_consensus().peg_in_abs.msats / 1000),
+        )
+        .await;
+    bitcoin.mine_blocks(finality_delay).await;
+    wallet_module.await_num_deposits(used_tweak_idx, 1).await?;
+
+    let (_op, addr, _tweak_idx, outcome) =
+        wallet_module.allocate_deposit_address_pooled(GAP).await?;
+    assert_eq!(
+        outcome,
+        AllocateDepositOutcome::Fresh,
+        "expected Fresh after deposit landed"
+    );
+    assert_ne!(
+        addr, used_addr,
+        "fresh allocation must not collide with the used address"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn construct_wallet_summary() -> anyhow::Result<()> {
     let fixtures = fixtures();
     let fed = fixtures.new_fed_degraded().await;
@@ -1652,6 +1793,7 @@ mod fedimint_migration_tests {
                         client_db::DbKeyPrefix::RecoveryFinalized => {}
                         client_db::DbKeyPrefix::RecoveryState => {}
                         client_db::DbKeyPrefix::SupportsSafeDeposit => {}
+                        client_db::DbKeyPrefix::PegInPoolCursor => {}
                         client_db::DbKeyPrefix::ExternalReservedStart
                         | client_db::DbKeyPrefix::CoreInternalReservedStart
                         | client_db::DbKeyPrefix::CoreInternalReservedEnd => {}

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -27,7 +27,8 @@ use fedimint_testing::fixtures::Fixtures;
 use fedimint_testing_core::config::API_AUTH;
 use fedimint_wallet_client::api::WalletFederationApi;
 use fedimint_wallet_client::{
-    AllocateDepositOutcome, DepositStateV2, WalletClientInit, WalletClientModule, WithdrawState,
+    AllocateDepositOutcome, DepositStateV2, MaybeNewAddress, WalletClientInit, WalletClientModule,
+    WithdrawState,
 };
 use fedimint_wallet_common::config::WalletConfig;
 use fedimint_wallet_common::tweakable::Tweakable;
@@ -959,6 +960,18 @@ async fn allocate_deposit_address_pooled_caps_and_reuses_round_robin() -> anyhow
     }
     let unique_addrs: HashSet<_> = fresh.iter().map(|(a, _)| a.script_pubkey()).collect();
     assert_eq!(unique_addrs.len(), GAP);
+
+    let stateless = wallet_module
+        .allocate_deposit_address_pooled_stateless(GAP)
+        .await?;
+    let MaybeNewAddress::TooManyUnusedAddresses { addresses } = stateless else {
+        panic!("expected reusable addresses from stateless allocation");
+    };
+    assert_eq!(addresses.len(), GAP);
+    for (available, expected) in addresses.iter().zip(&fresh) {
+        assert_eq!(available.address, expected.0);
+        assert_eq!(available.tweak_idx, expected.1);
+    }
 
     // Past the cap: round-robin reuse, starting from the oldest. Cursor
     // begins at TweakIdx(0) and advances to picked.next() each time, so the


### PR DESCRIPTION
…llocate_deposit_address_pooled`


With some Fedi app UI changes the on-chain deposit addresses are now more easy to generate, and we just had a first report where user generated a gap of addresses larger than our recovery MAX_GAP, then did a recovery close to time of the deposit, and did not see the funds afterwards. Generating the deposit 10 times re-derived same address and noticed the peg-in, but this is confusing and not a good UX.

So it made me think - maybe we could have a convenient way to cycle through the unused addresses within the current peg-in addresses gap range. This makes it so if the user just keeps generating addresses that they don't really use (no deposits), they will not cross the gab limit, balancing the privacy, resource usage and UX.

I think as a follow-up I'm also going to increase the max gap size during recovery to 20, just to make conditions like this even more unlikely.

This change:

Adds a sibling to `allocate_deposit_address_expert_only` that bounds the gap of consecutive unused addresses past the last-used one. UIs that show a "Receive on-chain" QR each time the user opens the screen would otherwise leave one peg-in tweak, `OperationId`, and `subscribe_deposit` task per visit, all re-spawned on every client start by walking `list_peg_in_tweak_idxes` — unbounded growth for users who never actually receive on-chain.

Unbounded growth in unused addresses also breaks recovery: for privacy and practical reasons we can only scan a fixed gap of unused addresses before giving up and assuming no further addresses were previously generated. A long sparse tail of never-used pool entries past the gap limit makes recovery silently miss the in-use ones beyond it.

`allocate_deposit_address_pooled(max_gap_size)` defines `gap` as the count of unused tweak indices strictly greater than the highest used one (or the count of all allocated tweaks if none have been used yet), and returns:
  - `Reused { original_tweak_idx }` when `gap >= max_gap_size` and there is at least one unused address to reuse, picking round-robin (cursor = next-to-consider, cycle [0, 1, 2, ...] with wraparound) via the persisted `PegInPoolCursorKey`.
  - `Fresh` otherwise, performing the same work as `allocate_deposit_address_expert_only`.

`max_gap_size == 0` therefore means "only allocate fresh when the previous address was already used"; the very first call still allocates fresh because there are no addresses to reuse. `max_gap_size == usize::MAX` matches `_expert_only` (always `Fresh`).

The "unused" check is authoritative against `DepositStateV2`: `PegInTweakIndexData::claimed.is_empty()` plus an empty `get_script_history` for the address. Relying on `claimed` alone would incorrectly reuse an address whose deposit `pegin_monitor` has already observed but not yet finished claiming.

Cursor advance and (in `Fresh` cases) the new tweak insertion happen inside a single `db.autocommit`, so concurrent callers can't both pick the same address or both decide to allocate fresh past the cap.

On reuse, `creation_time`, `last_check_time`, and `next_check_time` of the underlying tweak entry are reset to "now" and `pegin_monitor` is woken up. Without this an old entry keeps its long stale age-proportional next-check delay and a user sending to it could wait a long time before the client polls for the deposit.

Adds `DbKeyPrefix::PegInPoolCursor = 0x32` and `PegInPoolCursorKey -> TweakIdx`. Reads default to `TweakIdx(0)` when absent, so no migration record is needed for existing DBs.

Backward compatible: `_expert_only` is unchanged; this is the "with policy" sibling.

Tests cover `max_gap_size = 0` (fresh once, then reuse the same address indefinitely), the fresh-fill / round-robin / wraparound cycle for a non-trivial gap, and the case where an on-chain deposit lands on a tail address and shrinks the gap so the next call allocates fresh again.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
