### PR TITLE
test(mint): regression test for duplicate blind nonce panic

### DIFF
--- a/modules/fedimint-mint-server/src/test.rs
+++ b/modules/fedimint-mint-server/src/test.rs
@@ -1,15 +1,16 @@
 use assert_matches::assert_matches;
 use fedimint_core::config::{ClientModuleConfig, ServerModuleConfig};
-use fedimint_core::db::Database;
 use fedimint_core::db::mem_impl::MemDatabase;
+use fedimint_core::db::{Database, IDatabaseTransactionOpsCoreTyped};
 use fedimint_core::module::ModuleConsensusVersion;
 use fedimint_core::module::registry::ModuleRegistry;
-use fedimint_core::{Amount, BitcoinHash, InPoint, PeerId, TransactionId, secp256k1};
+use fedimint_core::{Amount, BitcoinHash, InPoint, OutPoint, PeerId, TransactionId, secp256k1};
 use fedimint_mint_common::config::FeeConsensus;
-use fedimint_mint_common::{MintInput, Nonce, Note};
+use fedimint_mint_common::{BlindNonce, MintInput, MintOutput, Nonce, Note};
 use fedimint_server_core::{ConfigGenModuleArgs, ServerModule, ServerModuleInit};
-use tbs::blind_message;
+use tbs::{BlindingKey, Message, blind_message};
 
+use crate::db::{BlindNonceKey, RecoveryBlindNonceOutpointKey};
 use crate::{Mint, MintConfig, MintConfigConsensus, MintConfigPrivate, MintInit};
 
 const MINTS: u16 = 5;
@@ -130,5 +131,69 @@ async fn test_detect_double_spends() {
         )
         .await,
         Err(_)
+    );
+}
+
+// Regression test for #8582 / v0.11.1: when two outputs in a single consensus
+// batch share a blind nonce, `process_output` used to panic on
+// `insert_new_entry(RecoveryBlindNonceOutpointKey, _)`. The fix in #8533
+// switched both call sites to `insert_entry`, so the second writer must just
+// warn and continue. Note that `RecoveryBlindNonceOutpointKey` ends up holding
+// the *second* outpoint (last-writer wins) — the #8533 commit message claims
+// "first-writer wins" but `insert_entry` overwrites, matching #8537's "the old
+// outpoint is quietly lost from the recovery index" review note.
+#[test_log::test(tokio::test)]
+async fn test_duplicate_blind_nonce_in_process_output_does_not_panic() {
+    let (mint_server_cfg, _) = build_configs();
+    let mint = Mint::new(mint_server_cfg[0].to_typed().unwrap());
+
+    let (_, tiered) = mint
+        .cfg
+        .consensus
+        .peer_tbs_pks
+        .first_key_value()
+        .expect("mint has peers");
+    let denomination = *tiered.max_tier();
+
+    let blind_nonce = BlindNonce(blind_message(
+        Message::from_bytes(b"dup-blind-nonce-test"),
+        BlindingKey::random(),
+    ));
+    let output = MintOutput::new_v0(denomination, blind_nonce);
+
+    let out_point_first = OutPoint {
+        txid: TransactionId::all_zeros(),
+        out_idx: 0,
+    };
+    let out_point_second = OutPoint {
+        txid: TransactionId::all_zeros(),
+        out_idx: 1,
+    };
+
+    let db = Database::new(MemDatabase::new(), ModuleRegistry::default());
+    let mut dbtx = db.begin_transaction().await;
+    let mut module_dbtx = dbtx.to_ref_with_prefix_module_id(42).0.into_nc();
+
+    mint.process_output(&mut module_dbtx, &output, out_point_first)
+        .await
+        .expect("first output is accepted");
+
+    // Pre-fix this call would panic on `insert_new_entry`; post-fix it must
+    // succeed and just warn.
+    mint.process_output(&mut module_dbtx, &output, out_point_second)
+        .await
+        .expect("duplicate blind nonce must not panic");
+
+    assert_eq!(
+        module_dbtx.get_value(&BlindNonceKey(blind_nonce)).await,
+        Some(()),
+        "blind nonce should be marked as used"
+    );
+    assert_eq!(
+        module_dbtx
+            .get_value(&RecoveryBlindNonceOutpointKey(blind_nonce))
+            .await,
+        Some(out_point_second),
+        "recovery index is overwritten by the second writer (last-writer wins)"
     );
 }

--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -780,12 +780,19 @@ mod fedimint_migration_tests {
     use fedimint_client_module::module::init::recovery::{
         RecoveryFromHistory, RecoveryFromHistoryCommon,
     };
-    use fedimint_core::core::OperationId;
+    use fedimint_core::core::{IntoDynInstance, OperationId};
+    use fedimint_core::db::mem_impl::MemDatabase;
     use fedimint_core::db::{
-        Database, DatabaseVersion, DatabaseVersionKeyV0, IDatabaseTransactionOpsCoreTyped,
+        Database, DatabaseVersion, DatabaseVersionKey, DatabaseVersionKeyV0,
+        IDatabaseTransactionOpsCoreTyped, apply_migrations,
     };
+    use fedimint_core::epoch::ConsensusItem;
+    use fedimint_core::module::CommonModuleInit;
+    use fedimint_core::module::registry::ModuleDecoderRegistry;
+    use fedimint_core::session_outcome::{AcceptedItem, SessionOutcome, SignedSessionOutcome};
+    use fedimint_core::transaction::{Transaction, TransactionSignature};
     use fedimint_core::{
-        Amount, BitcoinHash, OutPoint, Tiered, TieredMulti, TransactionId, secp256k1,
+        Amount, BitcoinHash, OutPoint, PeerId, Tiered, TieredMulti, TransactionId, secp256k1,
     };
     use fedimint_derive_secret::{ChildId, DerivableSecret};
     use fedimint_logging::TracingSetup;
@@ -800,15 +807,16 @@ mod fedimint_migration_tests {
     };
     use fedimint_mint_client::output::NoteIssuanceRequest;
     use fedimint_mint_client::{MintClientInit, MintClientModule, NoteIndex, SpendableNote};
-    use fedimint_mint_common::{MintCommonInit, MintOutputOutcome, Nonce};
+    use fedimint_mint_common::{BlindNonce, MintCommonInit, MintOutput, MintOutputOutcome, Nonce};
     use fedimint_mint_server::db::{
         DbKeyPrefix, MintAuditItemKey, MintAuditItemKeyPrefix, MintOutputOutcomeKey,
-        MintOutputOutcomePrefix, NonceKey, NonceKeyPrefix,
+        MintOutputOutcomePrefix, NonceKey, NonceKeyPrefix, RecoveryBlindNonceOutpointKey,
     };
+    use fedimint_server::consensus::db::{ServerDbMigrationContext, SignedSessionOutcomeKey};
     use fedimint_server::core::DynServerModuleInit;
     use fedimint_testing::db::{
-        BYTE_8, BYTE_32, snapshot_db_migrations, snapshot_db_migrations_client,
-        validate_migrations_client, validate_migrations_server,
+        BYTE_8, BYTE_32, TEST_MODULE_INSTANCE_ID, snapshot_db_migrations,
+        snapshot_db_migrations_client, validate_migrations_client, validate_migrations_server,
     };
     use ff::Field;
     use futures::StreamExt;
@@ -1045,6 +1053,96 @@ mod fedimint_migration_tests {
             Ok(())
         })
         .await
+    }
+
+    // Regression test for #8582: `migrate_db_v2` walks `ModuleHistoryItem`s
+    // assembled from `SignedSessionOutcome`s and used to call
+    // `insert_new_entry(RecoveryBlindNonceOutpointKey, _)`, which panics on a
+    // duplicate. Federations that had previously accepted a duplicate blind
+    // nonce therefore failed to migrate on the v0.11.0 -> v0.11.1 upgrade —
+    // that on-upgrade crash is what motivated cutting v0.11.1.
+    //
+    // Seed a session outcome containing one transaction with two `MintOutput`s
+    // that share a blind nonce, pin the on-disk db version to 2 so
+    // `apply_migrations` actually runs `migrate_db_v2`, and assert it
+    // completes without panic.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_migrate_db_v2_handles_duplicate_blind_nonce() -> anyhow::Result<()> {
+        use std::sync::Arc;
+
+        let _ = TracingSetup::default().init();
+
+        let decoders = ModuleDecoderRegistry::from_iter([(
+            TEST_MODULE_INSTANCE_ID,
+            MintCommonInit::KIND,
+            MintCommonInit::decoder(),
+        )]);
+        let db = Database::new(MemDatabase::new(), decoders);
+
+        let blind_nonce = BlindNonce(blind_message(
+            Message::from_bytes(&BYTE_8),
+            BlindingKey::random(),
+        ));
+        let mint_output = MintOutput::new_v0(Amount::from_sats(1), blind_nonce);
+        let tx = Transaction {
+            inputs: vec![],
+            outputs: vec![
+                mint_output.clone().into_dyn(TEST_MODULE_INSTANCE_ID),
+                mint_output.into_dyn(TEST_MODULE_INSTANCE_ID),
+            ],
+            nonce: [0u8; 8],
+            signatures: TransactionSignature::NaiveMultisig(vec![]),
+        };
+        let txid = tx.tx_hash();
+
+        let signed_outcome = SignedSessionOutcome {
+            session_outcome: SessionOutcome {
+                items: vec![AcceptedItem {
+                    item: ConsensusItem::Transaction(tx),
+                    peer: PeerId::from(0),
+                }],
+            },
+            signatures: BTreeMap::new(),
+        };
+
+        // Seed global namespace with the session-outcome record, and pin the
+        // module's DB version to 2 so `apply_migrations` runs `migrate_db_v2`.
+        let mut dbtx = db.begin_transaction().await;
+        dbtx.insert_new_entry(&SignedSessionOutcomeKey(0), &signed_outcome)
+            .await;
+        dbtx.insert_new_entry(
+            &DatabaseVersionKey(TEST_MODULE_INSTANCE_ID),
+            &DatabaseVersion(2),
+        )
+        .await;
+        dbtx.commit_tx().await;
+
+        // Pre-fix, this panics on the duplicate via `insert_new_entry`.
+        let module = DynServerModuleInit::from(MintInit);
+        apply_migrations(
+            &db,
+            Arc::new(ServerDbMigrationContext) as Arc<_>,
+            module.module_kind().to_string(),
+            module.get_database_migrations(),
+            Some(TEST_MODULE_INSTANCE_ID),
+            None,
+        )
+        .await?;
+
+        // Sanity-check the backfill: the recovery index must be populated, and
+        // — since `insert_entry` overwrites — it must hold the second outpoint
+        // (last-writer wins), consistent with the unit test in
+        // `fedimint-mint-server`.
+        let module_db = db.with_prefix_module_id(TEST_MODULE_INSTANCE_ID).0;
+        let mut module_dbtx = module_db.begin_transaction_nc().await;
+        let entry = module_dbtx
+            .get_value(&RecoveryBlindNonceOutpointKey(blind_nonce))
+            .await;
+        ensure!(
+            entry == Some(OutPoint { txid, out_idx: 1 }),
+            "migrate_db_v2 must backfill the recovery index (last-writer wins): got {entry:?}",
+        );
+        Ok(())
     }
 
     #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## Summary

Closes #8582 — adds regression tests for the v0.11.1 panic where the v1
mint module crashed the guardian on a duplicate blind nonce.

Two commits, one per panic site:

1. **Live `process_output` path** — unit test in
   `fedimint-mint-server/src/test.rs` that builds a `Mint`, calls
   `process_output` twice with the same `BlindNonce`, and asserts no
   panic plus `BlindNonceKey` / `RecoveryBlindNonceOutpointKey` state.
2. **`migrate_db_v2` backfill** — test in `fedimint-mint-tests` that
   seeds a `SignedSessionOutcomeKey` containing one transaction with
   two `MintOutput`s sharing a blind nonce, pins the on-disk DB
   version to 2, runs `apply_migrations`, and asserts the backfill
   completes without panic and populates
   `RecoveryBlindNonceOutpointKey`.

The migration path is the one that actually crashed guardians on the
v0.11.0 → v0.11.1 upgrade.

Both tests were verified to fail (`AlreadyExists` panic from
`insert_new_entry`) if their respective fix sites are reverted.

## Worth a look in review

The #8533 commit message says *"First-writer wins for the outpoint
mapping"*, but `insert_entry` overwrites, so the implementation is
actually **last-writer wins**. #8537's review note ("the old outpoint
is quietly lost from the recovery index") matches what the code does.
Both tests assert the implemented behavior; if first-writer-wins is
the intended semantics, the fix needs a follow-up (check the
`insert_entry` return value, skip the write on `is_some()`) and these
tests should flip their assertions.

## Test plan

- [x] `cargo test -p fedimint-mint-server --lib test_duplicate_blind_nonce` passes.
- [x] `cargo test -p fedimint-mint-tests --test fedimint_mint_tests test_migrate_db_v2` passes.
- [x] Both tests panic if their respective `insert_entry` is reverted to `insert_new_entry`.
- [x] `cargo clippy --tests -- -D warnings` clean on both crates.
- [ ] Full CI green.