### PR TITLE
chore: bump version references to v0.11.1

### DIFF
--- a/docker/fedimintd/docker-compose.yaml
+++ b/docker/fedimintd/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   fedimintd:
-    image: fedimint/fedimintd:v0.10.0
+    image: fedimint/fedimintd:v0.11.1
     ports:
       - 8173:8173/tcp # p2p tls
       - 8173:8173/udp # p2p iroh

--- a/docker/gatewayd/docker-compose.yaml
+++ b/docker/gatewayd/docker-compose.yaml
@@ -4,7 +4,7 @@
 
 services:
   gatewayd:
-    image: fedimint/gatewayd:v0.10.0
+    image: fedimint/gatewayd:v0.11.1
     command: gatewayd ldk
     restart: unless-stopped
     ports:
@@ -23,7 +23,7 @@ services:
       # REQUIRED: Set the password hash to your own password
       # Run:
       #
-      # docker run fedimint/gatewayd:v0.10.0 gateway-cli create-password-hash <REPLACE ME> | sed 's/\$/$$/g'
+      # docker run fedimint/gatewayd:v0.11.1 gateway-cli create-password-hash <REPLACE ME> | sed 's/\$/$$/g'
       #
       # Then paste the result here.
       FM_GATEWAY_BCRYPT_PASSWORD_HASH: ""

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -111,7 +111,7 @@ Or copy it from the repository at [`docker/gatewayd/docker-compose.yaml`](../doc
 2. **Generate a password hash:**
 
 ```bash
-docker run fedimint/gatewayd:v0.10.0 gateway-cli create-password-hash YOUR_PASSWORD_HERE | sed 's/\$/$$/g'
+docker run fedimint/gatewayd:v0.11.1 gateway-cli create-password-hash YOUR_PASSWORD_HERE | sed 's/\$/$$/g'
 ```
 
 3. **Configure the gateway:**

--- a/gatewayd-startos/manifest.yaml
+++ b/gatewayd-startos/manifest.yaml
@@ -1,8 +1,8 @@
 id: fedimint-gatewayd
 title: "Fedimint Gateway"
-version: 0.10.0
+version: 0.11.1
 release-notes: |
-  Initial Start9 release of Fedimint Gateway v0.10.0
+  Start9 release of Fedimint Gateway v0.11.1
 license: MIT
 wrapper-repo: "https://github.com/fedimint/fedimint/tree/master/gatewayd-startos"
 upstream-repo: "https://github.com/fedimint/fedimint"

--- a/justfile.fedimint.just
+++ b/justfile.fedimint.just
@@ -22,13 +22,13 @@ test-ci-all:
 test-count:
   ./scripts/tests/test-cov.sh
 
-test-compatibility *VERSIONS="v0.8.2 v0.9.1 v0.10.0":
+test-compatibility *VERSIONS="v0.9.1 v0.10.0 v0.11.1":
   ./scripts/tests/test-ci-all-backcompat.sh {{VERSIONS}}
 
 test-full-compatibility *VERSIONS="v0.4.4":
   env FM_FULL_VERSION_MATRIX=1 ./scripts/tests/test-ci-all-backcompat.sh {{VERSIONS}}
 
-test-upgrades *VERSIONS="v0.8.2 current, v0.9.1 current, v0.10.0 current":
+test-upgrades *VERSIONS="v0.9.1 current, v0.10.0 current, v0.11.1 current":
   ./scripts/tests/upgrade-test.sh {{VERSIONS}}
 
 # `cargo udeps` check


### PR DESCRIPTION
## Summary
- Update `justfile.fedimint.just` test-compatibility and test-upgrades defaults to include v0.11.1 (replacing v0.8.2)
- Bump docker-compose images for fedimintd and gatewayd from v0.10.0 to v0.11.1
- Update gatewayd-startos manifest version from 0.10.0 to 0.11.1
- Update docs/gateway.md docker image reference to v0.11.1

CI workflows (upgrade-tests.yml, ci-backwards-compatibility.yml) already reference v0.11.1.

## Test plan
- [ ] CI upgrade tests pass with v0.11.1 in the matrix
- [ ] CI backwards-compatibility tests pass
- [ ] Docker images `fedimint/fedimintd:v0.11.1` and `fedimint/gatewayd:v0.11.1` exist on Docker Hub

🤖 Generated with [Claude Code](https://claude.com/claude-code)