### PR TITLE
fix(server): check setup code bitcoin network

### DIFF
--- a/fedimint-core/src/setup_code.rs
+++ b/fedimint-core/src/setup_code.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeSet;
 
+use bitcoin::Network;
 use serde::Serialize;
 
 use crate::core::ModuleKind;
@@ -23,6 +24,8 @@ pub struct PeerSetupCode {
     /// Total number of guardians (including the one who sets this), set by the
     /// leader
     pub federation_size: Option<u32>,
+    /// Bitcoin network configured locally by the guardian
+    pub network: Network,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Encodable, Decodable, Serialize)]

--- a/fedimint-server/src/config/setup.rs
+++ b/fedimint-server/src/config/setup.rs
@@ -70,6 +70,8 @@ pub struct LocalParams {
     /// Total number of guardians (including the one who sets this), set by the
     /// leader
     federation_size: Option<u32>,
+    /// Bitcoin network configured locally
+    network: bitcoin::Network,
 }
 
 impl LocalParams {
@@ -81,6 +83,7 @@ impl LocalParams {
             disable_base_fees: self.disable_base_fees,
             enabled_modules: self.enabled_modules.clone(),
             federation_size: self.federation_size,
+            network: self.network,
         }
     }
 }
@@ -254,6 +257,7 @@ impl ISetupApi for SetupApi {
                 disable_base_fees,
                 enabled_modules,
                 federation_size,
+                network: self.settings.network,
             }
         } else {
             let (tls_cert, tls_key) =
@@ -283,6 +287,7 @@ impl ISetupApi for SetupApi {
                 disable_base_fees,
                 enabled_modules,
                 federation_size,
+                network: self.settings.network,
             }
         };
 
@@ -313,6 +318,13 @@ impl ISetupApi for SetupApi {
         ensure!(
             discriminant(&info.endpoints) == discriminant(&local_params.endpoints),
             "Guardian has different endpoint variant (TCP/Iroh) than us.",
+        );
+
+        ensure!(
+            info.network == local_params.network,
+            "Guardian uses Bitcoin network {} but we use {}",
+            info.network,
+            local_params.network,
         );
 
         if let Some(federation_name) = state
@@ -437,7 +449,7 @@ impl ISetupApi for SetupApi {
             )]),
             disable_base_fees,
             enabled_modules,
-            network: self.settings.network,
+            network: local_params.network,
         };
 
         self.sender
@@ -577,4 +589,89 @@ pub fn server_endpoints() -> Vec<ApiEndpoint<SetupApi>> {
             }
         },
     ]
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+    use bitcoin::Network;
+    use fedimint_core::db::IRawDatabaseExt;
+    use fedimint_core::db::mem_impl::MemDatabase;
+    use fedimint_core::module::ApiAuth;
+    use tokio::sync::mpsc;
+
+    use super::*;
+
+    fn setup_api(network: Network) -> SetupApi {
+        let (sender, _receiver) = mpsc::channel(1);
+        let bind = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0);
+
+        SetupApi::new(
+            ConfigGenSettings {
+                p2p_bind: bind,
+                api_bind: bind,
+                ui_bind: bind,
+                p2p_url: None,
+                api_url: None,
+                enable_iroh: true,
+                iroh_dns: None,
+                iroh_relays: Vec::new(),
+                network,
+                available_modules: BTreeSet::new(),
+                default_modules: BTreeSet::new(),
+            },
+            MemDatabase::new().into_database(),
+            sender,
+        )
+    }
+
+    async fn setup_code(api: &SetupApi, name: &str) -> String {
+        api.set_local_parameters(
+            ApiAuth::new(format!("{name}-password")),
+            name.to_string(),
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("setting local parameters should succeed")
+    }
+
+    #[tokio::test]
+    async fn accepts_peer_setup_code_with_matching_network() {
+        let api = setup_api(Network::Regtest);
+        let peer_api = setup_api(Network::Regtest);
+
+        setup_code(&api, "local").await;
+        let peer_code = setup_code(&peer_api, "peer").await;
+
+        let added_peer = api
+            .add_peer_setup_code(peer_code)
+            .await
+            .expect("peer setup code with matching network should be accepted");
+
+        assert_eq!(added_peer, "peer");
+    }
+
+    #[tokio::test]
+    async fn rejects_peer_setup_code_with_different_network() {
+        let api = setup_api(Network::Regtest);
+        let peer_api = setup_api(Network::Signet);
+
+        setup_code(&api, "local").await;
+        let peer_code = setup_code(&peer_api, "peer").await;
+
+        let err = api
+            .add_peer_setup_code(peer_code)
+            .await
+            .expect_err("peer setup code with different network should be rejected");
+
+        assert!(
+            err.to_string()
+                .contains("Guardian uses Bitcoin network signet but we use regtest")
+        );
+    }
 }

--- a/fedimint-testing-core/src/config.rs
+++ b/fedimint-testing-core/src/config.rs
@@ -61,6 +61,7 @@ pub fn local_config_gen_params(
                 disable_base_fees: Some(!enable_mint_fees),
                 enabled_modules: None,
                 federation_size: None,
+                network: bitcoin::Network::Regtest,
             };
             (*peer, params)
         })


### PR DESCRIPTION
### Summary

Fixes #7624 by carrying each guardian's configured Bitcoin network in setup codes and rejecting peer setup codes whose network does not match the local guardian before DKG starts.

### Details

This is a redo of #7669. Previously, guardians configured for different Bitcoin networks could proceed far enough for the mismatch to surface later as a consensus/config failure after DKG. The setup code now includes a `network` field, `LocalParams` keeps the local network, and peer setup code handling validates the peer's network while adding the guardian. Config generation then uses the already validated local network.

### Reviewing

The compatibility-sensitive part is adding `network` to `PeerSetupCode`; reviewers should consider setup-code encoding/decoding expectations and handling of old or stale setup codes.

### Testing

Unit tests cover accepting a peer setup code with a matching Bitcoin network and rejecting one with a mismatched network. Reviewers can also verify manually by attempting federation setup between guardians configured for different Bitcoin networks and confirming the mismatch is rejected before DKG.
