### PR TITLE
docs(gateway): document implicit event_kinds filtering in payment_log API

### DIFF
--- a/gateway/fedimint-gateway-common/src/lib.rs
+++ b/gateway/fedimint-gateway-common/src/lib.rs
@@ -275,6 +275,14 @@ pub struct PaymentLogPayload {
     pub pagination_size: usize,
 
     pub federation_id: FederationId,
+
+    /// Filter to only return events of these kinds. If empty, defaults to
+    /// `ALL_GATEWAY_EVENTS` (gateway payment-related events only, not all
+    /// events in the log).
+    ///
+    /// Note: returned event IDs may be non-contiguous because other internal
+    /// events (e.g. `tx-created`, `NoteCreated`) share the same ID space but
+    /// are filtered out.
     pub event_kinds: Vec<EventKind>,
 }
 

--- a/gateway/fedimint-gateway-server/src/events.rs
+++ b/gateway/fedimint-gateway-server/src/events.rs
@@ -13,6 +13,12 @@ use fedimint_gwv2_client::events::{
 use fedimint_mint_client::events::{OOBNotesReissued, OOBNotesSpent};
 use fedimint_wallet_client::events::{DepositConfirmed, WithdrawRequest};
 
+/// The set of gateway payment-related event kinds used as the default filter
+/// for the `payment_log` API when no explicit `event_kinds` are provided.
+///
+/// This does not include all events in the log (e.g. `tx-created`,
+/// `tx-accepted`, `NoteCreated`, `NoteSpent` are excluded), so paginated
+/// results filtered to these kinds will have non-contiguous event IDs.
 pub const ALL_GATEWAY_EVENTS: [EventKind; 11] = [
     OutgoingPaymentStarted::KIND,
     OutgoingPaymentSucceeded::KIND,

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -2651,6 +2651,16 @@ impl IAdminGateway for Gateway {
     }
 
     /// Queries the client log for payment events and returns to the user.
+    /// Returns a paginated list of gateway payment-related events, ordered from
+    /// newest to oldest.
+    ///
+    /// If `event_kinds` is empty, only events matching `ALL_GATEWAY_EVENTS`
+    /// are returned — this is **not** equivalent to "all events". Other
+    /// internal events (e.g. `tx-created`, `NoteCreated`) share the same event
+    /// log and consume IDs, so returned event IDs may be non-contiguous.
+    ///
+    /// Pagination works backwards from `end_position` (or the log tip if
+    /// `None`), returning at most `pagination_size` matching events.
     async fn handle_payment_log_msg(
         &self,
         PaymentLogPayload {
@@ -2669,6 +2679,9 @@ impl IAdminGateway for Gateway {
             })?
             .value();
 
+        // An empty `event_kinds` defaults to gateway payment-related events, not
+        // "all events". This means returned event IDs may be non-contiguous since
+        // other internal events share the same ID space.
         let event_kinds = if event_kinds.is_empty() {
             ALL_GATEWAY_EVENTS.to_vec()
         } else {

--- a/gateway/fedimint-gateway-server/src/rpc_server.rs
+++ b/gateway/fedimint-gateway-server/src/rpc_server.rs
@@ -806,6 +806,12 @@ pub(crate) async fn stop(
     Ok(Json(json!(())))
 }
 
+/// `POST /payment_log` — returns a paginated list of gateway payment events.
+///
+/// If `event_kinds` is empty, only gateway payment-related events
+/// ([`ALL_GATEWAY_EVENTS`](crate::events::ALL_GATEWAY_EVENTS)) are returned.
+/// This means returned event IDs may be non-contiguous because other internal
+/// events share the same ID space but are excluded by default.
 #[instrument(target = LOG_GATEWAY, skip_all, err)]
 async fn payment_log(
     Extension(gateway): Extension<Arc<Gateway>>,


### PR DESCRIPTION
## Summary
- Document that empty `event_kinds` defaults to `ALL_GATEWAY_EVENTS` (gateway payment-related events only), not all events in the log
- Document that returned event IDs may be non-contiguous since other internal events share the same ID space
- Add doc comments to the route handler, internal method, `PaymentLogPayload` struct field, and `ALL_GATEWAY_EVENTS` constant

Closes #8565

## Test plan
- [ ] `cargo check` passes
- [ ] `cargo doc` renders the new comments correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)