### PR TITLE
feat: Walletv2 Deposit and CLI Improvements

### DIFF
--- a/devimint/src/cli.rs
+++ b/devimint/src/cli.rs
@@ -23,7 +23,7 @@ use crate::envs::{
 };
 use crate::util::{ProcessManager, poll};
 use crate::vars::mkdir;
-use crate::{external_daemons, vars};
+use crate::{cmd, external_daemons, vars};
 
 fn random_test_dir_suffix() -> String {
     rand::thread_rng()
@@ -278,7 +278,7 @@ pub async fn handle_command(cmd: Cmd, common_args: CommonArgs) -> Result<()> {
                         const GW_PEGIN_AMOUNT: u64 = 1_000_000;
                         const CLIENT_PEGIN_AMOUNT: u64 = 1_000_000;
 
-                        let (operation_id, (), ()) = tokio::try_join!(
+                        let ((address, operation_id), (), ()) = tokio::try_join!(
                             async {
                                 let (address, operation_id) =
                                     dev_fed.internal_client().await?.get_deposit_addr().await?;
@@ -291,9 +291,9 @@ pub async fn handle_command(cmd: Cmd, common_args: CommonArgs) -> Result<()> {
                                 dev_fed
                                     .bitcoind()
                                     .await?
-                                    .send_to(address, CLIENT_PEGIN_AMOUNT)
+                                    .send_to(address.clone(), CLIENT_PEGIN_AMOUNT)
                                     .await?;
-                                Ok(operation_id)
+                                Ok((address, operation_id))
                             },
                             async {
                                 let address = dev_fed
@@ -342,11 +342,15 @@ pub async fn handle_command(cmd: Cmd, common_args: CommonArgs) -> Result<()> {
 
                         dev_fed.bitcoind().await?.mine_blocks_no_wait(11).await?;
                         if crate::util::supports_wallet_v2() {
-                            dev_fed
-                                .internal_client()
-                                .await?
-                                .await_balance(CLIENT_PEGIN_AMOUNT * 1000 * 9 / 10)
-                                .await?;
+                            cmd!(
+                                dev_fed.internal_client().await?,
+                                "module",
+                                "walletv2",
+                                "await-receive",
+                                &address
+                            )
+                            .run()
+                            .await?;
                         } else {
                             dev_fed
                                 .internal_client()

--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -218,25 +218,6 @@ impl Client {
             .unwrap())
     }
 
-    /// Waits for the client balance to reach at least `min_balance_msat`.
-    pub async fn await_balance(&self, min_balance_msat: u64) -> Result<()> {
-        loop {
-            cmd!(self, "dev", "wait", "3").out_json().await?;
-
-            let balance = self.balance().await?;
-            if balance >= min_balance_msat {
-                return Ok(());
-            }
-
-            info!(
-                target: LOG_DEVIMINT,
-                balance,
-                min_balance_msat,
-                "Waiting for client balance to reach minimum"
-            );
-        }
-    }
-
     pub async fn get_deposit_addr(&self) -> Result<(String, String)> {
         if crate::util::supports_wallet_v2() {
             let address = cmd!(self, "module", "walletv2", "receive")
@@ -693,7 +674,16 @@ impl Federation {
         Ok(())
     }
 
-    pub async fn pegin_client_no_wait(&self, amount: u64, client: &Client) -> Result<String> {
+    /// Send `amount` (sats) to a fresh deposit address on `client` and mine
+    /// confirmations. Returns `(address, operation_id)` so the caller can
+    /// drive the appropriate await — `operation_id` is meaningful for
+    /// walletv1's deposit state machine; `address` is what `await-receive`
+    /// keys off of for walletv2.
+    pub async fn pegin_client_no_wait(
+        &self,
+        amount: u64,
+        client: &Client,
+    ) -> Result<(String, String)> {
         let deposit_fees_msat = self.deposit_fees()?.msats;
         assert_eq!(
             deposit_fees_msat % 1000,
@@ -706,29 +696,20 @@ impl Federation {
         let (address, operation_id) = client.get_deposit_addr().await?;
 
         self.bitcoind
-            .send_to(address, amount + deposit_fees)
+            .send_to(address.clone(), amount + deposit_fees)
             .await?;
         self.bitcoind.mine_blocks(21).await?;
 
-        Ok(operation_id)
+        Ok((address, operation_id))
     }
 
     pub async fn pegin_client(&self, amount: u64, client: &Client) -> Result<()> {
-        // For walletv2, we need to capture the initial balance and wait for it to
-        // increase since there is no state machine - deposits are auto-claimed
-        let initial_balance = if crate::util::supports_wallet_v2() {
-            Some(client.balance().await?)
-        } else {
-            None
-        };
+        let (address, operation_id) = self.pegin_client_no_wait(amount, client).await?;
 
-        let operation_id = self.pegin_client_no_wait(amount, client).await?;
-
-        if let Some(initial) = initial_balance {
-            // Walletv2: wait for balance to increase. We expect slightly less than
-            // `amount` due to mint module fees when creating ecash notes.
-            let expected_balance = initial + (amount * 1000 * 9 / 10);
-            client.await_balance(expected_balance).await?;
+        if crate::util::supports_wallet_v2() {
+            cmd!(client, "module", "walletv2", "await-receive", address)
+                .run()
+                .await?;
         } else {
             client.await_deposit(&operation_id).await?;
         }

--- a/gateway/fedimint-gateway-server/src/client.rs
+++ b/gateway/fedimint-gateway-server/src/client.rs
@@ -12,6 +12,7 @@ use fedimint_connectors::ConnectorRegistry;
 use fedimint_core::config::FederationId;
 use fedimint_core::db::{Database, IDatabaseTransactionOpsCoreTyped};
 use fedimint_core::module::registry::ModuleDecoderRegistry;
+use fedimint_core::task::TaskGroup;
 use fedimint_derive_secret::DerivableSecret;
 use fedimint_gateway_common::FederationConfig;
 use fedimint_gateway_server_db::GatewayDbExt as _;
@@ -125,6 +126,7 @@ impl GatewayClientBuilder {
         config: FederationConfig,
         gateway: Arc<Gateway>,
         mnemonic: &Mnemonic,
+        task_group: &TaskGroup,
     ) -> AdminResult<fedimint_client::ClientHandleArc> {
         let invite_code = config.invite_code.clone();
         let federation_id = invite_code.federation_id();
@@ -159,9 +161,9 @@ impl GatewayClientBuilder {
 
         Self::verify_client_config(&db, federation_id).await?;
 
-        let client_builder = self.create_client_builder(&config, gateway).await?;
+        let client_builder = self.create_client_builder(&config, gateway.clone()).await?;
 
-        if Client::is_initialized(&db).await {
+        let client = if Client::is_initialized(&db).await {
             client_builder
                 .open(self.connectors.clone(), db, root_secret)
                 .await
@@ -173,7 +175,15 @@ impl GatewayClientBuilder {
                 .await
         }
         .map(Arc::new)
-        .map_err(AdminGatewayError::ClientCreationError)
+        .map_err(AdminGatewayError::ClientCreationError)?;
+
+        if let Ok(wallet_v2) =
+            client.get_first_module::<fedimint_walletv2_client::WalletClientModule>()
+        {
+            wallet_v2.spawn_output_scanner(task_group, &tracing::Span::current());
+        }
+
+        Ok(client)
     }
 
     /// Verifies that the saved `ClientConfig` contains the expected

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -1659,8 +1659,12 @@ impl Gateway {
             let federation_index = config.federation_index;
             match Box::pin(Spanned::try_new(
                 info_span!(target: LOG_GATEWAY, "client", federation_id  = %federation_id.clone()),
-                self.client_builder
-                    .build(config, Arc::new(self.clone()), &mnemonic),
+                self.client_builder.build(
+                    config,
+                    Arc::new(self.clone()),
+                    &mnemonic,
+                    &self.task_group,
+                ),
             ))
             .await
             {
@@ -2038,7 +2042,12 @@ impl IAdminGateway for Gateway {
 
         let client = self
             .client_builder
-            .build(federation_config.clone(), Arc::new(self.clone()), &mnemonic)
+            .build(
+                federation_config.clone(),
+                Arc::new(self.clone()),
+                &mnemonic,
+                &self.task_group,
+            )
             .await?;
 
         if recover {

--- a/modules/fedimint-wallet-tests/src/bin/wallet-module-tests.rs
+++ b/modules/fedimint-wallet-tests/src/bin/wallet-module-tests.rs
@@ -56,7 +56,7 @@ async fn wallet_recovery_test_1() -> anyhow::Result<()> {
                     .await?;
 
                 info!("Join, but not claim");
-                let operation_id = fed
+                let (_, operation_id) = fed
                     .pegin_client_no_wait(peg_in_amount_sats, &client)
                     .await?;
 
@@ -94,7 +94,7 @@ async fn wallet_recovery_test_1() -> anyhow::Result<()> {
                 cmd!(client, "backup").run().await?;
 
                 info!("Join more, but not claim");
-                let operation_id = fed
+                let (_, operation_id) = fed
                     .pegin_client_no_wait(peg_in_amount_sats, &client)
                     .await?;
 
@@ -140,7 +140,7 @@ async fn wallet_recovery_test_1() -> anyhow::Result<()> {
                 .await
                 .expect("timeouted waiting for session to close");
 
-                let operation_id = fed
+                let (_, operation_id) = fed
                     .pegin_client_no_wait(peg_in_amount_sats, &client)
                     .await?;
 

--- a/modules/fedimint-walletv2-client/src/cli.rs
+++ b/modules/fedimint-walletv2-client/src/cli.rs
@@ -24,9 +24,14 @@ enum Opts {
     },
     /// Return the next unused receive address.
     Receive,
-    /// Wait for a deposit to `address` to be observed and fully claimed.
-    /// Returns the final state of the claim operation.
-    AwaitReceive { address: Address<NetworkUnchecked> },
+    /// Wait for a deposit at each of the given addresses to be observed
+    /// and fully claimed, counting multiplicity (passing the same address
+    /// twice waits for two deposits at it). Returns the final state of
+    /// each claim operation as a JSON array.
+    AwaitReceive {
+        #[arg(required = true)]
+        addresses: Vec<Address<NetworkUnchecked>>,
+    },
 }
 
 #[derive(Clone, Subcommand, Serialize)]
@@ -68,7 +73,7 @@ pub(crate) async fn handle_cli_command(
                 .await,
         ),
         Opts::Receive => json(wallet.receive().await),
-        Opts::AwaitReceive { address } => json(wallet.await_receive(address).await?),
+        Opts::AwaitReceive { addresses } => json(wallet.await_receive(addresses).await?),
     };
 
     Ok(value)

--- a/modules/fedimint-walletv2-client/src/cli.rs
+++ b/modules/fedimint-walletv2-client/src/cli.rs
@@ -24,6 +24,9 @@ enum Opts {
     },
     /// Return the next unused receive address.
     Receive,
+    /// Wait for a deposit to `address` to be observed and fully claimed.
+    /// Returns the final state of the claim operation.
+    AwaitReceive { address: Address<NetworkUnchecked> },
 }
 
 #[derive(Clone, Subcommand, Serialize)]
@@ -65,6 +68,7 @@ pub(crate) async fn handle_cli_command(
                 .await,
         ),
         Opts::Receive => json(wallet.receive().await),
+        Opts::AwaitReceive { address } => json(wallet.await_receive(address).await?),
     };
 
     Ok(value)

--- a/modules/fedimint-walletv2-client/src/lib.rs
+++ b/modules/fedimint-walletv2-client/src/lib.rs
@@ -642,21 +642,6 @@ impl WalletClientModule {
         let handle = task_group.make_handle();
 
         task_group.spawn_cancellable_with_span(client_span.clone(), "output-scanner", async move {
-            let mut dbtx = module.db.begin_transaction().await;
-
-            if dbtx
-                .find_by_prefix(&ValidAddressIndexPrefix)
-                .await
-                .next()
-                .await
-                .is_none()
-                && let Some(idx) = module.next_valid_index(0, &handle)
-            {
-                dbtx.insert_new_entry(&ValidAddressIndexKey(idx), &()).await;
-            }
-
-            dbtx.commit_tx().await;
-
             loop {
                 match module.check_outputs(&handle).await {
                     Ok(progress) => {

--- a/modules/fedimint-walletv2-client/src/lib.rs
+++ b/modules/fedimint-walletv2-client/src/lib.rs
@@ -45,7 +45,8 @@ use fedimint_core::module::{
     AmountUnit, Amounts, ApiVersion, CommonModuleInit, ModuleCommon, ModuleInit, MultiApiVersion,
 };
 use fedimint_core::task::{TaskGroup, block_in_place, sleep};
-use fedimint_core::{Amount, OutPoint, TransactionId, apply, async_trait_maybe_send};
+use fedimint_core::util::FmtCompactAnyhow;
+use fedimint_core::{Amount, OutPoint, apply, async_trait_maybe_send};
 use fedimint_derive_secret::{ChildId, DerivableSecret};
 use fedimint_logging::LOG_CLIENT_MODULE_WALLETV2;
 use fedimint_walletv2_common::config::WalletClientConfig;
@@ -420,7 +421,11 @@ impl WalletClientModule {
     ///
     /// Submission and event logging happen inside the caller-supplied `dbtx`
     /// so that the caller can atomically advance `NextOutputIndexKey` in the
-    /// same commit.
+    /// same commit. Returns an error if the transaction cannot be assembled
+    /// locally — most commonly because the remaining value after
+    /// `receive_fee` is too small to cover the mint module's output fee.
+    /// Federation acceptance is tracked by the receive state machine and
+    /// does not block this call.
     async fn receive_output(
         &self,
         dbtx: &mut DatabaseTransaction<'_>,
@@ -428,7 +433,7 @@ impl WalletClientModule {
         value: bitcoin::Amount,
         address_index: u64,
         fee: bitcoin::Amount,
-    ) -> (OperationId, TransactionId) {
+    ) -> anyhow::Result<()> {
         let operation_id = OperationId::new_random();
 
         let client_input = ClientInput::<WalletInput> {
@@ -460,8 +465,7 @@ impl WalletClientModule {
             vec![client_input_sm],
         ));
 
-        let range = self
-            .client_ctx
+        self.client_ctx
             .finalize_and_submit_transaction_dbtx(
                 dbtx,
                 operation_id,
@@ -475,8 +479,7 @@ impl WalletClientModule {
                 },
                 TransactionBuilder::new().with_inputs(client_input_bundle),
             )
-            .await
-            .expect("Input amount is sufficient to finalize transaction");
+            .await?;
 
         self.client_ctx
             .log_event(
@@ -490,7 +493,7 @@ impl WalletClientModule {
             )
             .await;
 
-        (operation_id, range.txid())
+        Ok(())
     }
 
     fn spawn_output_scanner(&self, task_group: &TaskGroup, client_span: &tracing::Span) {
@@ -555,80 +558,109 @@ impl WalletClientModule {
         let mut matched_num: usize = 0;
 
         for output in &outputs {
-            if let Some(&address_index) = address_map.get(&output.script) {
-                matched_num += 1;
-                let next_address_index = valid_indices
-                    .last()
-                    .copied()
-                    .expect("we have at least one address index");
+            // If this output landed on our current highest derived address,
+            // pre-compute the next valid index but DON'T persist it yet — it
+            // gets written in the same commit as the matching cursor advance
+            // below, so a cancellation or congestion early-return can't leave
+            // a phantom address ahead of the deposit that triggered it.
+            let new_valid_index = match address_map.get(&output.script) {
+                Some(&address_index)
+                    if address_index
+                        == valid_indices
+                            .last()
+                            .copied()
+                            .expect("we have at least one address index") =>
+                {
+                    Some(self.next_valid_index(address_index + 1))
+                }
+                _ => None,
+            };
 
-                // If we used the highest valid index, add the next valid one
-                if address_index == next_address_index {
-                    let index = self.next_valid_index(next_address_index + 1);
-
-                    let mut dbtx = self.db.begin_transaction().await;
-
-                    dbtx.insert_entry(&ValidAddressIndexKey(index), &()).await;
-
-                    dbtx.commit_tx_result().await?;
-
-                    valid_indices.push(index);
-
-                    address_map.insert(self.derive_address(index).script_pubkey(), index);
+            if let Some(&address_index) = address_map.get(&output.script)
+                && !output.spent
+            {
+                // In order to not overpay on fees we choose to wait,
+                // the congestion will clear up within a few blocks.
+                if self.module_api.pending_tx_chain().await?.len() >= 3 {
+                    return Ok(false);
                 }
 
-                if !output.spent {
-                    // In order to not overpay on fees we choose to wait,
-                    // the congestion will clear up within a few blocks.
-                    if self.module_api.pending_tx_chain().await?.len() >= 3 {
-                        return Ok(false);
-                    }
+                matched_num += 1;
 
-                    let receive_fee = self
-                        .module_api
-                        .receive_fee()
-                        .await?
-                        .ok_or(anyhow!("No consensus feerate is available"))?;
+                let receive_fee = self
+                    .module_api
+                    .receive_fee()
+                    .await?
+                    .ok_or(anyhow!("No consensus feerate is available"))?;
 
-                    if output.value > receive_fee {
-                        // Submit the claim and advance the scan cursor in the
-                        // same commit so cancellation between them cannot
-                        // cause a duplicate claim on restart.
-                        let mut dbtx = self.db.begin_transaction().await;
+                if output.value > receive_fee {
+                    // Submit the claim, extend the address watermark (if any),
+                    // and advance the scan cursor in the same commit so
+                    // cancellation between them cannot cause a duplicate claim
+                    // or a phantom valid index on restart.
+                    let mut dbtx = self.db.begin_transaction().await;
 
-                        let (operation_id, txid) = self
-                            .receive_output(
-                                &mut dbtx.to_ref_nc(),
-                                output.index,
-                                output.value,
-                                address_index,
-                                receive_fee,
-                            )
-                            .await;
+                    let result = self
+                        .receive_output(
+                            &mut dbtx.to_ref_nc(),
+                            output.index,
+                            output.value,
+                            address_index,
+                            receive_fee,
+                        )
+                        .await;
 
-                        dbtx.insert_entry(&NextOutputIndexKey, &(output.index + 1))
-                            .await;
+                    match result {
+                        Ok(()) => {
+                            if let Some(idx) = new_valid_index {
+                                dbtx.insert_entry(&ValidAddressIndexKey(idx), &()).await;
+                            }
 
-                        dbtx.commit_tx_result().await?;
+                            dbtx.insert_entry(&NextOutputIndexKey, &(output.index + 1))
+                                .await;
 
-                        self.client_ctx
-                            .transaction_updates(operation_id)
-                            .await
-                            .await_tx_accepted(txid)
-                            .await
-                            .map_err(|e| anyhow!("Claim transaction was rejected: {e}"))?;
+                            dbtx.commit_tx_result().await?;
 
-                        continue;
+                            if let Some(idx) = new_valid_index {
+                                valid_indices.push(idx);
+                                address_map.insert(self.derive_address(idx).script_pubkey(), idx);
+                            }
+
+                            continue;
+                        }
+                        Err(err) => {
+                            // The receive's dbtx goes out of scope
+                            // uncommitted; control falls through to the
+                            // unconditional cursor advance below so we skip
+                            // past this output instead of looping on it
+                            // forever.
+                            warn!(
+                                target: LOG_CLIENT_MODULE_WALLETV2,
+                                output_index = output.index,
+                                value_sat = output.value.to_sat(),
+                                err = %err.fmt_compact_anyhow(),
+                                "Output not economical to claim, advancing past it",
+                            );
+                        }
                     }
                 }
             }
 
             let mut dbtx = self.db.begin_transaction().await;
 
+            if let Some(idx) = new_valid_index {
+                dbtx.insert_entry(&ValidAddressIndexKey(idx), &()).await;
+            }
+
             dbtx.insert_entry(&NextOutputIndexKey, &(output.index + 1))
                 .await;
 
             dbtx.commit_tx_result().await?;
+
+            if let Some(idx) = new_valid_index {
+                valid_indices.push(idx);
+                address_map.insert(self.derive_address(idx).script_pubkey(), idx);
+            }
         }
 
         debug!(

--- a/modules/fedimint-walletv2-client/src/lib.rs
+++ b/modules/fedimint-walletv2-client/src/lib.rs
@@ -14,9 +14,8 @@ pub mod events;
 mod receive_sm;
 mod send_sm;
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::sync::Arc;
-use std::time::Duration;
 
 use anyhow::anyhow;
 use api::WalletFederationApi;
@@ -55,6 +54,7 @@ use fedimint_walletv2_common::{
     WalletOutput, WalletOutputV0, descriptor, is_potential_receive,
 };
 use futures::StreamExt;
+use futures::future::join_all;
 use receive_sm::{ReceiveSMCommon, ReceiveSMState, ReceiveStateMachine};
 use secp256k1::Keypair;
 use send_sm::{SendSMCommon, SendSMState, SendStateMachine};
@@ -409,17 +409,34 @@ impl WalletClientModule {
         }
     }
 
-    /// Drive the deposit scanner until a claim for `address` is submitted,
-    /// then block until that claim's state machine reaches a terminal state.
+    /// Drive the deposit scanner until a claim has been submitted for each
+    /// address in `addresses` (counting multiplicity — `vec![addr, addr]`
+    /// waits for two deposits at `addr`), then block until every collected
+    /// claim's state machine reaches a terminal state.
     ///
-    /// Forward-looking: only awaits deposits submitted *during this call*. If
-    /// the address was claimed in a previous session, this won't surface that
-    /// history — the funds are already in the user's balance.
+    /// Forward-looking: only awaits deposits whose claims are submitted
+    /// *during this call*. Claims already in flight from a background
+    /// scanner or prior session won't be surfaced — if the funds have
+    /// already landed, they're in the user's balance.
+    ///
+    /// Returns immediately with `Ok(vec![])` if `addresses` is empty.
     pub async fn await_receive(
         &self,
-        address: Address<NetworkUnchecked>,
-    ) -> anyhow::Result<FinalReceiveState> {
-        let script = address.assume_checked().script_pubkey();
+        addresses: Vec<Address<NetworkUnchecked>>,
+    ) -> anyhow::Result<Vec<FinalReceiveState>> {
+        if addresses.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut remaining: HashMap<ScriptBuf, usize> = HashMap::new();
+        for address in &addresses {
+            *remaining
+                .entry(address.clone().assume_checked().script_pubkey())
+                .or_insert(0) += 1;
+        }
+        let total_expected: usize = remaining.values().sum();
+        let mut collected: Vec<OperationId> = Vec::with_capacity(total_expected);
+
         // Foreground caller — no shared shutdown signal, so use a fresh group
         // whose handle never reports shutting-down. The group is dropped when
         // this function returns.
@@ -430,9 +447,21 @@ impl WalletClientModule {
             let progress = self.check_outputs(&handle).await?;
 
             for (operation_id, claim_script) in progress.submitted {
-                if claim_script == script {
-                    return Ok(self.await_final_receive_operation_state(operation_id).await);
+                if let Some(count) = remaining.get_mut(&claim_script)
+                    && *count > 0
+                {
+                    collected.push(operation_id);
+                    *count -= 1;
                 }
+            }
+
+            if collected.len() == total_expected {
+                return Ok(join_all(
+                    collected
+                        .into_iter()
+                        .map(|op| self.await_final_receive_operation_state(op)),
+                )
+                .await);
             }
 
             if !progress.more_outputs {
@@ -441,24 +470,37 @@ impl WalletClientModule {
         }
     }
 
-    /// Returns the next unused receive address, polling until the initial
-    /// address derivation has completed.
+    /// Returns the highest unused receive address, deriving the first one
+    /// on demand if no addresses exist yet.
     pub async fn receive(&self) -> Address {
-        loop {
-            if let Some(entry) = self
-                .db
-                .begin_transaction_nc()
-                .await
-                .find_by_prefix_sorted_descending(&ValidAddressIndexPrefix)
-                .await
-                .next()
-                .await
-            {
-                return self.derive_address(entry.0.0);
-            }
+        let mut dbtx = self.db.begin_transaction().await;
 
-            sleep(Duration::from_secs(1)).await;
-        }
+        let index = if let Some(entry) = dbtx
+            .find_by_prefix_sorted_descending(&ValidAddressIndexPrefix)
+            .await
+            .next()
+            .await
+        {
+            entry.0.0
+        } else {
+            // First call on this client — derive the initial valid index now.
+            // `receive()` is foreground-only so we use a fresh task group whose
+            // handle never reports shutting-down; the search is guaranteed to
+            // complete.
+            let task_group = TaskGroup::new();
+            let handle = task_group.make_handle();
+            let index = self
+                .next_valid_index(0, &handle)
+                .expect("never-shutting handle: search must return Some");
+
+            dbtx.insert_new_entry(&ValidAddressIndexKey(index), &())
+                .await;
+            dbtx.commit_tx().await;
+
+            index
+        };
+
+        self.derive_address(index)
     }
 
     fn derive_address(&self, index: u64) -> Address {

--- a/modules/fedimint-walletv2-client/src/lib.rs
+++ b/modules/fedimint-walletv2-client/src/lib.rs
@@ -101,10 +101,14 @@ pub enum FinalSendOperationState {
 /// The final state of an operation claiming an onchain deposit.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum FinalReceiveState {
-    /// The deposit was successfully claimed.
+    /// The deposit was claimed and the issued ecash credited to the wallet.
     Success,
     /// The federation rejected the claim transaction.
     Aborted(String),
+    /// The federation accepted the claim transaction, but obtaining the
+    /// issued ecash from the mint module failed — the balance was not
+    /// credited.
+    MintFailure(String),
 }
 
 /// Result of a single pass of [`WalletClientModule::check_outputs`].
@@ -462,15 +466,13 @@ impl WalletClientModule {
                 return Ok(
                     join_all(collected.into_iter().map(|(op, change)| async move {
                         let state = self.await_final_receive_operation_state(op).await;
-                        // Wait for the primary (mint) module's outputs to finish
-                        // claiming so the caller sees the ecash in their balance —
-                        // the receive state machine only confirms the federation
-                        // accepted the claim transaction.
-                        if matches!(state, FinalReceiveState::Success) {
-                            let _ = self
+                        if matches!(state, FinalReceiveState::Success)
+                            && let Err(err) = self
                                 .client_ctx
                                 .await_primary_module_outputs(op, change)
-                                .await;
+                                .await
+                        {
+                            return FinalReceiveState::MintFailure(err.to_string());
                         }
                         state
                     }))

--- a/modules/fedimint-walletv2-client/src/lib.rs
+++ b/modules/fedimint-walletv2-client/src/lib.rs
@@ -417,8 +417,13 @@ impl WalletClientModule {
     }
 
     /// Issue ecash for an unspent output with a given fee.
+    ///
+    /// Submission and event logging happen inside the caller-supplied `dbtx`
+    /// so that the caller can atomically advance `NextOutputIndexKey` in the
+    /// same commit.
     async fn receive_output(
         &self,
+        dbtx: &mut DatabaseTransaction<'_>,
         output_index: u64,
         value: bitcoin::Amount,
         address_index: u64,
@@ -457,7 +462,8 @@ impl WalletClientModule {
 
         let range = self
             .client_ctx
-            .finalize_and_submit_transaction(
+            .finalize_and_submit_transaction_dbtx(
+                dbtx,
                 operation_id,
                 WalletCommonInit::KIND.as_str(),
                 move |change_outpoint_range| {
@@ -472,11 +478,9 @@ impl WalletClientModule {
             .await
             .expect("Input amount is sufficient to finalize transaction");
 
-        let mut dbtx = self.client_ctx.module_db().begin_transaction().await;
-
         self.client_ctx
             .log_event(
-                &mut dbtx,
+                dbtx,
                 ReceivePaymentEvent {
                     operation_id,
                     address: self.derive_address(address_index).as_unchecked().clone(),
@@ -485,8 +489,6 @@ impl WalletClientModule {
                 },
             )
             .await;
-
-        dbtx.commit_tx().await;
 
         (operation_id, range.txid())
     }
@@ -589,9 +591,25 @@ impl WalletClientModule {
                         .ok_or(anyhow!("No consensus feerate is available"))?;
 
                     if output.value > receive_fee {
+                        // Submit the claim and advance the scan cursor in the
+                        // same commit so cancellation between them cannot
+                        // cause a duplicate claim on restart.
+                        let mut dbtx = self.db.begin_transaction().await;
+
                         let (operation_id, txid) = self
-                            .receive_output(output.index, output.value, address_index, receive_fee)
+                            .receive_output(
+                                &mut dbtx.to_ref_nc(),
+                                output.index,
+                                output.value,
+                                address_index,
+                                receive_fee,
+                            )
                             .await;
+
+                        dbtx.insert_entry(&NextOutputIndexKey, &(output.index + 1))
+                            .await;
+
+                        dbtx.commit_tx_result().await?;
 
                         self.client_ctx
                             .transaction_updates(operation_id)
@@ -599,6 +617,8 @@ impl WalletClientModule {
                             .await_tx_accepted(txid)
                             .await
                             .map_err(|e| anyhow!("Claim transaction was rejected: {e}"))?;
+
+                        continue;
                     }
                 }
             }

--- a/modules/fedimint-walletv2-client/src/lib.rs
+++ b/modules/fedimint-walletv2-client/src/lib.rs
@@ -44,7 +44,7 @@ use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::{
     AmountUnit, Amounts, ApiVersion, CommonModuleInit, ModuleCommon, ModuleInit, MultiApiVersion,
 };
-use fedimint_core::task::{TaskGroup, block_in_place, sleep};
+use fedimint_core::task::{TaskGroup, TaskHandle, block_in_place, sleep};
 use fedimint_core::util::FmtCompactAnyhow;
 use fedimint_core::{Amount, OutPoint, apply, async_trait_maybe_send};
 use fedimint_derive_secret::{ChildId, DerivableSecret};
@@ -406,14 +406,19 @@ impl WalletClientModule {
     }
 
     /// Find the next valid index starting from (and including) `start_index`.
+    ///
+    /// Returns `None` if the task group begins shutting down before a valid
+    /// index is found — `block_in_place` itself cannot be interrupted, so we
+    /// poll the task handle each iteration so this CPU-bound loop doesn't
+    /// hold up shutdown for the duration of the search.
     #[allow(clippy::maybe_infinite_iter)]
-    fn next_valid_index(&self, start_index: u64) -> u64 {
+    fn next_valid_index(&self, start_index: u64, handle: &TaskHandle) -> Option<u64> {
         let pks_hash = self.cfg.bitcoin_pks.consensus_hash();
 
         block_in_place(|| {
             (start_index..)
+                .take_while(|_| !handle.is_shutting_down())
                 .find(|i| is_potential_receive(&self.derive_address(*i).script_pubkey(), &pks_hash))
-                .expect("Will always find a valid index")
         })
     }
 
@@ -498,6 +503,7 @@ impl WalletClientModule {
 
     fn spawn_output_scanner(&self, task_group: &TaskGroup, client_span: &tracing::Span) {
         let module = self.clone();
+        let handle = task_group.make_handle();
 
         task_group.spawn_cancellable_with_span(client_span.clone(), "output-scanner", async move {
             let mut dbtx = module.db.begin_transaction().await;
@@ -508,15 +514,15 @@ impl WalletClientModule {
                 .next()
                 .await
                 .is_none()
+                && let Some(idx) = module.next_valid_index(0, &handle)
             {
-                dbtx.insert_new_entry(&ValidAddressIndexKey(module.next_valid_index(0)), &())
-                    .await;
+                dbtx.insert_new_entry(&ValidAddressIndexKey(idx), &()).await;
             }
 
             dbtx.commit_tx().await;
 
             loop {
-                match module.check_outputs().await {
+                match module.check_outputs(&handle).await {
                     Ok(skip_wait) => {
                         if skip_wait {
                             continue;
@@ -532,17 +538,24 @@ impl WalletClientModule {
         });
     }
 
-    async fn check_outputs(&self) -> anyhow::Result<bool> {
-        let mut dbtx = self.db.begin_transaction_nc().await;
+    async fn check_outputs(&self, handle: &TaskHandle) -> anyhow::Result<bool> {
+        // Read both values from a single snapshot and drop the read-only
+        // dbtx before the RPC and loop run, so we don't pin a snapshot
+        // across the federation round-trips and inner write transactions.
+        let (next_output_index, mut valid_indices) = {
+            let mut dbtx = self.db.begin_transaction_nc().await;
 
-        let next_output_index = dbtx.get_value(&NextOutputIndexKey).await.unwrap_or(0);
+            let next_output_index = dbtx.get_value(&NextOutputIndexKey).await.unwrap_or(0);
 
-        let mut valid_indices: Vec<u64> = dbtx
-            .find_by_prefix(&ValidAddressIndexPrefix)
-            .await
-            .map(|entry| entry.0.0)
-            .collect()
-            .await;
+            let valid_indices: Vec<u64> = dbtx
+                .find_by_prefix(&ValidAddressIndexPrefix)
+                .await
+                .map(|entry| entry.0.0)
+                .collect()
+                .await;
+
+            (next_output_index, valid_indices)
+        };
 
         let mut address_map: BTreeMap<ScriptBuf, u64> = valid_indices
             .iter()
@@ -571,7 +584,12 @@ impl WalletClientModule {
                             .copied()
                             .expect("we have at least one address index") =>
                 {
-                    Some(self.next_valid_index(address_index + 1))
+                    // If shutdown is signaled mid-search, bail out without
+                    // committing anything — we'll resume on the next start.
+                    let Some(idx) = self.next_valid_index(address_index + 1, handle) else {
+                        return Ok(false);
+                    };
+                    Some(idx)
                 }
                 _ => None,
             };

--- a/modules/fedimint-walletv2-client/src/lib.rs
+++ b/modules/fedimint-walletv2-client/src/lib.rs
@@ -14,10 +14,11 @@ pub mod events;
 mod receive_sm;
 mod send_sm;
 
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
-use anyhow::anyhow;
+use anyhow::{anyhow, bail};
 use api::WalletFederationApi;
 use bitcoin::address::NetworkUnchecked;
 use bitcoin::{Address, ScriptBuf};
@@ -133,6 +134,10 @@ pub struct WalletClientModule {
     client_ctx: ClientContext<Self>,
     db: Database,
     module_api: DynModuleApi,
+    /// Nonzero while at least one [`Self::spawn_output_scanner`] task is
+    /// active. Used by [`Self::await_receive`] to detect concurrent claim
+    /// submissions that would prevent it from observing its deposits.
+    scanner_running: Arc<AtomicUsize>,
 }
 
 #[derive(Debug, Clone)]
@@ -219,6 +224,7 @@ impl ClientModuleInit for WalletClientInit {
             client_ctx: args.context(),
             db: args.db().clone(),
             module_api: args.module_api().clone(),
+            scanner_running: Arc::new(AtomicUsize::new(0)),
         };
 
         Ok(module)
@@ -384,7 +390,7 @@ impl WalletClientModule {
 
         loop {
             let Some(WalletClientStateMachines::Send(state)) = stream.next().await else {
-                panic!("stream must produce a terminal send state");
+                continue;
             };
 
             match state.state {
@@ -405,7 +411,7 @@ impl WalletClientModule {
 
         loop {
             let Some(WalletClientStateMachines::Receive(state)) = stream.next().await else {
-                panic!("stream must produce a terminal receive state");
+                continue;
             };
 
             match state.state {
@@ -427,6 +433,11 @@ impl WalletClientModule {
     /// already landed, they're in the user's balance.
     ///
     /// Returns immediately with `Ok(vec![])` if `addresses` is empty.
+    ///
+    /// Errors if [`Self::spawn_output_scanner`] is active on this client:
+    /// the background scanner can claim a deposit before this call's
+    /// internal `check_outputs` loop observes it, which would cause this
+    /// function to wait indefinitely.
     pub async fn await_receive(
         &self,
         addresses: Vec<Address<NetworkUnchecked>>,
@@ -435,7 +446,15 @@ impl WalletClientModule {
             return Ok(Vec::new());
         }
 
-        let mut remaining: HashMap<ScriptBuf, usize> = HashMap::new();
+        if self.scanner_running.load(Ordering::SeqCst) > 0 {
+            bail!(
+                "await_receive cannot run while spawn_output_scanner is active: \
+                 background claim submissions would prevent this call from \
+                 observing its deposits"
+            );
+        }
+
+        let mut remaining: BTreeMap<ScriptBuf, usize> = BTreeMap::new();
         for address in &addresses {
             *remaining
                 .entry(address.clone().assume_checked().script_pubkey())
@@ -640,6 +659,8 @@ impl WalletClientModule {
     /// one-shot callers (e.g. CLI) can use [`Self::await_receive`] instead,
     /// which drives its own scan loop for the duration of a single wait.
     pub fn spawn_output_scanner(&self, task_group: &TaskGroup, client_span: &tracing::Span) {
+        self.scanner_running.fetch_add(1, Ordering::SeqCst);
+
         let module = self.clone();
         let handle = task_group.make_handle();
 

--- a/modules/fedimint-walletv2-client/src/lib.rs
+++ b/modules/fedimint-walletv2-client/src/lib.rs
@@ -110,8 +110,11 @@ pub enum FinalReceiveState {
 /// Result of a single pass of [`WalletClientModule::check_outputs`].
 #[derive(Debug, Clone)]
 struct CheckOutputsProgress {
-    /// `(operation_id, script)` for each claim submitted during this pass.
-    submitted: Vec<(OperationId, ScriptBuf)>,
+    /// `(operation_id, script, change_outpoints)` for each claim submitted
+    /// during this pass. `change_outpoints` are the primary module's output
+    /// points (issued ecash) — callers awaiting completion need them to wait
+    /// for the mint state machines to credit the balance.
+    submitted: Vec<(OperationId, ScriptBuf, Vec<OutPoint>)>,
     /// True if the federation returned a non-empty slice, meaning there are
     /// likely more outputs to scan immediately; false if the slice was empty
     /// and the caller should back off before retrying.
@@ -435,7 +438,7 @@ impl WalletClientModule {
                 .or_insert(0) += 1;
         }
         let total_expected: usize = remaining.values().sum();
-        let mut collected: Vec<OperationId> = Vec::with_capacity(total_expected);
+        let mut collected: Vec<(OperationId, Vec<OutPoint>)> = Vec::with_capacity(total_expected);
 
         // Foreground caller — no shared shutdown signal, so use a fresh group
         // whose handle never reports shutting-down. The group is dropped when
@@ -446,22 +449,33 @@ impl WalletClientModule {
         loop {
             let progress = self.check_outputs(&handle).await?;
 
-            for (operation_id, claim_script) in progress.submitted {
+            for (operation_id, claim_script, change) in progress.submitted {
                 if let Some(count) = remaining.get_mut(&claim_script)
                     && *count > 0
                 {
-                    collected.push(operation_id);
+                    collected.push((operation_id, change));
                     *count -= 1;
                 }
             }
 
             if collected.len() == total_expected {
-                return Ok(join_all(
-                    collected
-                        .into_iter()
-                        .map(|op| self.await_final_receive_operation_state(op)),
-                )
-                .await);
+                return Ok(
+                    join_all(collected.into_iter().map(|(op, change)| async move {
+                        let state = self.await_final_receive_operation_state(op).await;
+                        // Wait for the primary (mint) module's outputs to finish
+                        // claiming so the caller sees the ecash in their balance —
+                        // the receive state machine only confirms the federation
+                        // accepted the claim transaction.
+                        if matches!(state, FinalReceiveState::Success) {
+                            let _ = self
+                                .client_ctx
+                                .await_primary_module_outputs(op, change)
+                                .await;
+                        }
+                        state
+                    }))
+                    .await,
+                );
             }
 
             if !progress.more_outputs {
@@ -552,7 +566,7 @@ impl WalletClientModule {
         value: bitcoin::Amount,
         address_index: u64,
         fee: bitcoin::Amount,
-    ) -> anyhow::Result<OperationId> {
+    ) -> anyhow::Result<(OperationId, OutPointRange)> {
         let operation_id = OperationId::new_random();
 
         let client_input = ClientInput::<WalletInput> {
@@ -584,7 +598,8 @@ impl WalletClientModule {
             vec![client_input_sm],
         ));
 
-        self.client_ctx
+        let change_range = self
+            .client_ctx
             .finalize_and_submit_transaction_dbtx(
                 dbtx,
                 operation_id,
@@ -612,7 +627,7 @@ impl WalletClientModule {
             )
             .await;
 
-        Ok(operation_id)
+        Ok((operation_id, change_range))
     }
 
     /// Spawn a background task that scans the federation's deposit log and
@@ -684,7 +699,7 @@ impl WalletClientModule {
             .map(|&i| (self.derive_address(i).script_pubkey(), i))
             .collect();
 
-        let mut submitted: Vec<(OperationId, ScriptBuf)> = Vec::new();
+        let mut submitted: Vec<(OperationId, ScriptBuf, Vec<OutPoint>)> = Vec::new();
 
         let outputs = self
             .module_api
@@ -759,7 +774,7 @@ impl WalletClientModule {
                         .await;
 
                     match result {
-                        Ok(operation_id) => {
+                        Ok((operation_id, change_range)) => {
                             if let Some(idx) = new_valid_index {
                                 dbtx.insert_entry(&ValidAddressIndexKey(idx), &()).await;
                             }
@@ -774,7 +789,11 @@ impl WalletClientModule {
                                 address_map.insert(self.derive_address(idx).script_pubkey(), idx);
                             }
 
-                            submitted.push((operation_id, output.script.clone()));
+                            submitted.push((
+                                operation_id,
+                                output.script.clone(),
+                                change_range.into_iter().collect(),
+                            ));
 
                             continue;
                         }

--- a/modules/fedimint-walletv2-client/src/lib.rs
+++ b/modules/fedimint-walletv2-client/src/lib.rs
@@ -98,6 +98,26 @@ pub enum FinalSendOperationState {
     Failure,
 }
 
+/// The final state of an operation claiming an onchain deposit.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum FinalReceiveState {
+    /// The deposit was successfully claimed.
+    Success,
+    /// The federation rejected the claim transaction.
+    Aborted(String),
+}
+
+/// Result of a single pass of [`WalletClientModule::check_outputs`].
+#[derive(Debug, Clone)]
+struct CheckOutputsProgress {
+    /// `(operation_id, script)` for each claim submitted during this pass.
+    submitted: Vec<(OperationId, ScriptBuf)>,
+    /// True if the federation returned a non-empty slice, meaning there are
+    /// likely more outputs to scan immediately; false if the slice was empty
+    /// and the caller should back off before retrying.
+    more_outputs: bool,
+}
+
 #[derive(Debug, Clone)]
 pub struct WalletClientModule {
     root_secret: DerivableSecret,
@@ -193,8 +213,6 @@ impl ClientModuleInit for WalletClientInit {
             db: args.db().clone(),
             module_api: args.module_api().clone(),
         };
-
-        module.spawn_output_scanner(args.task_group(), args.client_span());
 
         Ok(module)
     }
@@ -371,6 +389,58 @@ impl WalletClientModule {
         }
     }
 
+    /// Await the final state of the receive operation.
+    pub async fn await_final_receive_operation_state(
+        &self,
+        operation_id: OperationId,
+    ) -> FinalReceiveState {
+        let mut stream = self.notifier.subscribe(operation_id).await;
+
+        loop {
+            let Some(WalletClientStateMachines::Receive(state)) = stream.next().await else {
+                panic!("stream must produce a terminal receive state");
+            };
+
+            match state.state {
+                ReceiveSMState::Funding => {}
+                ReceiveSMState::Success => return FinalReceiveState::Success,
+                ReceiveSMState::Aborted(reason) => return FinalReceiveState::Aborted(reason),
+            }
+        }
+    }
+
+    /// Drive the deposit scanner until a claim for `address` is submitted,
+    /// then block until that claim's state machine reaches a terminal state.
+    ///
+    /// Forward-looking: only awaits deposits submitted *during this call*. If
+    /// the address was claimed in a previous session, this won't surface that
+    /// history — the funds are already in the user's balance.
+    pub async fn await_receive(
+        &self,
+        address: Address<NetworkUnchecked>,
+    ) -> anyhow::Result<FinalReceiveState> {
+        let script = address.assume_checked().script_pubkey();
+        // Foreground caller — no shared shutdown signal, so use a fresh group
+        // whose handle never reports shutting-down. The group is dropped when
+        // this function returns.
+        let task_group = TaskGroup::new();
+        let handle = task_group.make_handle();
+
+        loop {
+            let progress = self.check_outputs(&handle).await?;
+
+            for (operation_id, claim_script) in progress.submitted {
+                if claim_script == script {
+                    return Ok(self.await_final_receive_operation_state(operation_id).await);
+                }
+            }
+
+            if !progress.more_outputs {
+                sleep(fedimint_walletv2_common::sleep_duration()).await;
+            }
+        }
+    }
+
     /// Returns the next unused receive address, polling until the initial
     /// address derivation has completed.
     pub async fn receive(&self) -> Address {
@@ -426,8 +496,10 @@ impl WalletClientModule {
     ///
     /// Submission and event logging happen inside the caller-supplied `dbtx`
     /// so that the caller can atomically advance `NextOutputIndexKey` in the
-    /// same commit. Returns an error if the transaction cannot be assembled
-    /// locally — most commonly because the remaining value after
+    /// same commit. Returns the `OperationId` of the receive operation on
+    /// success — callers can use it to await the receive state machine's
+    /// terminal state. Returns an error if the transaction cannot be
+    /// assembled locally — most commonly because the remaining value after
     /// `receive_fee` is too small to cover the mint module's output fee.
     /// Federation acceptance is tracked by the receive state machine and
     /// does not block this call.
@@ -438,7 +510,7 @@ impl WalletClientModule {
         value: bitcoin::Amount,
         address_index: u64,
         fee: bitcoin::Amount,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<OperationId> {
         let operation_id = OperationId::new_random();
 
         let client_input = ClientInput::<WalletInput> {
@@ -498,10 +570,17 @@ impl WalletClientModule {
             )
             .await;
 
-        Ok(())
+        Ok(operation_id)
     }
 
-    fn spawn_output_scanner(&self, task_group: &TaskGroup, client_span: &tracing::Span) {
+    /// Spawn a background task that scans the federation's deposit log and
+    /// claims any deposits that land on this client's addresses.
+    ///
+    /// Opt-in: not called from [`ClientModuleInit::init`]. Stateful apps that
+    /// want continuous auto-claiming should spawn this once at startup;
+    /// one-shot callers (e.g. CLI) can use [`Self::await_receive`] instead,
+    /// which drives its own scan loop for the duration of a single wait.
+    pub fn spawn_output_scanner(&self, task_group: &TaskGroup, client_span: &tracing::Span) {
         let module = self.clone();
         let handle = task_group.make_handle();
 
@@ -523,8 +602,8 @@ impl WalletClientModule {
 
             loop {
                 match module.check_outputs(&handle).await {
-                    Ok(skip_wait) => {
-                        if skip_wait {
+                    Ok(progress) => {
+                        if progress.more_outputs {
                             continue;
                         }
                     }
@@ -538,7 +617,8 @@ impl WalletClientModule {
         });
     }
 
-    async fn check_outputs(&self, handle: &TaskHandle) -> anyhow::Result<bool> {
+    #[allow(clippy::too_many_lines)]
+    async fn check_outputs(&self, handle: &TaskHandle) -> anyhow::Result<CheckOutputsProgress> {
         // Read both values from a single snapshot and drop the read-only
         // dbtx before the RPC and loop run, so we don't pin a snapshot
         // across the federation round-trips and inner write transactions.
@@ -561,6 +641,8 @@ impl WalletClientModule {
             .iter()
             .map(|&i| (self.derive_address(i).script_pubkey(), i))
             .collect();
+
+        let mut submitted: Vec<(OperationId, ScriptBuf)> = Vec::new();
 
         let outputs = self
             .module_api
@@ -587,7 +669,10 @@ impl WalletClientModule {
                     // If shutdown is signaled mid-search, bail out without
                     // committing anything — we'll resume on the next start.
                     let Some(idx) = self.next_valid_index(address_index + 1, handle) else {
-                        return Ok(false);
+                        return Ok(CheckOutputsProgress {
+                            submitted,
+                            more_outputs: false,
+                        });
                     };
                     Some(idx)
                 }
@@ -600,7 +685,10 @@ impl WalletClientModule {
                 // In order to not overpay on fees we choose to wait,
                 // the congestion will clear up within a few blocks.
                 if self.module_api.pending_tx_chain().await?.len() >= 3 {
-                    return Ok(false);
+                    return Ok(CheckOutputsProgress {
+                        submitted,
+                        more_outputs: false,
+                    });
                 }
 
                 matched_num += 1;
@@ -629,7 +717,7 @@ impl WalletClientModule {
                         .await;
 
                     match result {
-                        Ok(()) => {
+                        Ok(operation_id) => {
                             if let Some(idx) = new_valid_index {
                                 dbtx.insert_entry(&ValidAddressIndexKey(idx), &()).await;
                             }
@@ -643,6 +731,8 @@ impl WalletClientModule {
                                 valid_indices.push(idx);
                                 address_map.insert(self.derive_address(idx).script_pubkey(), idx);
                             }
+
+                            submitted.push((operation_id, output.script.clone()));
 
                             continue;
                         }
@@ -690,7 +780,10 @@ impl WalletClientModule {
             "Scanning for outputs"
         );
 
-        Ok(!outputs.is_empty())
+        Ok(CheckOutputsProgress {
+            submitted,
+            more_outputs: !outputs.is_empty(),
+        })
     }
 }
 

--- a/modules/fedimint-walletv2-tests/bin/tests.rs
+++ b/modules/fedimint-walletv2-tests/bin/tests.rs
@@ -76,21 +76,6 @@ async fn ensure_federation_total_value(client: &Client, min_value: u64) -> anyho
     Ok(())
 }
 
-async fn await_client_balance(client: &Client, min_balance: u64) -> anyhow::Result<()> {
-    loop {
-        cmd!(client, "dev", "wait", "3").out_json().await?;
-
-        let balance = client.balance().await?;
-
-        // Client balance is in msats, min_balance is in sats
-        if balance >= min_balance * 1000 {
-            return Ok(());
-        }
-
-        info!("Waiting for client balance {balance} to reach {min_balance}");
-    }
-}
-
 async fn await_no_pending_txs(client: &Client) -> anyhow::Result<()> {
     loop {
         let value = cmd!(client, "module", "walletv2", "info", "pending-tx-chain")
@@ -203,7 +188,16 @@ async fn main() -> anyhow::Result<()> {
 
             info!("Wait for deposits to be claimed...");
 
-            await_client_balance(&client, 290_000).await?;
+            cmd!(
+                client,
+                "module",
+                "walletv2",
+                "await-receive",
+                federation_address_1.to_string(),
+                federation_address_1.to_string()
+            )
+            .run()
+            .await?;
 
             ensure_federation_total_value(&client, 290_000).await?;
 
@@ -221,7 +215,16 @@ async fn main() -> anyhow::Result<()> {
 
             info!("Wait for deposits to be claimed...");
 
-            await_client_balance(&client, 980_000).await?;
+            cmd!(
+                client,
+                "module",
+                "walletv2",
+                "await-receive",
+                federation_address_2.to_string(),
+                federation_address_2.to_string()
+            )
+            .run()
+            .await?;
 
             ensure_federation_total_value(&client, 980_000).await?;
 
@@ -313,7 +316,15 @@ async fn main() -> anyhow::Result<()> {
 
             bitcoind.poll_get_transaction(txid).await?;
 
-            await_client_balance(&client_two, 99_000).await?;
+            cmd!(
+                client_two,
+                "module",
+                "walletv2",
+                "await-receive",
+                circular_address.to_string()
+            )
+            .run()
+            .await?;
 
             await_no_pending_txs(&client).await?;
 

--- a/modules/fedimint-walletv2-tests/tests/tests.rs
+++ b/modules/fedimint-walletv2-tests/tests/tests.rs
@@ -130,28 +130,6 @@ async fn await_consensus_block_count(
     }
 }
 
-async fn await_federation_total_value(
-    client: &ClientHandleArc,
-    min_value: bitcoin::Amount,
-) -> anyhow::Result<()> {
-    loop {
-        let current_value = client
-            .get_first_module::<WalletClientModule>()?
-            .total_value()
-            .await?;
-
-        if current_value >= min_value {
-            return Ok(());
-        }
-
-        sleep_in_test(
-            format!("Waiting for federation total value of {current_value} to reach {min_value}"),
-            Duration::from_secs(1),
-        )
-        .await;
-    }
-}
-
 #[tokio::test(flavor = "multi_thread")]
 async fn fee_exceeds_one_bitcoin_with_many_pending_txs() -> anyhow::Result<()> {
     let fixtures = fixtures();
@@ -177,9 +155,12 @@ async fn fee_exceeds_one_bitcoin_with_many_pending_txs() -> anyhow::Result<()> {
 
     await_finality_delay(&client, &bitcoin).await?;
 
-    info!("Wait for deposit to be auto-claimed...");
+    info!("Wait for deposit to be claimed...");
 
-    await_federation_total_value(&client, Amount::from_sat(99_000_000)).await?;
+    client
+        .get_first_module::<WalletClientModule>()?
+        .await_receive(vec![federation_address.as_unchecked().clone()])
+        .await?;
 
     let address = bitcoin.get_new_address().await.as_unchecked().clone();
 


### PR DESCRIPTION
The CLI experience for walletv2 is currently pretty rough. It does not currently support a command for detecting deposits and relies on a background task to scan for deposits. The results in the tests and devimint needing a bunch of hacky code like monitoring balances or just calling `dev wait` to receive funds.

Additionally, the background task that auto-claims deposits has race conditions. These are problematic for the CLI because the CLI is not long-lived, meaning the background task can be cancelled at any time, resulting in these problems:

 - `NextOutputIndexKey` did not use the same database transaction has submission of the claim transaction. This could result in the claim transaction being submitted multiple times and causing a rejection.
 - `next_valid_index` is a long running operation but can't be interrupted, which can make the client hang when shutting down.
 - The submission of the claim transaction current calls `expect` if it can't submit the transaction, but the amount check doesn't account for mint fees. It is possible to crash the client if the amount is specified such that it is greater than the receive fee, but not enough mint fees to claim the ecash.
 - It's not necessary to call `await_tx_accepted`. If the transaction is not accepted, currently re-submission does not fix it.
 - `ValidAddressIndexKey` was commited in its own database transaction which would leave a phantom index if the task was cancelled before the claim transaction was submitted.

This PR:
 - Fixes the above issues by refactoring `check_outputs` to use one database transaction per output
 - Adds `await-receive` CLI command to allow the CLI to wait for a deposit to a set of addresses
 - Makes `spawn_output_scanner` public and optional. IMO background tasks should never be mandatory in the client, it causes race conditions like above.
 - Fixes all of the tests and devimint CLI calls to use `await-receive` instead of checking balances or calling `fedimint-cli dev wait`.
