### PR TITLE
feat: allow customization of LND's time preference

### DIFF
--- a/fedimint-testing/src/fixtures.rs
+++ b/fedimint-testing/src/fixtures.rs
@@ -17,7 +17,7 @@ use fedimint_core::db::mem_impl::MemDatabase;
 use fedimint_core::envs::BitcoinRpcConfig;
 use fedimint_core::task::{MaybeSend, MaybeSync};
 use fedimint_core::util::SafeUrl;
-use fedimint_gateway_common::{ChainSource, LightningInfo, LightningMode};
+use fedimint_gateway_common::{ChainSource, LND_DEFAULT_TIME_PREF, LightningInfo, LightningMode};
 use fedimint_gateway_server::Gateway;
 use fedimint_gateway_server::client::GatewayClientBuilder;
 use fedimint_gateway_server::config::DatabaseBackend;
@@ -271,6 +271,7 @@ impl Fixtures {
                 lnd_rpc_addr: "FakeRpcAddr".to_string(),
                 lnd_tls_cert: "FakeTlsCert".to_string(),
                 lnd_macaroon: "FakeMacaroon".to_string(),
+                lnd_time_pref: LND_DEFAULT_TIME_PREF,
             },
             client_builder,
             gateway_db,

--- a/gateway/fedimint-gateway-common/src/envs.rs
+++ b/gateway/fedimint-gateway-common/src/envs.rs
@@ -19,3 +19,8 @@ pub const FM_LDK_ALIAS_ENV: &str = "FM_LDK_ALIAS";
 
 /// Environment variable for overriding the iroh secret key
 pub const FM_GATEWAY_IROH_SECRET_KEY_OVERRIDE_ENV: &str = "FM_GATEWAY_IROH_SECRET_KEY_OVERRIDE";
+
+/// Environment variable that specifies the `time_pref` used in LND
+/// `SendPaymentRequest`. Must parse as an f64 in the range [-1.0, 1.0], where
+/// -1 optimizes for fees and 1 optimizes for reliability.
+pub const FM_LND_TIME_PREF_ENV: &str = "FM_LND_TIME_PREF";

--- a/gateway/fedimint-gateway-common/src/lib.rs
+++ b/gateway/fedimint-gateway-common/src/lib.rs
@@ -8,7 +8,8 @@ use bitcoin::secp256k1::PublicKey;
 use bitcoin::{Address, Network, OutPoint};
 use clap::Subcommand;
 use envs::{
-    FM_LDK_ALIAS_ENV, FM_LND_MACAROON_ENV, FM_LND_RPC_ADDR_ENV, FM_LND_TLS_CERT_ENV, FM_PORT_LDK,
+    FM_LDK_ALIAS_ENV, FM_LND_MACAROON_ENV, FM_LND_RPC_ADDR_ENV, FM_LND_TIME_PREF_ENV,
+    FM_LND_TLS_CERT_ENV, FM_PORT_LDK,
 };
 use fedimint_core::config::{FederationId, JsonClientConfig};
 use fedimint_core::encoding::{Decodable, Encodable};
@@ -524,7 +525,25 @@ pub enum PaymentStatus {
     Failed,
 }
 
-#[derive(Debug, Clone, Subcommand, Serialize, Deserialize, Eq, PartialEq)]
+/// Default value for LND's `SendPaymentRequest::time_pref`. LND interprets this
+/// as a value in [`LND_TIME_PREF_MIN`, `LND_TIME_PREF_MAX`], where -1 optimizes
+/// purely for fees and 1 optimizes purely for reliability. We default to 0.5 to
+/// favor reliability while still considering fees.
+pub const LND_DEFAULT_TIME_PREF: f64 = 0.5;
+pub const LND_TIME_PREF_MIN: f64 = -1.0;
+pub const LND_TIME_PREF_MAX: f64 = 1.0;
+
+fn parse_lnd_time_pref(s: &str) -> Result<f64, String> {
+    let parsed: f64 = s.parse().map_err(|e| format!("invalid f64: {e}"))?;
+    if !parsed.is_finite() || !(LND_TIME_PREF_MIN..=LND_TIME_PREF_MAX).contains(&parsed) {
+        return Err(format!(
+            "must be a finite value in [{LND_TIME_PREF_MIN}, {LND_TIME_PREF_MAX}]"
+        ));
+    }
+    Ok(parsed)
+}
+
+#[derive(Debug, Clone, Subcommand, Serialize, Deserialize, PartialEq)]
 pub enum LightningMode {
     #[clap(name = "lnd")]
     Lnd {
@@ -539,6 +558,16 @@ pub enum LightningMode {
         /// LND macaroon file path
         #[arg(long = "lnd-macaroon", env = FM_LND_MACAROON_ENV)]
         lnd_macaroon: String,
+
+        /// `time_pref` passed to LND `SendPaymentRequest`. -1.0 optimizes
+        /// purely for fees, 1.0 optimizes purely for reliability.
+        #[arg(
+            long = "lnd-time-pref",
+            env = FM_LND_TIME_PREF_ENV,
+            default_value_t = LND_DEFAULT_TIME_PREF,
+            value_parser = parse_lnd_time_pref,
+        )]
+        lnd_time_pref: f64,
     },
     #[clap(name = "ldk")]
     Ldk {

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -1811,10 +1811,12 @@ impl Gateway {
                 lnd_rpc_addr,
                 lnd_tls_cert,
                 lnd_macaroon,
+                lnd_time_pref,
             } => Box::new(GatewayLndClient::new(
                 lnd_rpc_addr,
                 lnd_tls_cert,
                 lnd_macaroon,
+                lnd_time_pref,
                 None,
             )),
             LightningMode::Ldk {

--- a/gateway/fedimint-gateway-ui/src/lightning.rs
+++ b/gateway/fedimint-gateway-ui/src/lightning.rs
@@ -184,7 +184,7 @@ where
                         aria-labelledby="connection-tab" {
 
                         @match &gateway_info.lightning_mode {
-                            LightningMode::Lnd { lnd_rpc_addr, lnd_tls_cert, lnd_macaroon } => {
+                            LightningMode::Lnd { lnd_rpc_addr, lnd_tls_cert, lnd_macaroon, .. } => {
                                 div id="node-type" class="alert alert-info" {
                                     "Node Type: " strong { "External LND" }
                                 }

--- a/gateway/fedimint-lightning/src/lnd.rs
+++ b/gateway/fedimint-lightning/src/lnd.rs
@@ -69,6 +69,7 @@ pub struct GatewayLndClient {
     address: String,
     tls_cert: String,
     macaroon: String,
+    time_pref: f64,
     lnd_sender: Option<mpsc::Sender<ForwardHtlcInterceptResponse>>,
 }
 
@@ -77,6 +78,7 @@ impl GatewayLndClient {
         address: String,
         tls_cert: String,
         macaroon: String,
+        time_pref: f64,
         lnd_sender: Option<mpsc::Sender<ForwardHtlcInterceptResponse>>,
     ) -> Self {
         info!(
@@ -84,12 +86,14 @@ impl GatewayLndClient {
             address = %address,
             tls_cert_path = %tls_cert,
             macaroon = %macaroon,
+            time_pref,
             "Gateway configured to connect to LND LnRpcClient",
         );
         GatewayLndClient {
             address,
             tls_cert,
             macaroon,
+            time_pref,
             lnd_sender,
         }
     }
@@ -843,6 +847,7 @@ impl ILnRpcClient for GatewayLndClient {
                         no_inflight_updates: false,
                         timeout_seconds: LND_PAYMENT_TIMEOUT_SECONDS,
                         fee_limit_msat,
+                        time_pref: self.time_pref,
                         ..Default::default()
                     })
                     .await
@@ -961,6 +966,7 @@ impl ILnRpcClient for GatewayLndClient {
             address: self.address.clone(),
             tls_cert: self.tls_cert.clone(),
             macaroon: self.macaroon.clone(),
+            time_pref: self.time_pref,
             lnd_sender: Some(lnd_sender.clone()),
         });
         Ok((Box::pin(ReceiverStream::new(gateway_receiver)), new_client))


### PR DESCRIPTION
LND exposes a `time_pref` parameter that allows the user to optimize for fees or for reliability. -1.0 optimizes for fees, 1.0 optimizes for reliability.

This PR sets this value to a default of 0.5, to favor reliability. It also exposes an environment variable to override this in case gateway operators want to change it.

@douglaz for awareness