### PR TITLE
fix: show correct invite code after API URL replacement

### DIFF
--- a/fedimint-server/src/config/io.rs
+++ b/fedimint-server/src/config/io.rs
@@ -92,7 +92,7 @@ pub fn write_server_config(
     plaintext_json_write(&server.consensus, &path.join(CONSENSUS_CONFIG))?;
     plaintext_display_write(
         &InviteCode::new(
-            server.consensus.api_endpoints[&server.local.identity]
+            server.consensus.api_endpoints()[&server.local.identity]
                 .url
                 .clone(),
             server.local.identity,

--- a/fedimint-server/src/config/io.rs
+++ b/fedimint-server/src/config/io.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::ensure;
 use fedimint_aead::{LessSafeKey, encrypted_read, encrypted_write, get_encryption_key};
+use fedimint_core::invite_code::InviteCode;
 use fedimint_core::module::ApiAuth;
 use fedimint_core::util::write_new;
 use fedimint_logging::LOG_CORE;
@@ -90,7 +91,14 @@ pub fn write_server_config(
     plaintext_json_write(&server.local, &path.join(LOCAL_CONFIG))?;
     plaintext_json_write(&server.consensus, &path.join(CONSENSUS_CONFIG))?;
     plaintext_display_write(
-        &server.get_invite_code(api_secret),
+        &InviteCode::new(
+            server.consensus.api_endpoints[&server.local.identity]
+                .url
+                .clone(),
+            server.local.identity,
+            server.calculate_federation_id(),
+            api_secret,
+        ),
         &path.join(CLIENT_INVITE_CODE_FILE),
     )?;
     plaintext_json_write(&client_config, &path.join(CLIENT_CONFIG))?;

--- a/fedimint-server/src/config/mod.rs
+++ b/fedimint-server/src/config/mod.rs
@@ -11,7 +11,6 @@ pub use fedimint_core::config::{
 };
 use fedimint_core::core::{ModuleInstanceId, ModuleKind};
 use fedimint_core::envs::{is_env_var_set, is_running_in_test_env};
-use fedimint_core::invite_code::InviteCode;
 use fedimint_core::module::{
     ApiAuth, ApiVersion, CORE_CONSENSUS_VERSION, CoreConsensusVersion, MultiApiVersion,
     SupportedApiVersionsSummary, SupportedCoreApiVersions,
@@ -372,17 +371,6 @@ impl ServerConfig {
             local,
             private,
         }
-    }
-
-    pub fn get_invite_code(&self, api_secret: Option<String>) -> InviteCode {
-        InviteCode::new(
-            self.consensus.api_endpoints()[&self.local.identity]
-                .url
-                .clone(),
-            self.local.identity,
-            self.calculate_federation_id(),
-            api_secret,
-        )
     }
 
     pub fn calculate_federation_id(&self) -> FederationId {

--- a/fedimint-server/src/consensus/api.rs
+++ b/fedimint-server/src/consensus/api.rs
@@ -37,6 +37,7 @@ use fedimint_core::endpoint_constants::{
     SUBMIT_GUARDIAN_METADATA_ENDPOINT, SUBMIT_TRANSACTION_ENDPOINT, VERSION_ENDPOINT,
 };
 use fedimint_core::epoch::ConsensusItem;
+use fedimint_core::invite_code::InviteCode;
 use fedimint_core::module::audit::{Audit, AuditSummary};
 use fedimint_core::module::{
     ApiAuth, ApiEndpoint, ApiEndpointContext, ApiError, ApiRequestErased, ApiResult, ApiVersion,
@@ -76,7 +77,7 @@ use crate::consensus::engine::get_finished_session_count_static;
 use crate::consensus::transaction::{TxProcessingMode, process_transaction_with_dbtx};
 use crate::metrics::{BACKUP_WRITE_SIZE_BYTES, STORED_BACKUPS_COUNT};
 use crate::net::api::HasApiContext;
-use crate::net::api::announcement::{ApiAnnouncementKey, ApiAnnouncementPrefix};
+use crate::net::api::announcement::{ApiAnnouncementKey, ApiAnnouncementPrefix, get_api_urls};
 use crate::net::p2p::P2PStatusReceivers;
 
 #[derive(Clone)]
@@ -664,6 +665,20 @@ impl ConsensusApi {
 
         Ok(())
     }
+
+    async fn get_invite_code(&self, api_secret: Option<String>) -> InviteCode {
+        let identity = self.cfg.local.identity;
+        let mut api_urls = get_api_urls(&self.db, &self.cfg.consensus).await;
+
+        InviteCode::new(
+            api_urls
+                .remove(&identity)
+                .expect("API URL for our identity must be present"),
+            identity,
+            self.cfg.calculate_federation_id(),
+            api_secret,
+        )
+    }
 }
 
 #[async_trait]
@@ -754,8 +769,8 @@ impl IDashboardApi for ConsensusApi {
     }
 
     async fn federation_invite_code(&self) -> String {
-        self.cfg
-            .get_invite_code(self.get_active_api_secret())
+        self.get_invite_code(self.get_active_api_secret())
+            .await
             .to_string()
     }
 
@@ -871,7 +886,7 @@ pub fn server_endpoints() -> Vec<ApiEndpoint<ConsensusApi>> {
             INVITE_CODE_ENDPOINT,
             ApiVersion::new(0, 0),
             async |fedimint: &ConsensusApi, _context,  _v: ()| -> String {
-                Ok(fedimint.cfg.get_invite_code(fedimint.get_active_api_secret()).to_string())
+                Ok(fedimint.get_invite_code(fedimint.get_active_api_secret()).await.to_string())
             }
         },
         api_endpoint! {

--- a/fedimint-testing/src/federation.rs
+++ b/fedimint-testing/src/federation.rs
@@ -202,7 +202,14 @@ impl FederationTest {
 
     /// Return first invite code for gateways
     pub fn invite_code(&self) -> InviteCode {
-        self.configs[&PeerId::from(0)].get_invite_code(None)
+        let peer_id = PeerId::from(0);
+        let cfg = &self.configs[&peer_id];
+        InviteCode::new(
+            cfg.consensus.api_endpoints[&peer_id].url.clone(),
+            peer_id,
+            cfg.calculate_federation_id(),
+            None,
+        )
     }
 
     ///  Return the federation id

--- a/fedimint-testing/src/federation.rs
+++ b/fedimint-testing/src/federation.rs
@@ -205,7 +205,7 @@ impl FederationTest {
         let peer_id = PeerId::from(0);
         let cfg = &self.configs[&peer_id];
         InviteCode::new(
-            cfg.consensus.api_endpoints[&peer_id].url.clone(),
+            cfg.consensus.api_endpoints()[&peer_id].url.clone(),
             peer_id,
             cfg.calculate_federation_id(),
             None,


### PR DESCRIPTION
Rebase of #7627 (by @elsirion) onto current master. Fixes #6977, closes #8612.

3 conflicts, all context drift, no logic changes. \`clippy\`/\`fmt\` clean, and verified on devimint that the \`invite_code\` endpoint reflects an overridden API URL."