### PR TITLE
chore(server): ban standard hash maps in server crates

### DIFF
--- a/fedimint-api-client/src/api/mod.rs
+++ b/fedimint-api-client/src/api/mod.rs
@@ -1,7 +1,7 @@
 mod error;
 pub mod global_api;
 
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Debug;
 use std::future::pending;
 use std::pin::Pin;
@@ -845,7 +845,7 @@ impl IRawFederationApi for FederationApi {
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct LegacyFederationStatus {
     pub session_count: u64,
-    pub status_by_peer: HashMap<PeerId, LegacyPeerStatus>,
+    pub status_by_peer: BTreeMap<PeerId, LegacyPeerStatus>,
     pub peers_online: u64,
     pub peers_offline: u64,
     /// This should always be 0 if everything is okay, so a monitoring tool

--- a/fedimint-core/src/module/audit.rs
+++ b/fedimint-core/src/module/audit.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use std::fmt::{Display, Formatter};
 
 use fedimint_core::core::ModuleInstanceId;
@@ -97,7 +97,7 @@ pub struct ModuleSummary {
 impl AuditSummary {
     pub fn from_audit(
         audit: &Audit,
-        module_instance_id_to_kind: &HashMap<ModuleInstanceId, String>,
+        module_instance_id_to_kind: &BTreeMap<ModuleInstanceId, String>,
     ) -> Self {
         let empty_module_placeholders = module_instance_id_to_kind
             .keys()
@@ -116,7 +116,7 @@ impl AuditSummary {
 
 fn generate_module_summaries<'a>(
     audit_items: impl Iterator<Item = &'a AuditItem>,
-    module_instance_id_to_kind: &HashMap<ModuleInstanceId, String>,
+    module_instance_id_to_kind: &BTreeMap<ModuleInstanceId, String>,
 ) -> BTreeMap<ModuleInstanceId, ModuleSummary> {
     audit_items
         .filter_map(|item| {
@@ -204,7 +204,7 @@ fn creates_audit_summary_from_audit() {
 
     let audit_summary = AuditSummary::from_audit(
         &audit,
-        &HashMap::from([
+        &BTreeMap::from([
             (0, "ln".to_string()),
             (1, "mint".to_string()),
             (2, "wallet".to_string()),
@@ -244,7 +244,7 @@ fn creates_audit_summary_from_audit() {
 fn audit_summary_includes_placeholders() {
     let audit_summary = AuditSummary::from_audit(
         &Audit::default(),
-        &HashMap::from([
+        &BTreeMap::from([
             (0, "ln".to_string()),
             (1, "mint".to_string()),
             (2, "wallet".to_string()),

--- a/fedimint-server-core/clippy.toml
+++ b/fedimint-server-core/clippy.toml
@@ -1,0 +1,1 @@
+../fedimint-server/clippy.toml

--- a/fedimint-server/clippy.toml
+++ b/fedimint-server/clippy.toml
@@ -1,0 +1,2 @@
+# Note: this file symlinked from multiple crates
+disallowed-types = ["std::collections::HashMap", "std::collections::HashSet"]

--- a/fedimint-server/src/config/mod.rs
+++ b/fedimint-server/src/config/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet};
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
@@ -480,7 +480,7 @@ impl ServerConfig {
     }
 
     pub fn trusted_dealer_gen(
-        params: &HashMap<PeerId, ConfigGenParams>,
+        params: &BTreeMap<PeerId, ConfigGenParams>,
         registry: &ServerModuleInitRegistry,
         code_version_str: &str,
     ) -> BTreeMap<PeerId, Self> {
@@ -554,7 +554,7 @@ impl ServerConfig {
         // in case we are running by ourselves, avoid DKG
         if params.peer_ids().len() == 1 {
             let server = Self::trusted_dealer_gen(
-                &HashMap::from([(params.identity, params.clone())]),
+                &BTreeMap::from([(params.identity, params.clone())]),
                 &registry,
                 &code_version_str,
             );

--- a/fedimint-server/src/consensus/api.rs
+++ b/fedimint-server/src/consensus/api.rs
@@ -1,6 +1,6 @@
 //! Implements the client API through which users interact with the federation
 use std::cmp::Ordering;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -285,7 +285,7 @@ impl ConsensusApi {
 
                 (*peer, consensus_status)
             })
-            .collect::<HashMap<PeerId, LegacyPeerStatus>>();
+            .collect::<BTreeMap<_, _>>();
 
         let peers_flagged = status_by_peer
             .values()
@@ -324,7 +324,7 @@ impl ConsensusApi {
         dbtx.ignore_uncommitted();
 
         let mut audit = Audit::default();
-        let mut module_instance_id_to_kind: HashMap<ModuleInstanceId, String> = HashMap::new();
+        let mut module_instance_id_to_kind = BTreeMap::new();
         for (module_instance_id, kind, module) in self.modules.iter_modules() {
             module_instance_id_to_kind.insert(module_instance_id, kind.as_str().to_string());
             module

--- a/fedimint-server/src/metrics.rs
+++ b/fedimint-server/src/metrics.rs
@@ -1,3 +1,6 @@
+#![allow(clippy::disallowed_types)]
+// Prometheus registration macros use `HashMap` internally.
+
 pub(crate) mod jsonrpsee;
 
 use std::sync::LazyLock;

--- a/fedimint-testing-core/src/config.rs
+++ b/fedimint-testing-core/src/config.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::{Arc, LazyLock};
 
 use fedimint_core::PeerId;
@@ -20,12 +20,12 @@ pub fn local_config_gen_params(
     base_port: u16,
     enable_mint_fees: bool,
     registry: &ServerModuleInitRegistry,
-) -> anyhow::Result<HashMap<PeerId, ConfigGenParams>> {
+) -> anyhow::Result<BTreeMap<PeerId, ConfigGenParams>> {
     let enabled_modules: BTreeSet<ModuleKind> =
         registry.iter().map(|(kind, _)| kind.clone()).collect();
 
     // Generate TLS cert and private key
-    let tls_keys: HashMap<
+    let tls_keys: BTreeMap<
         PeerId,
         (
             rustls::pki_types::CertificateDer<'static>,

--- a/modules/fedimint-dummy-server/clippy.toml
+++ b/modules/fedimint-dummy-server/clippy.toml
@@ -1,0 +1,1 @@
+../../fedimint-server/clippy.toml

--- a/modules/fedimint-empty-server/clippy.toml
+++ b/modules/fedimint-empty-server/clippy.toml
@@ -1,0 +1,1 @@
+../../fedimint-server/clippy.toml

--- a/modules/fedimint-ln-server/clippy.toml
+++ b/modules/fedimint-ln-server/clippy.toml
@@ -1,0 +1,1 @@
+../../fedimint-server/clippy.toml

--- a/modules/fedimint-ln-server/src/metrics.rs
+++ b/modules/fedimint-ln-server/src/metrics.rs
@@ -1,3 +1,6 @@
+#![allow(clippy::disallowed_types)]
+// Prometheus registration macros use `HashMap` internally.
+
 use std::sync::LazyLock;
 
 use fedimint_metrics::prometheus::{

--- a/modules/fedimint-lnv2-server/clippy.toml
+++ b/modules/fedimint-lnv2-server/clippy.toml
@@ -1,0 +1,1 @@
+../../fedimint-server/clippy.toml

--- a/modules/fedimint-meta-server/clippy.toml
+++ b/modules/fedimint-meta-server/clippy.toml
@@ -1,0 +1,1 @@
+../../fedimint-server/clippy.toml

--- a/modules/fedimint-mint-server/clippy.toml
+++ b/modules/fedimint-mint-server/clippy.toml
@@ -1,0 +1,1 @@
+../../fedimint-server/clippy.toml

--- a/modules/fedimint-mint-server/src/lib.rs
+++ b/modules/fedimint-mint-server/src/lib.rs
@@ -7,7 +7,7 @@
 pub mod db;
 mod metrics;
 
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet};
 
 use anyhow::bail;
 use fedimint_core::bitcoin::hashes::sha256;
@@ -218,7 +218,7 @@ impl ServerModuleInit for MintInit {
                     dealer_keygen(peers.to_num_peers().threshold(), peers.len());
                 (amount, (tbs_pk, tbs_pks, tbs_sks))
             })
-            .collect::<HashMap<_, _>>();
+            .collect::<BTreeMap<_, _>>();
 
         let mint_cfg: BTreeMap<_, MintConfig> = peers
             .iter()
@@ -268,7 +268,7 @@ impl ServerModuleInit for MintInit {
     ) -> anyhow::Result<ServerModuleConfig> {
         let denominations = gen_denominations();
 
-        let mut amount_keys = HashMap::new();
+        let mut amount_keys = BTreeMap::new();
 
         for amount in &denominations {
             amount_keys.insert(*amount, peers.run_dkg_g2().await?);
@@ -544,7 +544,7 @@ fn eval_polynomial(coefficients: &[Scalar], x: &Scalar) -> Scalar {
 pub struct Mint {
     cfg: MintConfig,
     sec_key: Tiered<SecretKeyShare>,
-    pub_key: HashMap<Amount, AggregatePublicKey>,
+    pub_key: BTreeMap<Amount, AggregatePublicKey>,
 }
 #[apply(async_trait_maybe_send!)]
 impl ServerModule for Mint {
@@ -970,7 +970,7 @@ impl Mint {
         }
     }
 
-    pub fn pub_key(&self) -> HashMap<Amount, AggregatePublicKey> {
+    pub fn pub_key(&self) -> BTreeMap<Amount, AggregatePublicKey> {
         self.pub_key.clone()
     }
 }

--- a/modules/fedimint-mintv2-server/clippy.toml
+++ b/modules/fedimint-mintv2-server/clippy.toml
@@ -1,0 +1,1 @@
+../../fedimint-server/clippy.toml

--- a/modules/fedimint-unknown-server/clippy.toml
+++ b/modules/fedimint-unknown-server/clippy.toml
@@ -1,0 +1,1 @@
+../../fedimint-server/clippy.toml

--- a/modules/fedimint-wallet-server/clippy.toml
+++ b/modules/fedimint-wallet-server/clippy.toml
@@ -1,0 +1,1 @@
+../../fedimint-server/clippy.toml

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -14,7 +14,7 @@ pub mod envs;
 
 use std::clone::Clone;
 use std::cmp::min;
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet};
 use std::convert::Infallible;
 use std::sync::Arc;
 #[cfg(not(target_family = "wasm"))]
@@ -1533,7 +1533,7 @@ impl Wallet {
                 .find_by_prefix(&PendingTransactionPrefixKey)
                 .await
                 .map(|(key, transaction)| (key.0, transaction))
-                .collect::<HashMap<Txid, PendingTransaction>>()
+                .collect::<BTreeMap<Txid, PendingTransaction>>()
                 .await;
             let pending_transactions_len = pending_transactions.len();
 

--- a/modules/fedimint-wallet-server/src/metrics.rs
+++ b/modules/fedimint-wallet-server/src/metrics.rs
@@ -1,3 +1,6 @@
+#![allow(clippy::disallowed_types)]
+// Prometheus registration macros use `HashMap` internally.
+
 use std::sync::LazyLock;
 
 use fedimint_metrics::prometheus::{

--- a/modules/fedimint-walletv2-server/clippy.toml
+++ b/modules/fedimint-walletv2-server/clippy.toml
@@ -1,0 +1,1 @@
+../../fedimint-server/clippy.toml

--- a/nix/flakebox.nix
+++ b/nix/flakebox.nix
@@ -43,13 +43,13 @@ let
   gitHashPlaceholderValue = "01234569abcdef7afa1d2683a099c7af48a523c1";
 
   filterWorkspaceDepsBuildFilesRegex = [
-    "Cargo.lock"
-    "Cargo.toml"
+    "Cargo\\.lock"
+    "Cargo\\.toml"
     ".cargo"
     ".cargo/.*"
     ".config"
     ".config/.*"
-    ".*/Cargo.toml"
+    ".*/Cargo\\.toml"
     ".*/proto/.*"
   ];
 
@@ -96,12 +96,13 @@ let
     filterSrcWithRegexes (
       filterWorkspaceDepsBuildFilesRegex
       ++ [
-        ".*.rs"
-        ".*.html"
+        ".*\\.rs"
+        ".*\\.html"
         ".*/proto/.*"
+        ".*/clippy\\.toml"
         "db/migrations/.*"
         "devimint/src/cfg/.*"
-        "docs/.*.md"
+        "docs/.*\\.md"
         "fedimint-ui-common/assets/.*"
       ]
     ) src;
@@ -112,13 +113,13 @@ let
     filterSrcWithRegexes (
       filterWorkspaceDepsBuildFilesRegex
       ++ [
-        ".*.rs"
-        ".*.html"
+        ".*\\.rs"
+        ".*\\.html"
         ".*/proto/.*"
         "db/migrations/.*"
         "devimint/src/cfg/.*"
         "scripts/.*"
-        "docs/.*.md"
+        "docs/.*\\.md"
         "fedimint-ui-common/assets/.*"
       ]
     ) src;


### PR DESCRIPTION
Redoing old forgotten PR https://github.com/fedimint/fedimint/pull/6674 on current master.

## Summary

- Add server-side `clippy.toml` coverage to disallow `std::collections::HashMap` and `std::collections::HashSet` in `fedimint-server`, `fedimint-server-core`, and module server crates.
- Include `clippy.toml` in the Nix source filter so the lint config participates in builds.
- Fix existing server-side violations by using ordered maps, including legacy status and audit helper APIs where HashMap would otherwise be inferred.
- Keep scoped allows for Prometheus macro internals that allocate hash maps internally.

## Testing

- `just format`
- `just lint`
- `just clippy`
