### PR TITLE
feat(gateway): LightningMode::None — gateway with no Lightning node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4117,6 +4117,7 @@ dependencies = [
  "fedimint-lnv2-common",
  "fedimint-lnv2-server",
  "fedimint-logging",
+ "fedimint-portalloc",
  "fedimint-testing",
  "futures",
  "itertools 0.14.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3870,6 +3870,7 @@ name = "fedimint-lightning"
 version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
+ "async-stream",
  "async-trait",
  "bitcoin",
  "fedimint-bip39",

--- a/devimint/src/external.rs
+++ b/devimint/src/external.rs
@@ -796,6 +796,12 @@ pub enum LightningNode {
         ldk_port: u16,
         metrics_port: u16,
     },
+    /// Run gatewayd with no Lightning node attached.
+    None {
+        name: String,
+        gw_port: u16,
+        metrics_port: u16,
+    },
 }
 
 impl LightningNode {
@@ -808,6 +814,7 @@ impl LightningNode {
                 ldk_port: _,
                 metrics_port: _,
             } => LightningNodeType::Ldk,
+            LightningNode::None { .. } => LightningNodeType::None,
         }
     }
 }

--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -61,6 +61,11 @@ pub struct Federation {
     pub vars: BTreeMap<usize, vars::Fedimintd>,
     pub bitcoind: Bitcoind,
 
+    /// Invite code for this federation, captured at construction time so it
+    /// survives even when a second federation overwrites the shared
+    /// `FM_CLIENT_DIR/invite-code` file.
+    invite_code_cached: Option<String>,
+
     /// Built in [`Client`], already joined
     client: JitTryAnyhow<Client>,
     #[allow(dead_code)] // Will need it later, maybe
@@ -467,11 +472,22 @@ impl Federation {
             }
         }
 
+        // Snapshot the invite code now, before another `Federation::new`
+        // overwrites the shared `FM_CLIENT_DIR/invite-code` file.
+        let invite_code_cached = if !skip_setup && !pre_dkg {
+            let client_dir: PathBuf = env::var(FM_CLIENT_DIR_ENV)?.parse()?;
+            Some(fs::read_to_string(client_dir.join("invite-code"))?)
+        } else {
+            None
+        };
+        let cached_for_client = invite_code_cached.clone();
+
         let client = JitTryAnyhow::new_try({
             move || async move {
                 let client = Client::open_or_create(federation_name.as_str())?;
-                let invite_code = Self::invite_code_static()?;
                 if !skip_setup && !pre_dkg {
+                    let invite_code = cached_for_client
+                        .ok_or_else(|| anyhow::anyhow!("invite code not captured"))?;
                     cmd!(client, "join-federation", invite_code).run().await?;
                 }
                 Ok(client)
@@ -482,6 +498,7 @@ impl Federation {
             members,
             vars: peer_to_env_vars_map,
             bitcoind,
+            invite_code_cached,
             client,
             connectors,
         })
@@ -627,8 +644,16 @@ impl Federation {
         }
     }
 
-    /// Read the invite code from the client data dir
+    /// Read the invite code for this federation.
+    ///
+    /// Prefers the value captured at construction time, since
+    /// `FM_CLIENT_DIR/invite-code` is shared across federations and gets
+    /// overwritten by later `Federation::new` calls. Falls back to the
+    /// shared file for backwards compatibility.
     pub fn invite_code(&self) -> Result<String> {
+        if let Some(cached) = &self.invite_code_cached {
+            return Ok(cached.clone());
+        }
         let data_dir: PathBuf = env::var(FM_CLIENT_DIR_ENV)?.parse()?;
         let invite_code = fs::read_to_string(data_dir.join("invite-code"))?;
         Ok(invite_code)
@@ -935,6 +960,7 @@ impl Federation {
             let gateway_id = gw.gateway_id.clone();
             let gateway_index = gw.gateway_index;
             let deposit_address = gateway_deposit_addrs[i].clone();
+            let is_none_gateway = matches!(gw.ln.ln_type(), LightningNodeType::None);
             let fed_id = fed_id.clone();
             poll("gateway pegin", move || {
                 let fed_id = fed_id.clone();
@@ -949,28 +975,33 @@ impl Federation {
                         .await
                         .map_err(ControlFlow::Continue)?;
 
-                    let block_height: u64 = if gw.gatewayd_version < *VERSION_0_10_0_ALPHA {
-                        gw_info["block_height"]
-                            .as_u64()
-                            .expect("Could not parse block height")
-                    } else {
-                        gw_info["lightning_info"]["connected"]["block_height"]
-                            .as_u64()
-                            .expect("Could not parse block height")
-                    };
+                    // Gateways with no Lightning node have no chain sync of
+                    // their own; deposits flow through federation consensus,
+                    // so skip the block-height liveness check.
+                    if !is_none_gateway {
+                        let block_height: u64 = if gw.gatewayd_version < *VERSION_0_10_0_ALPHA {
+                            gw_info["block_height"]
+                                .as_u64()
+                                .expect("Could not parse block height")
+                        } else {
+                            gw_info["lightning_info"]["connected"]["block_height"]
+                                .as_u64()
+                                .expect("Could not parse block height")
+                        };
 
-                    if bitcoind_block_height != block_height {
-                        debug!(
-                            gateway = %gateway_name,
-                            ln = %gateway_ln,
-                            bitcoind_block_height,
-                            gateway_block_height = block_height,
-                            elapsed_ms = %pegin_start.elapsed().as_millis(),
-                            "Waiting for gateway pegin block sync"
-                        );
-                        return Err(std::ops::ControlFlow::Continue(anyhow::anyhow!(
-                            "Gateway {gateway_name} ({gateway_id}, index {gateway_index}) block height {block_height} has not reached bitcoind block height {bitcoind_block_height}"
-                        )));
+                        if bitcoind_block_height != block_height {
+                            debug!(
+                                gateway = %gateway_name,
+                                ln = %gateway_ln,
+                                bitcoind_block_height,
+                                gateway_block_height = block_height,
+                                elapsed_ms = %pegin_start.elapsed().as_millis(),
+                                "Waiting for gateway pegin block sync"
+                            );
+                            return Err(std::ops::ControlFlow::Continue(anyhow::anyhow!(
+                                "Gateway {gateway_name} ({gateway_id}, index {gateway_index}) block height {block_height} has not reached bitcoind block height {bitcoind_block_height}"
+                            )));
+                        }
                     }
 
                     let gateway_balance = gw

--- a/devimint/src/gatewayd.rs
+++ b/devimint/src/gatewayd.rs
@@ -793,7 +793,7 @@ impl Gatewayd {
             LightningNode::Lnd(_) => (
                 "gatewayd-lnd".to_string(),
                 process_mgr.globals.FM_PORT_GW_LND,
-                process_mgr.globals.FM_PORT_LND_LISTEN,
+                Some(process_mgr.globals.FM_PORT_LND_LISTEN),
                 process_mgr.globals.FM_PORT_GW_LND_METRICS,
             ),
             LightningNode::Ldk {
@@ -804,13 +804,25 @@ impl Gatewayd {
             } => (
                 name.to_owned(),
                 gw_port.to_owned(),
-                ldk_port.to_owned(),
+                Some(ldk_port.to_owned()),
+                metrics_port.to_owned(),
+            ),
+            LightningNode::None {
+                name,
+                gw_port,
+                metrics_port,
+            } => (
+                name.to_owned(),
+                gw_port.to_owned(),
+                None,
                 metrics_port.to_owned(),
             ),
         };
         let test_dir = &process_mgr.globals.FM_TEST_DIR;
         let addr = format!("http://127.0.0.1:{port}/{V1_API_ENDPOINT}");
-        let lightning_node_addr = format!("127.0.0.1:{lightning_node_port}");
+        let lightning_node_addr = lightning_node_port
+            .map(|p| format!("127.0.0.1:{p}"))
+            .unwrap_or_default();
         let iroh_endpoint = process_mgr
             .globals
             .gatewayd_overrides
@@ -828,7 +840,6 @@ impl Gatewayd {
                 format!("127.0.0.1:{port}"),
             ),
             (FM_GATEWAY_API_ADDR_ENV.to_owned(), addr.clone()),
-            (FM_PORT_LDK_ENV.to_owned(), lightning_node_port.to_string()),
             (
                 FM_GATEWAY_IROH_LISTEN_ADDR_ENV.to_owned(),
                 format!("127.0.0.1:{}", iroh_endpoint.port()),
@@ -842,6 +853,10 @@ impl Gatewayd {
                 format!("127.0.0.1:{metrics_port}"),
             ),
         ]);
+
+        if let Some(p) = lightning_node_port {
+            gateway_env.insert(FM_PORT_LDK_ENV.to_owned(), p.to_string());
+        }
 
         let gatewayd_version = crate::util::Gatewayd::version_or_default().await;
 
@@ -921,7 +936,7 @@ impl Gatewayd {
             gw_name,
             log_path,
             gw_port: port,
-            ldk_port: lightning_node_port,
+            ldk_port: lightning_node_port.unwrap_or(0),
             metrics_port,
             gateway_id,
             iroh_gateway_id,
@@ -945,15 +960,14 @@ impl Gatewayd {
         info!(target: LOG_DEVIMINT, "Stopping lightning node");
         match self.ln.clone() {
             LightningNode::Lnd(lnd) => lnd.terminate().await,
-            LightningNode::Ldk {
-                name: _,
-                gw_port: _,
-                ldk_port: _,
-                metrics_port: _,
-            } => {
+            LightningNode::Ldk { .. } => {
                 // This is not implemented because the LDK node lives in
                 // the gateway process and cannot be stopped independently.
                 unimplemented!("LDK node termination not implemented")
+            }
+            LightningNode::None { .. } => {
+                // There is no Lightning process to stop for LN-less gateways.
+                unimplemented!("None gateway has no Lightning node to stop")
             }
         }
     }

--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -1819,6 +1819,9 @@ pub async fn do_try_create_and_pay_invoice(
         LightningNodeType::Ldk => {
             unimplemented!("do_try_create_and_pay_invoice not implemented for LDK yet");
         }
+        LightningNodeType::None => {
+            unreachable!("gw_lnd is the LND gateway, never None");
+        }
     }
     Ok(())
 }

--- a/devimint/src/vars.rs
+++ b/devimint/src/vars.rs
@@ -272,7 +272,9 @@ impl Global {
                     .unwrap(),
             )?
         };
-        let num_gateways: usize = 3;
+        // 3 are used by DevFed (lnd, ldk-0, ldk-second); cross-fed swap tests
+        // spawn two additional `LightningMode::None` gateways.
+        let num_gateways: usize = 5;
         let this = Self::init(
             test_dir,
             num_feds,

--- a/fedimint-testing-core/src/node_type.rs
+++ b/fedimint-testing-core/src/node_type.rs
@@ -5,6 +5,8 @@ use std::str::FromStr;
 pub enum LightningNodeType {
     Lnd,
     Ldk,
+    /// Gateway running without a Lightning node attached.
+    None,
 }
 
 impl fmt::Display for LightningNodeType {
@@ -12,6 +14,7 @@ impl fmt::Display for LightningNodeType {
         match self {
             LightningNodeType::Lnd => write!(f, "lnd"),
             LightningNodeType::Ldk => write!(f, "ldk"),
+            LightningNodeType::None => write!(f, "none"),
         }
     }
 }
@@ -23,6 +26,7 @@ impl FromStr for LightningNodeType {
         match s.to_lowercase().as_str() {
             "lnd" => Ok(LightningNodeType::Lnd),
             "ldk" => Ok(LightningNodeType::Ldk),
+            "none" => Ok(LightningNodeType::None),
             _ => Err(format!("Invalid value for LightningNodeType: {s}")),
         }
     }

--- a/fedimint-testing/src/fixtures.rs
+++ b/fedimint-testing/src/fixtures.rs
@@ -192,8 +192,36 @@ impl Fixtures {
         )
     }
 
-    /// Creates a new Gateway that can be used for module tests.
+    /// Creates a new Gateway that can be used for module tests, backed by
+    /// `FakeLightningTest`.
     pub async fn new_gateway(&self) -> Gateway {
+        let ln_client: Arc<dyn ILnRpcClient> = Arc::new(FakeLightningTest::new());
+        self.new_gateway_with_lightning(
+            ln_client,
+            LightningMode::Lnd {
+                lnd_rpc_addr: "FakeRpcAddr".to_string(),
+                lnd_tls_cert: "FakeTlsCert".to_string(),
+                lnd_macaroon: "FakeMacaroon".to_string(),
+                lnd_time_pref: LND_DEFAULT_TIME_PREF,
+            },
+        )
+        .await
+    }
+
+    /// Creates a new Gateway with a caller-supplied [`ILnRpcClient`].
+    ///
+    /// Use this when the test needs a specific Lightning backend, e.g.
+    /// [`fedimint_lightning::none::GatewayNoneClient`] for tests that exercise
+    /// the federation-to-federation swap paths under an LN-less gateway.
+    /// `lightning_mode` is recorded on the gateway as it would be in
+    /// production and used by the gateway's UI / status reporting; it does not
+    /// have to match `ln_client` byte-for-byte (the latter is what's actually
+    /// invoked).
+    pub async fn new_gateway_with_lightning(
+        &self,
+        ln_client: Arc<dyn ILnRpcClient>,
+        lightning_mode: LightningMode,
+    ) -> Gateway {
         // Use server_gens.iter() to match the alphabetical order used by the server
         // when assigning module instance IDs (BTreeMap iteration order)
         let module_kinds: Vec<_> = self
@@ -235,8 +263,6 @@ impl Fixtures {
                 .await
                 .expect("Failed to initialize gateway");
 
-        let ln_client: Arc<dyn ILnRpcClient> = Arc::new(FakeLightningTest::new());
-
         let LightningInfo::Connected {
             public_key: lightning_public_key,
             alias: lightning_alias,
@@ -264,38 +290,27 @@ impl Fixtures {
         ))
         .expect("Failed to parse default esplora server");
 
-        Gateway::builder(
-            // Fixtures does not use real lightning connection, so just fake the connection
-            // parameters
-            LightningMode::Lnd {
-                lnd_rpc_addr: "FakeRpcAddr".to_string(),
-                lnd_tls_cert: "FakeTlsCert".to_string(),
-                lnd_macaroon: "FakeMacaroon".to_string(),
-                lnd_time_pref: LND_DEFAULT_TIME_PREF,
-            },
-            client_builder,
-            gateway_db,
-        )
-        .listen(listen)
-        .api_addr(address)
-        .bcrypt_password_hash(
-            bcrypt::HashParts::from_str(
-                &bcrypt::hash(DEFAULT_GATEWAY_PASSWORD, bcrypt::DEFAULT_COST).unwrap(),
+        Gateway::builder(lightning_mode, client_builder, gateway_db)
+            .listen(listen)
+            .api_addr(address)
+            .bcrypt_password_hash(
+                bcrypt::HashParts::from_str(
+                    &bcrypt::hash(DEFAULT_GATEWAY_PASSWORD, bcrypt::DEFAULT_COST).unwrap(),
+                )
+                .unwrap(),
             )
-            .unwrap(),
-        )
-        .network(bitcoin::Network::Regtest)
-        .num_route_hints(0)
-        // Manually set the gateway's state to `Running`. In tests, we don't run the
-        // webserver or intercept HTLCs, so this is necessary for instructing the
-        // gateway that it is connected to the mock Lightning node.
-        .gateway_state(fedimint_gateway_server::GatewayState::Running { lightning_context })
-        .chain_source(ChainSource::Esplora {
-            server_url: esplora_server_url,
-        })
-        .build()
-        .await
-        .expect("Failed to create gateway")
+            .network(bitcoin::Network::Regtest)
+            .num_route_hints(0)
+            // Manually set the gateway's state to `Running`. In tests, we don't run the
+            // webserver or intercept HTLCs, so this is necessary for instructing the
+            // gateway that it is connected to the mock Lightning node.
+            .gateway_state(fedimint_gateway_server::GatewayState::Running { lightning_context })
+            .chain_source(ChainSource::Esplora {
+                server_url: esplora_server_url,
+            })
+            .build()
+            .await
+            .expect("Failed to create gateway")
     }
 
     /// Get a server bitcoin RPC config

--- a/gateway/fedimint-gateway-common/src/lib.rs
+++ b/gateway/fedimint-gateway-common/src/lib.rs
@@ -591,6 +591,11 @@ pub enum LightningMode {
         #[arg(long = "ldk-alias", env = FM_LDK_ALIAS_ENV)]
         alias: String,
     },
+    /// Run without a Lightning node. The gateway can still bridge between
+    /// federations it is registered with via internal swap short-circuits, but
+    /// cannot send to or receive from the wider Lightning Network.
+    #[clap(name = "none")]
+    None,
 }
 
 #[derive(Clone)]

--- a/gateway/fedimint-gateway-server/src/error.rs
+++ b/gateway/fedimint-gateway-server/src/error.rs
@@ -102,7 +102,7 @@ impl IntoResponse for PublicGatewayError {
 /// error details are returned to the admin client for debugging purposes.
 #[derive(Debug, Error)]
 pub enum AdminGatewayError {
-    #[error("Failed to create a federation client")]
+    #[error("Failed to create a federation client: {}", .0.fmt_compact_anyhow())]
     ClientCreationError(anyhow::Error),
     #[error("Failed to remove a federation client: {0}")]
     ClientRemovalError(String),

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -101,7 +101,7 @@ use fedimint_lightning::lnd::GatewayLndClient;
 use fedimint_lightning::{
     CreateInvoiceRequest, ILnRpcClient, InterceptPaymentRequest, InterceptPaymentResponse,
     InvoiceDescription, LightningContext, LightningRpcError, LnRpcTracked, Lnv2HoldInvoiceFilter,
-    PayInvoiceResponse, PaymentAction, RouteHtlcStream, ldk,
+    PayInvoiceResponse, PaymentAction, RouteHtlcStream, ldk, none,
 };
 use fedimint_ln_client::pay::PaymentData;
 use fedimint_ln_common::LightningCommonInit;
@@ -977,7 +977,7 @@ impl Gateway {
             .await;
         info!(target: LOG_GATEWAY, "Gateway is running");
 
-        if matches!(self.lightning_mode, LightningMode::Lnd { .. }) {
+        if self.supports_lnv1_gateway_registration() {
             // Re-register the gateway with all federations after connecting to the
             // lightning node
             let mut dbtx = self.gateway_db.begin_transaction_nc().await;
@@ -1780,7 +1780,7 @@ impl Gateway {
     /// include route hints in the registration.
     fn register_clients_timer(&self) {
         // Only spawn background registration thread if gateway is LND
-        if matches!(self.lightning_mode, LightningMode::Lnd { .. }) {
+        if self.supports_lnv1_gateway_registration() {
             info!(target: LOG_GATEWAY, "Spawning register task...");
             let gateway = self.clone();
             let register_task_group = self.task_group.make_subgroup();
@@ -1872,6 +1872,13 @@ impl Gateway {
         Ok(())
     }
 
+    fn supports_lnv1_gateway_registration(&self) -> bool {
+        matches!(
+            self.lightning_mode,
+            LightningMode::Lnd { .. } | LightningMode::None
+        )
+    }
+
     /// Checks the Gateway's current state and returns the proper
     /// `LightningContext` if it is available. Sometimes the lightning node
     /// will not be connected and this will return an error.
@@ -1888,7 +1895,7 @@ impl Gateway {
     /// Iterates through all of the federations the gateway is registered with
     /// and requests to remove the registration record.
     pub async fn unannounce_from_all_federations(&self) {
-        if matches!(self.lightning_mode, LightningMode::Lnd { .. }) {
+        if self.supports_lnv1_gateway_registration() {
             for registration in self.registrations.values() {
                 self.federation_manager
                     .read()
@@ -1960,6 +1967,15 @@ impl Gateway {
                 })
                 .await
                 .expect("Could not create LDK Node")
+            }
+            LightningMode::None => {
+                let mnemonic = Self::load_mnemonic(&self.gateway_db)
+                    .await
+                    .expect("mnemonic should be set");
+                Box::new(none::GatewayNoneClient::new(
+                    &mnemonic.to_seed(""),
+                    self.network,
+                ))
             }
         }
     }
@@ -2183,7 +2199,7 @@ impl IAdminGateway for Gateway {
         };
 
         Self::check_federation_network(&client, self.network).await?;
-        if matches!(self.lightning_mode, LightningMode::Lnd { .. })
+        if self.supports_lnv1_gateway_registration()
             && let Ok(lnv1) = client.get_first_module::<GatewayClientModule>()
         {
             for registration in self.registrations.values() {
@@ -2305,7 +2321,7 @@ impl IAdminGateway for Gateway {
 
         dbtx.commit_tx().await;
 
-        if matches!(self.lightning_mode, LightningMode::Lnd { .. }) {
+        if self.supports_lnv1_gateway_registration() {
             let register_task_group = TaskGroup::new();
 
             self.register_federations(&fed_configs, &register_task_group)

--- a/gateway/fedimint-gateway-server/tests/tests.rs
+++ b/gateway/fedimint-gateway-server/tests/tests.rs
@@ -23,7 +23,7 @@ use fedimint_core::{Amount, OutPoint, msats, sats, secp256k1};
 use fedimint_dummy_client::{DummyClientInit, DummyClientModule};
 use fedimint_dummy_server::DummyInit;
 use fedimint_eventlog::Event;
-use fedimint_gateway_common::{PaymentLogPayload, SetFeesPayload};
+use fedimint_gateway_common::{LightningMode, PaymentLogPayload, SetFeesPayload};
 use fedimint_gateway_server::Gateway;
 use fedimint_gateway_ui::IAdminGateway;
 use fedimint_gw_client::pay::{
@@ -37,6 +37,8 @@ use fedimint_gwv2_client::events::{
     OutgoingPaymentStarted, OutgoingPaymentSucceeded,
 };
 use fedimint_gwv2_client::{FinalReceiveState, GatewayClientModuleV2};
+use fedimint_lightning::ILnRpcClient;
+use fedimint_lightning::none::GatewayNoneClient;
 use fedimint_ln_client::api::LnFederationApi;
 use fedimint_ln_client::pay::{PayInvoicePayload, PaymentData};
 use fedimint_ln_client::{
@@ -130,10 +132,24 @@ async fn multi_federation_test<B>(
 where
     B: Future<Output = anyhow::Result<()>>,
 {
+    multi_federation_test_with_gateway(f, |fixtures| {
+        Box::pin(async move { fixtures.new_gateway().await })
+    })
+    .await
+}
+
+async fn multi_federation_test_with_gateway<B, G>(
+    f: impl FnOnce(Gateway, FederationTest, FederationTest, Arc<dyn BitcoinTest>) -> B + Copy,
+    new_gateway: G,
+) -> anyhow::Result<()>
+where
+    B: Future<Output = anyhow::Result<()>>,
+    G: for<'a> FnOnce(&'a Fixtures) -> std::pin::Pin<Box<dyn Future<Output = Gateway> + 'a>>,
+{
     let fixtures = fixtures();
     let fed1 = fixtures.new_fed_degraded().await;
     let fed2 = fixtures.new_fed_degraded().await;
-    let gateway = fixtures.new_gateway().await;
+    let gateway = new_gateway(&fixtures).await;
 
     f(gateway, fed1, fed2, fixtures.bitcoin()).await?;
     Ok(())
@@ -872,121 +888,156 @@ async fn test_gateway_cannot_pay_expired_invoice() -> anyhow::Result<()> {
     .await
 }
 
+async fn assert_lnv1_cross_fed_direct_swap(
+    gateway: Gateway,
+    fed1: FederationTest,
+    fed2: FederationTest,
+) -> anyhow::Result<()> {
+    let gateway_id = gateway.http_gateway_id().await;
+    let id1 = fed1.invite_code().federation_id();
+    let id2 = fed2.invite_code().federation_id();
+
+    fed1.connect_gateway(&gateway).await;
+    fed2.connect_gateway(&gateway).await;
+
+    // setting specific routing fees for fed1
+    gateway
+        .handle_set_fees_msg(SetFeesPayload {
+            federation_id: Some(id1),
+            lightning_base: Some(Amount::from_msats(10)),
+            lightning_parts_per_million: Some(10000),
+            transaction_base: None,
+            transaction_parts_per_million: None,
+        })
+        .await?;
+
+    send_msats_to_gateway(&gateway, id1, 10_000).await;
+    send_msats_to_gateway(&gateway, id2, 10_000).await;
+
+    let client1 = fed1.new_client().await;
+    // if lightning module is present, update the gateway cache
+    if let Ok(ln_client) = client1.get_first_module::<LightningClientModule>() {
+        let _ = ln_client.update_gateway_cache().await;
+    }
+    let client2 = fed2.new_client().await;
+    // if lightning module is present, update the gateway cache
+    if let Ok(ln_client) = client2.get_first_module::<LightningClientModule>() {
+        let _ = ln_client.update_gateway_cache().await;
+    }
+
+    // Check gateway balances before facilitating direct swap between federations
+    let pre_balances = get_balances(&gateway, [id1, id2].to_vec()).await;
+    assert_eq!(pre_balances[0], 10_000);
+    assert_eq!(pre_balances[1], 10_000);
+
+    let deposit_amt = msats(5_000);
+    let client1_dummy_module = client1.get_first_module::<DummyClientModule>()?;
+    client1_dummy_module
+        .mock_receive(deposit_amt, AmountUnit::BITCOIN)
+        .await?;
+    assert_eq!(client1.get_balance_for_btc().await?, deposit_amt);
+
+    // User creates invoice in federation 2
+    let invoice_amt = msats(2_500);
+    let ln_module = client2.get_first_module::<LightningClientModule>()?;
+    let lightning_gateway = ln_module.select_gateway(&gateway_id).await;
+    let desc = Description::new("description".to_string())?;
+    let (receive_op, invoice, _) = ln_module
+        .create_bolt11_invoice(
+            invoice_amt,
+            Bolt11InvoiceDescription::Direct(desc),
+            None,
+            "test gw swap between federations",
+            lightning_gateway,
+        )
+        .await?;
+    let mut receive_sub = ln_module
+        .subscribe_ln_receive(receive_op)
+        .await?
+        .into_stream();
+
+    // A client pays invoice in federation 1
+    let gateway_client = gateway.select_client(id1).await?.into_value();
+    gateway_pay_valid_invoice(
+        invoice,
+        &client1,
+        &gateway_client,
+        &gateway.http_gateway_id().await,
+    )
+    .await?;
+
+    // A client receives cash via swap in federation 2
+    assert_eq!(receive_sub.ok().await?, LnReceiveState::Created);
+    let waiting_payment = receive_sub.ok().await?;
+    assert_matches!(waiting_payment, LnReceiveState::WaitingForPayment { .. });
+    let funded = receive_sub.ok().await?;
+    assert_matches!(funded, LnReceiveState::Funded);
+    let waiting_funds = receive_sub.ok().await?;
+    assert_matches!(waiting_funds, LnReceiveState::AwaitingFunds);
+    let claimed = receive_sub.ok().await?;
+    assert_matches!(claimed, LnReceiveState::Claimed);
+    assert_eq!(client2.get_balance_for_btc().await?, invoice_amt);
+
+    // Check gateway balances after facilitating direct swap between federations
+    let gateway_fed1_balance = gateway_client.get_balance_for_btc().await?;
+    let gateway_fed2_client = gateway.select_client(id2).await?.into_value();
+    let gateway_fed2_balance = gateway_fed2_client.get_balance_for_btc().await?;
+
+    // Balance in gateway of sending federation is deducted the invoice amount
+    assert_eq!(
+        gateway_fed2_balance.msats,
+        pre_balances[1] - invoice_amt.msats
+    );
+
+    let fee = routing_fees_in_msats(
+        &PaymentFee {
+            base: Amount::from_msats(10),
+            parts_per_million: 10000,
+        },
+        &invoice_amt,
+    );
+
+    // Balance in gateway of receiving federation is increased `invoice_amt` + `fee`
+    assert_eq!(
+        gateway_fed1_balance.msats,
+        pre_balances[0] + invoice_amt.msats + fee
+    );
+
+    Ok(())
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn test_gateway_executes_swaps_between_connected_federations() -> anyhow::Result<()> {
     multi_federation_test(|gateway, fed1, fed2, _| async move {
-        let gateway_id = gateway.http_gateway_id().await;
-        let id1 = fed1.invite_code().federation_id();
-        let id2 = fed2.invite_code().federation_id();
-
-        fed1.connect_gateway(&gateway).await;
-        fed2.connect_gateway(&gateway).await;
-
-        // setting specific routing fees for fed1
-        gateway
-            .handle_set_fees_msg(SetFeesPayload {
-                federation_id: Some(id1),
-                lightning_base: Some(Amount::from_msats(10)),
-                lightning_parts_per_million: Some(10000),
-                transaction_base: None,
-                transaction_parts_per_million: None,
-            })
-            .await?;
-
-        send_msats_to_gateway(&gateway, id1, 10_000).await;
-        send_msats_to_gateway(&gateway, id2, 10_000).await;
-
-        let client1 = fed1.new_client().await;
-        // if lightning module is present, update the gateway cache
-        if let Ok(ln_client) = client1.get_first_module::<LightningClientModule>() {
-            let _ = ln_client.update_gateway_cache().await;
-        }
-        let client2 = fed2.new_client().await;
-        // if lightning module is present, update the gateway cache
-        if let Ok(ln_client) = client2.get_first_module::<LightningClientModule>() {
-            let _ = ln_client.update_gateway_cache().await;
-        }
-
-        // Check gateway balances before facilitating direct swap between federations
-        let pre_balances = get_balances(&gateway, [id1, id2].to_vec()).await;
-        assert_eq!(pre_balances[0], 10_000);
-        assert_eq!(pre_balances[1], 10_000);
-
-        let deposit_amt = msats(5_000);
-        let client1_dummy_module = client1.get_first_module::<DummyClientModule>()?;
-        client1_dummy_module
-            .mock_receive(deposit_amt, AmountUnit::BITCOIN)
-            .await?;
-        assert_eq!(client1.get_balance_for_btc().await?, deposit_amt);
-
-        // User creates invoice in federation 2
-        let invoice_amt = msats(2_500);
-        let ln_module = client2.get_first_module::<LightningClientModule>()?;
-        let lightning_gateway = ln_module.select_gateway(&gateway_id).await;
-        let desc = Description::new("description".to_string())?;
-        let (receive_op, invoice, _) = ln_module
-            .create_bolt11_invoice(
-                invoice_amt,
-                Bolt11InvoiceDescription::Direct(desc),
-                None,
-                "test gw swap between federations",
-                lightning_gateway,
-            )
-            .await?;
-        let mut receive_sub = ln_module
-            .subscribe_ln_receive(receive_op)
-            .await?
-            .into_stream();
-
-        // A client pays invoice in federation 1
-        let gateway_client = gateway.select_client(id1).await?.into_value();
-        gateway_pay_valid_invoice(
-            invoice,
-            &client1,
-            &gateway_client,
-            &gateway.http_gateway_id().await,
-        )
-        .await?;
-
-        // A client receives cash via swap in federation 2
-        assert_eq!(receive_sub.ok().await?, LnReceiveState::Created);
-        let waiting_payment = receive_sub.ok().await?;
-        assert_matches!(waiting_payment, LnReceiveState::WaitingForPayment { .. });
-        let funded = receive_sub.ok().await?;
-        assert_matches!(funded, LnReceiveState::Funded);
-        let waiting_funds = receive_sub.ok().await?;
-        assert_matches!(waiting_funds, LnReceiveState::AwaitingFunds);
-        let claimed = receive_sub.ok().await?;
-        assert_matches!(claimed, LnReceiveState::Claimed);
-        assert_eq!(client2.get_balance_for_btc().await?, invoice_amt);
-
-        // Check gateway balances after facilitating direct swap between federations
-        let gateway_fed1_balance = gateway_client.get_balance_for_btc().await?;
-        let gateway_fed2_client = gateway.select_client(id2).await?.into_value();
-        let gateway_fed2_balance = gateway_fed2_client.get_balance_for_btc().await?;
-
-        // Balance in gateway of sending federation is deducted the invoice amount
-        assert_eq!(
-            gateway_fed2_balance.msats,
-            pre_balances[1] - invoice_amt.msats
-        );
-
-        let fee = routing_fees_in_msats(
-            &PaymentFee {
-                base: Amount::from_msats(10),
-                parts_per_million: 10000,
-            },
-            &invoice_amt,
-        );
-
-        // Balance in gateway of receiving federation is increased `invoice_amt` + `fee`
-        assert_eq!(
-            gateway_fed1_balance.msats,
-            pre_balances[0] + invoice_amt.msats + fee
-        );
-
-        Ok(())
+        assert_lnv1_cross_fed_direct_swap(gateway, fed1, fed2).await
     })
+    .await
+}
+
+/// Same scenario as
+/// [`test_gateway_executes_swaps_between_connected_federations`] but with a
+/// gateway that has no Lightning node attached ([`LightningMode::None`]).
+/// Cross-federation LNv1 swaps must short-circuit before any LN RPC is called,
+/// so the absence of a backend should not affect the outcome.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_lnless_gateway_executes_lnv1_swaps_between_connected_federations()
+-> anyhow::Result<()> {
+    multi_federation_test_with_gateway(
+        |gateway, fed1, fed2, _| async move {
+            assert_lnv1_cross_fed_direct_swap(gateway, fed1, fed2).await
+        },
+        |fixtures| {
+            Box::pin(async move {
+                let ln_client: Arc<dyn ILnRpcClient> = Arc::new(GatewayNoneClient::new(
+                    b"test-lnless-gateway-seed",
+                    bitcoin::Network::Regtest,
+                ));
+                fixtures
+                    .new_gateway_with_lightning(ln_client, LightningMode::None)
+                    .await
+            })
+        },
+    )
     .await
 }
 

--- a/gateway/fedimint-gateway-ui/src/lightning.rs
+++ b/gateway/fedimint-gateway-ui/src/lightning.rs
@@ -266,6 +266,20 @@ where
                                     }
                                 }
                             }
+                            LightningMode::None => {
+                                div id="node-type" class="alert alert-warning" {
+                                    "Node Type: " strong { "None (Lightning disabled)" }
+                                    " — only federation-to-federation swaps are supported."
+                                }
+                                table class="table table-sm mb-0" {
+                                    tbody {
+                                        tr {
+                                            th { "Network" }
+                                            td { (network) }
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
 

--- a/gateway/fedimint-lightning/Cargo.toml
+++ b/gateway/fedimint-lightning/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/lib.rs"
 
 [dependencies]
 anyhow = { workspace = true }
+async-stream = { workspace = true }
 async-trait = { workspace = true }
 bitcoin = { workspace = true }
 fedimint-bip39 = { workspace = true }

--- a/gateway/fedimint-lightning/src/lib.rs
+++ b/gateway/fedimint-lightning/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod ldk;
 pub mod lnd;
 pub mod metrics;
+pub mod none;
 
 use std::fmt::Debug;
 use std::str::FromStr;

--- a/gateway/fedimint-lightning/src/none.rs
+++ b/gateway/fedimint-lightning/src/none.rs
@@ -1,0 +1,318 @@
+//! "None" Lightning backend.
+//!
+//! An [`ILnRpcClient`] implementation that runs the gateway with no Lightning
+//! node attached. It cannot pay or be paid over the Lightning Network.
+//!
+//! The gateway is still useful for federation-to-federation swaps, where a
+//! single gateway is registered with multiple federations and the LNv1/LNv2
+//! receive contracts on one federation can be settled by spending an outgoing
+//! contract on another. Those paths short-circuit before any LN RPC is invoked
+//! (see `is_direct_swap`, `is_lnv1_invoice`, `get_client_for_invoice` in
+//! `fedimint-gateway-server`).
+//!
+//! `info` returns a synthetic identity that is stable across restarts (derived
+//! from the gateway mnemonic). `create_invoice` mints a Bolt11 signed by that
+//! identity so LNv2 receive offers can register a payment hash with the
+//! federation. Everything else returns an error.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_stream::stream;
+use async_trait::async_trait;
+use bitcoin::Network;
+use bitcoin::secp256k1::{Keypair, Secp256k1, SecretKey};
+use fedimint_core::Amount;
+use fedimint_core::task::TaskGroup;
+use fedimint_core::util::BoxStream;
+use fedimint_gateway_common::{
+    CloseChannelsWithPeerRequest, CloseChannelsWithPeerResponse, GetInvoiceRequest,
+    GetInvoiceResponse, ListTransactionsResponse, OpenChannelRequest, SendOnchainRequest,
+    SetChannelFeesRequest,
+};
+use fedimint_ln_common::PrunedInvoice;
+use fedimint_ln_common::contracts::Preimage;
+use lightning_invoice::{Currency, InvoiceBuilder, PaymentSecret};
+use tokio::sync::mpsc;
+
+use crate::{
+    CreateInvoiceRequest, CreateInvoiceResponse, GetBalancesResponse, GetLnOnchainAddressResponse,
+    GetNodeInfoResponse, GetRouteHintsResponse, ILnRpcClient, InterceptPaymentRequest,
+    InterceptPaymentResponse, LightningRpcError, ListChannelsResponse, OpenChannelResponse,
+    PayInvoiceResponse, RouteHtlcStream, SendOnchainResponse,
+};
+
+const NOT_SUPPORTED: &str = "gateway is running without a Lightning node";
+
+/// Lightning backend used when the gateway has no Lightning node.
+pub struct GatewayNoneClient {
+    keypair: Keypair,
+    network: Network,
+}
+
+impl std::fmt::Debug for GatewayNoneClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GatewayNoneClient")
+            .field("public_key", &self.keypair.public_key())
+            .field("network", &self.network)
+            .finish_non_exhaustive()
+    }
+}
+
+impl GatewayNoneClient {
+    /// Build a new client. `seed` is used to derive the synthetic Lightning
+    /// identity deterministically (so the gateway has a stable pubkey across
+    /// restarts). Callers should pass material that already identifies this
+    /// gateway instance, e.g. the bip39 seed.
+    pub fn new(seed: &[u8], network: Network) -> Self {
+        let secp = Secp256k1::new();
+        let secret_key = derive_secret(seed);
+        let keypair = Keypair::from_secret_key(&secp, &secret_key);
+
+        Self { keypair, network }
+    }
+}
+
+fn derive_secret(seed: &[u8]) -> SecretKey {
+    use bitcoin::hashes::{Hash, HashEngine, sha256};
+
+    // Domain-separated tagged hash so this key cannot collide with any other
+    // key derived from the same seed for a different purpose.
+    let mut engine = sha256::HashEngine::default();
+    engine.input(b"fedimint-lightning-none/v1");
+    engine.input(seed);
+    let hash = sha256::Hash::from_engine(engine);
+
+    SecretKey::from_slice(hash.as_byte_array())
+        .expect("sha256 output is a valid secp256k1 secret key with overwhelming probability")
+}
+
+#[async_trait]
+impl ILnRpcClient for GatewayNoneClient {
+    async fn info(&self) -> Result<GetNodeInfoResponse, LightningRpcError> {
+        Ok(GetNodeInfoResponse {
+            pub_key: self.keypair.public_key(),
+            alias: "fedimint-none".to_string(),
+            network: self.network.to_string(),
+            block_height: 0,
+            synced_to_chain: true,
+        })
+    }
+
+    async fn routehints(
+        &self,
+        _num_route_hints: usize,
+    ) -> Result<GetRouteHintsResponse, LightningRpcError> {
+        Ok(GetRouteHintsResponse {
+            route_hints: vec![],
+        })
+    }
+
+    async fn pay(
+        &self,
+        _invoice: lightning_invoice::Bolt11Invoice,
+        _max_delay: u64,
+        _max_fee: Amount,
+    ) -> Result<PayInvoiceResponse, LightningRpcError> {
+        Err(LightningRpcError::FailedPayment {
+            failure_reason: NOT_SUPPORTED.to_string(),
+        })
+    }
+
+    fn supports_private_payments(&self) -> bool {
+        true
+    }
+
+    async fn pay_private(
+        &self,
+        _invoice: PrunedInvoice,
+        _max_delay: u64,
+        _max_fee: Amount,
+    ) -> Result<PayInvoiceResponse, LightningRpcError> {
+        Err(LightningRpcError::FailedPayment {
+            failure_reason: NOT_SUPPORTED.to_string(),
+        })
+    }
+
+    async fn route_htlcs<'a>(
+        self: Box<Self>,
+        task_group: &TaskGroup,
+    ) -> Result<(RouteHtlcStream<'a>, Arc<dyn ILnRpcClient>), LightningRpcError> {
+        let handle = task_group.make_handle();
+        let shutdown_receiver = handle.make_shutdown_rx();
+
+        // No Lightning node, so no HTLCs ever arrive. Hold the stream open
+        // until shutdown so the consumer doesn't see end-of-stream.
+        let (_sender, mut receiver) = mpsc::channel::<InterceptPaymentRequest>(0);
+        let stream: BoxStream<'a, InterceptPaymentRequest> = Box::pin(stream! {
+            shutdown_receiver.await;
+            // Satisfy the type checker; this branch is never taken.
+            if let Some(htlc) = receiver.recv().await {
+                yield htlc;
+            }
+        });
+
+        let arc_self = Arc::new(GatewayNoneClient {
+            keypair: self.keypair,
+            network: self.network,
+        });
+        Ok((stream, arc_self))
+    }
+
+    async fn complete_htlc(
+        &self,
+        _htlc: InterceptPaymentResponse,
+    ) -> Result<(), LightningRpcError> {
+        Err(LightningRpcError::FailedToCompleteHtlc {
+            failure_reason: NOT_SUPPORTED.to_string(),
+        })
+    }
+
+    async fn create_invoice(
+        &self,
+        request: CreateInvoiceRequest,
+    ) -> Result<CreateInvoiceResponse, LightningRpcError> {
+        // We must produce a syntactically valid Bolt11 so that `is_direct_swap`
+        // can match it against the gateway's own pubkey. The invoice is
+        // unpayable from outside (no real route hints, signed by a key that is
+        // not announced on the LN gossip network). It is only used as a
+        // payment-hash carrier for federation-to-federation swaps.
+        let payment_hash =
+            request
+                .payment_hash
+                .ok_or_else(|| LightningRpcError::FailedToGetInvoice {
+                    failure_reason: "GatewayNoneClient requires a payment_hash".to_string(),
+                })?;
+
+        let ctx = Secp256k1::new();
+        let invoice = InvoiceBuilder::new(currency_from_network(self.network))
+            .description(String::new())
+            .payment_hash(payment_hash)
+            .current_timestamp()
+            .min_final_cltv_expiry_delta(0)
+            .payment_secret(PaymentSecret([0; 32]))
+            .amount_milli_satoshis(request.amount_msat)
+            .expiry_time(Duration::from_secs(u64::from(request.expiry_secs)))
+            .build_signed(|m| ctx.sign_ecdsa_recoverable(m, &self.keypair.secret_key()))
+            .map_err(|e| LightningRpcError::FailedToGetInvoice {
+                failure_reason: format!("synthetic invoice signing failed: {e}"),
+            })?;
+
+        Ok(CreateInvoiceResponse {
+            invoice: invoice.to_string(),
+        })
+    }
+
+    async fn get_ln_onchain_address(
+        &self,
+    ) -> Result<GetLnOnchainAddressResponse, LightningRpcError> {
+        Err(LightningRpcError::FailedToGetLnOnchainAddress {
+            failure_reason: NOT_SUPPORTED.to_string(),
+        })
+    }
+
+    async fn send_onchain(
+        &self,
+        _payload: SendOnchainRequest,
+    ) -> Result<SendOnchainResponse, LightningRpcError> {
+        Err(LightningRpcError::FailedToWithdrawOnchain {
+            failure_reason: NOT_SUPPORTED.to_string(),
+        })
+    }
+
+    async fn open_channel(
+        &self,
+        _payload: OpenChannelRequest,
+    ) -> Result<OpenChannelResponse, LightningRpcError> {
+        Err(LightningRpcError::FailedToOpenChannel {
+            failure_reason: NOT_SUPPORTED.to_string(),
+        })
+    }
+
+    async fn close_channels_with_peer(
+        &self,
+        _payload: CloseChannelsWithPeerRequest,
+    ) -> Result<CloseChannelsWithPeerResponse, LightningRpcError> {
+        Err(LightningRpcError::FailedToCloseChannelsWithPeer {
+            failure_reason: NOT_SUPPORTED.to_string(),
+        })
+    }
+
+    async fn list_channels(&self) -> Result<ListChannelsResponse, LightningRpcError> {
+        Ok(ListChannelsResponse { channels: vec![] })
+    }
+
+    async fn set_channel_fees(
+        &self,
+        _payload: SetChannelFeesRequest,
+    ) -> Result<(), LightningRpcError> {
+        Err(LightningRpcError::FailedToSetChannelFees {
+            failure_reason: NOT_SUPPORTED.to_string(),
+        })
+    }
+
+    async fn get_balances(&self) -> Result<GetBalancesResponse, LightningRpcError> {
+        Ok(GetBalancesResponse {
+            onchain_balance_sats: 0,
+            lightning_balance_msats: 0,
+            inbound_lightning_liquidity_msats: 0,
+        })
+    }
+
+    async fn get_invoice(
+        &self,
+        _request: GetInvoiceRequest,
+    ) -> Result<Option<GetInvoiceResponse>, LightningRpcError> {
+        Ok(None)
+    }
+
+    async fn list_transactions(
+        &self,
+        _start_secs: u64,
+        _end_secs: u64,
+    ) -> Result<ListTransactionsResponse, LightningRpcError> {
+        Ok(ListTransactionsResponse {
+            transactions: vec![],
+        })
+    }
+
+    fn create_offer(
+        &self,
+        _amount: Option<Amount>,
+        _description: Option<String>,
+        _expiry_secs: Option<u32>,
+        _quantity: Option<u64>,
+    ) -> Result<String, LightningRpcError> {
+        Err(LightningRpcError::Bolt12Error {
+            failure_reason: NOT_SUPPORTED.to_string(),
+        })
+    }
+
+    async fn pay_offer(
+        &self,
+        _offer: String,
+        _quantity: Option<u64>,
+        _amount: Option<Amount>,
+        _payer_note: Option<String>,
+    ) -> Result<Preimage, LightningRpcError> {
+        Err(LightningRpcError::Bolt12Error {
+            failure_reason: NOT_SUPPORTED.to_string(),
+        })
+    }
+
+    fn sync_wallet(&self) -> Result<(), LightningRpcError> {
+        Ok(())
+    }
+}
+
+fn currency_from_network(network: Network) -> Currency {
+    match network {
+        Network::Bitcoin => Currency::Bitcoin,
+        Network::Testnet => Currency::BitcoinTestnet,
+        Network::Signet => Currency::Signet,
+        Network::Regtest => Currency::Regtest,
+        // Unknown networks default to regtest; this backend is not used in
+        // production with mainnet-like settings outside of dev/test anyway.
+        _ => Currency::Regtest,
+    }
+}

--- a/gateway/fedimint-lightning/src/none.rs
+++ b/gateway/fedimint-lightning/src/none.rs
@@ -143,7 +143,7 @@ impl ILnRpcClient for GatewayNoneClient {
 
         // No Lightning node, so no HTLCs ever arrive. Hold the stream open
         // until shutdown so the consumer doesn't see end-of-stream.
-        let (_sender, mut receiver) = mpsc::channel::<InterceptPaymentRequest>(0);
+        let (_sender, mut receiver) = mpsc::channel::<InterceptPaymentRequest>(1);
         let stream: BoxStream<'a, InterceptPaymentRequest> = Box::pin(stream! {
             shutdown_receiver.await;
             // Satisfy the type checker; this branch is never taken.

--- a/gateway/integration_tests/src/main.rs
+++ b/gateway/integration_tests/src/main.rs
@@ -176,6 +176,11 @@ async fn config_test(gw_type: LightningNodeType) -> anyhow::Result<()> {
                 let gw = match gw_type {
                     LightningNodeType::Lnd => dev_fed.gw_lnd_registered().await?,
                     LightningNodeType::Ldk => dev_fed.gw_ldk_connected().await?,
+                    LightningNodeType::None => {
+                        anyhow::bail!(
+                            "gateway integration tests are not parametrized for LightningMode::None"
+                        )
+                    }
                 };
 
                 // Try to connect to already connected federation

--- a/modules/fedimint-lnv2-tests/Cargo.toml
+++ b/modules/fedimint-lnv2-tests/Cargo.toml
@@ -15,6 +15,10 @@ path = "bin/tests.rs"
 name = "lnv1-lnv2-swap-tests"
 path = "bin/swap_tests.rs"
 
+[[bin]]
+name = "cross-fed-swap-tests"
+path = "bin/cross_fed_swap_tests.rs"
+
 [[test]]
 name = "fedimint_lnv2_tests"
 path = "tests/tests.rs"
@@ -41,6 +45,7 @@ fedimint-lnv2-client = { workspace = true }
 fedimint-lnv2-common = { workspace = true }
 fedimint-lnv2-server = { workspace = true }
 fedimint-logging = { workspace = true }
+fedimint-portalloc = { workspace = true }
 fedimint-testing = { workspace = true }
 futures = { workspace = true }
 itertools = { workspace = true }

--- a/modules/fedimint-lnv2-tests/bin/common.rs
+++ b/modules/fedimint-lnv2-tests/bin/common.rs
@@ -96,3 +96,64 @@ pub async fn await_receive_claimed(
 
     Ok(())
 }
+
+#[allow(dead_code)]
+pub async fn receive_lnv1(
+    client: &Client,
+    gateway_id: &str,
+    amount_msats: u64,
+) -> anyhow::Result<(Bolt11Invoice, OperationId)> {
+    let invoice_response = cmd!(
+        client,
+        "module",
+        "ln",
+        "invoice",
+        amount_msats,
+        "--gateway-id",
+        gateway_id
+    )
+    .out_json()
+    .await?;
+    let invoice = serde_json::from_value::<Bolt11Invoice>(
+        invoice_response
+            .get("invoice")
+            .expect("Invoice should be present")
+            .clone(),
+    )?;
+    let operation_id = serde_json::from_value::<OperationId>(
+        invoice_response
+            .get("operation_id")
+            .expect("OperationId should be present")
+            .clone(),
+    )?;
+    Ok((invoice, operation_id))
+}
+
+#[allow(dead_code)]
+pub async fn send_lnv1(client: &Client, gateway_id: &str, invoice: &str) -> anyhow::Result<()> {
+    let payment_result = cmd!(
+        client,
+        "module",
+        "ln",
+        "pay",
+        invoice,
+        "--gateway-id",
+        gateway_id
+    )
+    .out_json()
+    .await?;
+    assert!(
+        payment_result.get("Success").is_some() || payment_result.get("preimage").is_some(),
+        "LNv1 payment failed: {payment_result:?}"
+    );
+    Ok(())
+}
+
+#[allow(dead_code)]
+pub async fn await_receive_lnv1(client: &Client, operation_id: OperationId) -> anyhow::Result<()> {
+    let lnv1_response = cmd!(client, "await-invoice", operation_id.fmt_full())
+        .out_json()
+        .await?;
+    assert!(lnv1_response.get("total_amount_msat").is_some());
+    Ok(())
+}

--- a/modules/fedimint-lnv2-tests/bin/cross_fed_swap_tests.rs
+++ b/modules/fedimint-lnv2-tests/bin/cross_fed_swap_tests.rs
@@ -1,0 +1,193 @@
+//! Cross-federation swap tests.
+//!
+//! Exercises the four sender/receiver direction combinations of LNv1 and LNv2
+//! when a single gateway is registered with two federations. Each path should
+//! settle internally on the gateway via the existing short-circuit logic
+//! (`get_client_for_invoice` for LNv1->LNv1, `is_lnv2_direct_swap` for
+//! LNv1->LNv2, `is_lnv1_invoice` for LNv2->LNv1, `is_direct_swap` for
+//! LNv2->LNv2) without invoking the Lightning RPC.
+//!
+//! Runs the matrix twice: once against the LND gateway (regression that the
+//! short-circuit logic works cross-fed for backends that have an LN node) and
+//! once against a fresh gateway running `LightningMode::None` (the LN-less
+//! gateway introduced for this test).
+
+use devimint::external::LightningNode;
+use devimint::federation::Federation;
+use devimint::util::ProcessManager;
+use devimint::version_constants::VERSION_0_12_0_ALPHA;
+use devimint::{Gatewayd, util};
+use fedimint_lnv2_client::FinalSendOperationState;
+use fedimint_portalloc::port_alloc;
+use tracing::info;
+
+#[path = "common.rs"]
+mod common;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    devimint::run_devfed_test()
+        .num_feds(2)
+        .call(|dev_fed, process_mgr| async move {
+            if !util::supports_lnv2() {
+                info!("lnv2 is disabled, skipping");
+                return Ok(());
+            }
+
+            let fed1 = dev_fed.fed().await?.clone();
+            let bitcoind = dev_fed.bitcoind().await?.clone();
+            let mut fed2 = Federation::new(
+                &process_mgr,
+                bitcoind,
+                false,
+                false,
+                false,
+                1,
+                "cross-fed-2".to_string(),
+            )
+            .await?;
+            fed2.degrade_federation(&process_mgr).await?;
+            info!(
+                fed1_id = %fed1.calculate_federation_id(),
+                fed1_invite = %fed1.invite_code()?,
+                fed2_id = %fed2.calculate_federation_id(),
+                fed2_invite = %fed2.invite_code()?,
+                "Cross-fed test federations",
+            );
+            anyhow::ensure!(
+                fed1.calculate_federation_id() != fed2.calculate_federation_id(),
+                "Test setup produced two federations with the same id"
+            );
+
+            // First pass: existing LND gateway, registered with both feds.
+            info!("--- cross-fed swaps via LND gateway ---");
+            let gw_lnd = dev_fed.gw_lnd().await?.clone();
+            gw_lnd.client().connect_fed(fed2.invite_code()?).await?;
+            run_cross_fed_matrix(&fed1, &fed2, &gw_lnd).await?;
+
+            let gatewayd_version = util::Gatewayd::version_or_default().await;
+            if gatewayd_version >= *VERSION_0_12_0_ALPHA {
+                // Second pass: a fresh gateway with no Lightning node,
+                // registered with both feds.
+                info!("--- cross-fed swaps via LN-less gateway ---");
+                let gw_none = spawn_none_gateway(&process_mgr, "gatewayd-none", 3).await?;
+                gw_none.client().connect_fed(fed1.invite_code()?).await?;
+                gw_none.client().connect_fed(fed2.invite_code()?).await?;
+                run_cross_fed_matrix(&fed1, &fed2, &gw_none).await?;
+
+                // Third pass: gateway underfunded on the receiving side. The
+                // sender's payment should refund instead of completing the swap.
+                info!("--- cross-fed refund when gateway has no ecash on receiver ---");
+                run_refund_when_receiver_gateway_unfunded(&process_mgr, &fed1, &fed2).await?;
+            } else {
+                info!(
+                    %gatewayd_version,
+                    "gatewayd does not support LightningMode::None, skipping LN-less gateway cases"
+                );
+            }
+
+            info!("Cross-federation swap tests complete!");
+            Ok(())
+        })
+        .await
+}
+
+/// Spawn a gateway with `LightningMode::None`. Allocates fresh ports so it
+/// can coexist with the LND and LDK gateways from the dev federation.
+async fn spawn_none_gateway(
+    process_mgr: &ProcessManager,
+    name: &str,
+    gateway_index: usize,
+) -> anyhow::Result<Gatewayd> {
+    let gw_port = port_alloc(1)?;
+    let metrics_port = port_alloc(1)?;
+    Gatewayd::new(
+        process_mgr,
+        LightningNode::None {
+            name: name.to_string(),
+            gw_port,
+            metrics_port,
+        },
+        gateway_index,
+    )
+    .await
+}
+
+/// Spin up a fresh `None` gateway, register it with both federations, peg-in
+/// ecash *only* in the sender's federation, and attempt an LNv2 cross-fed
+/// swap. The gateway has no ecash on the receiver side and so cannot fund the
+/// incoming contract; the sender's outgoing contract must refund.
+async fn run_refund_when_receiver_gateway_unfunded(
+    process_mgr: &ProcessManager,
+    fed_sender: &Federation,
+    fed_receiver: &Federation,
+) -> anyhow::Result<()> {
+    let gw = spawn_none_gateway(process_mgr, "gatewayd-none-refund", 4).await?;
+    gw.client().connect_fed(fed_sender.invite_code()?).await?;
+    gw.client().connect_fed(fed_receiver.invite_code()?).await?;
+
+    // Fund the gateway on the sender side only. Receiver-side gateway has 0
+    // ecash and will fail to fund the incoming contract.
+    fed_sender.pegin_gateways(1_000_000, vec![&gw]).await?;
+
+    let sender = fed_sender.new_joined_client("refund-test-sender").await?;
+    let receiver = fed_receiver
+        .new_joined_client("refund-test-receiver")
+        .await?;
+    fed_sender.pegin_client(10_000, &sender).await?;
+
+    info!("LNv2 -> LNv2 cross-fed swap with unfunded receiver gateway");
+    let (invoice, _receive_op) = common::receive(&receiver, &gw.addr, 1_000_000).await?;
+    let state = common::send(&sender, &gw.addr, &invoice.to_string()).await?;
+    assert!(
+        matches!(state, FinalSendOperationState::Refunded),
+        "expected refund, got {state:?}"
+    );
+    Ok(())
+}
+
+async fn run_cross_fed_matrix(
+    fed1: &Federation,
+    fed2: &Federation,
+    gw: &Gatewayd,
+) -> anyhow::Result<()> {
+    fed1.pegin_gateways(1_000_000, vec![gw]).await?;
+    fed2.pegin_gateways(1_000_000, vec![gw]).await?;
+
+    let client_a = fed1.new_joined_client("cross-fed-client-a").await?;
+    let client_b = fed2.new_joined_client("cross-fed-client-b").await?;
+    fed1.pegin_client(10_000, &client_a).await?;
+    fed2.pegin_client(10_000, &client_b).await?;
+
+    let gw_id = gw.gateway_id.clone();
+
+    info!("LNv1 -> LNv1 cross-fed swap");
+    let (lnv1_invoice, lnv1_op) = common::receive_lnv1(&client_b, &gw_id, 1_000_000).await?;
+    common::send_lnv1(&client_a, &gw_id, &lnv1_invoice.to_string()).await?;
+    common::await_receive_lnv1(&client_b, lnv1_op).await?;
+
+    info!("LNv2 -> LNv2 cross-fed swap");
+    let (lnv2_invoice, lnv2_op) = common::receive(&client_b, &gw.addr, 1_000_000).await?;
+    let state = common::send(&client_a, &gw.addr, &lnv2_invoice.to_string()).await?;
+    assert!(
+        matches!(state, FinalSendOperationState::Success(_)),
+        "expected success, got {state:?}"
+    );
+    common::await_receive_claimed(&client_b, lnv2_op).await?;
+
+    info!("LNv1 -> LNv2 cross-fed swap");
+    let (lnv2_invoice, lnv2_op) = common::receive(&client_b, &gw.addr, 1_000_000).await?;
+    common::send_lnv1(&client_a, &gw_id, &lnv2_invoice.to_string()).await?;
+    common::await_receive_claimed(&client_b, lnv2_op).await?;
+
+    info!("LNv2 -> LNv1 cross-fed swap");
+    let (lnv1_invoice, lnv1_op) = common::receive_lnv1(&client_b, &gw_id, 1_000_000).await?;
+    let state = common::send(&client_a, &gw.addr, &lnv1_invoice.to_string()).await?;
+    assert!(
+        matches!(state, FinalSendOperationState::Success(_)),
+        "expected success, got {state:?}"
+    );
+    common::await_receive_lnv1(&client_b, lnv1_op).await?;
+
+    Ok(())
+}

--- a/modules/fedimint-lnv2-tests/bin/swap_tests.rs
+++ b/modules/fedimint-lnv2-tests/bin/swap_tests.rs
@@ -1,8 +1,5 @@
-use devimint::federation::Client;
-use devimint::{cmd, util};
-use fedimint_core::core::OperationId;
+use devimint::util;
 use fedimint_lnv2_client::FinalSendOperationState;
-use lightning_invoice::Bolt11Invoice;
 use tracing::info;
 
 #[path = "common.rs"]
@@ -33,76 +30,19 @@ async fn main() -> anyhow::Result<()> {
             info!("Testing LNv1 client can pay LNv2 invoice...");
             let lnd_gw_id = gw_lnd.gateway_id.clone();
             let (invoice, receive_op) = common::receive(&client, &gw_lnd.addr, 1_000_000).await?;
-            send_lnv1(&client, &lnd_gw_id, &invoice.to_string()).await?;
+            common::send_lnv1(&client, &lnd_gw_id, &invoice.to_string()).await?;
             common::await_receive_claimed(&client, receive_op).await?;
 
             info!("Testing LNv2 client can pay LNv1 invoice...");
-            let (invoice, receive_op) = receive_lnv1(&client, &lnd_gw_id, 1_000_000).await?;
+            let (invoice, receive_op) =
+                common::receive_lnv1(&client, &lnd_gw_id, 1_000_000).await?;
             let state = common::send(&client, &gw_lnd.addr, &invoice.to_string()).await?;
             assert!(matches!(state, FinalSendOperationState::Success(_)));
-            await_receive_lnv1(&client, receive_op).await?;
+            common::await_receive_lnv1(&client, receive_op).await?;
 
             info!("LNv1 <-> LNv2 swap tests complete!");
 
             Ok(())
         })
         .await
-}
-
-async fn receive_lnv1(
-    client: &Client,
-    gateway_id: &String,
-    amount_msats: u64,
-) -> anyhow::Result<(Bolt11Invoice, OperationId)> {
-    let invoice_response = cmd!(
-        client,
-        "module",
-        "ln",
-        "invoice",
-        amount_msats,
-        "--gateway-id",
-        gateway_id
-    )
-    .out_json()
-    .await?;
-    let invoice = serde_json::from_value::<Bolt11Invoice>(
-        invoice_response
-            .get("invoice")
-            .expect("Invoice should be present")
-            .clone(),
-    )?;
-    let operation_id = serde_json::from_value::<OperationId>(
-        invoice_response
-            .get("operation_id")
-            .expect("OperationId should be present")
-            .clone(),
-    )?;
-    Ok((invoice, operation_id))
-}
-
-async fn send_lnv1(client: &Client, gateway_id: &str, invoice: &str) -> anyhow::Result<()> {
-    let payment_result = cmd!(
-        client,
-        "module",
-        "ln",
-        "pay",
-        invoice,
-        "--gateway-id",
-        gateway_id
-    )
-    .out_json()
-    .await?;
-    assert!(
-        payment_result.get("Success").is_some() || payment_result.get("preimage").is_some(),
-        "LNv1 payment failed: {payment_result:?}"
-    );
-    Ok(())
-}
-
-async fn await_receive_lnv1(client: &Client, operation_id: OperationId) -> anyhow::Result<()> {
-    let lnv1_response = cmd!(client, "await-invoice", operation_id.fmt_full())
-        .out_json()
-        .await?;
-    assert!(lnv1_response.get("total_amount_msat").is_some());
-    Ok(())
 }

--- a/scripts/tests/cross-fed-swap-test.sh
+++ b/scripts/tests/cross-fed-swap-test.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+export RUST_LOG="${RUST_LOG:-info}"
+
+source scripts/_common.sh
+build_workspace
+add_target_dir_to_path
+
+cross-fed-swap-tests

--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -181,6 +181,11 @@ function lnv1_lnv2_swap() {
 }
 export -f lnv1_lnv2_swap
 
+function cross_fed_swap() {
+  fm-run-test "${FUNCNAME[0]}" env FM_OFFLINE_NODES=0 ./scripts/tests/cross-fed-swap-test.sh
+}
+export -f cross_fed_swap
+
 function walletv2_module() {
   fm-run-test "${FUNCNAME[0]}" env FM_OFFLINE_NODES=0 ./scripts/tests/walletv2-module-test.sh
 }
@@ -481,6 +486,7 @@ tests_to_run_in_parallel+=(
   "lnv2_module_lnurl_pay"
   "lnv2_module_lnurl_recovery"
   "lnv1_lnv2_swap"
+  "cross_fed_swap"
   "walletv2_module"
   "mintv2_module_test"
   "devimint_cli_test"


### PR DESCRIPTION
## Summary

- Add `LightningMode::None`, a gatewayd backend that runs without any Lightning node attached. The gateway can no longer send to or receive from the wider LN network, but it stays useful as a federation-to-federation bridge: when it is registered with multiple federations, payments between users of those federations short-circuit on the gateway itself and never touch a Lightning RPC.
- The four short-circuit code paths already exist in the gateway (`get_client_for_invoice`, `is_lnv2_direct_swap`, `is_lnv1_invoice`, `is_direct_swap`) but were largely uncovered for cross-federation scenarios. Add an end-to-end devimint test that runs all four sender/receiver combinations between two federations, validated against both the LND gateway (regression) and a fresh `LightningMode::None` gateway.
- Drive-by fixes uncovered while wiring up the devimint test: `Federation::invite_code()` was reading a shared file that gets overwritten on the next `Federation::new`, the `AdminGatewayError::ClientCreationError` display swallowed the inner error, and `Federation::pegin_gateways` polled the gateway's chain-sync block height (None has no chain sync).

The motivation is making the gateway usable for federation-to-federation payments in environments where running a Lightning node is operationally infeasible or undesirable, without losing any of the existing swap routing logic. Discussion led with @elsirion in the working sketch on this branch.

## Cross-fed swap matrix

| Sender → Receiver | Impl                                                            | LND gateway | None gateway |
|-------------------|-----------------------------------------------------------------|-------------|--------------|
| LNv1 → LNv1       | `get_client_for_invoice` → `buy_preimage_via_direct_swap`       | ✅          | ✅           |
| LNv1 → LNv2       | `is_lnv2_direct_swap` → `buy_lnv2_preimage`                     | ✅          | ✅           |
| LNv2 → LNv1       | `is_lnv1_invoice` → `relay_lnv1_swap`                           | ✅          | ✅           |
| LNv2 → LNv2       | `is_direct_swap` → `relay_direct_swap`                          | ✅          | ✅           |

All eight cells are verified end-to-end by the new `cross-fed-swap-tests` devimint binary.

## Commits

1. `feat(gateway): add LightningMode::None backend` — new `GatewayNoneClient` (`info` returns a synthetic identity, `create_invoice` mints a Bolt11 signed by that identity, everything else errors), `LightningMode::None` clap variant, UI handling, and extending the five LNv1 federation-registration gates so None gateways register their LNv1 module.
2. `test(gateway): cross-fed LNv1 swap with no Lightning node` — in-process regression: existing LNv1↔LNv1 cross-fed swap against a None-backend gateway via a new `Fixtures::new_gateway_with_lightning` helper.
3. `fix(gateway): None backend mpsc channel needs non-zero capacity` — `tokio::sync::mpsc::channel(0)` panics; 1-slot buffer.
4. `feat(devimint): LightningMode::None gateway and multi-fed support` — `LightningNodeType::None`, `external::LightningNode::None`, gateway-port plumbing, fix to `Federation::invite_code()` so cross-fed tests don't silently use the same invite code for both feds, `pegin_gateways` block-height skip for None, and showing the wrapped anyhow error on `AdminGatewayError::ClientCreationError`.
5. `test(devimint): cross-federation swap test matrix` — `cross-fed-swap-tests` binary (LNv1/LNv2 × send/receive × LND/None), test script, and CI wiring.

## Test plan

Local runs in `nix develop`:

- [x] `just lint`
- [x] `just clippy`
- [x] `just cargo-sort-check`
- [x] `just typos`
- [x] `cargo test --doc --workspace`
- [x] `cargo nextest run --workspace --all-targets` — 309 passed
- [x] `fm-run-test cross_fed_swap …` — new test, 105s
- [x] `fm-run-test lnv1_lnv2_swap …` — same-fed regression, 32s
- [x] `fm-run-test gw_config_test_lnd …` — gateway regression, 36s
- [x] `fm-run-test gw_liquidity_test …` — gateway regression, 128s
- [x] `fm-run-test lnv2_module_payments …` — LNv2 regression, 120s
- [ ] `just check-wasm` — not run locally (requires `nix develop .#crossWasm`); my changes are confined to gateway/devimint, not WASM-targeted crates

Draft PR; happy to take feedback on the design (synthetic Bolt11 vs. refactoring `create_bolt11_invoice_v2` to bypass `lnrpc.create_invoice` entirely) before un-drafting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)