### PR TITLE
feat(gateway): Set Channel Feerate and Fees when opening a channel

### DIFF
--- a/devimint/src/gatewayd.rs
+++ b/devimint/src/gatewayd.rs
@@ -464,6 +464,12 @@ impl<'a> GatewayClient {
                 let remote_address = channel
                     .get("remote_address")
                     .map(std::string::ToString::to_string);
+                let base_fee_msat = channel
+                    .get("base_fee_msat")
+                    .and_then(serde_json::Value::as_u64);
+                let parts_per_million = channel
+                    .get("parts_per_million")
+                    .and_then(serde_json::Value::as_u64);
                 Ok(ChannelInfo {
                     remote_pubkey: remote_pubkey
                         .parse()
@@ -475,6 +481,8 @@ impl<'a> GatewayClient {
                     funding_outpoint,
                     remote_node_alias,
                     remote_address,
+                    base_fee_msat,
+                    parts_per_million,
                 })
             })
             .collect::<Result<Vec<ChannelInfo>>>()?;

--- a/gateway/fedimint-gateway-client/src/lightning_commands.rs
+++ b/gateway/fedimint-gateway-client/src/lightning_commands.rs
@@ -49,6 +49,20 @@ pub enum LightningCommands {
         /// The amount to push to the other side of the channel
         #[clap(long)]
         push_amount_sats: Option<u64>,
+
+        /// Feerate (sat/vB) for the channel-opening on-chain transaction.
+        /// Not honored by all backends (e.g. LDK).
+        #[clap(long)]
+        fee_rate_sats_per_vbyte: Option<u64>,
+
+        /// Base routing fee (msat) advertised for the new channel.
+        #[clap(long)]
+        base_fee_msat: Option<u64>,
+
+        /// Proportional routing fee (parts per million) advertised for the
+        /// new channel.
+        #[clap(long)]
+        parts_per_million: Option<u64>,
     },
     /// Close all channels with a peer, claiming the funds to the lightning
     /// node's on-chain wallet.
@@ -152,12 +166,18 @@ impl LightningCommands {
                 host,
                 channel_size_sats,
                 push_amount_sats,
+                fee_rate_sats_per_vbyte,
+                base_fee_msat,
+                parts_per_million,
             } => {
                 let payload = OpenChannelRequest {
                     pubkey,
                     host,
                     channel_size_sats,
                     push_amount_sats: push_amount_sats.unwrap_or(0),
+                    fee_rate_sats_per_vbyte,
+                    base_fee_msat,
+                    parts_per_million,
                 };
                 let funding_txid = if payload.push_amount_sats > 0 {
                     open_channel_with_push(client, base_url, payload).await?

--- a/gateway/fedimint-gateway-common/src/lib.rs
+++ b/gateway/fedimint-gateway-common/src/lib.rs
@@ -342,6 +342,47 @@ pub struct OpenChannelRequest {
     pub host: String,
     pub channel_size_sats: u64,
     pub push_amount_sats: u64,
+    /// Feerate (sat/vB) for the channel-opening on-chain transaction. If
+    /// `None`, the Lightning backend picks a feerate. Not honored by all
+    /// backends (e.g. LDK manages its own fee estimation).
+    #[serde(default, deserialize_with = "empty_string_as_none")]
+    pub fee_rate_sats_per_vbyte: Option<u64>,
+    /// Base routing fee (msat) advertised for the opened channel. If `None`,
+    /// the backend's default policy is used.
+    #[serde(default, deserialize_with = "empty_string_as_none")]
+    pub base_fee_msat: Option<u64>,
+    /// Proportional routing fee (parts per million) advertised for the opened
+    /// channel. If `None`, the backend's default policy is used.
+    #[serde(default, deserialize_with = "empty_string_as_none")]
+    pub parts_per_million: Option<u64>,
+}
+
+/// Helper for serde: deserializes missing values and empty form strings as
+/// `None`. Lets the same struct be used for JSON payloads and HTMX form
+/// submissions where numeric inputs may be left blank.
+fn empty_string_as_none<'de, D, T>(deserializer: D) -> Result<Option<T>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: std::str::FromStr + Deserialize<'de>,
+    T::Err: std::fmt::Display,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum StringOrT<T> {
+        String(String),
+        T(T),
+    }
+
+    match Option::<StringOrT<T>>::deserialize(deserializer)? {
+        None => Ok(None),
+        Some(StringOrT::T(value)) => Ok(Some(value)),
+        Some(StringOrT::String(s)) if s.trim().is_empty() => Ok(None),
+        Some(StringOrT::String(s)) => s
+            .trim()
+            .parse::<T>()
+            .map(Some)
+            .map_err(serde::de::Error::custom),
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/gateway/fedimint-gateway-common/src/lib.rs
+++ b/gateway/fedimint-gateway-common/src/lib.rs
@@ -334,6 +334,15 @@ pub struct ChannelInfo {
     pub remote_node_alias: Option<String>,
     #[serde(default)]
     pub remote_address: Option<String>,
+    /// The local-side base routing fee (msat) currently advertised for this
+    /// channel. `None` if the backend could not report a fee policy.
+    #[serde(default)]
+    pub base_fee_msat: Option<u64>,
+    /// The local-side proportional routing fee (parts per million) currently
+    /// advertised for this channel. `None` if the backend could not report a
+    /// fee policy.
+    #[serde(default)]
+    pub parts_per_million: Option<u64>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/gateway/fedimint-gateway-ui/src/lightning.rs
+++ b/gateway/fedimint-gateway-ui/src/lightning.rs
@@ -1109,6 +1109,8 @@ where
                                     th { "Funding OutPoint" }
                                     th { "Size (sats)" }
                                     th { "Active" }
+                                    th { "Base Fee (msat)" }
+                                    th { "Fee Rate (ppm)" }
                                     th { "Liquidity" }
                                     th { "" }
                                 }
@@ -1179,6 +1181,20 @@ where
                                                 span class="badge bg-secondary" { "inactive" }
                                             }
                                         }
+                                        td {
+                                            @if let Some(base) = ch.base_fee_msat {
+                                                (base)
+                                            } @else {
+                                                span class="text-muted" { "-" }
+                                            }
+                                        }
+                                        td {
+                                            @if let Some(ppm) = ch.parts_per_million {
+                                                (ppm)
+                                            } @else {
+                                                span class="text-muted" { "-" }
+                                            }
+                                        }
 
                                         // Liquidity bar: single horizontal bar split by two divs
                                         td {
@@ -1224,7 +1240,7 @@ where
 
                                     // Collapsible open channel form for this peer
                                     tr class="collapse" id=(format!("open-form-{}", ch.remote_pubkey)) {
-                                        td colspan="8" {
+                                        td colspan="10" {
                                             div class="card card-body" {
                                                 form
                                                     hx-post=(OPEN_CHANNEL_ROUTE)
@@ -1280,7 +1296,7 @@ where
                                     }
 
                                     tr class="collapse" id=(row_id) {
-                                        td colspan="8" {
+                                        td colspan="10" {
                                             div class="card card-body" {
                                                 form
                                                     hx-post=(CLOSE_CHANNEL_ROUTE)

--- a/gateway/fedimint-gateway-ui/src/lightning.rs
+++ b/gateway/fedimint-gateway-ui/src/lightning.rs
@@ -1395,6 +1395,23 @@ where
                                     input type="number" name="channel_size_sats" class="form-control" placeholder="1000000" required {}
                                 }
 
+                                @if is_lnd {
+                                    div class="mb-2" {
+                                        label class="form-label" { "Funding Tx Feerate (sat/vB, optional)" }
+                                        input type="number" name="fee_rate_sats_per_vbyte" class="form-control" placeholder="Leave blank for node default" min="1" {}
+                                    }
+                                }
+
+                                div class="mb-2" {
+                                    label class="form-label" { "Channel Base Fee (msat, optional)" }
+                                    input type="number" name="base_fee_msat" class="form-control" placeholder="Leave blank for node default" min="0" {}
+                                }
+
+                                div class="mb-2" {
+                                    label class="form-label" { "Channel Fee Rate (ppm, optional)" }
+                                    input type="number" name="parts_per_million" class="form-control" placeholder="Leave blank for node default" min="0" {}
+                                }
+
                                 input type="hidden" name="push_amount_sats" value="0" {}
 
                                 button type="submit" class="btn btn-success" { "Confirm Open" }

--- a/gateway/fedimint-lightning/src/ldk.rs
+++ b/gateway/fedimint-lightning/src/ldk.rs
@@ -723,6 +723,12 @@ impl ILnRpcClient for GatewayLdkClient {
                 funding_outpoint: channel_details.funding_txo,
                 remote_node_alias,
                 remote_address,
+                base_fee_msat: Some(u64::from(channel_details.config.forwarding_fee_base_msat)),
+                parts_per_million: Some(u64::from(
+                    channel_details
+                        .config
+                        .forwarding_fee_proportional_millionths,
+                )),
             });
         }
 

--- a/gateway/fedimint-lightning/src/ldk.rs
+++ b/gateway/fedimint-lightning/src/ldk.rs
@@ -16,6 +16,7 @@ use fedimint_gateway_common::{
 };
 use fedimint_ln_common::contracts::Preimage;
 use fedimint_logging::LOG_LIGHTNING;
+use ldk_node::config::ChannelConfig;
 use ldk_node::lightning::ln::msgs::SocketAddress;
 use ldk_node::lightning::routing::gossip::{NodeAlias, NodeId};
 use ldk_node::payment::{PaymentDirection, PaymentKind, PaymentStatus, SendingParameters};
@@ -550,12 +551,49 @@ impl ILnRpcClient for GatewayLdkClient {
             host,
             channel_size_sats,
             push_amount_sats,
+            fee_rate_sats_per_vbyte,
+            base_fee_msat,
+            parts_per_million,
         }: OpenChannelRequest,
     ) -> Result<OpenChannelResponse, LightningRpcError> {
         let push_amount_msats_or = if push_amount_sats == 0 {
             None
         } else {
             Some(push_amount_sats * 1000)
+        };
+
+        if fee_rate_sats_per_vbyte.is_some() {
+            // LDK manages its own fee estimation for funding transactions; the
+            // user-supplied rate cannot be applied here.
+            warn!(
+                target: LOG_LIGHTNING,
+                "Ignoring fee_rate_sats_per_vbyte on LDK channel open; LDK uses its built-in fee estimator"
+            );
+        }
+
+        let channel_config = match (base_fee_msat, parts_per_million) {
+            (None, None) => None,
+            (base, ppm) => {
+                let mut config = ChannelConfig::default();
+                if let Some(base) = base {
+                    config.forwarding_fee_base_msat = u32::try_from(base).map_err(|_| {
+                        LightningRpcError::FailedToOpenChannel {
+                            failure_reason: format!(
+                                "base_fee_msat {base} does not fit in u32 (LDK limit)"
+                            ),
+                        }
+                    })?;
+                }
+                if let Some(ppm) = ppm {
+                    config.forwarding_fee_proportional_millionths =
+                        u32::try_from(ppm).map_err(|_| LightningRpcError::FailedToOpenChannel {
+                            failure_reason: format!(
+                                "parts_per_million {ppm} does not fit in u32 (LDK limit)"
+                            ),
+                        })?;
+                }
+                Some(config)
+            }
         };
 
         let (tx, rx) = oneshot::channel::<anyhow::Result<OutPoint>>();
@@ -573,7 +611,7 @@ impl ILnRpcClient for GatewayLdkClient {
                     })?,
                     channel_size_sats,
                     push_amount_msats_or,
-                    None,
+                    channel_config,
                 )
                 .map_err(|e| LightningRpcError::FailedToOpenChannel {
                     failure_reason: e.to_string(),

--- a/gateway/fedimint-lightning/src/lnd.rs
+++ b/gateway/fedimint-lightning/src/lnd.rs
@@ -1167,6 +1167,9 @@ impl ILnRpcClient for GatewayLndClient {
             host,
             channel_size_sats,
             push_amount_sats,
+            fee_rate_sats_per_vbyte,
+            base_fee_msat,
+            parts_per_million,
         }: crate::OpenChannelRequest,
     ) -> Result<OpenChannelResponse, LightningRpcError> {
         let mut client = self.connect().await?;
@@ -1200,17 +1203,28 @@ impl ILnRpcClient for GatewayLndClient {
                 })?;
         }
 
+        // Build the request, leaving unspecified fee fields at their
+        // protobuf defaults so LND falls back to its own configuration.
+        let mut open_request = OpenChannelRequest {
+            node_pubkey: pubkey.serialize().to_vec(),
+            local_funding_amount: channel_size_sats.try_into().expect("u64 -> i64"),
+            push_sat: push_amount_sats.try_into().expect("u64 -> i64"),
+            ..Default::default()
+        };
+        if let Some(rate) = fee_rate_sats_per_vbyte {
+            open_request.sat_per_vbyte = rate;
+        }
+        if let Some(base_fee) = base_fee_msat {
+            open_request.base_fee = base_fee;
+            open_request.use_base_fee = true;
+        }
+        if let Some(ppm) = parts_per_million {
+            open_request.fee_rate = ppm;
+            open_request.use_fee_rate = true;
+        }
+
         // Open the channel
-        match client
-            .lightning()
-            .open_channel_sync(OpenChannelRequest {
-                node_pubkey: pubkey.serialize().to_vec(),
-                local_funding_amount: channel_size_sats.try_into().expect("u64 -> i64"),
-                push_sat: push_amount_sats.try_into().expect("u64 -> i64"),
-                ..Default::default()
-            })
-            .await
-        {
+        match client.lightning().open_channel_sync(open_request).await {
             Ok(res) => Ok(OpenChannelResponse {
                 funding_txid: match res.into_inner().funding_txid {
                     Some(txid) => match txid {

--- a/gateway/fedimint-lightning/src/lnd.rs
+++ b/gateway/fedimint-lightning/src/lnd.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::fmt::{self, Display};
 use std::str::FromStr;
 use std::sync::Arc;
@@ -33,9 +34,9 @@ use tonic_lnd::lnrpc::invoice::InvoiceState;
 use tonic_lnd::lnrpc::payment::PaymentStatus;
 use tonic_lnd::lnrpc::{
     ChanInfoRequest, ChannelBalanceRequest, ChannelPoint, CloseChannelRequest, ConnectPeerRequest,
-    GetInfoRequest, Invoice, InvoiceSubscription, LightningAddress, ListChannelsRequest,
-    ListInvoiceRequest, ListPaymentsRequest, ListPeersRequest, OpenChannelRequest,
-    SendCoinsRequest, WalletBalanceRequest,
+    FeeReportRequest, GetInfoRequest, Invoice, InvoiceSubscription, LightningAddress,
+    ListChannelsRequest, ListInvoiceRequest, ListPaymentsRequest, ListPeersRequest,
+    OpenChannelRequest, SendCoinsRequest, WalletBalanceRequest,
 };
 use tonic_lnd::routerrpc::{
     CircuitKey, ForwardHtlcInterceptResponse, ResolveHoldForwardAction, SendPaymentRequest,
@@ -1331,7 +1332,7 @@ impl ILnRpcClient for GatewayLndClient {
         let mut client = self.connect().await?;
 
         // Fetch peer addresses so we can populate remote_address on each channel
-        let peer_addresses: std::collections::HashMap<String, String> = client
+        let peer_addresses: BTreeMap<String, String> = client
             .lightning()
             .list_peers(ListPeersRequest {
                 latest_error: false,
@@ -1347,6 +1348,26 @@ impl ILnRpcClient for GatewayLndClient {
                         } else {
                             Some((peer.pub_key, peer.address))
                         }
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        // Fetch the local fee policy for every channel in one call so we can
+        // join it onto each ChannelInfo below.
+        let fee_report: BTreeMap<u64, (u64, u64)> = client
+            .lightning()
+            .fee_report(FeeReportRequest {})
+            .await
+            .map(|resp| {
+                resp.into_inner()
+                    .channel_fees
+                    .into_iter()
+                    .map(|report| {
+                        let base_fee_msat = u64::try_from(report.base_fee_msat).unwrap_or_default();
+                        let parts_per_million =
+                            u64::try_from(report.fee_per_mil).unwrap_or_default();
+                        (report.chan_id, (base_fee_msat, parts_per_million))
                     })
                     .collect()
             })
@@ -1396,6 +1417,12 @@ impl ILnRpcClient for GatewayLndClient {
 
                         let remote_address = peer_addresses.get(&channel.remote_pubkey).cloned();
 
+                        let (base_fee_msat, parts_per_million) =
+                            match fee_report.get(&channel.chan_id) {
+                                Some((base, ppm)) => (Some(*base), Some(*ppm)),
+                                None => (None, None),
+                            };
+
                         ChannelInfo {
                             remote_pubkey: PublicKey::from_str(&channel.remote_pubkey)
                                 .expect("Lightning node returned invalid remote channel pubkey"),
@@ -1410,6 +1437,8 @@ impl ILnRpcClient for GatewayLndClient {
                                 Some(channel.peer_alias.clone())
                             },
                             remote_address,
+                            base_fee_msat,
+                            parts_per_million,
                         }
                     })
                     .collect(),


### PR DESCRIPTION
Right now the gateway does not have the ability to set the funding channel feerate or channel fees (base + ppm) when opening a channel. This PR adds this feature to both the CLI and the UI