### PR TITLE
chore: add PR submission checklist

### DIFF
--- a/.agents/skills/pr-submissions-checklist/SKILL.md
+++ b/.agents/skills/pr-submissions-checklist/SKILL.md
@@ -9,7 +9,7 @@ Use this before creating or updating a PR for the Fedimint project.
 
 ## Pre-submit checks
 
-- Verify `just final-lint` passes locally before submitting, to catch easy issues without waiting for CI.
+- Verify `just final-lint` passes locally before submitting, to catch easy issues without waiting for CI. This is the fast lint-only subset of `just final-check`, which also runs tests and WASM checks.
 
 ## PR description
 

--- a/.agents/skills/pr-submissions-checklist/SKILL.md
+++ b/.agents/skills/pr-submissions-checklist/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: pr-submissions-checklist
+description: Must read before submitting PRs to Fedimint project
+---
+
+# PR Submissions Checklist
+
+Use this before creating or updating a PR for the Fedimint project.
+
+## Pre-submit checks
+
+- Verify `just final-lint` passes locally before submitting, to catch easy issues without waiting for CI.
+
+## PR description
+
+A PR description should typically use these sections:
+
+### Summary
+
+Start with a single paragraph summarizing the change.
+
+### Details
+
+Explain why the change is being done, how its goals are achieved, and the most important design decisions.
+
+### Reviewing
+
+Optionally explain which aspects reviewers should think through carefully, be opinionated about, or just be aware of.
+
+### Testing
+
+Optionally explain how reviewers can gain confidence that the change is solid. Mention automated tests added, existing tests that cover the functionality, or manual testing instructions.

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ Fedimint is a modular framework for building federated financial applications. I
 
 ### Testing
 - `just test-ci-all` - Run all tests in parallel like CI
+- `just final-lint` - Fast lint-only subset of pre-PR checks
 - `just final-check` - All checks recommended before opening a PR
 - `just check-wasm` - Verify WASM compatibility
 
@@ -109,7 +110,11 @@ fedimint-<module>-server/     # Server-side consensus logic
 - Always run `just format` after making code changes to ensure formatting is correct
 
 ### Before Opening a PR
-Run `just final-check` which includes:
+Read the `pr-submissions-checklist` skill for PR description and pre-submit guidance.
+
+Run `just final-lint` before submitting a PR to catch easy issues without waiting for CI. This is the fast lint-only subset of `just final-check`.
+
+Run `just final-check` before opening larger or riskier PRs, or when extra confidence is needed. It includes:
 - Linting and formatting
 - Full test suite
 - Documentation tests

--- a/justfile.fedimint.just
+++ b/justfile.fedimint.just
@@ -38,48 +38,67 @@ udeps:
 bench:
   cargo bench
 
-final-lint: lint
-  just clippy
-  just cargo-sort-check
+[private]
+run-quietly *COMMAND:
+  #!/usr/bin/env bash
+  set -euo pipefail
+
+  log="$(mktemp)"
+  trap 'rm -f "$log"' EXIT
+
+  >&2 printf 'Running: %s...\n' '{{COMMAND}}'
+
+  if ! {{COMMAND}} >"$log" 2>&1; then
+    >&2 printf 'Command failed: %s\n' '{{COMMAND}}'
+    cat "$log" >&2
+    exit 1
+  fi
+
+final-lint:
+  @just run-quietly just lint
+  @just run-quietly cargo clippy -q --locked --offline --workspace --all-targets -- -D warnings
+  @just run-quietly just cargo-sort-check
 
 # run all checks recommended before opening a PR
-final-check: lint
+final-check:
+  @just run-quietly just lint
   # can't use nextest due to: https://github.com/nextest-rs/nextest/issues/16
-  cargo test --doc --workspace
-  just check-wasm
-  just test
+  @just run-quietly cargo test --doc --workspace
+  @just run-quietly just check-wasm
+  @just run-quietly just test
 
 # run all/most checks a CI would run
-final-check-ci: lint
-  just clippy
-  just cargo-sort-check
-  cargo test --doc --workspace
-  just check-wasm
-  ./scripts/tests/test-ci-all.sh
-  just test-compatibility
-  just udeps
+final-check-ci:
+  @just run-quietly just lint
+  @just run-quietly cargo clippy -q --locked --offline --workspace --all-targets -- -D warnings
+  @just run-quietly just cargo-sort-check
+  @just run-quietly cargo test --doc --workspace
+  @just run-quietly just check-wasm
+  @just run-quietly ./scripts/tests/test-ci-all.sh
+  @just run-quietly just test-compatibility
+  @just run-quietly just udeps
 
 # check before making a release
 final-check-release:
-  just check-packages-features
-  just final-check-ci
+  @just run-quietly just check-packages-features
+  @just run-quietly just final-check-ci
 
 # verify verify various feature combinations we might care about
 check-packages-features:
-  just check-wasm --no-default-features
+  @just run-quietly just check-wasm --no-default-features
   # TODO: broken, seems like one of the deps
   # just check-wasm --features iroh
-  cargo workspaces exec cargo check
-  cargo workspaces exec cargo check --no-default-features
+  @just run-quietly cargo workspaces exec cargo check
+  @just run-quietly cargo workspaces exec cargo check --no-default-features
   # there are some features that require nightly
-  nix shell github:nix-community/fenix#latest.toolchain -c cargo workspaces exec cargo check --all-features
+  @just run-quietly nix shell github:nix-community/fenix#latest.toolchain -c cargo workspaces exec cargo check --all-features
 
 # like `check-packages-features` but using nix
 check-packages-features-using-nix:
-  nix build -L .#wasm32-unknown.ci.cargoCheckWasmNoDefaultFeatures
-  nix build -L .#ci.cargoWorkspacesCheckNoDefaultFeatures
-  nix build -L .#nightly.ci.cargoWorkspacesCheckAllFeatures
-  nix build -L .#ci.cargoWorkspacesCheckDefaultFeatures
+  @just run-quietly nix build -L .#wasm32-unknown.ci.cargoCheckWasmNoDefaultFeatures
+  @just run-quietly nix build -L .#ci.cargoWorkspacesCheckNoDefaultFeatures
+  @just run-quietly nix build -L .#nightly.ci.cargoWorkspacesCheckAllFeatures
+  @just run-quietly nix build -L .#ci.cargoWorkspacesCheckDefaultFeatures
 
 check-wasm *EXTRA_ARGS:
   #!/usr/bin/env bash

--- a/justfile.fedimint.just
+++ b/justfile.fedimint.just
@@ -38,6 +38,10 @@ udeps:
 bench:
   cargo bench
 
+final-lint: lint
+  just clippy
+  just cargo-sort-check
+
 # run all checks recommended before opening a PR
 final-check: lint
   # can't use nextest due to: https://github.com/nextest-rs/nextest/issues/16


### PR DESCRIPTION
*PR published by Tau/OpenAI*

### Summary

Adds a Fedimint PR submission checklist skill and a `just final-lint` helper so PR authors can catch straightforward lint issues before waiting for CI.

### Details

The new `.agents/skills/pr-submissions-checklist` skill documents the expected pre-submit lint check and preferred PR description structure. It calls out that `just final-lint` is the fast lint-only subset of `just final-check`, while `final-check` remains the broader test-inclusive check. `CLAUDE.md` is updated to point agents at this skill and to align its pre-PR guidance with the new `final-lint` workflow.

`just final-lint` groups the inexpensive PR lint checks behind one command by running the existing `lint`, `clippy`, and `cargo-sort-check` checks. The final check recipes now use a shared private `run-quietly` helper. It prints `Running: {cmd}...` before each step, captures command output, and only prints that captured output if the command fails. The same helper is shared by `final-lint`, `final-check`, `final-check-ci`, `final-check-release`, and related package-feature check recipes. `.claude/skills` is added as a symlink to `.agents/skills` so Claude Code can discover the same shared skills without duplicating their contents.

### Reviewing

Please check that `final-lint` includes the right set of quick pre-submit checks, that the quiet runner preserves useful failure output, that `CLAUDE.md` and the skill give consistent PR guidance, and that sharing skills with Claude Code through the `.claude/skills` symlink is acceptable for repository tooling.

### Testing

Reviewers can run `just final-lint` to verify the helper recipe and the existing lint checks. Reviewers can also run broader recipes such as `just final-check` to verify the shared quiet runner on longer checks.
