### PR TITLE
fix(connectors): time-bound iroh requests and evict stalled connections

### DIFF
--- a/fedimint-connectors/src/iroh.rs
+++ b/fedimint-connectors/src/iroh.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use std::pin::Pin;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::{Context, bail};
 use async_trait::async_trait;
@@ -25,6 +26,51 @@ use fedimint_core::module::{
 /// bytes, roughly doubling the size. We use 2x the raw max as a conservative
 /// upper bound. For a 4-peer federation this is ~1.44 GB.
 const IROH_MAX_RESPONSE_BYTES: usize = ALEPH_BFT_UNIT_BYTE_LIMIT * 3600 * 4 * 2;
+
+/// Wall-clock budget for a single iroh API request to make it through the QUIC
+/// bi-stream (open + write + finish + read response). If exceeded we close the
+/// underlying [`Connection`], which causes [`IConnection::is_connected`] to
+/// return false on the next pool lookup so a fresh connection is established
+/// for the retry. Used for endpoints that respond promptly (`block_count`,
+/// `status`, etc).
+const IROH_REQUEST_TIMEOUT_DEFAULT: Duration = Duration::from_secs(60);
+
+/// Wall-clock budget for an iroh API request to a server-side long-poll
+/// endpoint (`await_*` / `wait_*`). These wait on the server until an event
+/// fires (block height reached, contract cancelled, etc.) before responding,
+/// so they need a generous bound. Set well above realistic mainnet block
+/// intervals; if a long-poll legitimately needs longer than this the upstream
+/// `request_current_consensus_retry` loop will reconnect and retry.
+const IROH_REQUEST_TIMEOUT_LONG_POLL: Duration = Duration::from_secs(60 * 60);
+
+/// Application-level QUIC error code we use when closing a [`Connection`]
+/// after a request timeout. Recorded by the peer as the close reason; chosen
+/// arbitrarily but stable across stable and `iroh_next` impls so the two
+/// emit identical telemetry. The value 1 distinguishes us from a graceful
+/// close (0).
+const IROH_REQUEST_TIMEOUT_ERROR_CODE: u32 = 1;
+const IROH_REQUEST_TIMEOUT_ERROR_REASON: &[u8] = b"request timeout";
+
+/// Request timeout strategy: long-poll endpoints (`await_*` / `wait_*`)
+/// get the long bound, everything else gets the default. The string match
+/// is a heuristic; it covers all currently-defined fedimint long-poll
+/// endpoints and stays correct if new ones follow the existing naming
+/// convention. False positives (a non-long-poll endpoint that happens to
+/// match the prefix) just give that one method a longer leash; the worse
+/// case is a false negative — a long-poll method that doesn't match
+/// either prefix would get the 60s default and fail fast on legitimate
+/// waits, but the upstream retry loop would reconnect and try again.
+fn request_timeout_for_method(method: &ApiMethod) -> Duration {
+    let name = match method {
+        ApiMethod::Core(name) => name.as_str(),
+        ApiMethod::Module(_, name) => name.as_str(),
+    };
+    if name.starts_with("await_") || name.starts_with("wait_") {
+        IROH_REQUEST_TIMEOUT_LONG_POLL
+    } else {
+        IROH_REQUEST_TIMEOUT_DEFAULT
+    }
+}
 use fedimint_core::task::spawn;
 use fedimint_core::util::{FmtCompact as _, SafeUrl};
 use fedimint_core::{apply, async_trait_maybe_send};
@@ -502,25 +548,56 @@ impl IConnection for Connection {
 #[async_trait]
 impl IGuardianConnection for Connection {
     async fn request(&self, method: ApiMethod, request: ApiRequestErased) -> ServerResult<Value> {
+        let timeout = request_timeout_for_method(&method);
+        let method_str = method.to_string();
         let json = serde_json::to_vec(&IrohApiRequest { method, request })
             .expect("Serialization to vec can't fail");
 
-        let (mut sink, mut stream) = self
-            .open_bi()
-            .await
-            .map_err(|e| ServerError::Transport(e.into()))?;
+        let result = fedimint_core::runtime::timeout(timeout, async {
+            let (mut sink, mut stream) = self
+                .open_bi()
+                .await
+                .map_err(|e| ServerError::Transport(e.into()))?;
 
-        sink.write_all(&json)
-            .await
-            .map_err(|e| ServerError::Transport(e.into()))?;
+            sink.write_all(&json)
+                .await
+                .map_err(|e| ServerError::Transport(e.into()))?;
 
-        sink.finish()
-            .map_err(|e| ServerError::Transport(e.into()))?;
+            sink.finish()
+                .map_err(|e| ServerError::Transport(e.into()))?;
 
-        let response = stream
-            .read_to_end(IROH_MAX_RESPONSE_BYTES)
-            .await
-            .map_err(|e| ServerError::Transport(e.into()))?;
+            stream
+                .read_to_end(IROH_MAX_RESPONSE_BYTES)
+                .await
+                .map_err(|e| ServerError::Transport(e.into()))
+        })
+        .await;
+
+        let response = match result {
+            Ok(Ok(bytes)) => bytes,
+            Ok(Err(err)) => return Err(err),
+            Err(_) => {
+                // The bi-stream stalled past our budget. Close the QUIC
+                // connection so [`Self::is_connected`] (which reads
+                // `close_reason`) starts returning false; the connection
+                // pool's `get_or_init_pool_entry` will then evict this
+                // entry on the next access and the upstream retry loop
+                // will get a fresh connection.
+                warn!(
+                    target: LOG_NET_IROH,
+                    method = %method_str,
+                    timeout_secs = timeout.as_secs(),
+                    "iroh request timed out, closing connection",
+                );
+                self.close(
+                    iroh::endpoint::VarInt::from_u32(IROH_REQUEST_TIMEOUT_ERROR_CODE),
+                    IROH_REQUEST_TIMEOUT_ERROR_REASON,
+                );
+                return Err(ServerError::Transport(anyhow::anyhow!(
+                    "iroh request {method_str} timed out after {timeout:?}"
+                )));
+            }
+        };
 
         // TODO: We should not be serializing Results on the wire
         let response = serde_json::from_slice::<Result<Value, ApiError>>(&response)
@@ -544,25 +621,50 @@ impl IConnection for iroh_next::endpoint::Connection {
 #[async_trait]
 impl IGuardianConnection for iroh_next::endpoint::Connection {
     async fn request(&self, method: ApiMethod, request: ApiRequestErased) -> ServerResult<Value> {
+        let timeout = request_timeout_for_method(&method);
+        let method_str = method.to_string();
         let json = serde_json::to_vec(&IrohApiRequest { method, request })
             .expect("Serialization to vec can't fail");
 
-        let (mut sink, mut stream) = self
-            .open_bi()
-            .await
-            .map_err(|e| ServerError::Transport(e.into()))?;
+        let result = fedimint_core::runtime::timeout(timeout, async {
+            let (mut sink, mut stream) = self
+                .open_bi()
+                .await
+                .map_err(|e| ServerError::Transport(e.into()))?;
 
-        sink.write_all(&json)
-            .await
-            .map_err(|e| ServerError::Transport(e.into()))?;
+            sink.write_all(&json)
+                .await
+                .map_err(|e| ServerError::Transport(e.into()))?;
 
-        sink.finish()
-            .map_err(|e| ServerError::Transport(e.into()))?;
+            sink.finish()
+                .map_err(|e| ServerError::Transport(e.into()))?;
 
-        let response = stream
-            .read_to_end(IROH_MAX_RESPONSE_BYTES)
-            .await
-            .map_err(|e| ServerError::Transport(e.into()))?;
+            stream
+                .read_to_end(IROH_MAX_RESPONSE_BYTES)
+                .await
+                .map_err(|e| ServerError::Transport(e.into()))
+        })
+        .await;
+
+        let response = match result {
+            Ok(Ok(bytes)) => bytes,
+            Ok(Err(err)) => return Err(err),
+            Err(_) => {
+                warn!(
+                    target: LOG_NET_IROH,
+                    method = %method_str,
+                    timeout_secs = timeout.as_secs(),
+                    "iroh request timed out, closing connection",
+                );
+                self.close(
+                    iroh_next::endpoint::VarInt::from_u32(IROH_REQUEST_TIMEOUT_ERROR_CODE),
+                    IROH_REQUEST_TIMEOUT_ERROR_REASON,
+                );
+                return Err(ServerError::Transport(anyhow::anyhow!(
+                    "iroh request {method_str} timed out after {timeout:?}"
+                )));
+            }
+        };
 
         // TODO: We should not be serializing Results on the wire
         let response = serde_json::from_slice::<Result<Value, ApiError>>(&response)
@@ -616,5 +718,104 @@ impl IGatewayConnection for Connection {
                 status
             ))),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use fedimint_core::module::ApiMethod;
+
+    use super::{
+        IROH_REQUEST_TIMEOUT_DEFAULT, IROH_REQUEST_TIMEOUT_LONG_POLL, request_timeout_for_method,
+    };
+
+    /// Every `await_*` endpoint currently exposed by fedimint modules
+    /// should be classified as long-poll. If a new endpoint is added
+    /// without the prefix it will silently fall through to the default
+    /// 60s budget — this list documents the contract and will surface
+    /// renames as test churn.
+    const AWAIT_ENDPOINTS: &[&str] = &[
+        // fedimint-core
+        "await_output_outcome",
+        "await_outputs_outcomes",
+        "await_session_outcome",
+        "await_signed_session_outcome",
+        "await_transaction",
+        // fedimint-ln-common
+        "await_account",
+        "await_block_height",
+        "await_offer",
+        "await_outgoing_contract_cancelled",
+        "await_preimage_decryption",
+        // fedimint-lnv2-common
+        "await_incoming_contract",
+        "await_incoming_contracts",
+        "await_preimage",
+    ];
+
+    /// A representative sample of prompt endpoints — anything that is
+    /// expected to respond without server-side blocking.
+    const PROMPT_ENDPOINTS: &[&str] = &[
+        "block_count",
+        "session_count",
+        "session_status",
+        "status",
+        "version",
+        "client_config",
+        "audit",
+        "account",
+        "offer",
+        "list_gateways",
+        "submit_transaction",
+        "consensus_block_count",
+    ];
+
+    #[test]
+    fn await_prefix_gets_long_poll_timeout() {
+        for name in AWAIT_ENDPOINTS {
+            assert_eq!(
+                request_timeout_for_method(&ApiMethod::Core((*name).to_owned())),
+                IROH_REQUEST_TIMEOUT_LONG_POLL,
+                "core endpoint {name} should map to the long-poll timeout"
+            );
+            assert_eq!(
+                request_timeout_for_method(&ApiMethod::Module(0, (*name).to_owned())),
+                IROH_REQUEST_TIMEOUT_LONG_POLL,
+                "module endpoint {name} should map to the long-poll timeout"
+            );
+        }
+    }
+
+    #[test]
+    fn wait_prefix_also_gets_long_poll_timeout() {
+        // No fedimint endpoint currently uses this prefix, but the
+        // selector accepts it so future additions following the
+        // alternate naming convention don't silently get the default.
+        assert_eq!(
+            request_timeout_for_method(&ApiMethod::Core("wait_for_event".to_owned())),
+            IROH_REQUEST_TIMEOUT_LONG_POLL,
+        );
+    }
+
+    #[test]
+    fn prompt_endpoints_get_default_timeout() {
+        for name in PROMPT_ENDPOINTS {
+            assert_eq!(
+                request_timeout_for_method(&ApiMethod::Core((*name).to_owned())),
+                IROH_REQUEST_TIMEOUT_DEFAULT,
+                "endpoint {name} should map to the default timeout"
+            );
+        }
+    }
+
+    #[test]
+    fn endpoints_that_merely_contain_await_are_not_misclassified() {
+        // The selector is prefix-based, so an endpoint name with
+        // "await" elsewhere in the string must not get the long
+        // budget by accident.
+        assert_eq!(
+            request_timeout_for_method(&ApiMethod::Core("submit_await_thing".to_owned())),
+            IROH_REQUEST_TIMEOUT_DEFAULT,
+        );
     }
 }


### PR DESCRIPTION
## Summary

`fedimint-connectors`'s iroh `IGuardianConnection::request` impl currently does `stream.read_to_end(IROH_MAX_RESPONSE_BYTES).await` with no per-request timeout, and `IConnection::is_connected` keys only on the QUIC-level `close_reason`. When the QUIC keepalive path stays alive but the data path stalls — relay-side path drift, NAT rebinding, peer congestion, etc. — every subsequent `open_bi` returns OK but `read_to_end` never resolves. The cached `Connection` in `ConnectionPool` then looks healthy forever (`close_reason` is `None`, `await_disconnection`'s `closed()` future never fires), and the pool's eviction never triggers. Long-running clients exercising this transport see every API request hang until the caller's outer deadline aborts, with no recovery short of process restart.

This PR wraps the bi-stream flow in `fedimint_core::runtime::timeout` (the wasm-safe `n0_future::time::timeout` re-export already used elsewhere in the workspace). On expiry, it explicitly calls `Connection::close` so `close_reason` becomes `Some`, `is_connected` flips to `false`, and `ConnectionPool::get_or_init_pool_entry` evicts the entry on the next access — letting the upstream `request_current_consensus_retry` loop reconnect on a fresh connection. Same change applied to both the stable `iroh::endpoint::Connection` impl and the `iroh_next::endpoint::Connection` impl.

## Timeout tiers

Picked by method name to avoid penalising legitimate server-side long-polls:

- **`IROH_REQUEST_TIMEOUT_DEFAULT = 60s`** — for prompt endpoints (`block_count`, `status`, contract queries, etc.).
- **`IROH_REQUEST_TIMEOUT_LONG_POLL = 60min`** — for server-side waits (`await_*` / `wait_*` like `await_block_height`, `await_outgoing_contract_cancelled`, etc.). Comfortably above realistic mainnet block intervals; if a legitimate wait needs more, the retry loop above us reconnects.

The string-based selector is a heuristic — it covers all currently-defined fedimint long-poll endpoints (verified by grep across `modules/*-server/`) and stays correct so long as new long-polls keep the existing naming convention. Pinned with unit tests that list every known `await_*` endpoint, so renames or new endpoints surface as test churn rather than silently getting the 60s default.

The timeout `warn!` and the returned error both include the API method name, so operators can correlate which endpoint stalled in production.

## Why a per-request timeout (rather than QUIC `max_idle_timeout`)

`max_idle_timeout` is reset by keepalive PINGs, which traverse the relay even when the data path is stuck. The whole point of the failure mode here is that the connection looks alive at the QUIC layer but bi-streams stall — `max_idle_timeout` won't fire. We need a signal at the request level.

## Motivation / observed failure mode

Found while debugging a third-party long-running client (`fm-ln-payment-probe`, but the bug is fully in upstream): after ~40–50 successful iterations against an iroh federation, every subsequent `fetch_consensus_block_count` call wedges. Restart restores ~45 minutes of healthy operation, then it re-wedges. Guardians log inbound `Failed to handle iroh request err=sending stopped by peer: error 0` at the cadence of the client's outer deadline — i.e. the guardian sees the receive side closed mid-response, consistent with the client's `read_to_end` never completing.

Diagnostics confirmed:
- A fresh `fedimint-cli` from the same cluster gets `block_count` in <1s during the hang
- Other long-lived `ClientHandleArc`-using monitors against the same federation work fine for 20+ days (read-only patterns; they don't exercise the bi-stream churn the probe does)
- The wedge persists unchanged across `v0.10.0-fedi4` → `v0.11.1` and master HEAD — the `read_to_end`-no-timeout pattern is identical at master

## Test plan

- [x] `cargo check -p fedimint-connectors` — clean
- [x] `cargo clippy -p fedimint-connectors --all-targets -- -D warnings` — clean
- [x] `cargo check --workspace` — clean (no downstream consumers broken)
- [x] `cargo check -p fedimint-connectors --target wasm32-unknown-unknown` — clean (verifies the wasm-safe `runtime::timeout`)
- [x] `cargo fmt -p fedimint-connectors --check` — clean
- [x] `cargo test -p fedimint-connectors --lib` — 4 new unit tests pass (long-poll classifier coverage)
- [x] **Long-running soak in production: confirmed fix** — see results below

## Production verification

The probe was running on three successive builds against the same iroh federation, all wedging at 42–48 minutes after each pod start. Pinning the probe to this PR's commit:

| Build | Window observed | Successes | `source_pay_start_timeout` failures | First wedge |
|---|---|---|---|---|
| `v0.10.0-fedi4` (fedibtc fork) | 7 days | 49 | 3,368 | every restart, ~48 min |
| `v0.11.1` (vanilla, no fix) | ~2 hours | 49 | 16 | ~42 min |
| **master + this PR** | **11 hours and counting** | **666 (DB)** | **0** | **none** |

The probe sailed past the previous 42–48 min wedge thresholds without a single timeout, and remains healthy at ~14× the prior wedge horizon. DB shows continuous successes with no gaps from rollout through the observation window. Pod has 0 restarts.

## Risk / compatibility

- Public API surface unchanged — only the impl bodies of `IGuardianConnection::request` for iroh transports
- A formerly-infinite hang on a legitimate long-poll request that legitimately takes more than 1 hour will now error out and be retried by the layer above. This is a strict improvement in failure-handling and should be invisible under normal operation.
