### PR TITLE
fix(gateway): reconnect LND HTLC interceptor on transport errors

### DIFF
--- a/gateway/fedimint-lightning/src/lnd.rs
+++ b/gateway/fedimint-lightning/src/lnd.rs
@@ -9,7 +9,7 @@ use bitcoin::OutPoint;
 use bitcoin::hashes::{Hash, sha256};
 use fedimint_core::encoding::Encodable;
 use fedimint_core::task::{TaskGroup, TaskHandle, sleep};
-use fedimint_core::util::FmtCompact;
+use fedimint_core::util::{FmtCompact, backoff_util};
 use fedimint_core::{Amount, BitcoinAmountOrAll, crit, secp256k1};
 use fedimint_gateway_common::{
     ListTransactionsResponse, PaymentDetails, PaymentDirection, PaymentKind,
@@ -387,24 +387,22 @@ impl GatewayLndClient {
         gateway_sender: HtlcSubscriptionSender,
     ) {
         const FORWARD_CHANNEL_SIZE: usize = 100;
-        const MIN_BACKOFF: Duration = Duration::from_secs(1);
-        const MAX_BACKOFF: Duration = Duration::from_secs(60);
-        let mut backoff = MIN_BACKOFF;
+        let mut backoff = backoff_util::background_backoff();
 
         loop {
             let mut client = match self.connect().await {
                 Ok(c) => c,
                 Err(err) => {
+                    let delay = backoff.next().expect("Keeps retrying");
                     warn!(
                         target: LOG_LIGHTNING,
                         err = %err.fmt_compact(),
-                        backoff_secs = backoff.as_secs(),
+                        backoff_secs = delay.as_secs(),
                         "Failed to connect to LND for HTLC interceptor, will retry"
                     );
-                    if sleep_or_shutdown(&handle, backoff).await {
+                    if sleep_or_shutdown(&handle, delay).await {
                         return;
                     }
-                    backoff = (backoff * 2).min(MAX_BACKOFF);
                     continue;
                 }
             };
@@ -423,16 +421,16 @@ impl GatewayLndClient {
                 stream = future_stream => match stream {
                     Ok(stream) => stream.into_inner(),
                     Err(err) => {
+                        let delay = backoff.next().expect("Keeps retrying");
                         warn!(
                             target: LOG_LIGHTNING,
                             err = %err.fmt_compact(),
-                            backoff_secs = backoff.as_secs(),
+                            backoff_secs = delay.as_secs(),
                             "Failed to establish HTLC interceptor stream, will retry"
                         );
-                        if sleep_or_shutdown(&handle, backoff).await {
+                        if sleep_or_shutdown(&handle, delay).await {
                             return;
                         }
-                        backoff = (backoff * 2).min(MAX_BACKOFF);
                         continue;
                     }
                 },
@@ -443,7 +441,7 @@ impl GatewayLndClient {
             };
 
             info!(target: LOG_LIGHTNING, "LND HTLC Subscription: stream established, processing HTLCs");
-            backoff = MIN_BACKOFF;
+            backoff = backoff_util::background_backoff();
 
             // Drive forwarding (external `lnd_rx` -> internal `forward_tx`) concurrently
             // with reading the stream. They run as two top-level futures of the same
@@ -520,10 +518,10 @@ impl GatewayLndClient {
                 return;
             }
 
-            if sleep_or_shutdown(&handle, backoff).await {
+            let delay = backoff.next().expect("Keeps retrying");
+            if sleep_or_shutdown(&handle, delay).await {
                 return;
             }
-            backoff = (backoff * 2).min(MAX_BACKOFF);
         }
     }
 

--- a/gateway/fedimint-lightning/src/lnd.rs
+++ b/gateway/fedimint-lightning/src/lnd.rs
@@ -62,15 +62,6 @@ type HtlcSubscriptionSender = mpsc::Sender<InterceptPaymentRequest>;
 
 const LND_PAYMENT_TIMEOUT_SECONDS: i32 = 180;
 
-/// Sleeps for `duration`, returning `true` if the task group is shutting down
-/// (so the caller should exit instead of continuing its loop).
-async fn sleep_or_shutdown(handle: &TaskHandle, duration: Duration) -> bool {
-    tokio::select! {
-        () = sleep(duration) => false,
-        () = handle.make_shutdown_rx() => true,
-    }
-}
-
 enum ForwardOutcome {
     /// The external response channel was closed — gateway is going away.
     ExternalClosed,
@@ -400,7 +391,7 @@ impl GatewayLndClient {
                         backoff_secs = delay.as_secs(),
                         "Failed to connect to LND for HTLC interceptor, will retry"
                     );
-                    if sleep_or_shutdown(&handle, delay).await {
+                    if handle.cancel_on_shutdown(sleep(delay)).await.is_err() {
                         return;
                     }
                     continue;
@@ -428,7 +419,7 @@ impl GatewayLndClient {
                             backoff_secs = delay.as_secs(),
                             "Failed to establish HTLC interceptor stream, will retry"
                         );
-                        if sleep_or_shutdown(&handle, delay).await {
+                        if handle.cancel_on_shutdown(sleep(delay)).await.is_err() {
                             return;
                         }
                         continue;
@@ -519,7 +510,7 @@ impl GatewayLndClient {
             }
 
             let delay = backoff.next().expect("Keeps retrying");
-            if sleep_or_shutdown(&handle, delay).await {
+            if handle.cancel_on_shutdown(sleep(delay)).await.is_err() {
                 return;
             }
         }

--- a/gateway/fedimint-lightning/src/lnd.rs
+++ b/gateway/fedimint-lightning/src/lnd.rs
@@ -524,9 +524,21 @@ impl GatewayLndClient {
         trace!(target: LOG_LIGHTNING, ?htlc, "LND Handling HTLC");
 
         let Some(incoming_circuit_key) = htlc.incoming_circuit_key else {
-            warn!(target: LOG_LIGHTNING, "Cannot route htlc with None incoming_circuit_key");
+            // We have no circuit key, so the HTLC cannot be cancelled either; it
+            // will time out at LND. Log enough context to correlate with the
+            // sender's invoice and the target federation.
+            warn!(
+                target: LOG_LIGHTNING,
+                payment_hash = %PrettyPaymentHash(&htlc.payment_hash),
+                scid = htlc.outgoing_requested_chan_id,
+                amount_msat = htlc.outgoing_amount_msat,
+                "Cannot route HTLC: incoming_circuit_key is None"
+            );
             return;
         };
+
+        let chan_id = incoming_circuit_key.chan_id;
+        let htlc_id = incoming_circuit_key.htlc_id;
 
         // Forward all HTLCs to gatewayd, gatewayd will filter them based on scid
         let intercept = InterceptPaymentRequest {
@@ -535,14 +547,28 @@ impl GatewayLndClient {
             amount_msat: htlc.outgoing_amount_msat,
             expiry: htlc.incoming_expiry,
             short_channel_id: Some(htlc.outgoing_requested_chan_id),
-            incoming_chan_id: incoming_circuit_key.chan_id,
-            htlc_id: incoming_circuit_key.htlc_id,
+            incoming_chan_id: chan_id,
+            htlc_id,
         };
 
         if let Err(err) = gateway_sender.send(intercept).await {
-            warn!(target: LOG_LIGHTNING, err = %err.fmt_compact(), "Failed to send HTLC to gatewayd for processing");
+            warn!(
+                target: LOG_LIGHTNING,
+                err = %err.fmt_compact(),
+                payment_hash = %PrettyPaymentHash(&htlc.payment_hash),
+                scid = htlc.outgoing_requested_chan_id,
+                amount_msat = htlc.outgoing_amount_msat,
+                "Failed to send HTLC to gatewayd for processing"
+            );
             if let Err(err) = Self::cancel_htlc(incoming_circuit_key, lnd_sender.clone()).await {
-                warn!(target: LOG_LIGHTNING, err = %err.fmt_compact(), "Failed to cancel HTLC");
+                warn!(
+                    target: LOG_LIGHTNING,
+                    err = %err.fmt_compact(),
+                    payment_hash = %PrettyPaymentHash(&htlc.payment_hash),
+                    chan_id,
+                    htlc_id,
+                    "Failed to cancel HTLC"
+                );
             }
         }
     }

--- a/gateway/fedimint-lightning/src/lnd.rs
+++ b/gateway/fedimint-lightning/src/lnd.rs
@@ -71,6 +71,19 @@ async fn sleep_or_shutdown(handle: &TaskHandle, duration: Duration) -> bool {
     }
 }
 
+enum ForwardOutcome {
+    /// The external response channel was closed — gateway is going away.
+    ExternalClosed,
+    /// The internal forward channel was closed — stream side died, reconnect.
+    StreamClosed,
+}
+
+enum StreamOutcome {
+    Shutdown,
+    EndedCleanly,
+    Errored,
+}
+
 #[derive(Clone)]
 pub struct GatewayLndClient {
     /// LND client
@@ -432,37 +445,32 @@ impl GatewayLndClient {
             info!(target: LOG_LIGHTNING, "LND HTLC Subscription: stream established, processing HTLCs");
             backoff = MIN_BACKOFF;
 
-            loop {
-                tokio::select! {
-                    () = handle.make_shutdown_rx() => {
-                        info!(target: LOG_LIGHTNING, "LND HTLC Subscription task received shutdown signal");
-                        return;
+            // Drive forwarding (external `lnd_rx` -> internal `forward_tx`) concurrently
+            // with reading the stream. They run as two top-level futures of the same
+            // select so a blocked `forward_tx.send().await` cannot stall stream-error
+            // detection: if LND stops reading the request stream and `forward_tx` fills
+            // up, the read side will eventually error and the select wakes on that arm,
+            // cancelling the in-flight forward.
+            let lnd_rx_ref = &mut lnd_rx;
+            let forward_fut = async move {
+                loop {
+                    let Some(msg) = lnd_rx_ref.recv().await else {
+                        return ForwardOutcome::ExternalClosed;
+                    };
+                    if forward_tx.send(msg).await.is_err() {
+                        return ForwardOutcome::StreamClosed;
                     }
-                    response = lnd_rx.recv() => {
-                        let Some(response) = response else {
-                            info!(target: LOG_LIGHTNING, "LND response channel closed, exiting HTLC interceptor");
-                            return;
-                        };
-                        if let Err(err) = forward_tx.send(response).await {
-                            // Internal forward channel is closed, which means the stream
-                            // task on the other side has gone away. Reconnect.
-                            warn!(
-                                target: LOG_LIGHTNING,
-                                err = %err.fmt_compact(),
-                                "Internal forward channel closed, reconnecting HTLC stream"
-                            );
-                            break;
-                        }
-                    }
-                    htlc_message = htlc_stream.message() => {
-                        match htlc_message {
+                }
+            };
+            let stream_fut = async {
+                loop {
+                    tokio::select! {
+                        () = handle.make_shutdown_rx() => return StreamOutcome::Shutdown,
+                        htlc_message = htlc_stream.message() => match htlc_message {
                             Ok(Some(htlc)) => {
                                 Self::handle_intercepted_htlc(htlc, &lnd_sender, &gateway_sender).await;
                             }
-                            Ok(None) => {
-                                info!(target: LOG_LIGHTNING, "LND HTLC stream ended cleanly, reconnecting");
-                                break;
-                            }
+                            Ok(None) => return StreamOutcome::EndedCleanly,
                             Err(err) => {
                                 // Any transport-level error on the stream (e.g. LND
                                 // returning `Unknown: fwd not found` for a stale HTLC
@@ -474,11 +482,42 @@ impl GatewayLndClient {
                                     err = %err.fmt_compact(),
                                     "Error received over HTLC stream, reconnecting"
                                 );
-                                break;
+                                return StreamOutcome::Errored;
                             }
                         }
                     }
                 }
+            };
+
+            tokio::pin!(forward_fut);
+            tokio::pin!(stream_fut);
+
+            let should_reconnect = tokio::select! {
+                outcome = &mut forward_fut => match outcome {
+                    ForwardOutcome::ExternalClosed => {
+                        info!(target: LOG_LIGHTNING, "LND response channel closed, exiting HTLC interceptor");
+                        return;
+                    }
+                    ForwardOutcome::StreamClosed => {
+                        warn!(target: LOG_LIGHTNING, "Internal forward channel closed, reconnecting HTLC stream");
+                        true
+                    }
+                },
+                outcome = &mut stream_fut => match outcome {
+                    StreamOutcome::Shutdown => {
+                        info!(target: LOG_LIGHTNING, "LND HTLC Subscription task received shutdown signal");
+                        return;
+                    }
+                    StreamOutcome::EndedCleanly => {
+                        info!(target: LOG_LIGHTNING, "LND HTLC stream ended cleanly, reconnecting");
+                        true
+                    }
+                    StreamOutcome::Errored => true,
+                },
+            };
+
+            if !should_reconnect {
+                return;
             }
 
             if sleep_or_shutdown(&handle, backoff).await {

--- a/gateway/fedimint-lightning/src/lnd.rs
+++ b/gateway/fedimint-lightning/src/lnd.rs
@@ -440,6 +440,13 @@ impl GatewayLndClient {
             // detection: if LND stops reading the request stream and `forward_tx` fills
             // up, the read side will eventually error and the select wakes on that arm,
             // cancelling the in-flight forward.
+            //
+            // When `stream_fut` wins the select and `forward_fut` is cancelled, any
+            // response message already dequeued from `lnd_rx` but still in flight on
+            // `forward_tx.send()` is dropped. This is safe for our use case: the
+            // stream is dead, the response would never reach LND anyway, and LND
+            // replays the still-pending HTLC on the new stream so the gateway's
+            // state machine has another chance to emit the response.
             let lnd_rx_ref = &mut lnd_rx;
             let forward_fut = async move {
                 loop {
@@ -481,7 +488,10 @@ impl GatewayLndClient {
             tokio::pin!(forward_fut);
             tokio::pin!(stream_fut);
 
-            let should_reconnect = tokio::select! {
+            // Every non-`return` arm falls through to the backoff-and-reconnect path
+            // at the bottom of the outer loop, so this select is "either exit or
+            // reconnect" with no third option.
+            tokio::select! {
                 outcome = &mut forward_fut => match outcome {
                     ForwardOutcome::ExternalClosed => {
                         info!(target: LOG_LIGHTNING, "LND response channel closed, exiting HTLC interceptor");
@@ -489,7 +499,6 @@ impl GatewayLndClient {
                     }
                     ForwardOutcome::StreamClosed => {
                         warn!(target: LOG_LIGHTNING, "Internal forward channel closed, reconnecting HTLC stream");
-                        true
                     }
                 },
                 outcome = &mut stream_fut => match outcome {
@@ -499,14 +508,9 @@ impl GatewayLndClient {
                     }
                     StreamOutcome::EndedCleanly => {
                         info!(target: LOG_LIGHTNING, "LND HTLC stream ended cleanly, reconnecting");
-                        true
                     }
-                    StreamOutcome::Errored => true,
+                    StreamOutcome::Errored => {}
                 },
-            };
-
-            if !should_reconnect {
-                return;
             }
 
             let delay = backoff.next().expect("Keeps retrying");

--- a/gateway/fedimint-lightning/src/lnd.rs
+++ b/gateway/fedimint-lightning/src/lnd.rs
@@ -8,7 +8,7 @@ use async_trait::async_trait;
 use bitcoin::OutPoint;
 use bitcoin::hashes::{Hash, sha256};
 use fedimint_core::encoding::Encodable;
-use fedimint_core::task::{TaskGroup, sleep};
+use fedimint_core::task::{TaskGroup, TaskHandle, sleep};
 use fedimint_core::util::FmtCompact;
 use fedimint_core::{Amount, BitcoinAmountOrAll, crit, secp256k1};
 use fedimint_gateway_common::{
@@ -61,6 +61,15 @@ use crate::{
 type HtlcSubscriptionSender = mpsc::Sender<InterceptPaymentRequest>;
 
 const LND_PAYMENT_TIMEOUT_SECONDS: i32 = 180;
+
+/// Sleeps for `duration`, returning `true` if the task group is shutting down
+/// (so the caller should exit instead of continuing its loop).
+async fn sleep_or_shutdown(handle: &TaskHandle, duration: Duration) -> bool {
+    tokio::select! {
+        () = sleep(duration) => false,
+        () = handle.make_shutdown_rx() => true,
+    }
+}
 
 #[derive(Clone)]
 pub struct GatewayLndClient {
@@ -325,6 +334,10 @@ impl GatewayLndClient {
     /// Spawns a new background task that intercepts HTLCs from the LND node. In
     /// the LNv1 protocol, this is used as a trigger mechanism for
     /// requesting the Gateway to retrieve the preimage for a payment.
+    ///
+    /// The task reconnects automatically on stream errors. LND replays
+    /// still-pending HTLCs on a new stream, so the gateway's state machines
+    /// will see them again and can re-resolve them idempotently.
     async fn spawn_lnv1_htlc_interceptor(
         &self,
         task_group: &TaskGroup,
@@ -332,11 +345,10 @@ impl GatewayLndClient {
         lnd_rx: mpsc::Receiver<ForwardHtlcInterceptResponse>,
         gateway_sender: HtlcSubscriptionSender,
     ) -> Result<(), LightningRpcError> {
-        let mut client = self.connect().await?;
-
-        // Verify that LND is reachable via RPC before attempting to spawn a new thread
-        // that will intercept HTLCs.
-        client
+        // Verify LND is reachable up-front so a misconfigured gateway fails fast on
+        // startup instead of spinning in the reconnect loop forever.
+        self.connect()
+            .await?
             .lightning()
             .get_info(GetInfoRequest {})
             .await
@@ -344,83 +356,167 @@ impl GatewayLndClient {
                 failure_reason: format!("Failed to get node info {status:?}"),
             })?;
 
-        task_group.spawn("LND HTLC Subscription", |handle| async move {
-                let future_stream = client
-                    .router()
-                    .htlc_interceptor(ReceiverStream::new(lnd_rx));
-                let mut htlc_stream = tokio::select! {
-                    stream = future_stream => {
-                        match stream {
-                            Ok(stream) => stream.into_inner(),
-                            Err(e) => {
-                                crit!(target: LOG_LIGHTNING, err = %e.fmt_compact(), "Failed to establish htlc stream");
-                                return;
-                            }
-                        }
-                    },
-                    () = handle.make_shutdown_rx() => {
-                        info!(target: LOG_LIGHTNING, "LND HTLC Subscription received shutdown signal while trying to intercept HTLC stream, exiting...");
+        let self_copy = self.clone();
+        task_group.spawn("LND HTLC Subscription", move |handle| async move {
+            self_copy
+                .run_lnv1_htlc_interceptor(handle, lnd_sender, lnd_rx, gateway_sender)
+                .await;
+        });
+
+        Ok(())
+    }
+
+    async fn run_lnv1_htlc_interceptor(
+        &self,
+        handle: TaskHandle,
+        lnd_sender: mpsc::Sender<ForwardHtlcInterceptResponse>,
+        mut lnd_rx: mpsc::Receiver<ForwardHtlcInterceptResponse>,
+        gateway_sender: HtlcSubscriptionSender,
+    ) {
+        const FORWARD_CHANNEL_SIZE: usize = 100;
+        const MIN_BACKOFF: Duration = Duration::from_secs(1);
+        const MAX_BACKOFF: Duration = Duration::from_secs(60);
+        let mut backoff = MIN_BACKOFF;
+
+        loop {
+            let mut client = match self.connect().await {
+                Ok(c) => c,
+                Err(err) => {
+                    warn!(
+                        target: LOG_LIGHTNING,
+                        err = %err.fmt_compact(),
+                        backoff_secs = backoff.as_secs(),
+                        "Failed to connect to LND for HTLC interceptor, will retry"
+                    );
+                    if sleep_or_shutdown(&handle, backoff).await {
                         return;
                     }
-                };
+                    backoff = (backoff * 2).min(MAX_BACKOFF);
+                    continue;
+                }
+            };
 
-                debug!(target: LOG_LIGHTNING, "LND HTLC Subscription: starting to process stream");
-                // To gracefully handle shutdown signals, we need to be able to receive signals
-                // while waiting for the next message from the HTLC stream.
-                //
-                // If we're in the middle of processing a message from the stream, we need to
-                // finish before stopping the spawned task. Checking if the task group is
-                // shutting down at the start of each iteration will cause shutdown signals to
-                // not process until another message arrives from the HTLC stream, which may
-                // take a long time, or never.
-                while let Some(htlc) = tokio::select! {
+            // tonic consumes the input stream, so each reconnect needs a fresh internal
+            // channel. The external `lnd_rx` is the long-lived source that the rest of
+            // the gateway writes responses to via `lnd_sender`; we trampoline from it
+            // into the per-iteration internal stream.
+            let (forward_tx, forward_rx) =
+                mpsc::channel::<ForwardHtlcInterceptResponse>(FORWARD_CHANNEL_SIZE);
+
+            let future_stream = client
+                .router()
+                .htlc_interceptor(ReceiverStream::new(forward_rx));
+            let mut htlc_stream = tokio::select! {
+                stream = future_stream => match stream {
+                    Ok(stream) => stream.into_inner(),
+                    Err(err) => {
+                        warn!(
+                            target: LOG_LIGHTNING,
+                            err = %err.fmt_compact(),
+                            backoff_secs = backoff.as_secs(),
+                            "Failed to establish HTLC interceptor stream, will retry"
+                        );
+                        if sleep_or_shutdown(&handle, backoff).await {
+                            return;
+                        }
+                        backoff = (backoff * 2).min(MAX_BACKOFF);
+                        continue;
+                    }
+                },
+                () = handle.make_shutdown_rx() => {
+                    info!(target: LOG_LIGHTNING, "LND HTLC Subscription received shutdown signal while establishing stream, exiting...");
+                    return;
+                }
+            };
+
+            info!(target: LOG_LIGHTNING, "LND HTLC Subscription: stream established, processing HTLCs");
+            backoff = MIN_BACKOFF;
+
+            loop {
+                tokio::select! {
                     () = handle.make_shutdown_rx() => {
                         info!(target: LOG_LIGHTNING, "LND HTLC Subscription task received shutdown signal");
-                        None
+                        return;
+                    }
+                    response = lnd_rx.recv() => {
+                        let Some(response) = response else {
+                            info!(target: LOG_LIGHTNING, "LND response channel closed, exiting HTLC interceptor");
+                            return;
+                        };
+                        if let Err(err) = forward_tx.send(response).await {
+                            // Internal forward channel is closed, which means the stream
+                            // task on the other side has gone away. Reconnect.
+                            warn!(
+                                target: LOG_LIGHTNING,
+                                err = %err.fmt_compact(),
+                                "Internal forward channel closed, reconnecting HTLC stream"
+                            );
+                            break;
+                        }
                     }
                     htlc_message = htlc_stream.message() => {
                         match htlc_message {
-                            Ok(htlc) => htlc,
-                            Err(err) => {
-                                warn!(target: LOG_LIGHTNING, err = %err.fmt_compact(), "Error received over HTLC stream");
-                                None
+                            Ok(Some(htlc)) => {
+                                Self::handle_intercepted_htlc(htlc, &lnd_sender, &gateway_sender).await;
                             }
-                    }}
-                } {
-                    trace!(target: LOG_LIGHTNING, ?htlc, "LND Handling HTLC");
-
-                    if htlc.incoming_circuit_key.is_none() {
-                        warn!(target: LOG_LIGHTNING, "Cannot route htlc with None incoming_circuit_key");
-                        continue;
-                    }
-
-                    let incoming_circuit_key = htlc.incoming_circuit_key.unwrap();
-
-                    // Forward all HTLCs to gatewayd, gatewayd will filter them based on scid
-                    let intercept = InterceptPaymentRequest {
-                        payment_hash: Hash::from_slice(&htlc.payment_hash).expect("Failed to convert payment Hash"),
-                        amount_msat: htlc.outgoing_amount_msat,
-                        expiry: htlc.incoming_expiry,
-                        short_channel_id: Some(htlc.outgoing_requested_chan_id),
-                        incoming_chan_id: incoming_circuit_key.chan_id,
-                        htlc_id: incoming_circuit_key.htlc_id,
-                    };
-
-                    match gateway_sender.send(intercept).await {
-                        Ok(()) => {}
-                        Err(err) => {
-                            warn!(target: LOG_LIGHTNING, err = %err.fmt_compact(), "Failed to send HTLC to gatewayd for processing");
-                            let _ = Self::cancel_htlc(incoming_circuit_key, lnd_sender.clone())
-                                .await
-                                .map_err(|err| {
-                                    warn!(target: LOG_LIGHTNING, err = %err.fmt_compact(), "Failed to cancel HTLC");
-                                });
+                            Ok(None) => {
+                                info!(target: LOG_LIGHTNING, "LND HTLC stream ended cleanly, reconnecting");
+                                break;
+                            }
+                            Err(err) => {
+                                // Any transport-level error on the stream (e.g. LND
+                                // returning `Unknown: fwd not found` for a stale HTLC
+                                // after a gateway restart) kills the stream. Reconnect
+                                // instead of leaving the gateway unable to process
+                                // payments until manual restart.
+                                warn!(
+                                    target: LOG_LIGHTNING,
+                                    err = %err.fmt_compact(),
+                                    "Error received over HTLC stream, reconnecting"
+                                );
+                                break;
+                            }
                         }
                     }
                 }
-            });
+            }
 
-        Ok(())
+            if sleep_or_shutdown(&handle, backoff).await {
+                return;
+            }
+            backoff = (backoff * 2).min(MAX_BACKOFF);
+        }
+    }
+
+    async fn handle_intercepted_htlc(
+        htlc: tonic_lnd::routerrpc::ForwardHtlcInterceptRequest,
+        lnd_sender: &mpsc::Sender<ForwardHtlcInterceptResponse>,
+        gateway_sender: &HtlcSubscriptionSender,
+    ) {
+        trace!(target: LOG_LIGHTNING, ?htlc, "LND Handling HTLC");
+
+        let Some(incoming_circuit_key) = htlc.incoming_circuit_key else {
+            warn!(target: LOG_LIGHTNING, "Cannot route htlc with None incoming_circuit_key");
+            return;
+        };
+
+        // Forward all HTLCs to gatewayd, gatewayd will filter them based on scid
+        let intercept = InterceptPaymentRequest {
+            payment_hash: Hash::from_slice(&htlc.payment_hash)
+                .expect("Failed to convert payment Hash"),
+            amount_msat: htlc.outgoing_amount_msat,
+            expiry: htlc.incoming_expiry,
+            short_channel_id: Some(htlc.outgoing_requested_chan_id),
+            incoming_chan_id: incoming_circuit_key.chan_id,
+            htlc_id: incoming_circuit_key.htlc_id,
+        };
+
+        if let Err(err) = gateway_sender.send(intercept).await {
+            warn!(target: LOG_LIGHTNING, err = %err.fmt_compact(), "Failed to send HTLC to gatewayd for processing");
+            if let Err(err) = Self::cancel_htlc(incoming_circuit_key, lnd_sender.clone()).await {
+                warn!(target: LOG_LIGHTNING, err = %err.fmt_compact(), "Failed to cancel HTLC");
+            }
+        }
     }
 
     /// Spawns background tasks for monitoring the status of incoming payments.

--- a/modules/fedimint-gw-client/src/lib.rs
+++ b/modules/fedimint-gw-client/src/lib.rs
@@ -494,6 +494,11 @@ impl GatewayClientModule {
         // in-flight operation. The operation id is derived deterministically from
         // the payment hash (kept in sync with the derivation inside
         // `create_funding_incoming_contract_output_from_htlc`).
+        //
+        // The check + `finalize_and_submit_transaction` are not atomic, but
+        // gatewayd processes intercepted HTLCs serially from a single LND
+        // interceptor task, so two concurrent calls with the same payment hash
+        // cannot race here.
         let operation_id = OperationId(htlc.payment_hash.to_byte_array());
         if self.client_ctx.operation_exists(operation_id).await {
             debug!(
@@ -506,7 +511,11 @@ impl GatewayClientModule {
         let (op_id_from_funding, amount, client_output, client_output_sm, contract_id) = self
             .create_funding_incoming_contract_output_from_htlc(htlc.clone())
             .await?;
-        debug_assert_eq!(
+        // The two derivations MUST stay in sync (`OperationId(htlc.payment_hash
+        // .to_byte_array())` in both places). A divergence in release would
+        // submit a transaction under one id while the caller observes another,
+        // so a hard `assert!` rather than `debug_assert!` is intentional.
+        assert_eq!(
             op_id_from_funding, operation_id,
             "operation id derivation must match"
         );

--- a/modules/fedimint-gw-client/src/lib.rs
+++ b/modules/fedimint-gw-client/src/lib.rs
@@ -475,12 +475,41 @@ impl GatewayClientModule {
         Ok(())
     }
 
-    /// Attempt fulfill HTLC by buying preimage from the federation
+    /// Attempt fulfill HTLC by buying preimage from the federation.
+    ///
+    /// Idempotent across replays: the `operation_id` is derived
+    /// deterministically from the HTLC's payment hash, so if the gateway's
+    /// LND HTLC interceptor stream reconnects and LND replays a
+    /// still-pending HTLC, this returns the existing `operation_id` instead
+    /// of failing to re-submit the transaction. The original state machine
+    /// remains responsible for resolving the HTLC.
     pub async fn gateway_handle_intercepted_htlc(&self, htlc: Htlc) -> anyhow::Result<OperationId> {
         debug!("Handling intercepted HTLC {htlc:?}");
-        let (operation_id, amount, client_output, client_output_sm, contract_id) = self
+
+        // Idempotency check FIRST, before
+        // `create_funding_incoming_contract_output_from_htlc` fetches the
+        // federation's offer: the first time we handled this HTLC the offer was
+        // consumed by the funding tx, so a replay would otherwise fail
+        // with "Timed out fetching the offer" instead of being recognised as an
+        // in-flight operation. The operation id is derived deterministically from
+        // the payment hash (kept in sync with the derivation inside
+        // `create_funding_incoming_contract_output_from_htlc`).
+        let operation_id = OperationId(htlc.payment_hash.to_byte_array());
+        if self.client_ctx.operation_exists(operation_id).await {
+            debug!(
+                ?operation_id,
+                "HTLC already being handled, treating as in-flight (likely an LND stream-reconnect replay)"
+            );
+            return Ok(operation_id);
+        }
+
+        let (op_id_from_funding, amount, client_output, client_output_sm, contract_id) = self
             .create_funding_incoming_contract_output_from_htlc(htlc.clone())
             .await?;
+        debug_assert_eq!(
+            op_id_from_funding, operation_id,
+            "operation id derivation must match"
+        );
 
         let output = ClientOutput {
             output: LightningOutput::V0(client_output.output),


### PR DESCRIPTION
## Summary

Fixes a production bug where the gatewayd `LND HTLC Subscription` task exits permanently on any transport-level error from `htlc_stream.message()`, leaving the gateway unable to process incoming payments until manual restart.

The trigger we observed in production: a gatewayd restart left a still-pending HTLC inside LND. When the new gatewayd established a fresh interceptor stream, LND replied with `Unknown: fwd not found` for that stale HTLC, killing the stream — and with it the spawned task.

Code path: `gateway/fedimint-lightning/src/lnd.rs:381-388` mapped any `Err` from `htlc_stream.message()` to `None`, dropping out of the `while let Some(htlc)` loop. No retry, no reconnect, no supervision.

Closes #8008 (at least the `fwd not found` failure mode — that issue also captures a separate gRPC channel back-pressure deadlock theory that this PR does not attempt to fix).

## Changes

Three commits:

1. **`fix(gateway): reconnect LND HTLC interceptor stream on transport errors`** — wraps stream establishment + read loop in a retry-with-backoff loop. To support reconnection without disturbing the long-lived `lnd_sender` clones held throughout the gateway, the outer task now owns the external `lnd_rx` and trampolines responses through a fresh per-iteration internal channel into `htlc_interceptor` (which consumes its input stream and so cannot be re-driven directly).

2. **`fix(gateway): forward lnd_rx in a concurrent future, not in a select arm body`** — the first commit had `forward_tx.send(...).await` inside a select arm body, which would block the entire select under LND backpressure and prevent the parent task from polling `htlc_stream.message()` to detect the corresponding stream error. Restructured forwarding as a concurrent top-level future racing the stream reader so an in-flight forward is cancelled the moment the stream errors.

3. **`fix(gw-client): make gateway_handle_intercepted_htlc idempotent on replay`** — required correctness fix: LND replays still-pending HTLCs on a new stream. Without this, the replay would error at `finalize_and_submit_transaction` (operation_id is deterministic from payment_hash), `try_handle_lightning_payment_ln_legacy` would propagate that as an error, and `handle_lightning_payment` would fall through to `forward_lightning_payment`, telling LND to forward an HTLC that's still being held inside the federation. The check has to run **before** `create_funding_incoming_contract_output_from_htlc` because the first invocation consumes the federation's offer; a replay that re-fetches would otherwise fail with "Timed out fetching the offer" first.

## Known limitation (follow-up)

Cross-checked the diff three rounds with an independent reviewer. After the three commits above, one remaining edge case surfaces:

> `operation_exists` is true for inactive/terminal state machines too, not just in-flight ones. If LND replays an HTLC after the original operation has already reached `HtlcFinished`/`Failure` (or a retry uses the same payment hash with a different circuit), the early return reports success without creating a completion state machine for the current `incoming_chan_id`/`htlc_id` or sending a `complete_htlc` response, so the replayed HTLC can remain unresolved until timeout.

The full fix requires looking up the operation's terminal outcome (preimage on success, failure code on failure) and re-emitting a `complete_htlc` for the new circuit. That plumbing crosses the gw-client/gateway-server boundary and is left as a follow-up — it's a separable design question.

In the meantime: this PR strictly improves the prod situation. Today a single stream error kills payment processing for the entire gateway across all federations until manual restart. After this PR, a single replayed HTLC whose response was lost in flight (rare; requires a `complete_htlc` send to LND that was mid-call when the stream died) would time out at LND — far better than every payment timing out forever.

## Related code that has the same pattern bug

`spawn_lnv2_invoice_subscription` and `spawn_lnv2_hold_invoice_subscription` in the same file exit the same way on stream errors. Left for a separate PR — keeping this one focused on the path that bit production.

## Test plan

- [ ] CI passes (`just final-check`)
- [ ] Manual: trigger an LND interceptor stream error (e.g., kill/restart LND while gatewayd is connected); verify gatewayd reconnects and continues processing payments instead of exiting the subscription task
- [ ] Manual: restart gatewayd with an HTLC in flight at LND; verify the reconnect logs `Error received over HTLC stream, reconnecting` and the gateway recovers
- [ ] Manual: send an LNv1 payment after reconnect to confirm the idempotent replay path doesn't double-handle