### PR TITLE
feat(gateway): record lightning route failure details

### DIFF
--- a/gateway/fedimint-lightning/src/ldk.rs
+++ b/gateway/fedimint-lightning/src/ldk.rs
@@ -32,7 +32,10 @@ use tokio::sync::{RwLock, oneshot};
 use tokio_stream::wrappers::ReceiverStream;
 use tracing::{debug, error, info, trace, warn};
 
-use super::{ChannelInfo, ILnRpcClient, LightningRpcError, ListChannelsResponse, RouteHtlcStream};
+use super::{
+    ChannelInfo, ILnRpcClient, LightningPaymentBackend, LightningPaymentFailure, LightningRpcError,
+    ListChannelsResponse, RouteHtlcStream,
+};
 use crate::{
     CloseChannelsWithPeerRequest, CloseChannelsWithPeerResponse, CreateInvoiceRequest,
     CreateInvoiceResponse, GetBalancesResponse, GetLnOnchainAddressResponse, GetNodeInfoResponse,
@@ -135,11 +138,22 @@ pub struct GatewayLdkClient {
         Arc<RwLock<BTreeMap<UserChannelId, oneshot::Sender<anyhow::Result<OutPoint>>>>>,
 
     /// Waiters for outgoing LDK payments that are woken by terminal payment
-    /// events (`PaymentSuccessful` / `PaymentFailed`). This lets `pay()` block
-    /// until the payment resolves instead of polling `node.payment()`. The
-    /// actual result is still read from `node.payment()` after the wakeup; this
-    /// map only signals that a terminal event has arrived.
-    pending_payments: Arc<RwLock<HashMap<PaymentId, oneshot::Sender<()>>>>,
+    /// events (`PaymentSuccessful` / `PaymentFailed`) and failure reasons that
+    /// arrived before a waiter was registered.
+    ///
+    /// This lets `pay()` block until the payment resolves instead of polling
+    /// `node.payment()`. The actual result is still read from `node.payment()`
+    /// after the wakeup; for failed payments the event reason is carried here
+    /// because `PaymentDetails` does not retain it.
+    pending_payments: PendingPayments,
+}
+
+type PendingPaymentSender = oneshot::Sender<Option<String>>;
+type PendingPayments = Arc<RwLock<HashMap<PaymentId, PendingPaymentCompletion>>>;
+
+enum PendingPaymentCompletion {
+    Waiting(PendingPaymentSender),
+    Failed { failure_reason: String },
 }
 
 impl std::fmt::Debug for GatewayLdkClient {
@@ -266,7 +280,7 @@ impl GatewayLdkClient {
         pending_channels: Arc<
             RwLock<BTreeMap<UserChannelId, oneshot::Sender<anyhow::Result<OutPoint>>>>,
         >,
-        pending_payments: Arc<RwLock<HashMap<PaymentId, oneshot::Sender<()>>>>,
+        pending_payments: PendingPayments,
     ) {
         // We manually check for task termination in case we receive a payment while the
         // task is shutting down. In that case, we want to finish the payment
@@ -346,12 +360,28 @@ impl GatewayLdkClient {
             ldk_node::Event::PaymentSuccessful {
                 payment_id: Some(payment_id),
                 ..
+            } => {
+                Self::wake_pending_payment(&pending_payments, payment_id, None, false).await;
             }
-            | ldk_node::Event::PaymentFailed {
+            ldk_node::Event::PaymentFailed {
                 payment_id: Some(payment_id),
+                payment_hash,
+                reason,
                 ..
             } => {
-                Self::wake_pending_payment(&pending_payments, payment_id).await;
+                let cache_failure_reason = payment_hash
+                    .is_some_and(|payment_hash| PaymentId(payment_hash.0) == payment_id);
+                Self::wake_pending_payment(
+                    &pending_payments,
+                    payment_id,
+                    Some(
+                        reason
+                            .map(|reason| format!("{reason:?}"))
+                            .unwrap_or_else(|| "LDK payment failed".to_string()),
+                    ),
+                    cache_failure_reason,
+                )
+                .await;
             }
             _ => {}
         }
@@ -367,20 +397,78 @@ impl GatewayLdkClient {
 
     /// Wakes the `pay()` waiter (if any) for `payment_id` once a terminal
     /// payment event has been observed. The actual payment result is read from
-    /// `node.payment()` by the woken waiter.
+    /// `node.payment()` by the woken waiter, but `PaymentFailed`'s reason is
+    /// delivered through the wakeup because `ldk-node` does not expose it in
+    /// `PaymentDetails`.
     async fn wake_pending_payment(
-        pending_payments: &Arc<RwLock<HashMap<PaymentId, oneshot::Sender<()>>>>,
+        pending_payments: &PendingPayments,
         payment_id: PaymentId,
+        failure_reason: Option<String>,
+        cache_failure_reason: bool,
     ) -> PendingPaymentWakeup {
-        let Some(sender) = pending_payments.write().await.remove(&payment_id) else {
+        let mut pending_payments = pending_payments.write().await;
+        let Some(completion) = pending_payments.remove(&payment_id) else {
+            if cache_failure_reason && let Some(failure_reason) = failure_reason {
+                pending_payments.insert(
+                    payment_id,
+                    PendingPaymentCompletion::Failed { failure_reason },
+                );
+            }
             return PendingPaymentWakeup::NoWaiter;
         };
 
-        if sender.send(()).is_ok() {
+        let PendingPaymentCompletion::Waiting(sender) = completion else {
+            warn!(
+                ?payment_id,
+                "LDK payment terminal event found cached payment completion"
+            );
+            if cache_failure_reason && let Some(failure_reason) = failure_reason {
+                pending_payments.insert(
+                    payment_id,
+                    PendingPaymentCompletion::Failed { failure_reason },
+                );
+            }
+            return PendingPaymentWakeup::NoWaiter;
+        };
+
+        if sender.send(failure_reason).is_ok() {
             PendingPaymentWakeup::Woken
         } else {
             PendingPaymentWakeup::ReceiverDropped
         }
+    }
+
+    async fn register_pending_payment(
+        &self,
+        payment_id: PaymentId,
+        sender: PendingPaymentSender,
+    ) -> Option<String> {
+        let mut pending_payments = self.pending_payments.write().await;
+        match pending_payments.remove(&payment_id) {
+            Some(PendingPaymentCompletion::Failed { failure_reason }) => Some(failure_reason),
+            Some(PendingPaymentCompletion::Waiting(_)) => {
+                warn!(
+                    ?payment_id,
+                    "Replacing unexpected existing LDK payment waiter"
+                );
+                pending_payments.insert(payment_id, PendingPaymentCompletion::Waiting(sender));
+                None
+            }
+            None => {
+                pending_payments.insert(payment_id, PendingPaymentCompletion::Waiting(sender));
+                None
+            }
+        }
+    }
+
+    async fn take_cached_payment_failure(&self, payment_id: PaymentId) -> Option<String> {
+        let mut pending_payments = self.pending_payments.write().await;
+        let Some(PendingPaymentCompletion::Failed { failure_reason }) =
+            pending_payments.remove(&payment_id)
+        else {
+            return None;
+        };
+        Some(failure_reason)
     }
 
     /// Reads the result of an outgoing payment from `node.payment()`.
@@ -390,6 +478,7 @@ impl GatewayLdkClient {
     fn ldk_payment_result(
         &self,
         payment_id: PaymentId,
+        event_failure_reason: Option<String>,
     ) -> Option<Result<PayInvoiceResponse, LightningRpcError>> {
         let payment_details = self.node.payment(&payment_id)?;
         match payment_details.status {
@@ -409,9 +498,14 @@ impl GatewayLdkClient {
                     }))
                 }
             }
-            PaymentStatus::Failed => Some(Err(LightningRpcError::FailedPayment {
-                failure_reason: "LDK payment failed".to_string(),
-            })),
+            PaymentStatus::Failed => {
+                let failure_reason =
+                    event_failure_reason.unwrap_or_else(|| "LDK payment failed".to_string());
+                Some(Err(LightningRpcError::FailedPaymentWithDetails {
+                    payment_failure: ldk_payment_failure(Some(&failure_reason)),
+                    failure_reason,
+                }))
+            }
         }
     }
 }
@@ -488,14 +582,32 @@ impl ILnRpcClient for GatewayLdkClient {
             .async_lock(payment_id)
             .await;
 
+        // If a resumed payment was already terminal before this call registered
+        // for completion events, there is no event reason left for us to wait
+        // on. Return the persisted payment result as-is in that case.
+        let preexisting_terminal_payment = self
+            .node
+            .payment(&payment_id)
+            .is_some_and(|payment| payment.status != PaymentStatus::Pending);
+        if preexisting_terminal_payment {
+            let failure_reason = self.take_cached_payment_failure(payment_id).await;
+            return self.ldk_payment_result(payment_id, failure_reason).expect(
+                "payment was present and checked to be terminal immediately before reading result",
+            );
+        }
+
         // Register a waiter before initiating the payment so that a terminal
         // payment event firing immediately after `send()` returns still wakes
         // us, rather than racing ahead of the registration.
         let (payment_sender, payment_receiver) = oneshot::channel();
-        self.pending_payments
-            .write()
+        if let Some(failure_reason) = self
+            .register_pending_payment(payment_id, payment_sender)
             .await
-            .insert(payment_id, payment_sender);
+        {
+            return self
+                .ldk_payment_result(payment_id, Some(failure_reason))
+                .expect("payment failure event was cached before registering a waiter");
+        }
 
         // If a payment is not known to the node we can initiate it, and if it is known
         // we can skip calling `ldk-node::Bolt11Payment::send()` and wait for the
@@ -526,27 +638,35 @@ impl ILnRpcClient for GatewayLdkClient {
             assert_eq!(sent_payment_id, payment_id);
         }
 
-        // The payment may already be in a terminal state (a known/resumed
-        // payment, or an event that fired before we registered the waiter), so
-        // check once up front before waiting.
-        if let Some(result) = self.ldk_payment_result(payment_id) {
+        // The payment may have succeeded after the pre-waiter check above but
+        // before the waiter was registered. A failed payment in the same window
+        // is not handled here because the event handler caches failure reasons
+        // when no waiter exists; otherwise, we wait below for the event reason.
+        if self
+            .node
+            .payment(&payment_id)
+            .is_some_and(|payment| payment.status == PaymentStatus::Succeeded)
+        {
             self.pending_payments.write().await.remove(&payment_id);
-            return result;
+            return self.ldk_payment_result(payment_id, None).expect(
+                "payment was present and checked to be succeeded immediately before reading result",
+            );
         }
 
         // Otherwise wait for the event handler to wake us when a terminal
         // `PaymentSuccessful` / `PaymentFailed` event arrives, instead of
         // polling. A wakeup is delivered exactly once; the payment status is
         // terminal by the time it fires.
-        let _ = payment_receiver.await;
+        let event_failure_reason = payment_receiver.await.unwrap_or(None);
 
         self.pending_payments.write().await.remove(&payment_id);
-        self.ldk_payment_result(payment_id).unwrap_or_else(|| {
-            Err(LightningRpcError::FailedPayment {
-                failure_reason: "LDK payment event fired without terminal payment status"
-                    .to_string(),
+        self.ldk_payment_result(payment_id, event_failure_reason)
+            .unwrap_or_else(|| {
+                Err(LightningRpcError::FailedPayment {
+                    failure_reason: "LDK payment event fired without terminal payment status"
+                        .to_string(),
+                })
             })
-        })
     }
 
     async fn route_htlcs<'a>(
@@ -1199,6 +1319,16 @@ fn get_preimage_and_payment_hash(
             fedimint_gateway_common::PaymentKind::Bolt11,
         ),
         PaymentKind::Onchain { .. } => (None, None, fedimint_gateway_common::PaymentKind::Onchain),
+    }
+}
+
+// `ldk-node` currently exposes only the high-level failure reason through its
+// public event API, so per-attempt route details are intentionally unavailable.
+fn ldk_payment_failure(reason: Option<&str>) -> LightningPaymentFailure {
+    LightningPaymentFailure {
+        backend: LightningPaymentBackend::Ldk,
+        failure_reason: reason.map(ToOwned::to_owned),
+        attempts: vec![],
     }
 }
 

--- a/gateway/fedimint-lightning/src/ldk/tests.rs
+++ b/gateway/fedimint-lightning/src/ldk/tests.rs
@@ -5,7 +5,7 @@ use fedimint_core::util::SafeUrl;
 use lightning::ln::channelmanager::PaymentId;
 use tokio::sync::{RwLock, oneshot};
 
-use super::{GatewayLdkClient, PendingPaymentWakeup, get_esplora_url};
+use super::{GatewayLdkClient, PendingPaymentCompletion, PendingPaymentWakeup, get_esplora_url};
 
 #[test]
 fn verify_ldk_esplora_url() {
@@ -32,26 +32,64 @@ async fn wake_pending_payment_reports_waiter_state() {
 
     // No waiter registered yet.
     assert_eq!(
-        GatewayLdkClient::wake_pending_payment(&pending_payments, payment_id).await,
+        GatewayLdkClient::wake_pending_payment(
+            &pending_payments,
+            payment_id,
+            Some("RouteNotFound".to_string()),
+            true,
+        )
+        .await,
         PendingPaymentWakeup::NoWaiter
     );
+    assert!(matches!(
+        pending_payments.read().await.get(&payment_id),
+        Some(PendingPaymentCompletion::Failed { failure_reason })
+            if failure_reason == "RouteNotFound"
+    ));
+    pending_payments.write().await.remove(&payment_id);
+
+    // No-waiter failures for non-Bolt11 payment ids are not cached, since only
+    // the Bolt11 `pay()` path consumes this map.
+    assert_eq!(
+        GatewayLdkClient::wake_pending_payment(
+            &pending_payments,
+            payment_id,
+            Some("RouteNotFound".to_string()),
+            false,
+        )
+        .await,
+        PendingPaymentWakeup::NoWaiter
+    );
+    assert!(pending_payments.read().await.is_empty());
 
     // A registered waiter is woken and removed from the map.
     let (sender, receiver) = oneshot::channel();
-    pending_payments.write().await.insert(payment_id, sender);
+    pending_payments
+        .write()
+        .await
+        .insert(payment_id, PendingPaymentCompletion::Waiting(sender));
     assert_eq!(
-        GatewayLdkClient::wake_pending_payment(&pending_payments, payment_id).await,
+        GatewayLdkClient::wake_pending_payment(
+            &pending_payments,
+            payment_id,
+            Some("RouteNotFound".to_string()),
+            true,
+        )
+        .await,
         PendingPaymentWakeup::Woken
     );
-    assert!(receiver.await.is_ok());
+    assert_eq!(receiver.await, Ok(Some("RouteNotFound".to_string())));
     assert!(pending_payments.read().await.is_empty());
 
     // A waiter whose receiver was dropped is reported as such and removed.
     let (sender, receiver) = oneshot::channel();
     drop(receiver);
-    pending_payments.write().await.insert(payment_id, sender);
+    pending_payments
+        .write()
+        .await
+        .insert(payment_id, PendingPaymentCompletion::Waiting(sender));
     assert_eq!(
-        GatewayLdkClient::wake_pending_payment(&pending_payments, payment_id).await,
+        GatewayLdkClient::wake_pending_payment(&pending_payments, payment_id, None, false).await,
         PendingPaymentWakeup::ReceiverDropped
     );
     assert!(pending_payments.read().await.is_empty());

--- a/gateway/fedimint-lightning/src/lib.rs
+++ b/gateway/fedimint-lightning/src/lib.rs
@@ -45,6 +45,71 @@ pub type RouteHtlcStream<'a> = BoxStream<'a, InterceptPaymentRequest>;
 pub type Lnv2HoldInvoiceFilter =
     Arc<dyn Fn(sha256::Hash) -> BoxFuture<'static, bool> + Send + Sync + 'static>;
 
+/// Lightning backend that produced structured payment failure details.
+#[derive(Debug, Serialize, Deserialize, Encodable, Decodable, Clone, Eq, PartialEq, Hash)]
+pub enum LightningPaymentBackend {
+    /// LND lightning backend.
+    Lnd,
+    /// LDK lightning backend.
+    Ldk,
+}
+
+/// Best-effort structured details for a failed outgoing Lightning payment.
+#[derive(Debug, Serialize, Deserialize, Encodable, Decodable, Clone, Eq, PartialEq, Hash)]
+pub struct LightningPaymentFailure {
+    /// Backend that produced these diagnostics.
+    pub backend: LightningPaymentBackend,
+    /// Backend-level failure reason, when available.
+    pub failure_reason: Option<String>,
+    /// Per-attempt failure details, when exposed by the backend.
+    pub attempts: Vec<LightningPaymentFailureAttempt>,
+}
+
+/// Best-effort details for one failed Lightning payment attempt.
+#[derive(Debug, Serialize, Deserialize, Encodable, Decodable, Clone, Eq, PartialEq, Hash)]
+pub struct LightningPaymentFailureAttempt {
+    /// Backend-specific payment attempt id.
+    pub attempt_id: Option<u64>,
+    /// BOLT failure source index, when provided by the backend.
+    pub failure_source_index: Option<u32>,
+    /// BOLT or backend-specific failure code.
+    pub failure_code: Option<String>,
+    /// Public key of the node that failed the attempt, when known.
+    pub failure_node_pub_key: Option<String>,
+    /// Channel id associated with the failure, when known.
+    pub failure_channel_id: Option<u64>,
+    /// Route attempted by this failed payment attempt, when known.
+    pub route: Option<LightningPaymentRoute>,
+}
+
+/// Route attempted by a failed Lightning payment attempt.
+#[derive(Debug, Serialize, Deserialize, Encodable, Decodable, Clone, Eq, PartialEq, Hash)]
+pub struct LightningPaymentRoute {
+    /// Total amount carried by the route in millisatoshis.
+    pub total_amount_msat: Option<u64>,
+    /// Total routing fees for the route in millisatoshis.
+    pub total_fees_msat: Option<u64>,
+    /// Total CLTV time lock for the route.
+    pub total_time_lock: u32,
+    /// Hops that made up this attempted route.
+    pub hops: Vec<LightningPaymentRouteHop>,
+}
+
+/// Hop in a route attempted by a failed Lightning payment attempt.
+#[derive(Debug, Serialize, Deserialize, Encodable, Decodable, Clone, Eq, PartialEq, Hash)]
+pub struct LightningPaymentRouteHop {
+    /// Public key of the hop node, when known.
+    pub pub_key: Option<String>,
+    /// Channel id used for this hop, when known.
+    pub channel_id: Option<u64>,
+    /// Amount forwarded by this hop in millisatoshis.
+    pub amount_to_forward_msat: Option<u64>,
+    /// Fee paid to this hop in millisatoshis.
+    pub fee_msat: Option<u64>,
+    /// CLTV expiry for this hop.
+    pub expiry: u32,
+}
+
 #[derive(
     Error, Debug, Serialize, Deserialize, Encodable, Decodable, Clone, Eq, PartialEq, Hash,
 )]
@@ -87,6 +152,20 @@ pub enum LightningRpcError {
     InvalidMetadata { failure_reason: String },
     #[error("Bolt12 Error: {failure_reason}")]
     Bolt12Error { failure_reason: String },
+    /// Payment failed and backend-specific structured diagnostics are
+    /// available.
+    ///
+    /// `failure_reason` is the human-readable summary used for display and
+    /// compatibility with [`LightningRpcError::FailedPayment`].
+    /// `payment_failure` carries best-effort backend diagnostics that may
+    /// repeat the summary in `payment_failure.failure_reason` and may
+    /// include richer per-attempt route details when the backend exposes
+    /// them.
+    #[error("Payment failed: {failure_reason}")]
+    FailedPaymentWithDetails {
+        failure_reason: String,
+        payment_failure: LightningPaymentFailure,
+    },
 }
 
 /// Represents an active connection to the lightning node.

--- a/gateway/fedimint-lightning/src/lnd.rs
+++ b/gateway/fedimint-lightning/src/lnd.rs
@@ -35,9 +35,10 @@ use tonic_lnd::lnrpc::payment::PaymentStatus;
 use tonic_lnd::lnrpc::policy_update_request::Scope as PolicyUpdateScope;
 use tonic_lnd::lnrpc::{
     ChanInfoRequest, ChannelBalanceRequest, ChannelPoint, CloseChannelRequest, ConnectPeerRequest,
-    FeeReportRequest, GetInfoRequest, Invoice, InvoiceSubscription, LightningAddress,
-    ListChannelsRequest, ListInvoiceRequest, ListPaymentsRequest, ListPeersRequest,
-    OpenChannelRequest, PolicyUpdateRequest, SendCoinsRequest, UpdateFailure, WalletBalanceRequest,
+    FeeReportRequest, GetInfoRequest, Hop, HtlcAttempt, Invoice, InvoiceSubscription,
+    LightningAddress, ListChannelsRequest, ListInvoiceRequest, ListPaymentsRequest,
+    ListPeersRequest, OpenChannelRequest, Payment, PolicyUpdateRequest, Route, SendCoinsRequest,
+    UpdateFailure, WalletBalanceRequest,
 };
 use tonic_lnd::routerrpc::{
     CircuitKey, ForwardHtlcInterceptResponse, ResolveHoldForwardAction, SendPaymentRequest,
@@ -49,8 +50,10 @@ use tonic_lnd::{Client as LndClient, connect};
 use tracing::{debug, info, trace, warn};
 
 use super::{
-    ChannelInfo, ILnRpcClient, LightningRpcError, ListChannelsResponse, Lnv2HoldInvoiceFilter,
-    MAX_LIGHTNING_RETRIES, RouteHtlcStream,
+    ChannelInfo, ILnRpcClient, LightningPaymentBackend, LightningPaymentFailure,
+    LightningPaymentFailureAttempt, LightningPaymentRoute, LightningPaymentRouteHop,
+    LightningRpcError, ListChannelsResponse, Lnv2HoldInvoiceFilter, MAX_LIGHTNING_RETRIES,
+    RouteHtlcStream,
 };
 use crate::{
     CloseChannelsWithPeerRequest, CloseChannelsWithPeerResponse, CreateInvoiceRequest,
@@ -64,6 +67,106 @@ use crate::{
 type HtlcSubscriptionSender = mpsc::Sender<InterceptPaymentRequest>;
 
 const LND_PAYMENT_TIMEOUT_SECONDS: i32 = 180;
+
+fn lnd_payment_failure(payment: &Payment) -> LightningPaymentFailure {
+    LightningPaymentFailure {
+        backend: LightningPaymentBackend::Lnd,
+        failure_reason: Some(format!("{:?}", payment.failure_reason())),
+        attempts: payment
+            .htlcs
+            .iter()
+            .filter_map(lnd_payment_failure_attempt)
+            .collect(),
+    }
+}
+
+fn lnd_payment_failure_attempt(htlc: &HtlcAttempt) -> Option<LightningPaymentFailureAttempt> {
+    if htlc.status() != tonic_lnd::lnrpc::htlc_attempt::HtlcStatus::Failed {
+        return None;
+    }
+
+    let route = htlc.route.as_ref().map(lnd_payment_route);
+    let failure = htlc.failure.as_ref();
+    let failure_source_index = failure.map(|failure| failure.failure_source_index);
+    let failure_channel_id = failure
+        .and_then(|failure| {
+            failure
+                .channel_update
+                .as_ref()
+                .map(|channel_update| channel_update.chan_id)
+        })
+        .or_else(|| {
+            route
+                .as_ref()
+                .and_then(|route| lnd_route_failure_channel_id(route, failure_source_index))
+        });
+    let failure_node_pub_key = route
+        .as_ref()
+        .and_then(|route| lnd_route_failure_node_pub_key(route, failure_source_index));
+
+    Some(LightningPaymentFailureAttempt {
+        attempt_id: Some(htlc.attempt_id),
+        failure_source_index,
+        failure_code: failure.map(|failure| format!("{:?}", failure.code())),
+        failure_node_pub_key,
+        failure_channel_id,
+        route,
+    })
+}
+
+fn lnd_route_failure_channel_id(
+    route: &LightningPaymentRoute,
+    failure_source_index: Option<u32>,
+) -> Option<u64> {
+    let failure_source_index = failure_source_index?;
+    if failure_source_index == 0 {
+        return None;
+    }
+
+    let hop_index = usize::try_from(failure_source_index - 1).ok()?;
+    route.hops.get(hop_index).and_then(|hop| hop.channel_id)
+}
+
+fn lnd_route_failure_node_pub_key(
+    route: &LightningPaymentRoute,
+    failure_source_index: Option<u32>,
+) -> Option<String> {
+    let failure_source_index = failure_source_index?;
+    if failure_source_index == 0 {
+        return None;
+    }
+
+    let hop_index = usize::try_from(failure_source_index - 1).ok()?;
+    route.hops.get(hop_index)?.pub_key.clone()
+}
+
+fn lnd_payment_route(route: &Route) -> LightningPaymentRoute {
+    LightningPaymentRoute {
+        total_amount_msat: non_negative_i64_to_u64(route.total_amt_msat),
+        total_fees_msat: non_negative_i64_to_u64(route.total_fees_msat),
+        total_time_lock: route.total_time_lock,
+        hops: route.hops.iter().map(lnd_payment_route_hop).collect(),
+    }
+}
+
+fn lnd_payment_route_hop(hop: &Hop) -> LightningPaymentRouteHop {
+    LightningPaymentRouteHop {
+        pub_key: (!hop.pub_key.is_empty()).then(|| hop.pub_key.clone()),
+        channel_id: (hop.chan_id != 0).then_some(hop.chan_id),
+        amount_to_forward_msat: non_negative_i64_to_u64(hop.amt_to_forward_msat),
+        fee_msat: non_negative_i64_to_u64(hop.fee_msat),
+        expiry: hop.expiry,
+    }
+}
+
+fn non_negative_i64_to_u64(value: i64) -> Option<u64> {
+    if value < 0 {
+        debug!(value, "LND returned negative millisatoshi value");
+        return None;
+    }
+
+    Some(u64::try_from(value).expect("value was checked to be non-negative"))
+}
 
 #[derive(Clone)]
 pub struct GatewayLndClient {
@@ -611,8 +714,9 @@ impl GatewayLndClient {
                         }
 
                         let failure_reason = payment.failure_reason();
-                        return Err(LightningRpcError::FailedPayment {
+                        return Err(LightningRpcError::FailedPaymentWithDetails {
                             failure_reason: format!("{failure_reason:?}"),
+                            payment_failure: lnd_payment_failure(&payment),
                         });
                     }
                 }
@@ -1007,8 +1111,9 @@ impl ILnRpcClient for GatewayLndClient {
                                 "LND payment failed",
                             );
                             let failure_reason = payment.failure_reason();
-                            return Err(LightningRpcError::FailedPayment {
+                            return Err(LightningRpcError::FailedPaymentWithDetails {
                                 failure_reason: format!("{failure_reason:?}"),
+                                payment_failure: lnd_payment_failure(&payment),
                             });
                         }
                         Ok(None) => {

--- a/modules/fedimint-gwv2-client/src/send_sm.rs
+++ b/modules/fedimint-gwv2-client/src/send_sm.rs
@@ -9,6 +9,7 @@ use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::Amounts;
 use fedimint_core::secp256k1::Keypair;
 use fedimint_core::{Amount, OutPoint};
+use fedimint_lightning::LightningRpcError;
 use fedimint_lnv2_common::contracts::OutgoingContract;
 use fedimint_lnv2_common::{LightningInput, LightningInputV0, LightningInvoice, OutgoingWitness};
 use serde::{Deserialize, Serialize};
@@ -92,7 +93,10 @@ pub enum Cancelled {
     Rejected,
     Refunded,
     Failure,
+    /// Legacy flattened Lightning RPC failure string.
     LightningRpcError(String),
+    /// Lightning RPC failure preserving structured backend diagnostics.
+    LightningRpcPaymentError(LightningRpcError),
 }
 
 #[cfg_attr(doc, aquamarine::aquamarine)]
@@ -231,7 +235,7 @@ impl SendStateMachine {
                     .gateway
                     .pay(invoice, max_delay, max_fee)
                     .await
-                    .map_err(|e| Cancelled::LightningRpcError(e.to_string()))?;
+                    .map_err(Cancelled::LightningRpcPaymentError)?;
                 Ok(PaymentResponse {
                     preimage,
                     target_federation: None,


### PR DESCRIPTION
## Summary

- add structured Lightning payment failure details to gateway RPC errors
- populate LND failures with failed HTLC attempts, failure source indexes, BOLT failure codes, failed node/channel ids, and attempted routes
- preserve structured Lightning RPC errors in LNv2 outgoing failure events instead of flattening them to strings

Fixes #8592

## Testing

- `just format`
- `cargo check -q -p fedimint-lightning`
- `cargo check -q -p fedimint-gwv2-client`
- `cargo check -q -p fedimint-gw-client`
- `cargo check -q -p fedimint-gateway-server`
- `cargo clippy -q -p fedimint-lightning -- -D warnings`
- `cargo clippy -q -p fedimint-gwv2-client -- -D warnings`
- `cargo clippy -q -p fedimint-gw-client -- -D warnings`

## Notes

LDK currently records only the high-level failure reason exposed through `ldk-node`. The per-path `PaymentPathFailed` route data mentioned in the issue is handled internally by `ldk-node` and is not exposed through its public event API in the version used here.
