### PR TITLE
test(wallet): split bitcoind wallet tests into groups

### DIFF
--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -52,6 +52,28 @@ fn bsats(satoshi: u64) -> bitcoin::Amount {
 
 const PEG_IN_AMOUNT_SATS: u64 = 10000;
 const PEG_OUT_AMOUNT_SATS: u64 = 1000;
+const FM_BITCOIND_WALLET_TEST_GROUP_ENV: &str = "FM_BITCOIND_WALLET_TEST_GROUP";
+
+fn should_skip_wallet_test_group(test_group: &str) -> bool {
+    match env::var(FM_BITCOIND_WALLET_TEST_GROUP_ENV) {
+        Ok(selected_group) if selected_group != test_group => {
+            info!(
+                selected_group,
+                test_group, "Skipping wallet test not in selected test group"
+            );
+            true
+        }
+        _ => false,
+    }
+}
+
+macro_rules! skip_if_not_wallet_test_group {
+    ($test_group:literal) => {
+        if $crate::should_skip_wallet_test_group($test_group) {
+            return Ok(());
+        }
+    };
+}
 
 async fn peg_in<'a>(
     client: &'a ClientHandleArc,
@@ -177,6 +199,7 @@ async fn await_consensus_upgrade(
 
 #[tokio::test(flavor = "multi_thread")]
 async fn sanity_check_bitcoin_blocks() -> anyhow::Result<()> {
+    skip_if_not_wallet_test_group!("1");
     let fixtures = fixtures();
     let fed = fixtures.new_fed_degraded().await;
     let client = fed.new_client().await;
@@ -219,6 +242,7 @@ async fn sanity_check_bitcoin_blocks() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn on_chain_peg_in_and_peg_out_happy_case() -> anyhow::Result<()> {
+    skip_if_not_wallet_test_group!("2");
     let fixtures = fixtures();
     let fed = fixtures.new_fed_degraded().await;
     let client = fed.new_client().await;
@@ -374,6 +398,7 @@ async fn on_chain_peg_in_and_peg_out_happy_case() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn on_chain_peg_in_detects_multiple() -> anyhow::Result<()> {
+    skip_if_not_wallet_test_group!("2");
     let fixtures = fixtures();
     let fed = fixtures.new_fed_degraded().await;
     let client = fed.new_client().await;
@@ -454,6 +479,7 @@ async fn on_chain_peg_in_detects_multiple() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn peg_out_fail_refund() -> anyhow::Result<()> {
+    skip_if_not_wallet_test_group!("2");
     let fixtures = fixtures();
     let fed = fixtures.new_fed_degraded().await;
     let client = fed.new_client().await;
@@ -502,6 +528,7 @@ async fn peg_out_fail_refund() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn rbf_withdrawals_are_rejected() -> anyhow::Result<()> {
+    skip_if_not_wallet_test_group!("2");
     let fixtures = fixtures();
     let fed = fixtures.new_fed_degraded().await;
     let client = fed.new_client().await;
@@ -597,6 +624,7 @@ async fn rbf_withdrawals_are_rejected() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn peg_outs_must_wait_for_available_utxos() -> anyhow::Result<()> {
+    skip_if_not_wallet_test_group!("2");
     let fixtures = fixtures();
     let fed = fixtures.new_fed_degraded().await;
     let client = fed.new_client().await;
@@ -685,6 +713,7 @@ async fn peg_outs_must_wait_for_available_utxos() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn peg_ins_that_are_unconfirmed_are_rejected() -> anyhow::Result<()> {
+    skip_if_not_wallet_test_group!("1");
     let fixtures = fixtures();
     let bitcoin = fixtures.bitcoin();
     let bitcoin = bitcoin.lock_exclusive().await;
@@ -832,6 +861,7 @@ async fn peg_ins_that_are_unconfirmed_are_rejected() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn dust_deposits_are_ignored() -> anyhow::Result<()> {
+    skip_if_not_wallet_test_group!("1");
     let fixtures = fixtures();
     let fed = fixtures.new_fed_degraded().await;
     let client = fed.new_client().await;
@@ -910,6 +940,7 @@ async fn dust_deposits_are_ignored() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn allocate_deposit_address_pooled_zero_gap_reuses_until_used() -> anyhow::Result<()> {
+    skip_if_not_wallet_test_group!("1");
     let fixtures = fixtures();
     let fed = fixtures.new_fed_degraded().await;
     let client = fed.new_client().await;
@@ -957,6 +988,7 @@ async fn allocate_deposit_address_pooled_zero_gap_reuses_until_used() -> anyhow:
 
 #[tokio::test(flavor = "multi_thread")]
 async fn allocate_deposit_address_pooled_caps_and_reuses_round_robin() -> anyhow::Result<()> {
+    skip_if_not_wallet_test_group!("2");
     let fixtures = fixtures();
     let fed = fixtures.new_fed_degraded().await;
     let client = fed.new_client().await;
@@ -1019,6 +1051,7 @@ async fn allocate_deposit_address_pooled_caps_and_reuses_round_robin() -> anyhow
 
 #[tokio::test(flavor = "multi_thread")]
 async fn allocate_deposit_address_pooled_reuse_resets_monitoring_schedule() -> anyhow::Result<()> {
+    skip_if_not_wallet_test_group!("1");
     let fixtures = fixtures();
     let fed = fixtures.new_fed_degraded().await;
     let client = fed.new_client().await;
@@ -1074,6 +1107,7 @@ async fn allocate_deposit_address_pooled_reuse_resets_monitoring_schedule() -> a
 
 #[tokio::test(flavor = "multi_thread")]
 async fn allocate_deposit_address_pooled_used_address_shrinks_gap() -> anyhow::Result<()> {
+    skip_if_not_wallet_test_group!("2");
     let fixtures = fixtures();
     let fed = fixtures.new_fed_degraded().await;
     let client = fed.new_client().await;
@@ -1127,6 +1161,7 @@ async fn allocate_deposit_address_pooled_used_address_shrinks_gap() -> anyhow::R
 
 #[tokio::test(flavor = "multi_thread")]
 async fn construct_wallet_summary() -> anyhow::Result<()> {
+    skip_if_not_wallet_test_group!("1");
     let fixtures = fixtures();
     let fed = fixtures.new_fed_degraded().await;
     let client = fed.new_client().await;
@@ -1331,6 +1366,7 @@ async fn construct_wallet_summary() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn verify_auto_consensus_voting() -> anyhow::Result<()> {
+    skip_if_not_wallet_test_group!("1");
     let fixtures = fixtures();
     let fed = fixtures.new_fed_not_degraded().await;
     let client = fed.new_client().await;
@@ -1644,6 +1680,7 @@ mod fedimint_migration_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn snapshot_server_db_migrations() -> anyhow::Result<()> {
+        skip_if_not_wallet_test_group!("1");
         snapshot_db_migrations::<_, WalletCommonInit>("wallet-server-v0", |db| {
             Box::pin(async {
                 create_server_db_with_v0_data(db.clone()).await;
@@ -1655,6 +1692,7 @@ mod fedimint_migration_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_server_db_migrations() -> anyhow::Result<()> {
+        skip_if_not_wallet_test_group!("1");
         let _ = TracingSetup::default().init();
 
         let module = DynServerModuleInit::from(WalletInit);
@@ -1848,6 +1886,7 @@ mod fedimint_migration_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn snapshot_client_db_migrations() -> anyhow::Result<()> {
+        skip_if_not_wallet_test_group!("1");
         snapshot_db_migrations_client::<_, _, WalletCommonInit>(
             "wallet-client-v0",
             |db| Box::pin(async { create_client_db_with_v0_data(db).await }),
@@ -1858,6 +1897,7 @@ mod fedimint_migration_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_client_db_migrations() -> anyhow::Result<()> {
+        skip_if_not_wallet_test_group!("1");
         let _ = TracingSetup::default().init();
 
         let module = DynClientModuleInit::from(WalletClientInit::default());
@@ -1899,6 +1939,9 @@ mod fedimint_migration_tests {
 
 #[test]
 fn verify_bitcoind_backend() {
+    if should_skip_wallet_test_group("1") {
+        return;
+    }
     let fixtures = fixtures();
     let dyn_bitcoin_rpc = fixtures.server_bitcoin_rpc();
     let bitcoin_rpc_kind = dyn_bitcoin_rpc.get_bitcoin_rpc_config().kind;

--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -299,7 +299,16 @@ export -f bckn_bitcoind_mint
 function bckn_bitcoind_wallet() {
   # backend tests don't support different versions, so we skip for backwards-compatibility tests
   if [ -z "${FM_BACKWARDS_COMPATIBILITY_TEST:-}" ]; then
-    fm-run-test "${FUNCNAME[0]}" env FM_TEST_ONLY=bitcoind FM_BITCOIND_TEST_ONLY=wallet ./scripts/tests/backend-test.sh
+    fm-run-test "${FUNCNAME[0]}_group_1" env \
+      FM_TEST_ONLY=bitcoind \
+      FM_BITCOIND_TEST_ONLY=wallet \
+      FM_BITCOIND_WALLET_TEST_GROUP=1 \
+      ./scripts/tests/backend-test.sh
+    fm-run-test "${FUNCNAME[0]}_group_2" env \
+      FM_TEST_ONLY=bitcoind \
+      FM_BITCOIND_TEST_ONLY=wallet \
+      FM_BITCOIND_WALLET_TEST_GROUP=2 \
+      ./scripts/tests/backend-test.sh
   fi
 }
 export -f bckn_bitcoind_wallet


### PR DESCRIPTION
The bitcoind wallet test suite contains several tests that need exclusive access to the shared bitcoin backend. When all of them run in one nextest invocation, tests can spend most of their per-test timeout waiting for that shared resource instead of doing useful work. This has caused merge-queue flakes where a test times out even though it would have completed quickly once it got the backend lock.

Split the CI bckn_bitcoind_wallet job into two fm-run-test invocations, each with its own devimint instance and FM_BITCOIND_WALLET_TEST_GROUP selection. The Rust tests check that variable at startup and immediately return if they do not belong to the selected group. With the variable unset, all tests still run as before for local/default use.

This reduces contention inside each nextest run and lowers the chance that one slow queued wallet test consumes the whole 90s timeout budget.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
