### PR TITLE
fix(devimint): scan tip block when polling transactions

### DIFF
--- a/devimint/src/external.rs
+++ b/devimint/src/external.rs
@@ -311,14 +311,14 @@ impl Bitcoind {
             other => return other,
         }
 
-        let block_height = self.get_block_count().await? - 1;
+        let block_count = self.get_block_count().await?;
 
         // Check each block for the tx, starting at the chain tip.
         // Buffer the requests to avoid spamming bitcoind.
         // We're doing this after checking the mempool since the tx should
         // usually be in the mempool, and we don't want to needlessly hit
         // the bitcoind with block requests.
-        let mut buffered_tx_stream = futures::stream::iter((0..block_height).rev())
+        let mut buffered_tx_stream = futures::stream::iter((0..block_count).rev())
             .map(|height| async move {
                 let block_hash = self.get_block_hash(height).await?;
                 self.get_raw_transaction(txid, Some(block_hash)).await


### PR DESCRIPTION
CI failure: https://github.com/fedimint/fedimint/actions/runs/25274001329/job/74100857773

Investigation found gw_liquidity_test_mintv2 failing during peg-out verification with "Polling Waiting for transaction in mempool failed". The peg-out transaction had already been mined, but devimint::Bitcoind::get_transaction scanned blocks with 0..block_count after subtracting one from the devimint block count. Since devimint::Bitcoind::get_block_count returns the total number of blocks, valid block heights are 0..block_count, and the previous range skipped the chain tip.

Fix by scanning 0..block_count in reverse, so every valid block height, including the latest block, is checked.

BTW. This is a first PR made with Tau.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
