### PR TITLE
fix: peg-in monitor improvements

### DIFF
--- a/modules/fedimint-wallet-client/src/pegin_monitor.rs
+++ b/modules/fedimint-wallet-client/src/pegin_monitor.rs
@@ -190,6 +190,32 @@ async fn check_and_claim_idx_pegins(
                 .autocommit(
                     |dbtx, _| {
                         Box::pin(async {
+                            // Re-read inside the transaction so a concurrent
+                            // `recheck_pegin_address` that landed while we were
+                            // doing Bitcoin RPC calls isn't silently overwritten.
+                            // Peg-in entries are never deleted, only updated,
+                            // so the entry is guaranteed to still exist even
+                            // across `autocommit` retries.
+                            let current = dbtx
+                                .get_value(&due_key)
+                                .await
+                                .expect("Peg-in entries are never deleted");
+
+                            // If `next_check_time` changed under us (a recheck set
+                            // it to "now"), keep the earliest of the two so the
+                            // recheck still triggers the next monitor iteration.
+                            let merged_next_check_time = if current.next_check_time
+                                == due_val.next_check_time
+                            {
+                                next_check_time
+                            } else {
+                                match (current.next_check_time, next_check_time) {
+                                    (Some(a), Some(b)) => Some(a.min(b)),
+                                    (a, None) => a,
+                                    (None, b) => b,
+                                }
+                            };
+
                             let claimed_now = CheckOutcome::get_claimed_now_outpoints(&outcomes);
 
                             let claimed_sender = pengin_claimed_sender.clone();
@@ -198,15 +224,15 @@ async fn check_and_claim_idx_pegins(
                             });
 
                             let peg_in_tweak_index_data = PegInTweakIndexData {
-                                next_check_time,
+                                next_check_time: merged_next_check_time,
                                 last_check_time: Some(now),
-                                claimed: [due_val.claimed.clone(), claimed_now].concat(),
-                                ..due_val
+                                claimed: [current.claimed.clone(), claimed_now].concat(),
+                                ..current
                             };
                             trace!(
                                 target: LOG_CLIENT_MODULE_WALLET,
                                 tweak_idx=%due_key.0,
-                                due_in_secs=?next_check_time.map(|next_check_time| next_check_time.duration_since(now).unwrap_or_default().as_secs()),
+                                due_in_secs=?merged_next_check_time.map(|next_check_time| next_check_time.duration_since(now).unwrap_or_default().as_secs()),
                                 data=?peg_in_tweak_index_data,
                                 "Updating"
                             );

--- a/modules/fedimint-wallet-client/src/pegin_monitor.rs
+++ b/modules/fedimint-wallet-client/src/pegin_monitor.rs
@@ -104,6 +104,14 @@ pub(crate) async fn run_peg_in_monitor(
         Duration::from_secs(30)
     };
 
+    // Whether the previous iteration was triggered by an external wakeup
+    // signal (manual `recheck_pegin_address`, new address allocation). On
+    // such iterations we drop the `min_sleep` floor so the user-initiated
+    // recheck isn't artificially throttled — particularly relevant for
+    // fresh addresses where `retry_delay_vec` returns `age / 10`, which
+    // would otherwise be clamped to the 30s production minimum.
+    let mut woke_via_signal = false;
+
     loop {
         if let Err(err) = check_for_deposits(
             &db,
@@ -125,14 +133,20 @@ pub(crate) async fn run_peg_in_monitor(
         let next_wakeup = NextActions::from_db_state(&db).await.next.unwrap_or_else(||
             /* for simplicity just wake up every hour, even when there's no need */
               now + Duration::from_hours(1));
+        let effective_min_sleep = if woke_via_signal {
+            Duration::ZERO
+        } else {
+            min_sleep
+        };
         let next_wakeup_duration = next_wakeup
             .duration_since(now)
             .unwrap_or_default()
-            .max(min_sleep);
-        debug!(target: LOG_CLIENT_MODULE_WALLET, sleep_msecs=%next_wakeup_duration.as_millis(), "Sleep after completing due checks");
+            .max(effective_min_sleep);
+        debug!(target: LOG_CLIENT_MODULE_WALLET, sleep_msecs=%next_wakeup_duration.as_millis(), woke_via_signal, "Sleep after completing due checks");
         tokio::select! {
             () = sleep(next_wakeup_duration) => {
                 debug!(target: LOG_CLIENT_MODULE_WALLET, "Woken up by a scheduled wakeup");
+                woke_via_signal = false;
             },
             res = wakeup_receiver.changed() => {
                 debug!(target: LOG_CLIENT_MODULE_WALLET, "Woken up by a signal");
@@ -140,6 +154,7 @@ pub(crate) async fn run_peg_in_monitor(
                     debug!(target: LOG_CLIENT_MODULE_WALLET,  "Terminating peg-in monitor");
                     return;
                 }
+                woke_via_signal = true;
             }
         }
     }

--- a/modules/fedimint-wallet-client/src/pegin_monitor.rs
+++ b/modules/fedimint-wallet-client/src/pegin_monitor.rs
@@ -104,15 +104,29 @@ pub(crate) async fn run_peg_in_monitor(
         Duration::from_secs(30)
     };
 
-    // Whether the previous iteration was triggered by an external wakeup
-    // signal (manual `recheck_pegin_address`, new address allocation). On
-    // such iterations we drop the `min_sleep` floor so the user-initiated
-    // recheck isn't artificially throttled — particularly relevant for
-    // fresh addresses where `retry_delay_vec` returns `age / 10`, which
-    // would otherwise be clamped to the 30s production minimum.
-    let mut woke_via_signal = false;
+    // How long to wait before the next check. Seeded to ZERO so the
+    // first iteration runs a check immediately. Recomputed at the end
+    // of each successful iteration based on DB scheduling and how the
+    // previous wakeup arrived (see `woke_via_signal` below).
+    let mut next_wakeup_duration = Duration::ZERO;
 
     loop {
+        debug!(target: LOG_CLIENT_MODULE_WALLET, sleep_msecs=%next_wakeup_duration.as_millis(), "Sleeping before next check");
+        let woke_via_signal = tokio::select! {
+            () = sleep(next_wakeup_duration) => {
+                debug!(target: LOG_CLIENT_MODULE_WALLET, "Woken up by a scheduled wakeup");
+                false
+            },
+            res = wakeup_receiver.changed() => {
+                debug!(target: LOG_CLIENT_MODULE_WALLET, "Woken up by a signal");
+                if res.is_err() {
+                    debug!(target: LOG_CLIENT_MODULE_WALLET,  "Terminating peg-in monitor");
+                    return;
+                }
+                true
+            }
+        };
+
         if let Err(err) = check_for_deposits(
             &db,
             &data,
@@ -124,8 +138,9 @@ pub(crate) async fn run_peg_in_monitor(
         .await
         {
             warn!(target: LOG_CLIENT_MODULE_WALLET, error = %err.fmt_compact_anyhow(), "Error checking for deposits");
-            // Avoid tight-looping on a persistent failure (e.g. bitcoind down).
-            sleep(min_sleep).await;
+            // Retry after `min_sleep`. The next iteration's select still
+            // honours signals, so a manual recheck wakes us up sooner.
+            next_wakeup_duration = min_sleep;
             continue;
         }
 
@@ -133,30 +148,20 @@ pub(crate) async fn run_peg_in_monitor(
         let next_wakeup = NextActions::from_db_state(&db).await.next.unwrap_or_else(||
             /* for simplicity just wake up every hour, even when there's no need */
               now + Duration::from_hours(1));
+        // When this iteration was signal-driven (manual recheck, new
+        // address allocation) drop the `min_sleep` floor so the natural
+        // retry_delay_vec drives timing — relevant for fresh addresses
+        // where the natural delay is `age / 10` and would otherwise be
+        // clamped to 30s in production.
         let effective_min_sleep = if woke_via_signal {
             Duration::ZERO
         } else {
             min_sleep
         };
-        let next_wakeup_duration = next_wakeup
+        next_wakeup_duration = next_wakeup
             .duration_since(now)
             .unwrap_or_default()
             .max(effective_min_sleep);
-        debug!(target: LOG_CLIENT_MODULE_WALLET, sleep_msecs=%next_wakeup_duration.as_millis(), woke_via_signal, "Sleep after completing due checks");
-        tokio::select! {
-            () = sleep(next_wakeup_duration) => {
-                debug!(target: LOG_CLIENT_MODULE_WALLET, "Woken up by a scheduled wakeup");
-                woke_via_signal = false;
-            },
-            res = wakeup_receiver.changed() => {
-                debug!(target: LOG_CLIENT_MODULE_WALLET, "Woken up by a signal");
-                if res.is_err() {
-                    debug!(target: LOG_CLIENT_MODULE_WALLET,  "Terminating peg-in monitor");
-                    return;
-                }
-                woke_via_signal = true;
-            }
-        }
     }
 }
 

--- a/modules/fedimint-wallet-client/src/pegin_monitor.rs
+++ b/modules/fedimint-wallet-client/src/pegin_monitor.rs
@@ -116,6 +116,8 @@ pub(crate) async fn run_peg_in_monitor(
         .await
         {
             warn!(target: LOG_CLIENT_MODULE_WALLET, error = %err.fmt_compact_anyhow(), "Error checking for deposits");
+            // Avoid tight-looping on a persistent failure (e.g. bitcoind down).
+            sleep(min_sleep).await;
             continue;
         }
 


### PR DESCRIPTION
After Fedi user report we've uncovered some peg-in monitor misbehavior.

In particular overwritting the next-recheck, could lead to monitor just ignoring user's request to check for new pegins.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
