### PR TITLE
fix(lnv2): skip lnurl-recovery backcompat test for CLI < v0.10.0

### DIFF
--- a/modules/fedimint-lnv2-tests/bin/tests.rs
+++ b/modules/fedimint-lnv2-tests/bin/tests.rs
@@ -585,6 +585,13 @@ async fn test_lnurl_pay(dev_fed: &DevJitFed) -> anyhow::Result<()> {
 /// 2. Payments to a pre-recovery LNURL are still claimed by the restored
 ///    client.
 async fn test_lnurl_recovery(dev_fed: &DevJitFed) -> anyhow::Result<()> {
+    // Before v0.10.0 the CLI registered LNURLs via a POST to the recurringd
+    // server.  That endpoint no longer exists, so old CLIs cannot generate
+    // LNURLs against the current recurringdv2.
+    if util::FedimintCli::version_or_default().await < *VERSION_0_10_0_ALPHA {
+        return Ok(());
+    }
+
     let federation = dev_fed.fed().await?;
     let gw_lnd = dev_fed.gw_lnd().await?;
     let gw_ldk = dev_fed.gw_ldk().await?;


### PR DESCRIPTION
## Summary
- Skip `test_lnurl_recovery` in backwards-compatibility tests when CLI version is below v0.10.0
- Before v0.10.0 the CLI registered LNURLs via a POST to a `{recurringd}lnurl` endpoint that no longer exists in `recurringdv2`, causing "error decoding response body" failures
- This was the root cause of the merge queue failure in #8569 — the `CLI: v0.9.1` combo only runs in the merge queue (not PR checks), so the gap was invisible until then

## Test plan
- [x] `cargo check -p fedimint-lnv2-tests` passes
- [ ] Backwards-compatibility tests pass in CI with v0.9.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)