### PR TITLE
feat(ln-client): recover funds from past timed-out LNv1 receives

### DIFF
--- a/fedimint-client-module/src/module/mod.rs
+++ b/fedimint-client-module/src/module/mod.rs
@@ -155,6 +155,14 @@ impl FinalClientIface {
             .expect("client module context must not be use past client shutdown")
     }
 
+    /// Like [`Self::get`] but returns `None` if the client has not been
+    /// finalized yet rather than panicking. Useful for background tasks
+    /// spawned during module init that may start before [`Self::set`] has
+    /// been called by the builder.
+    pub(crate) fn try_get(&self) -> Option<Arc<dyn ClientContextIface>> {
+        self.0.get()?.upgrade()
+    }
+
     pub fn set(&self, client: Weak<dyn ClientContextIface>) {
         self.0.set(client).expect("FinalLazyClient already set");
     }
@@ -255,6 +263,21 @@ where
             client: self.client.get(),
             module_instance_id: self.module_instance_id,
             _marker: marker::PhantomData,
+        }
+    }
+
+    /// Poll until the underlying client is fully constructed, then return.
+    ///
+    /// Background tasks spawned from `ClientModule::new` may start running
+    /// before the [`fedimint_client::Client`] is finished being built; calls
+    /// like [`Self::get_own_active_states`] would then panic. Tasks that need
+    /// to use the full client should await this future first.
+    pub async fn wait_for_client_ready(&self) {
+        use fedimint_core::task::sleep;
+        // 50ms keeps the polling cheap; setup typically completes in a few ms.
+        const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(50);
+        while self.client.try_get().is_none() {
+            sleep(POLL_INTERVAL).await;
         }
     }
 
@@ -474,6 +497,27 @@ where
             .get()
             .executor()
             .get_active_states()
+            .await
+            .into_iter()
+            .filter(|s| s.0.module_instance_id() == self.module_instance_id)
+            .map(|s| {
+                (
+                    Clone::clone(
+                        s.0.as_any()
+                            .downcast_ref::<M::States>()
+                            .expect("incorrect output type passed to module plugin"),
+                    ),
+                    s.1,
+                )
+            })
+            .collect()
+    }
+
+    pub async fn get_own_inactive_states(&self) -> Vec<(M::States, InactiveStateMeta)> {
+        self.client
+            .get()
+            .executor()
+            .get_inactive_states()
             .await
             .into_iter()
             .filter(|s| s.0.module_instance_id() == self.module_instance_id)

--- a/fedimint-client-module/src/module/mod.rs
+++ b/fedimint-client-module/src/module/mod.rs
@@ -269,7 +269,7 @@ where
     /// Poll until the underlying client is fully constructed, then return.
     ///
     /// Background tasks spawned from `ClientModule::new` may start running
-    /// before the [`fedimint_client::Client`] is finished being built; calls
+    /// before the `fedimint_client::Client` is finished being built; calls
     /// like [`Self::get_own_active_states`] would then panic. Tasks that need
     /// to use the full client should await this future first.
     pub async fn wait_for_client_ready(&self) {

--- a/fedimint-client-module/src/sm/executor.rs
+++ b/fedimint-client-module/src/sm/executor.rs
@@ -127,6 +127,8 @@ pub struct InactiveStateMeta {
 pub trait IExecutor {
     async fn get_active_states(&self) -> Vec<(DynState, ActiveStateMeta)>;
 
+    async fn get_inactive_states(&self) -> Vec<(DynState, InactiveStateMeta)>;
+
     async fn add_state_machines_dbtx(
         &self,
         dbtx: &mut DatabaseTransaction<'_>,

--- a/fedimint-client/src/sm/executor.rs
+++ b/fedimint-client/src/sm/executor.rs
@@ -181,6 +181,10 @@ impl Executor {
         self.inner.get_active_states().await
     }
 
+    pub async fn get_inactive_states(&self) -> Vec<(DynState, InactiveStateMeta)> {
+        self.inner.get_inactive_states().await
+    }
+
     /// Adds a number of state machines to the executor atomically. They will be
     /// driven to completion automatically in the background.
     ///
@@ -1231,6 +1235,10 @@ impl ActiveOrInactiveState {
 impl IExecutor for Executor {
     async fn get_active_states(&self) -> Vec<(DynState, ActiveStateMeta)> {
         Self::get_active_states(self).await
+    }
+
+    async fn get_inactive_states(&self) -> Vec<(DynState, InactiveStateMeta)> {
+        Self::get_inactive_states(self).await
     }
 
     async fn add_state_machines_dbtx(

--- a/modules/fedimint-ln-client/src/db.rs
+++ b/modules/fedimint-ln-client/src/db.rs
@@ -32,6 +32,7 @@ pub enum DbKeyPrefix {
     MetaOverridesDeprecated = 0x30,
     LightningGateway = 0x45,
     RecurringPaymentKey = 0x46,
+    ExpiredReceiveRecoveryCompleted = 0x47,
     /// Prefixes between 0xb0..=0xcf shall all be considered allocated for
     /// historical and future external use
     ExternalReservedStart = 0xb0,
@@ -120,6 +121,28 @@ impl_db_record!(
 impl_db_lookup!(
     key = RecurringPaymentCodeKey,
     query_prefix = RecurringPaymentCodeKeyPrefix
+);
+
+/// Marker that the one-shot auto-recovery sweep for past timed-out LN receives
+/// (see <https://github.com/fedimint/fedimint/issues/8455>) has run to completion.
+/// Absent on existing wallets so the sweep runs once after upgrade; present
+/// afterwards to avoid re-probing the federation on every restart, which would
+/// leak the count and timing of historical expired receives.
+#[derive(Debug, Encodable, Decodable, Serialize)]
+pub struct ExpiredReceiveRecoveryCompletedKey;
+
+#[derive(Debug, Encodable, Decodable)]
+pub struct ExpiredReceiveRecoveryCompletedKeyPrefix;
+
+impl_db_record!(
+    key = ExpiredReceiveRecoveryCompletedKey,
+    value = (),
+    db_prefix = DbKeyPrefix::ExpiredReceiveRecoveryCompleted,
+);
+
+impl_db_lookup!(
+    key = ExpiredReceiveRecoveryCompletedKey,
+    query_prefix = ExpiredReceiveRecoveryCompletedKeyPrefix
 );
 
 /// Migrates `SubmittedOfferV0` to `SubmittedOffer` and `ConfirmedInvoiceV0` to

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -31,7 +31,8 @@ use async_stream::{stream, try_stream};
 use bitcoin::Network;
 use bitcoin::hashes::{Hash, HashEngine, Hmac, HmacEngine, sha256};
 use db::{
-    DbKeyPrefix, LightningGatewayKey, LightningGatewayKeyPrefix, PaymentResult, PaymentResultKey,
+    DbKeyPrefix, ExpiredReceiveRecoveryCompletedKey, ExpiredReceiveRecoveryCompletedKeyPrefix,
+    LightningGatewayKey, LightningGatewayKeyPrefix, PaymentResult, PaymentResultKey,
     RecurringPaymentCodeKeyPrefix,
 };
 use fedimint_api_client::api::{DynModuleApi, ServerError};
@@ -65,7 +66,9 @@ use fedimint_core::{
 use fedimint_derive_secret::{ChildId, DerivableSecret};
 use fedimint_ln_common::client::GatewayApi;
 use fedimint_ln_common::config::{FeeToAmount, LightningClientConfig};
-use fedimint_ln_common::contracts::incoming::{IncomingContract, IncomingContractOffer};
+use fedimint_ln_common::contracts::incoming::{
+    IncomingContract, IncomingContractAccount, IncomingContractOffer,
+};
 use fedimint_ln_common::contracts::outgoing::{
     OutgoingContract, OutgoingContractAccount, OutgoingContractData,
 };
@@ -96,7 +99,7 @@ use reqwest::Method;
 use serde::{Deserialize, Serialize};
 use strum::IntoEnumIterator;
 use tokio::sync::Notify;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 use crate::db::PaymentResultPrefix;
 use crate::incoming::{
@@ -268,6 +271,16 @@ pub struct LightningOperationMeta {
     pub extra_meta: serde_json::Value,
 }
 
+/// Result entry for [`LightningClientModule::recover_expired_receives`],
+/// describing a single LN receive whose stuck funds were claimed.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RecoveredReceive {
+    pub original_operation_id: OperationId,
+    pub recovery_operation_id: OperationId,
+    pub amount: Amount,
+    pub payment_hash: sha256::Hash,
+}
+
 pub use deprecated_variant_hack::LightningOperationMetaVariant;
 
 /// This is a hack to allow us to use the deprecated variant in the database
@@ -354,6 +367,16 @@ impl ModuleInit for LightningClientInit {
                         RecurringPaymentCodeEntry,
                         ln_client_items,
                         "Recurring Payment Code"
+                    );
+                }
+                DbKeyPrefix::ExpiredReceiveRecoveryCompleted => {
+                    push_db_pair_items!(
+                        dbtx,
+                        ExpiredReceiveRecoveryCompletedKeyPrefix,
+                        ExpiredReceiveRecoveryCompletedKey,
+                        (),
+                        ln_client_items,
+                        "Expired Receive Recovery Completed"
                     );
                 }
                 DbKeyPrefix::ExternalReservedStart
@@ -725,6 +748,11 @@ impl LightningClientModule {
                 args.context(),
                 new_recurring_payment_code.clone(),
             ),
+        );
+
+        args.spawn_cancellable(
+            "Recover expired LN receives",
+            Self::recover_expired_receives_if_needed(args.context()),
         );
 
         Self {
@@ -1704,7 +1732,6 @@ impl LightningClientModule {
     /// Claim the funded, unspent incoming contract by submitting a transaction
     /// to the federation and awaiting the primary module's outputs
     #[deprecated(since = "0.7.0", note = "Use recurring payment functionality instead")]
-    #[allow(deprecated)]
     pub async fn claim_funded_incoming_contract<M: Serialize + Send + Sync>(
         &self,
         key_pair: Keypair,
@@ -1716,18 +1743,249 @@ impl LightningClientModule {
             .ok_or(anyhow!("No contract account found"))
             .with_context(|| format!("No contract found for {contract_id:?}"))?;
 
-        let input = incoming_contract_account.claim();
+        let extra_meta = serde_json::to_value(extra_meta).expect("extra_meta is serializable");
+        Self::submit_incoming_contract_claim(
+            &self.client_ctx,
+            incoming_contract_account,
+            key_pair,
+            extra_meta,
+        )
+        .await
+    }
+
+    /// Recover funds for past `LNv1` receives that terminated with
+    /// [`LightningReceiveError::Timeout`] but were nevertheless funded by a
+    /// payer after the invoice expired.
+    ///
+    /// Pre-#8348 the federation, gateway and paying client all skipped
+    /// invoice-expiry validation. If a receiver's state machine timed out
+    /// before the payer's contract-funding transaction landed, the contract
+    /// was created but never claimed and the funds were stuck. This method
+    /// scans the local state machine history for such timed-out receives,
+    /// probes the federation for a still-claimable contract, and submits a
+    /// claim transaction. It is naturally idempotent: once claimed, the
+    /// contract no longer exists on the server and subsequent runs skip it.
+    ///
+    /// Only [`ReceivingKey::Personal`] receives are recoverable here, since
+    /// the secret key for `External` receives is held by another client.
+    pub async fn recover_expired_receives(&self) -> anyhow::Result<Vec<RecoveredReceive>> {
+        Self::recover_expired_receives_with_ctx(&self.client_ctx).await
+    }
+
+    /// Auto-spawned task that runs the recovery sweep at most once per wallet
+    /// lifetime, gated by [`ExpiredReceiveRecoveryCompletedKey`]. Repeated
+    /// federation probes on every restart would leak the count and timing of
+    /// historical expired receives, hence the one-shot design.
+    async fn recover_expired_receives_if_needed(client_ctx: ClientContext<Self>) {
+        let already_completed = client_ctx
+            .module_db()
+            .begin_transaction_nc()
+            .await
+            .get_value(&ExpiredReceiveRecoveryCompletedKey)
+            .await
+            .is_some();
+        if already_completed {
+            return;
+        }
+
+        // The recovery sweep reads from the SM executor and submits
+        // transactions, both of which need the [`fedimint_client::Client`] to
+        // be fully constructed. This task is spawned from
+        // [`LightningClientModule::new`] which runs before the builder calls
+        // `FinalClientIface::set`, so wait until the client is wired up.
+        client_ctx.wait_for_client_ready().await;
+
+        let recovered = match retry(
+            "recover_expired_receives",
+            backoff_util::background_backoff(),
+            || async {
+                Self::recover_expired_receives_with_ctx(&client_ctx)
+                    .await
+                    .inspect_err(|err| {
+                        debug!(
+                            target: LOG_CLIENT_MODULE_LN,
+                            err = %err.fmt_compact_anyhow(),
+                            "Expired-receive recovery sweep failed, will retry"
+                        );
+                    })
+            },
+        )
+        .await
+        {
+            Ok(r) => r,
+            Err(err) => {
+                warn!(
+                    target: LOG_CLIENT_MODULE_LN,
+                    err = %err.fmt_compact_anyhow(),
+                    "Expired-receive recovery exhausted retries; will try again on next startup"
+                );
+                return;
+            }
+        };
+
+        if !recovered.is_empty() {
+            info!(
+                target: LOG_CLIENT_MODULE_LN,
+                count = recovered.len(),
+                "Expired-receive recovery sweep claimed funds for previously stuck receives"
+            );
+        }
+
+        let mut dbtx = client_ctx.module_db().begin_transaction().await;
+        dbtx.insert_new_entry(&ExpiredReceiveRecoveryCompletedKey, &())
+            .await;
+        dbtx.commit_tx().await;
+    }
+
+    async fn recover_expired_receives_with_ctx(
+        client_ctx: &ClientContext<Self>,
+    ) -> anyhow::Result<Vec<RecoveredReceive>> {
+        let inactive = client_ctx.get_own_inactive_states().await;
+
+        // Bucket inactive states by operation_id. For each operation_id we want
+        // both the terminal state (to check it's `Canceled(Timeout)`) and the
+        // prior state that carries the receiving key.
+        let mut by_op: BTreeMap<OperationId, Vec<LightningReceiveStateMachine>> = BTreeMap::new();
+        for (state, _meta) in inactive {
+            if let LightningClientStateMachines::Receive(sm) = state {
+                by_op.entry(sm.operation_id).or_default().push(sm);
+            }
+        }
+
+        let module_api = client_ctx.module_api();
+        let mut recovered = Vec::new();
+        for (operation_id, states) in by_op {
+            let timed_out = states.iter().any(|sm| {
+                matches!(
+                    sm.state,
+                    LightningReceiveStates::Canceled(LightningReceiveError::Timeout)
+                )
+            });
+            if !timed_out {
+                continue;
+            }
+
+            let Some((invoice, keypair)) = states.iter().find_map(|sm| match &sm.state {
+                LightningReceiveStates::ConfirmedInvoice(c) => match c.receiving_key {
+                    ReceivingKey::Personal(kp) => Some((c.invoice.clone(), kp)),
+                    ReceivingKey::External(_) => None,
+                },
+                LightningReceiveStates::SubmittedOffer(s) => match s.receiving_key {
+                    ReceivingKey::Personal(kp) => Some((s.invoice.clone(), kp)),
+                    ReceivingKey::External(_) => None,
+                },
+                _ => None,
+            }) else {
+                // Either an `External` receive (someone else's key) or the
+                // state machine record is missing the offer/invoice state for
+                // some unexpected reason. Either way, nothing to do here.
+                continue;
+            };
+
+            let payment_hash = *invoice.payment_hash();
+            let contract_id = payment_hash.into();
+            let contract = match get_incoming_contract(module_api.clone(), contract_id).await {
+                Ok(Some(c)) => c,
+                Ok(None) => continue,
+                Err(err) => {
+                    return Err(anyhow::anyhow!(
+                        "Failed to fetch contract {contract_id} during expired-receive recovery: {err}"
+                    ));
+                }
+            };
+
+            // After a prior claim the contract entry still exists but is
+            // empty; skip rather than submitting a no-op claim tx.
+            if contract.amount == Amount::ZERO {
+                continue;
+            }
+
+            match contract.contract.decrypted_preimage {
+                DecryptedPreimage::Some(_) => {}
+                DecryptedPreimage::Pending => {
+                    debug!(
+                        target: LOG_CLIENT_MODULE_LN,
+                        %contract_id,
+                        "Skipping expired-receive recovery: preimage still pending"
+                    );
+                    continue;
+                }
+                DecryptedPreimage::Invalid => {
+                    warn!(
+                        target: LOG_CLIENT_MODULE_LN,
+                        %contract_id,
+                        "Skipping expired-receive recovery: decrypted preimage invalid"
+                    );
+                    continue;
+                }
+            }
+
+            let amount = contract.amount;
+            let recovery_operation_id = match Self::submit_incoming_contract_claim(
+                client_ctx,
+                contract,
+                keypair,
+                serde_json::Value::Null,
+            )
+            .await
+            {
+                Ok(op) => op,
+                Err(err) => {
+                    // Most likely the contract was just claimed by a parallel
+                    // sweep (manual + auto), making the input already-spent.
+                    // Log and continue with other candidates rather than
+                    // aborting the whole sweep.
+                    warn!(
+                        target: LOG_CLIENT_MODULE_LN,
+                        operation_id = %operation_id.fmt_short(),
+                        %contract_id,
+                        err = %err.fmt_compact_anyhow(),
+                        "Failed to submit claim for expired receive; skipping"
+                    );
+                    continue;
+                }
+            };
+
+            info!(
+                target: LOG_CLIENT_MODULE_LN,
+                original_operation_id = %operation_id.fmt_short(),
+                recovery_operation_id = %recovery_operation_id.fmt_short(),
+                %amount,
+                "Recovered funds from previously timed-out LN receive"
+            );
+
+            recovered.push(RecoveredReceive {
+                original_operation_id: operation_id,
+                recovery_operation_id,
+                amount,
+                payment_hash,
+            });
+        }
+
+        Ok(recovered)
+    }
+
+    /// Submit a claim transaction for an already-fetched funded incoming
+    /// contract, returning the new operation id under which the claim is
+    /// tracked (a fresh random id, since the original receive state machine —
+    /// if any — has already terminated and cannot be revived).
+    #[allow(deprecated)]
+    async fn submit_incoming_contract_claim(
+        client_ctx: &ClientContext<Self>,
+        contract: IncomingContractAccount,
+        key_pair: Keypair,
+        extra_meta: serde_json::Value,
+    ) -> anyhow::Result<OperationId> {
+        let input = contract.claim();
         let client_input = ClientInput::<LightningInput> {
             input,
-            amounts: Amounts::new_bitcoin(incoming_contract_account.amount),
+            amounts: Amounts::new_bitcoin(contract.amount),
             keys: vec![key_pair],
         };
 
         let tx = TransactionBuilder::new().with_inputs(
-            self.client_ctx
-                .make_client_inputs(ClientInputBundle::new_no_sm(vec![client_input])),
+            client_ctx.make_client_inputs(ClientInputBundle::new_no_sm(vec![client_input])),
         );
-        let extra_meta = serde_json::to_value(extra_meta).expect("extra_meta is serializable");
         let operation_meta_gen = move |change_range: OutPointRange| LightningOperationMeta {
             variant: LightningOperationMetaVariant::Claim {
                 out_points: change_range.into_iter().collect(),
@@ -1735,7 +1993,7 @@ impl LightningClientModule {
             extra_meta: extra_meta.clone(),
         };
         let operation_id = OperationId::new_random();
-        self.client_ctx
+        client_ctx
             .finalize_and_submit_transaction(
                 operation_id,
                 LightningCommonInit::KIND.as_str(),

--- a/modules/fedimint-ln-tests/tests/tests.rs
+++ b/modules/fedimint-ln-tests/tests/tests.rs
@@ -11,16 +11,24 @@ use fedimint_client_module::oplog::OperationLogEntry;
 use fedimint_core::core::{IntoDynInstance, OperationId};
 use fedimint_core::module::{AmountUnit, Amounts, CommonModuleInit as _};
 use fedimint_core::util::{BoxStream, NextOrPending};
-use fedimint_core::{Amount, sats, secp256k1};
+use fedimint_core::{Amount, TransactionId, sats, secp256k1};
 use fedimint_dummy_client::{DummyClientInit, DummyClientModule};
 use fedimint_dummy_server::DummyInit;
-use fedimint_ln_client::{
-    InternalPayState, LightningClientInit, LightningClientModule, LightningOperationMeta,
-    LnPayState, LnReceiveState, MockGatewayConnection, OutgoingLightningPayment, PayType,
+use fedimint_ln_client::db::ExpiredReceiveRecoveryCompletedKey;
+use fedimint_ln_client::receive::{
+    LightningReceiveError, LightningReceiveStateMachine, LightningReceiveStates,
+    LightningReceiveSubmittedOffer,
 };
-use fedimint_ln_common::contracts::incoming::IncomingContractOffer;
-use fedimint_ln_common::contracts::{EncryptedPreimage, PreimageKey};
-use fedimint_ln_common::{LightningCommonInit, LightningOutput};
+use fedimint_ln_client::{
+    InternalPayState, LightningClientInit, LightningClientModule, LightningClientStateMachines,
+    LightningOperationMeta, LnPayState, LnReceiveState, MockGatewayConnection,
+    OutgoingLightningPayment, PayType, ReceivingKey,
+};
+use fedimint_ln_common::contracts::incoming::{IncomingContract, IncomingContractOffer};
+use fedimint_ln_common::contracts::{
+    Contract, ContractId, DecryptedPreimage, EncryptedPreimage, PreimageKey,
+};
+use fedimint_ln_common::{ContractOutput, LightningCommonInit, LightningOutput};
 use fedimint_ln_server::LightningInit;
 use fedimint_testing::Gateway;
 use fedimint_testing::federation::FederationTest;
@@ -32,6 +40,22 @@ use lightning_invoice::{
 };
 use rand::rngs::OsRng;
 use secp256k1::Keypair;
+
+async fn await_tx_accepted_helper(
+    tx_updates: BoxStream<'static, TxSubmissionStatesSM>,
+) -> Result<(), String> {
+    tx_updates
+        .filter_map(|tx_update| {
+            std::future::ready(match tx_update.state {
+                TxSubmissionStates::Accepted(_) => Some(Ok(())),
+                TxSubmissionStates::Rejected(_, submit_error) => Some(Err(submit_error)),
+                _ => None,
+            })
+        })
+        .next()
+        .await
+        .expect("Tx either accepted or rejected")
+}
 
 pub async fn ln_operation(
     client: &ClientHandleArc,
@@ -832,6 +856,239 @@ async fn server_rejects_duplicate_offer() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Reproduce the stuck-funds scenario behind #8455 and verify that
+/// [`LightningClientModule::recover_expired_receives`] claims them.
+///
+/// We bypass the natural state-machine timeout (which requires waiting ~60s
+/// for `CLOCK_SKEW_TOLERANCE` in `receive.rs`) by:
+///   1. Submitting an `IncomingContractOffer` directly, then a contract funding
+///      output that funds it — this exercises the real pre-#8348 server
+///      behavior (no expiry validation in `process_output`).
+///   2. Injecting a `Canceled(Timeout)` plus `SubmittedOffer` inactive state
+///      machine record into the receiver's DB to mimic what would naturally be
+///      persisted by the receive SM after a timeout.
+///   3. Calling `recover_expired_receives()` and asserting the claim succeeds.
+#[tokio::test(flavor = "multi_thread")]
+async fn recovers_expired_timed_out_receives() -> anyhow::Result<()> {
+    use std::time::Duration;
+
+    use fedimint_client::sm::executor::InactiveStateKeyDb;
+    use fedimint_client_module::sm::executor::{InactiveStateKey, InactiveStateMeta};
+    use fedimint_core::core::IntoDynInstance;
+    use fedimint_core::db::IDatabaseTransactionOpsCoreTyped;
+    use fedimint_core::time::{duration_since_epoch, now};
+    use fedimint_ln_client::api::LnFederationApi;
+
+    let fixtures = fixtures();
+    let fed = fixtures.new_fed_degraded().await;
+    let (receiver, payer) = fed.two_clients().await;
+
+    // Give the payer enough primary-module balance to fund a contract.
+    payer
+        .get_first_module::<DummyClientModule>()?
+        .mock_receive(sats(1000), AmountUnit::BITCOIN)
+        .await?;
+
+    let receiver_ln = receiver.get_first_module::<LightningClientModule>()?;
+    let payer_ln = payer.get_first_module::<LightningClientModule>()?;
+    let threshold_pub_key = receiver_ln.cfg.threshold_pub_key;
+    let ln_module_id = receiver_ln.id;
+
+    // 1. Derive the receiver's keypair, preimage and payment hash. These mirror
+    // the relations enforced by `IncomingContract::contract_id()`.
+    let secp = secp256k1::Secp256k1::new();
+    let receiver_kp = Keypair::new(&secp, &mut OsRng);
+    let preimage_bytes: [u8; 32] =
+        sha256::Hash::hash(&receiver_kp.public_key().serialize()).to_byte_array();
+    let payment_hash = sha256::Hash::hash(&preimage_bytes);
+    let contract_id: ContractId = payment_hash.into();
+    let operation_id = OperationId(payment_hash.to_byte_array());
+
+    // 2. Craft a Bolt11Invoice for that payment hash that is "old" enough that
+    // the receive state machine would consider it past the clock-skew tolerance.
+    // The actual receive SM never runs in this test; this invoice lives in the
+    // injected inactive state purely so `recover_expired_receives` can extract
+    // the payment hash and keypair.
+    let invoice_sk = secp256k1::SecretKey::new(&mut OsRng);
+    let now_secs = duration_since_epoch().as_secs();
+    let invoice = InvoiceBuilder::new(Currency::Regtest)
+        .description(String::new())
+        .payment_hash(payment_hash)
+        .duration_since_epoch(Duration::from_secs(now_secs - 600))
+        .min_final_cltv_expiry_delta(0)
+        .payment_secret(PaymentSecret([0; 32]))
+        .amount_milli_satoshis(250_000)
+        .expiry_time(Duration::from_secs(1))
+        .build_signed(|m| secp.sign_ecdsa_recoverable(m, &invoice_sk))?;
+    let amount = sats(250);
+
+    // 3. Receiver publishes the offer for this payment hash. We submit
+    // `LightningOutput::Offer` directly to match what `create_bolt11_invoice`
+    // would have done, without running the receive state machine.
+    let encrypted_preimage = EncryptedPreimage::new(
+        &PreimageKey(receiver_kp.public_key().serialize()),
+        &threshold_pub_key,
+    );
+    let offer = IncomingContractOffer {
+        amount,
+        hash: payment_hash,
+        encrypted_preimage: encrypted_preimage.clone(),
+        expiry_time: Some(now_secs.saturating_sub(60)),
+    };
+    let offer_tx = TransactionBuilder::new().with_outputs(
+        ClientOutputBundle::new_no_sm(vec![ClientOutput {
+            output: LightningOutput::new_v0_offer(offer),
+            amounts: Amounts::ZERO,
+        }])
+        .into_dyn(ln_module_id),
+    );
+    let offer_op = OperationId::new_random();
+    receiver
+        .finalize_and_submit_transaction(offer_op, "", |_| (), offer_tx)
+        .await?;
+    await_tx_accepted_helper(receiver.transaction_updates(offer_op).await.update_stream)
+        .await
+        .expect("Offer tx should be accepted");
+
+    // 4. Payer funds the contract for this offer. By submitting the
+    // `ContractOutput` directly we bypass `pay_bolt11_invoice`'s post-#8348
+    // expiry guard, reproducing the pre-#8348 path that left funds stuck.
+    let contract = IncomingContract {
+        hash: payment_hash,
+        encrypted_preimage,
+        decrypted_preimage: DecryptedPreimage::Pending,
+        gateway_key: secp256k1::PublicKey::from_keypair(&receiver_kp),
+    };
+    let contract_tx = TransactionBuilder::new().with_outputs(
+        ClientOutputBundle::new_no_sm(vec![ClientOutput {
+            output: LightningOutput::new_v0_contract(ContractOutput {
+                amount,
+                contract: Contract::Incoming(contract),
+            }),
+            amounts: Amounts::new_bitcoin(amount),
+        }])
+        .into_dyn(payer_ln.id),
+    );
+    let contract_op = OperationId::new_random();
+    payer
+        .finalize_and_submit_transaction(contract_op, "", |_| (), contract_tx)
+        .await?;
+    await_tx_accepted_helper(payer.transaction_updates(contract_op).await.update_stream)
+        .await
+        .expect("Contract tx should be accepted");
+
+    // 5. Wait for the federation to decrypt the preimage. Once decrypted the
+    // contract is claimable.
+    let module_api = receiver.api_clone().with_module(ln_module_id);
+    let (_account, _preimage) = module_api.wait_preimage_decrypted(contract_id).await?;
+
+    // 6. Inject the inactive state machine records that would have been
+    // persisted by a real receive SM that timed out before the funding tx
+    // landed.
+    let submitted_offer_sm = LightningClientStateMachines::Receive(LightningReceiveStateMachine {
+        operation_id,
+        state: LightningReceiveStates::SubmittedOffer(LightningReceiveSubmittedOffer {
+            offer_txid: TransactionId::all_zeros(),
+            invoice: invoice.clone(),
+            receiving_key: ReceivingKey::Personal(receiver_kp),
+        }),
+    });
+    let canceled_sm = LightningClientStateMachines::Receive(LightningReceiveStateMachine {
+        operation_id,
+        state: LightningReceiveStates::Canceled(LightningReceiveError::Timeout),
+    });
+    let meta = InactiveStateMeta {
+        created_at: now(),
+        exited_at: now(),
+    };
+    let mut dbtx = receiver.db().begin_transaction().await;
+    for sm in [submitted_offer_sm, canceled_sm] {
+        let dyn_state = sm.into_dyn(ln_module_id);
+        dbtx.insert_new_entry(
+            &InactiveStateKeyDb(InactiveStateKey {
+                operation_id,
+                state: dyn_state,
+            }),
+            &meta,
+        )
+        .await;
+    }
+    dbtx.commit_tx().await;
+
+    // 7. Run recovery. Expect one recovered entry matching the stuck contract.
+    let recovered = receiver_ln.recover_expired_receives().await?;
+    assert_eq!(
+        recovered.len(),
+        1,
+        "should recover exactly one stuck receive"
+    );
+    let entry = &recovered[0];
+    assert_eq!(entry.original_operation_id, operation_id);
+    assert_eq!(entry.payment_hash, payment_hash);
+    assert_eq!(entry.amount, amount);
+
+    // 8. Wait for the claim tx itself to be accepted by the federation. The
+    // primary-module finalization that mints e-cash for the recovered amount
+    // is exercised end-to-end by the SM executor; we just need to confirm the
+    // claim made it onto the federation log.
+    await_tx_accepted_helper(
+        receiver
+            .transaction_updates(entry.recovery_operation_id)
+            .await
+            .update_stream,
+    )
+    .await
+    .expect("Claim tx should be accepted");
+
+    // 9. Second invocation is a no-op: the contract is spent.
+    let again = receiver_ln.recover_expired_receives().await?;
+    assert!(again.is_empty(), "recovery is idempotent once claimed");
+
+    Ok(())
+}
+
+/// Verify that the auto-spawned recovery sweep records the
+/// [`ExpiredReceiveRecoveryCompletedKey`] flag once it completes, so future
+/// client restarts don't re-probe the federation (preserves privacy).
+#[tokio::test(flavor = "multi_thread")]
+async fn auto_recovery_sets_one_shot_flag() -> anyhow::Result<()> {
+    use std::time::Duration;
+
+    use fedimint_core::db::IDatabaseTransactionOpsCoreTyped;
+
+    let fixtures = fixtures();
+    let fed = fixtures.new_fed_degraded().await;
+    let client = fed.new_client().await;
+    let ln_module = client.get_first_module::<LightningClientModule>()?;
+    let module_db = client.db().with_prefix_module_id(ln_module.id).0;
+
+    // The auto-spawn runs in background. Wait briefly for it to complete on a
+    // wallet with no candidates (the sweep is a no-op trip through the
+    // operation log).
+    let deadline = fedimint_core::time::now() + Duration::from_secs(10);
+    loop {
+        let is_set = module_db
+            .begin_transaction_nc()
+            .await
+            .get_value(&ExpiredReceiveRecoveryCompletedKey)
+            .await
+            .is_some();
+        if is_set {
+            break;
+        }
+        if fedimint_core::time::now() > deadline {
+            panic!("Auto recovery never set the one-shot completion flag");
+        }
+        fedimint_core::task::sleep_in_test(
+            "Waiting for auto recovery flag",
+            Duration::from_millis(100),
+        )
+        .await;
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod fedimint_migration_tests {
     use std::str::FromStr;
@@ -1562,6 +1819,10 @@ mod fedimint_migration_tests {
                             );
 
                             info!("Validated RecurringPaymentCodes");
+                        }
+                        fedimint_ln_client::db::DbKeyPrefix::ExpiredReceiveRecoveryCompleted => {
+                            // New in 0.12 — old migration snapshots predate it,
+                            // so the flag is correctly absent.
                         }
                         fedimint_ln_client::db::DbKeyPrefix::CoreInternalReservedStart
                         | fedimint_ln_client::db::DbKeyPrefix::ExternalReservedStart


### PR DESCRIPTION
## Summary
- Adds `LightningClientModule::recover_expired_receives()` to claim `IncomingContract`s that were funded after their invoice expired but never picked up by the receiver's now-terminated state machine — the stuck-funds scenario from #8455 (root cause fixed prospectively in #8348).
- One-shot auto-sweep on module init, gated by a new `ExpiredReceiveRecoveryCompletedKey` DB record so subsequent restarts don't re-probe the federation for historical receives (privacy).
- Public method stays available for manual recovery, e.g. post-backup-restore.

## Approach
1. Enumerate inactive state machines via the new `ClientContext::get_own_inactive_states`.
2. Bucket by `operation_id`; pick the ones whose terminal state is `Canceled(Timeout)` and whose prior `SubmittedOffer`/`ConfirmedInvoice` state carries a `ReceivingKey::Personal(keypair)` (`External` receives belong to another client and aren't recoverable here).
3. Probe the federation; if the contract is funded with `DecryptedPreimage::Some` and non-zero balance, submit a claim via a fresh `Claim` operation. Naturally idempotent — once claimed the contract balance is zero and subsequent sweeps skip it.

Supporting plumbing in `fedimint-client`/`fedimint-client-module`:
- `IExecutor::get_inactive_states` to mirror `get_active_states`
- `ClientContext::wait_for_client_ready` polls `FinalClientIface` so tasks spawned from `ClientModule::new` can use the full client once the builder finishes wiring it up (previously this would have panicked).

## Test plan
- [x] `cargo test -p fedimint-ln-tests` — 16 pass, including the new `recovers_expired_timed_out_receives` (reproduces stuck funds by bypassing `pay_bolt11_invoice`'s post-#8348 expiry guard and submitting a contract output directly, asserts recovery claims it) and `auto_recovery_sets_one_shot_flag`
- [x] `cargo test -p fedimint-client -p fedimint-client-module -p fedimint-ln-client --lib` — all green
- [x] `cargo clippy -p fedimint-ln-client -p fedimint-ln-tests -p fedimint-client-module -p fedimint-client --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [ ] Manual `just devimint-env` smoke through CLI

Closes #8455

🤖 Generated with [Claude Code](https://claude.com/claude-code)