### PR TITLE
fix(rocksdb): use TolerateCorruptedTailRecords WAL recovery mode

### DIFF
--- a/fedimint-rocksdb/src/lib.rs
+++ b/fedimint-rocksdb/src/lib.rs
@@ -54,9 +54,6 @@ impl RocksDb {
     #[builder(finish_fn = open_blocking)]
     pub fn open_blocking(
         #[builder(start_fn)] db_path: impl AsRef<Path>,
-        /// Relaxed consistency allows opening the database
-        /// even if the wal got corrupted.
-        relaxed_consistency: Option<bool>,
     ) -> anyhow::Result<Locked<RocksDb>> {
         let db_path = db_path.as_ref();
 
@@ -66,9 +63,7 @@ impl RocksDb {
                     .parent()
                     .ok_or_else(|| anyhow::anyhow!("db path must have a base dir"))?,
             )?;
-            LockedBuilder::new(db_path)?.with_db(|| {
-                Self::open_blocking_unlocked(db_path, relaxed_consistency.unwrap_or_default())
-            })
+            LockedBuilder::new(db_path)?.with_db(|| Self::open_blocking_unlocked(db_path))
         })
     }
 }
@@ -86,19 +81,16 @@ where
 }
 
 impl RocksDb {
-    fn open_blocking_unlocked(
-        db_path: &Path,
-        relaxed_consistency: bool,
-    ) -> anyhow::Result<RocksDb> {
+    fn open_blocking_unlocked(db_path: &Path) -> anyhow::Result<RocksDb> {
         let mut opts = get_default_options()?;
-        if relaxed_consistency {
-            // https://github.com/fedimint/fedimint/issues/8072
-            opts.set_wal_recovery_mode(DBRecoveryMode::TolerateCorruptedTailRecords);
-        } else {
-            // Since we turned synchronous writes one we should never encounter a corrupted
-            // WAL and should rather fail in this case
-            opts.set_wal_recovery_mode(DBRecoveryMode::AbsoluteConsistency);
-        }
+        // Synchronous writes (set_sync(true)) ensure completed writes are
+        // durable, but a SIGKILL mid-write can still leave a truncated WAL tail
+        // record. TolerateCorruptedTailRecords (RocksDB's own default) discards
+        // only incomplete tail records — no committed data is lost.
+        // AbsoluteConsistency was used previously but made the database
+        // permanently unrecoverable after any unclean shutdown.
+        // See: https://github.com/fedimint/fedimint/issues/8072
+        opts.set_wal_recovery_mode(DBRecoveryMode::TolerateCorruptedTailRecords);
         let db: rocksdb::OptimisticTransactionDB =
             rocksdb::OptimisticTransactionDB::<rocksdb::SingleThreaded>::open(&opts, db_path)?;
         Ok(RocksDb(db))


### PR DESCRIPTION
## Summary

- Switch default WAL recovery mode from `AbsoluteConsistency` to `TolerateCorruptedTailRecords` (RocksDB's own default)
- Remove the unused `relaxed_consistency` builder parameter — `AbsoluteConsistency` is never the correct choice since `set_sync(true)` does not prevent truncated WAL tail records on SIGKILL

## Motivation

`AbsoluteConsistency` was used under the assumption that synchronous writes (`set_sync(true)`) prevent WAL corruption. This is incorrect: sync writes ensure durability of *completed* writes, but a SIGKILL mid-write can still leave a truncated WAL tail record. `AbsoluteConsistency` then refuses to open the database entirely, causing a permanent CrashLoopBackOff requiring manual intervention.

`TolerateCorruptedTailRecords` discards only incomplete tail records — these represent writes that never committed (the write call never returned to the application), so no committed data is lost. This is RocksDB's own default recovery mode for exactly this reason.

A production guardian hit this after OOM-induced SIGKILL restarts, entering 1187+ continuous restart loops with no automatic recovery path.

## Why committed transactions are never lost

The two mechanisms reinforce each other:

- **`set_sync(true)` guarantees the ordering.** A transaction's `commit()` only returns `Ok` to the caller *after* `fsync()` completes. So if the application saw a successful commit, the WAL record is fully written and durable on disk.
- **`TolerateCorruptedTailRecords` only discards the incomplete tail.** A truncated tail record can only exist for a write where `fsync()` never finished — which means `commit()` never returned `Ok`. The application never observed that transaction as committed.

| SIGKILL timing | WAL state | Recovery behavior | Data committed? |
|---|---|---|---|
| Before fsync completes | Truncated tail record | Discarded | No — commit never returned |
| After fsync, before commit returns | Complete record on disk | Recovered | Technically yes, but app never saw it |
| After commit returns | Complete record on disk | Recovered | Yes |

`AbsoluteConsistency` doesn't provide any additional safety — it just refuses to open the database at all when it sees a truncated tail, turning a benign incomplete write into a permanent outage.

Closes #8072

cc @douglaz

## Test plan

- [x] `cargo check` — clean
- [x] `just clippy` — clean
- [x] `just format` — no changes
- [ ] Existing integration tests exercise the RocksDB path and should continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)