### PR TITLE
fix(mint): make repair wallet transaction atomic

### DIFF
--- a/modules/fedimint-mint-client/src/repair_wallet.rs
+++ b/modules/fedimint-mint-client/src/repair_wallet.rs
@@ -43,16 +43,80 @@ impl MintClientModule {
     /// sure that the user has a backup of their seed before running this
     /// function.
     pub async fn try_repair_wallet(&self, gap_limit: u64) -> anyhow::Result<RepairSummary> {
-        let mut summary = RepairSummary::default();
-
         let module_api = self.client_ctx.module_api();
-        let mut dbtx = self.client_ctx.module_db().begin_transaction().await;
 
-        // First check if any of our notes are already spent and remove them
-        let spent_notes: Vec<NoteKey> = dbtx
-            .find_by_prefix_sorted_descending(&NoteKeyPrefix)
+        self.client_ctx
+            .module_db()
+            .autocommit(
+                |dbtx, _| {
+                    let module_api = module_api.clone();
+
+                    Box::pin(async move {
+                        let mut summary = RepairSummary::default();
+
+                        let note_keys = dbtx
+                            .find_by_prefix_sorted_descending(&NoteKeyPrefix)
+                            .await
+                            .map(|(key, _)| key)
+                            .collect::<Vec<_>>()
+                            .await;
+
+                        let spent_notes = Self::find_spent_notes(&module_api, note_keys).await?;
+
+                        for note_key in spent_notes {
+                            summary.spent_notes.inc(note_key.amount, 1);
+                            dbtx.remove_entry(&note_key).await;
+                        }
+
+                        let next_indices: BTreeMap<_, _> = {
+                            let mut db_next_indexes = dbtx
+                                .find_by_prefix_sorted_descending(&NextECashNoteIndexKeyPrefix)
+                                .await
+                                .map(|(key, idx)| (key.0, idx))
+                                .collect::<BTreeMap<_, _>>()
+                                .await;
+
+                            self.cfg
+                                .tbs_pks
+                                .tiers()
+                                .map(|&denomination| {
+                                    (
+                                        denomination,
+                                        db_next_indexes.remove(&denomination).unwrap_or_default(),
+                                    )
+                                })
+                                .collect()
+                        };
+
+                        let used_nonces = self
+                            .find_used_nonces(&module_api, next_indices, gap_limit)
+                            .await?;
+
+                        for (amount, next_index) in used_nonces {
+                            let old_index = dbtx
+                                .insert_entry(&NextECashNoteIndexKey(amount), &next_index)
+                                .await
+                                .unwrap_or_default();
+                            summary
+                                .used_indices
+                                .inc(amount, (next_index - old_index) as usize);
+                        }
+
+                        Ok::<_, anyhow::Error>(summary)
+                    })
+                },
+                Some(100),
+            )
             .await
-            .map(|(key, _)| {
+            .map_err(anyhow::Error::from)
+    }
+
+    async fn find_spent_notes(
+        module_api: &DynModuleApi,
+        note_keys: Vec<NoteKey>,
+    ) -> anyhow::Result<Vec<NoteKey>> {
+        stream::iter(note_keys.into_iter())
+            .map(|key| {
                 let module_api_inner = module_api.clone();
                 async move {
                     let spent = retry("fetch e-cash spentness", aggressive_backoff(), || async {
@@ -65,35 +129,16 @@ impl MintClientModule {
             .buffer_unordered(CHECK_PARALLELISM)
             .try_filter_map(|result| async move { Ok(result) })
             .try_collect()
-            .await?;
+            .await
+    }
 
-        for note_key in spent_notes {
-            summary.spent_notes.inc(note_key.amount, 1);
-            dbtx.remove_entry(&note_key).await;
-        }
-
-        let next_indices: BTreeMap<_, _> = {
-            let mut db_next_indexes = dbtx
-                .find_by_prefix_sorted_descending(&NextECashNoteIndexKeyPrefix)
-                .await
-                .map(|(key, idx)| (key.0, idx))
-                .collect::<BTreeMap<_, _>>()
-                .await;
-
-            self.cfg
-                .tbs_pks
-                .tiers()
-                .map(|&denomination| {
-                    (
-                        denomination,
-                        db_next_indexes.remove(&denomination).unwrap_or_default(),
-                    )
-                })
-                .collect()
-        };
-
-        // Next check if any of the indices for issuing new notes are already used
-        let used_nonces = stream::iter(next_indices.into_iter())
+    async fn find_used_nonces(
+        &self,
+        module_api: &DynModuleApi,
+        next_indices: BTreeMap<Amount, u64>,
+        gap_limit: u64,
+    ) -> anyhow::Result<Vec<(Amount, u64)>> {
+        stream::iter(next_indices.into_iter())
             .map(|(amount, original_next_index)| {
                 let module_api_inner = module_api.clone();
                 async move {
@@ -127,20 +172,7 @@ impl MintClientModule {
             .buffer_unordered(CHECK_PARALLELISM)
             .try_filter_map(|advanced_index| async move { Ok(advanced_index) })
             .try_collect::<Vec<_>>()
-            .await?;
-
-        for (amount, next_index) in used_nonces {
-            let old_index = dbtx
-                .insert_entry(&NextECashNoteIndexKey(amount), &next_index)
-                .await
-                .unwrap_or_default();
-            summary
-                .used_indices
-                .inc(amount, (next_index - old_index) as usize);
-        }
-
-        dbtx.commit_tx().await;
-        Ok(summary)
+            .await
     }
 
     /// Checks up to `gap_limit` nonces starting from `base_index` for having

--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -767,6 +767,67 @@ async fn repair_wallet() -> anyhow::Result<()> {
         );
     }
 
+    // Check that a repair based on stale index candidates does not panic or
+    // roll back an index that was concurrently advanced while repair was doing
+    // federation API checks.
+    {
+        let mut dbtx = client_mint.db.begin_transaction().await;
+        const TEST_NOTE_INDEX_KEY: NextECashNoteIndexKey =
+            NextECashNoteIndexKey(Amount::from_msats(1));
+        let old_nonce_index = dbtx
+            .get_value(&TEST_NOTE_INDEX_KEY)
+            .await
+            .expect("Amount tier exists");
+        let stale_nonce_index = old_nonce_index
+            .checked_sub(1)
+            .expect("Amount tier index was advanced");
+        dbtx.insert_entry(&TEST_NOTE_INDEX_KEY, &stale_nonce_index)
+            .await
+            .expect("Failed to insert test note index");
+        dbtx.commit_tx().await;
+
+        let repair_fut = client_mint.try_repair_wallet(100);
+        tokio::pin!(repair_fut);
+
+        tokio::select! {
+            biased;
+
+            repair_result = &mut repair_fut => {
+                panic!("Repair completed before concurrent index advance: {repair_result:?}");
+            }
+            () = tokio::task::yield_now() => {}
+        }
+
+        let concurrently_advanced_index = old_nonce_index + 1;
+        let mut dbtx = client_mint.db.begin_transaction().await;
+        dbtx.insert_entry(&TEST_NOTE_INDEX_KEY, &concurrently_advanced_index)
+            .await
+            .expect("Failed to concurrently advance test note index");
+        dbtx.commit_tx().await;
+
+        let repair_summary = repair_fut.await.expect("Repair should succeed");
+        assert!(
+            repair_summary.spent_notes.is_empty(),
+            "No spent notes should be found"
+        );
+        let repaired_index = client_mint
+            .db
+            .begin_transaction_nc()
+            .await
+            .get_value(&TEST_NOTE_INDEX_KEY)
+            .await
+            .expect("Amount tier exists");
+        assert!(
+            concurrently_advanced_index <= repaired_index,
+            "Repair should not roll back concurrently advanced index"
+        );
+        let repaired_indices = repair_summary.used_indices.get(Amount::from_msats(1)) as u64;
+        assert!(
+            repaired_indices <= repaired_index - concurrently_advanced_index,
+            "Concurrently advanced stale index should not be counted as repaired"
+        );
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
*PR published by Tau/AI assistant*

### Summary

Make `repair_wallet` atomic by running the whole repair operation inside one `autocommit` block.

### Details

`try_repair_wallet` previously used one writable transaction for the whole repair and could panic on a `WriteConflict` if background client DB writes overlapped with slow federation spentness or nonce checks. The first revision of this PR tried to shorten the writable phase by splitting candidate loading, API checks, and repair application, but that made the operation harder to reason about because repair decisions were based on a stale DB snapshot.

This version keeps the repair flow as one atomic `autocommit`: it loads wallet state, performs federation checks, and applies repairs in the same retry unit. If another wallet task changes the same DB keys while repair is waiting on federation API checks, `autocommit` retries the whole operation from a fresh DB view. The `repair_wallet` test covers the concurrent stale-index update case.

### Reviewing

Please check that wrapping the whole operation in `autocommit` addresses the race concern from review.

### Testing

Reviewers can run `cargo test -p fedimint-mint-tests --test fedimint_mint_tests repair_wallet` or `just final-lint` for local confidence.
