### PR TITLE
fix(devimint): use non-empty bitcoind wallet name

### DIFF
--- a/devimint/src/external.rs
+++ b/devimint/src/external.rs
@@ -75,7 +75,7 @@ impl Bitcoind {
             .without_auth()
             .map_err(|()| anyhow!("Failed to strip auth from Bitcoin Rpc Url"))?
             .to_string();
-        let wallet_name = "";
+        let wallet_name = "default";
         let host = format!("{host}wallet/{wallet_name}");
 
         debug!(target: LOG_DEVIMINT, "bitcoind host: {:?}, auth: {:?}", &host, auth);
@@ -124,7 +124,7 @@ impl Bitcoind {
         debug!(target: LOG_DEVIMINT, "Setting up bitcoind...");
         // create RPC wallet
         for attempt in 0.. {
-            match block_in_place(|| client.create_wallet("", None, None, None, None)) {
+            match block_in_place(|| client.create_wallet("default", None, None, None, None)) {
                 Ok(_) => {
                     break;
                 }

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "advisory-db": {
       "flake": false,
       "locked": {
-        "lastModified": 1774906818,
-        "narHash": "sha256-COucnjXdgN4H1Ze1EIAxmdrv2CtGKIAMv9Fp9GCMMf0=",
+        "lastModified": 1777660670,
+        "narHash": "sha256-C8hgon8MOPJWA67TH1PHEziDwpsSdJN2CpFdKTwb6ZI=",
         "owner": "rustsec",
         "repo": "advisory-db",
-        "rev": "4d2c416daab78050bd9bf5d84e3d91c43d7b04c9",
+        "rev": "20377f44edabca7c4a765ccdcd05935331b6191f",
         "type": "github"
       },
       "original": {
@@ -535,11 +535,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1775002709,
-        "narHash": "sha256-d3Yx83vSrN+2z/loBh4mJpyRqr9aAJqlke4TkpFmRJA=",
+        "lastModified": 1777673416,
+        "narHash": "sha256-5c2POKPOjU40Kh0MirOdScBLG0bu9TAuPYAtPRNZMBs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "bcd464ccd2a1a7cd09aa2f8d4ffba83b761b1d0e",
+        "rev": "26ef669cffa904b6f6832ab57b77892a37c1a671",
         "type": "github"
       },
       "original": {
@@ -742,11 +742,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775089439,
-        "narHash": "sha256-Ef2A6YON5N9GsapHg0Tvidig5Fn2kZxHo9NdqzEA6vk=",
+        "lastModified": 1777897549,
+        "narHash": "sha256-jjaMgzO+TS21nGPgPs9+8PfCnpaNWTUfZxhuGpzvH74=",
         "owner": "davidlattimore",
         "repo": "wild",
-        "rev": "9a7ad7cb05bce0487a7089bffe95452b43d07cfb",
+        "rev": "6afbc3116954367411bf073e8b32276447b6ef74",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
- Includes `nix flake update` from #8564
- Bitcoin Core (updated via the flake update) now rejects empty wallet names with `"Wallet name cannot be empty"`
- Changes devimint's bitcoind wallet name from `""` to `"default"` in both the URL path and `create_wallet` call

## Test plan
- [ ] Build on linux passes
- [ ] Backwards-compatibility tests pass
- [ ] Upgrade tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)