### PR TITLE
fix: walletv2 receive generates new index if there are `None`

### DIFF
--- a/modules/fedimint-walletv2-client/src/lib.rs
+++ b/modules/fedimint-walletv2-client/src/lib.rs
@@ -16,7 +16,6 @@ mod send_sm;
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
-use std::time::Duration;
 
 use anyhow::anyhow;
 use api::WalletFederationApi;
@@ -370,24 +369,27 @@ impl WalletClientModule {
         }
     }
 
-    /// Returns the next unused receive address, polling until the initial
-    /// address derivation has completed.
+    /// Returns the next unused receive address. If no valid address index has
+    /// been derived yet (e.g. the output scanner is disabled or hasn't run),
+    /// derive one inline.
     pub async fn receive(&self) -> Address {
-        loop {
-            if let Some(entry) = self
-                .db
-                .begin_transaction_nc()
-                .await
-                .find_by_prefix_sorted_descending(&ValidAddressIndexPrefix)
-                .await
-                .next()
-                .await
-            {
-                return self.derive_address(entry.0.0);
-            }
-
-            sleep(Duration::from_secs(1)).await;
+        if let Some(entry) = self
+            .db
+            .begin_transaction_nc()
+            .await
+            .find_by_prefix_sorted_descending(&ValidAddressIndexPrefix)
+            .await
+            .next()
+            .await
+        {
+            return self.derive_address(entry.0.0);
         }
+
+        let idx = self.next_valid_index(0);
+        let mut dbtx = self.db.begin_transaction().await;
+        dbtx.insert_entry(&ValidAddressIndexKey(idx), &()).await;
+        dbtx.commit_tx().await;
+        self.derive_address(idx)
     }
 
     fn derive_address(&self, index: u64) -> Address {
@@ -495,21 +497,6 @@ impl WalletClientModule {
         let module = self.clone();
 
         task_group.spawn_cancellable_with_span(client_span.clone(), "output-scanner", async move {
-            let mut dbtx = module.db.begin_transaction().await;
-
-            if dbtx
-                .find_by_prefix(&ValidAddressIndexPrefix)
-                .await
-                .next()
-                .await
-                .is_none()
-            {
-                dbtx.insert_new_entry(&ValidAddressIndexKey(module.next_valid_index(0)), &())
-                    .await;
-            }
-
-            dbtx.commit_tx().await;
-
             loop {
                 match module.check_outputs().await {
                     Ok(skip_wait) => {


### PR DESCRIPTION
WIP

<details>
<summary>Example Output</summary>

```
\[\]\[\]jumoell@asus\[\]:\[\]~/Projects/fedimint\[\]$ fedimint-cli join fed11qgqpv9rhwvaz7te3xgmjuvpwxqhrzw3jxqcrztcrqysyj6r4x0cqah7ry3mw6yqapuwev0vq7z6f3988el7nrqdn6mrcw2su2d8t2
2026-05-19T20:41:23.857642Z  INFO fm::db: Migrating module... kind="fedimint-client" current_db_version=DatabaseVersion(0) target_db_version=DatabaseVersion(4)
2026-05-19T20:41:23.857719Z  INFO fm::db: Migrating module... kind="fedimint-client" current_db_version=DatabaseVersion(1) target_db_version=DatabaseVersion(4)
2026-05-19T20:41:23.857762Z  INFO fm::db: Migrating module... kind="fedimint-client" current_db_version=DatabaseVersion(2) target_db_version=DatabaseVersion(4)
2026-05-19T20:41:23.857808Z  INFO fm::db: Migrating module... kind="fedimint-client" current_db_version=DatabaseVersion(3) target_db_version=DatabaseVersion(4)
2026-05-19T20:41:54.030570Z  WARN client{fed_id=49687533}: fm::task: Timeout waiting for task to shut down task=output-scanner
{
  "joined": "fed11qgqpv9rhwvaz7te3xgmjuvpwxqhrzw3jxqcrztcrqysyj6r4x0cqah7ry3mw6yqapuwev0vq7z6f3988el7nrqdn6mrcw2su2d8t2"
}

thread 'tokio-runtime-worker' (24316) panicked at /home/jumoell/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.48.0/src/runtime/time/entry.rs:602:9:
A Tokio 1.x context was found, but it is being shutdown.
stack backtrace:
   0: __rustc::rust_begin_unwind
             at /rustc/254b59607d4417e9dffbc307138ae5c86280fe4c/library/std/src/panicking.rs:689:5
   1: core::panicking::panic_fmt
             at /rustc/254b59607d4417e9dffbc307138ae5c86280fe4c/library/core/src/panicking.rs:80:14
   2: core::panicking::panic_display
             at /nix/store/sbyxhn9dlw3iabbqq5v56q60c6xsfmnz-rust-mixed/lib/rustlib/src/rust/library/core/src/panicking.rs:259:5
   3: poll_elapsed
             at /home/jumoell/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.48.0/src/runtime/time/entry.rs:602:9
   4: poll_elapsed
             at /home/jumoell/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.48.0/src/time/sleep.rs:414:31
   5: poll
             at /home/jumoell/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.48.0/src/time/sleep.rs:446:36
   6: {async_block#0}<dyn fedimint_connectors::IGuardianConnection, fedimint_api_client::api::{impl#2}::get_or_create_connection::{async_fn#0}::{closure_env#0}, fedimint_api_client::api::{impl#2}::get_or_create_connection::{async_fn#0}::{closure#0}::{async_block_env#0}>
             at ./fedimint-connectors/src/lib.rs:729:60
   7: {async_fn#0}<alloc::sync::Arc<dyn fedimint_connectors::IGuardianConnection, alloc::alloc::Global>, fedimint_connectors::error::ServerError, fedimint_connectors::{impl#4}::get_or_create_connection::{async_fn#0}::{closure_env#0}<dyn fedimint_connectors::IGuardianConnection, fedimint_api_client::api::{impl#2}::get_or_create_connection::{async_fn#0}::{closure_env#0}, fedimint_api_client::api::{impl#2}::get_or_create_connection::{async_fn#0}::{closure#0}::{async_block_env#0}>, fedimint_connectors::{impl#4}::get_or_create_connection::{async_fn#0}::{closure#0}::{async_block_env#0}<dyn fedimint_connectors::IGuardianConnection, fedimint_api_client::api::{impl#2}::get_or_create_connection::{async_fn#0}::{closure_env#0}, fedimint_api_client::api::{impl#2}::get_or_create_connection::{async_fn#0}::{closure#0}::{async_block_env#0}>>
             at /home/jumoell/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.48.0/src/sync/once_cell.rs:418:37
   8: {async_fn#0}<dyn fedimint_connectors::IGuardianConnection, fedimint_api_client::api::{impl#2}::get_or_create_connection::{async_fn#0}::{closure_env#0}, fedimint_api_client::api::{impl#2}::get_or_create_connection::{async_fn#0}::{closure#0}::{async_block_env#0}>
             at ./fedimint-connectors/src/lib.rs:773:14
   9: {async_fn#0}
             at ./fedimint-api-client/src/api/mod.rs:690:14
  10: {async_fn#0}
             at ./fedimint-api-client/src/api/mod.rs:706:14
  11: {async_block#0}
             at ./fedimint-api-client/src/api/mod.rs:782:55
  12: poll<fedimint_api_client::api::{impl#21}::request_raw::{async_block#0}::{async_block_env#0}>
             at /home/jumoell/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tracing-0.1.44/src/instrument.rs:321:15
  13: {async_block#0}
             at ./fedimint-api-client/src/api/mod.rs:762:5
  14: poll<alloc::boxed::Box<(dyn core::future::future::Future<Output=core::result::Result<serde_json::value::Value, fedimint_connectors::error::ServerError>> + core::marker::Send), alloc::alloc::Global>>
             at /nix/store/sbyxhn9dlw3iabbqq5v56q60c6xsfmnz-rust-mixed/lib/rustlib/src/rust/library/core/src/future/future.rs:133:9
  15: {async_block#0}<(dyn fedimint_api_client::api::IModuleFederationApi + core::marker::Send + core::marker::Sync), alloc::vec::Vec<fedimint_walletv2_common::OutputInfo, alloc::alloc::Global>>
             at ./fedimint-api-client/src/api/mod.rs:148:14
  16: poll<alloc::boxed::Box<(dyn core::future::future::Future<Output=core::result::Result<alloc::vec::Vec<fedimint_walletv2_common::OutputInfo, alloc::alloc::Global>, fedimint_connectors::error::ServerError>> + core::marker::Send), alloc::alloc::Global>>
             at /nix/store/sbyxhn9dlw3iabbqq5v56q60c6xsfmnz-rust-mixed/lib/rustlib/src/rust/library/core/src/future/future.rs:133:9
  17: {async_block#0}<(dyn fedimint_api_client::api::IModuleFederationApi + core::marker::Send + core::marker::Sync), alloc::vec::Vec<fedimint_walletv2_common::OutputInfo, alloc::alloc::Global>, alloc::vec::Vec<fedimint_walletv2_common::OutputInfo, alloc::alloc::Global>, fedimint_api_client::query::ThresholdConsensus<alloc::vec::Vec<fedimint_walletv2_common::OutputInfo, alloc::alloc::Global>>>
             at ./fedimint-api-client/src/api/mod.rs:197:26
  18: poll<alloc::boxed::Box<(dyn core::future::future::Future<Output=(fedimint_core::peer_id::PeerId, core::result::Result<alloc::vec::Vec<fedimint_walletv2_common::OutputInfo, alloc::alloc::Global>, fedimint_connectors::error::ServerError>)> + core::marker::Send), alloc::alloc::Global>>
             at /nix/store/sbyxhn9dlw3iabbqq5v56q60c6xsfmnz-rust-mixed/lib/rustlib/src/rust/library/core/src/future/future.rs:133:9
  19: poll_next<core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output=(fedimint_core::peer_id::PeerId, core::result::Result<alloc::vec::Vec<fedimint_walletv2_common::OutputInfo, alloc::alloc::Global>, fedimint_connectors::error::ServerError>)> + core::marker::Send), alloc::alloc::Global>>>
             at /home/jumoell/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/futures-util-0.3.32/src/stream/futures_unordered/mod.rs:528:24
  20: futures_util::stream::stream::StreamExt::poll_next_unpin
             at /home/jumoell/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/futures-util-0.3.32/src/stream/stream/mod.rs:1638:24
  21: <futures_util::stream::stream::next::Next<St> as core::future::future::Future>::poll
             at /home/jumoell/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/futures-util-0.3.32/src/stream/stream/next.rs:32:21
  22: {async_block#0}<(dyn fedimint_api_client::api::IModuleFederationApi + core::marker::Send + core::marker::Sync), alloc::vec::Vec<fedimint_walletv2_common::OutputInfo, alloc::alloc::Global>, alloc::vec::Vec<fedimint_walletv2_common::OutputInfo, alloc::alloc::Global>, fedimint_api_client::query::ThresholdConsensus<alloc::vec::Vec<fedimint_walletv2_common::OutputInfo, alloc::alloc::Global>>>
             at ./fedimint-api-client/src/api/mod.rs:210:18
  23: poll<fedimint_api_client::api::FederationApiExt::request_with_strategy::{async_block#0}::{async_block_env#0}<(dyn fedimint_api_client::api::IModuleFederationApi + core::marker::Send + core::marker::Sync), alloc::vec::Vec<fedimint_walletv2_common::OutputInfo, alloc::alloc::Global>, alloc::vec::Vec<fedimint_walletv2_common::OutputInfo, alloc::alloc::Global>, fedimint_api_client::query::ThresholdConsensus<alloc::vec::Vec<fedimint_walletv2_common::OutputInfo, alloc::alloc::Global>>>>
             at /home/jumoell/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tracing-0.1.44/src/instrument.rs:321:15
  24: {async_block#0}<(dyn fedimint_api_client::api::IModuleFederationApi + core::marker::Send + core::marker::Sync), alloc::vec::Vec<fedimint_walletv2_common::OutputInfo, alloc::alloc::Global>, alloc::vec::Vec<fedimint_walletv2_common::OutputInfo, alloc::alloc::Global>, fedimint_api_client::query::ThresholdConsensus<alloc::vec::Vec<fedimint_walletv2_common::OutputInfo, alloc::alloc::Global>>>
             at ./fedimint-api-client/src/api/mod.rs:175:5
  25: poll<alloc::boxed::Box<(dyn core::future::future::Future<Output=core::result::Result<alloc::vec::Vec<fedimint_walletv2_common::OutputInfo, alloc::alloc::Global>, fedimint_api_client::api::error::FederationError>> + core::marker::Send), alloc::alloc::Global>>
             at /nix/store/sbyxhn9dlw3iabbqq5v56q60c6xsfmnz-rust-mixed/lib/rustlib/src/rust/library/core/src/future/future.rs:133:9
  26: {async_block#0}<(dyn fedimint_api_client::api::IModuleFederationApi + core::marker::Send + core::marker::Sync), alloc::vec::Vec<fedimint_walletv2_common::OutputInfo, alloc::alloc::Global>>
             at ./fedimint-api-client/src/api/mod.rs:353:10
  27: poll<alloc::boxed::Box<(dyn core::future::future::Future<Output=core::result::Result<alloc::vec::Vec<fedimint_walletv2_common::OutputInfo, alloc::alloc::Global>, fedimint_api_client::api::error::FederationError>> + core::marker::Send), alloc::alloc::Global>>
             at /nix/store/sbyxhn9dlw3iabbqq5v56q60c6xsfmnz-rust-mixed/lib/rustlib/src/rust/library/core/src/future/future.rs:133:9
  28: {async_block#0}<(dyn fedimint_api_client::api::IModuleFederationApi + core::marker::Send + core::marker::Sync)>
             at ./modules/fedimint-walletv2-client/src/api.rs:101:10
  29: poll<alloc::boxed::Box<(dyn core::future::future::Future<Output=core::result::Result<alloc::vec::Vec<fedimint_walletv2_common::OutputInfo, alloc::alloc::Global>, fedimint_api_client::api::error::FederationError>> + core::marker::Send), alloc::alloc::Global>>
             at /nix/store/sbyxhn9dlw3iabbqq5v56q60c6xsfmnz-rust-mixed/lib/rustlib/src/rust/library/core/src/future/future.rs:133:9
  30: {async_fn#0}
             at ./modules/fedimint-walletv2-client/src/lib.rs:550:14
  31: {async_block#0}
             at ./modules/fedimint-walletv2-client/src/lib.rs:514:46
  32: poll<&mut fedimint_walletv2_client::{impl#2}::spawn_output_scanner::{async_block_env#0}>
             at /nix/store/sbyxhn9dlw3iabbqq5v56q60c6xsfmnz-rust-mixed/lib/rustlib/src/rust/library/core/src/future/future.rs:133:9
  33: futures_util::future::future::FutureExt::poll_unpin
             at /home/jumoell/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/futures-util-0.3.32/src/future/future/mod.rs:556:24
  34: poll<core::pin::Pin<&mut fedimint_core::task::TaskShutdownToken>, core::pin::Pin<&mut fedimint_walletv2_client::{impl#2}::spawn_output_scanner::{async_block_env#0}>>
             at /home/jumoell/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/futures-util-0.3.32/src/future/select.rs:117:37
  35: {async_fn#0}<fedimint_walletv2_client::{impl#2}::spawn_output_scanner::{async_block_env#0}>
             at ./fedimint-core/src/task.rs:391:51
  36: {async_block#0}<!, &str, fedimint_walletv2_client::{impl#2}::spawn_output_scanner::{async_block_env#0}>
             at ./fedimint-core/src/task.rs:286:59
  37: {async_block#0}<fedimint_core::task::{impl#0}::spawn_cancellable_with_span::{closure#0}::{async_block_env#0}<!, &str, fedimint_walletv2_client::{impl#2}::spawn_output_scanner::{async_block_env#0}>, core::result::Result<!, fedimint_core::task::ShuttingDownError>, &str, fedimint_core::task::{impl#0}::spawn_cancellable_with_span::{closure_env#0}<!, &str, fedimint_walletv2_client::{impl#2}::spawn_output_scanner::{async_block_env#0}>>
             at ./fedimint-core/src/task.rs:228:51
  38: poll<fedimint_core::task::{impl#0}::spawn_inner::{closure#0}::{async_block_env#0}<fedimint_core::task::{impl#0}::spawn_cancellable_with_span::{closure#0}::{async_block_env#0}<!, &str, fedimint_walletv2_client::{impl#2}::spawn_output_scanner::{async_block_env#0}>, core::result::Result<!, fedimint_core::task::ShuttingDownError>, &str, fedimint_core::task::{impl#0}::spawn_cancellable_with_span::{closure_env#0}<!, &str, fedimint_walletv2_client::{impl#2}::spawn_output_scanner::{async_block_env#0}>>>
             at /home/jumoell/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tracing-0.1.44/src/instrument.rs:321:15
  39: poll<alloc::boxed::Box<tracing::instrument::Instrumented<fedimint_core::task::{impl#0}::spawn_inner::{closure#0}::{async_block_env#0}<fedimint_core::task::{impl#0}::spawn_cancellable_with_span::{closure#0}::{async_block_env#0}<!, &str, fedimint_walletv2_client::{impl#2}::spawn_output_scanner::{async_block_env#0}>, core::result::Result<!, fedimint_core::task::ShuttingDownError>, &str, fedimint_core::task::{impl#0}::spawn_cancellable_with_span::{closure_env#0}<!, &str, fedimint_walletv2_client::{impl#2}::spawn_output_scanner::{async_block_env#0}>>>, alloc::alloc::Global>>
             at /nix/store/sbyxhn9dlw3iabbqq5v56q60c6xsfmnz-rust-mixed/lib/rustlib/src/rust/library/core/src/future/future.rs:133:9
  40: tokio::runtime::task::core::Core<T,S>::poll::{{closure}}
             at /home/jumoell/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.48.0/src/runtime/task/core.rs:365:24
  41: with_mut<tokio::runtime::task::core::Stage<core::pin::Pin<alloc::boxed::Box<tracing::instrument::Instrumented<fedimint_core::task::{impl#0}::spawn_inner::{closure#0}::{async_block_env#0}<fedimint_core::task::{impl#0}::spawn_cancellable_with_span::{closure#0}::{async_block_env#0}<!, &str, fedimint_walletv2_client::{impl#2}::spawn_output_scanner::{async_block_env#0}>, core::result::Result<!, fedimint_core::task::ShuttingDownError>, &str, fedimint_core::task::{impl#0}::spawn_cancellable_with_span::{closure_env#0}<!, &str, fedimint_walletv2_client::{impl#2}::spawn_output_scanner::{async_block_env#0}>>>, alloc::alloc::Global>>>, core::task::poll::Poll<()>, tokio::runtime::task::core::{impl#6}::poll::{closure_env#0}<core::pin::Pin<alloc::boxed::Box<tracing::instrument::Instrumented<fedimint_core::task::{impl#0}::spawn_inner::{closure#0}::{async_block_env#0}<fedimint_core::task::{impl#0}::spawn_cancellable_with_span::{closure#0}::{async_block_env#0}<!, &str, fedimint_walletv2_client::{impl#2}::spawn_output_scanner::{async_block_env#0}>, core::result::Result<!, fedimint_core::task::ShuttingDownError>, &str, fedimint_core::task::{impl#0}::spawn_cancellable_with_span::{closure_env#0}<!, &str, fedimint_walletv2_client::{impl#2}::spawn_output_scanner::{async_block_env#0}>>>, alloc::alloc::Global>>, alloc::sync::Arc<tokio::runtime::scheduler::multi_thread::handle::Handle, alloc::alloc::Global>>>
             at /home/jumoell/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.48.0/src/loom/std/unsafe_cell.rs:16:9
  42: poll<core::pin::Pin<alloc::boxed::Box<tracing::instrument::Instrumented<fedimint_core::task::{impl#0}::spawn_inner::{closure#0}::{async_block_env#0}<fedimint_core::task::{impl#0}::spawn_cancellable_with_span::{closure#0}::{async_block_env#0}<!, &str, fedimint_walletv2_client::{impl#2}::spawn_output_scanner::{async_block_env#0}>, core::result::Result<!, fedimint_core::task::ShuttingDownError>, &str, fedimint_core::task::{impl#0}::spawn_cancellable_with_span::{closure_env#0}<!, &str, fedimint_walletv2_client::{impl#2}::spawn_output_scanner::{async_block_env#0}>>>, alloc::alloc::Global>>, alloc::sync::Arc<tokio::runtime::scheduler::multi_thread::handle::Handle, alloc::alloc::Global>>
             at /home/jumoell/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.48.0/src/runtime/task/core.rs:354:30
  43: tokio::runtime::task::harness::poll_future::{{closure}}
             at /home/jumoell/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.48.0/src/runtime/task/harness.rs:535:30
  44: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /nix/store/sbyxhn9dlw3iabbqq5v56q60c6xsfmnz-rust-mixed/lib/rustlib/src/rust/library/core/src/panic/unwind_safe.rs:274:9
  45: do_call<core::panic::unwind_safe::AssertUnwindSafe<tokio::runtime::task::harness::poll_future::{closure_env#0}<core::pin::Pin<alloc::boxed::Box<tracing::instrument::Instrumented<fedimint_core::task::{impl#0}::spawn_inner::{closure#0}::{async_block_env#0}<fedimint_core::task::{impl#0}::spawn_cancellable_with_span::{closure#0}::{async_block_env#0}<!, &str, fedimint_walletv2_client::{impl#2}::spawn_output_scanner::{async_block_env#0}>, core::result::Result<!, fedimint_core::task::ShuttingDownError>, &str, fedimint_core::task::{impl#0}::spawn_cancellable_with_span::{closure_env#0}<!, &str, fedimint_walletv2_client::{impl#2}::spawn_output_scanner::{async_block_env#0}>>>, alloc::alloc::Global>>, alloc::sync::Arc<tokio::runtime::scheduler::multi_thread::handle::Handle, alloc::alloc::Global>>>, core::task::poll::Poll<()>>
             at /nix/store/sbyxhn9dlw3iabbqq5v56q60c6xsfmnz-rust-mixed/lib/rustlib/src/rust/library/std/src/panicking.rs:581:40
  46: __rust_try
  47: catch_unwind<core::task::poll::Poll<()>, core::panic::unwind_safe::AssertUnwindSafe<tokio::runtime::task::harness::poll_future::{closure_env#0}<core::pin::Pin<alloc::boxed::Box<tracing::instrument::Instrumented<fedimint_core::task::{impl#0}::spawn_inner::{closure#0}::{async_block_env#0}<fedimint_core::task::{impl#0}::spawn_cancellable_with_span::{closure#0}::{async_block_env#0}<!, &str, fedimint_walletv2_client::{impl#2}::spawn_output_scanner::{async_block_env#0}>, core::result::Result<!, fedimint_core::task::ShuttingDownError>, &str, fedimint_core::task::{impl#0}::spawn_cancellable_with_span::{closure_env#0}<!, &str, fedimint_walletv2_client::{impl#2}::spawn_output_scanner::{async_block_env#0}>>>, alloc::alloc::Global>>, alloc::sync::Arc<tokio::runtime::scheduler::multi_thread::handle::Handle, alloc::alloc::Global>>>>
             at /nix/store/sbyxhn9dlw3iabbqq5v56q60c6xsfmnz-rust-mixed/lib/rustlib/src/rust/library/std/src/panicking.rs:544:19
  48: catch_unwind<core::panic::unwind_safe::AssertUnwindSafe<tokio::runtime::task::harness::poll_future::{closure_env#0}<core::pin::Pin<alloc::boxed::Box<tracing::instrument::Instrumented<fedimint_core::task::{impl#0}::spawn_inner::{closure#0}::{async_block_env#0}<fedimint_core::task::{impl#0}::spawn_cancellable_with_span::{closure#0}::{async_block_env#0}<!, &str, fedimint_walletv2_client::{impl#2}::spawn_output_scanner::{async_block_env#0}>, core::result::Result<!, fedimint_core::task::ShuttingDownError>, &str, fedimint_core::task::{impl#0}::spawn_cancellable_with_span::{closure_env#0}<!, &str, fedimint_walletv2_client::{impl#2}::spawn_output_scanner::{async_block_env#0}>>>, alloc::alloc::Global>>, alloc::sync::Arc<tokio::runtime::scheduler::multi_thread::handle::Handle, alloc::alloc::Global>>>, core::task::poll::Poll<()>>
             at /nix/store/sbyxhn9dlw3iabbqq5v56q60c6xsfmnz-rust-mixed/lib/rustlib/src/rust/library/std/src/panic.rs:359:14
  49: tokio::runtime::task::harness::poll_future
             at /home/jumoell/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.48.0/src/runtime/task/harness.rs:523:18
  50: tokio::runtime::task::harness::Harness<T,S>::poll_inner
             at /home/jumoell/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.48.0/src/runtime/task/harness.rs:210:27
  51: tokio::runtime::task::harness::Harness<T,S>::poll
             at /home/jumoell/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.48.0/src/runtime/task/harness.rs:155:20
  52: tokio::runtime::task::raw::poll
             at /home/jumoell/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.48.0/src/runtime/task/raw.rs:325:13
  53: poll
             at /home/jumoell/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.48.0/src/runtime/task/raw.rs:255:18
  54: run<alloc::sync::Arc<tokio::runtime::scheduler::multi_thread::handle::Handle, alloc::alloc::Global>>
             at /home/jumoell/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.48.0/src/runtime/task/mod.rs:509:13
  55: {closure#0}
             at /home/jumoell/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.48.0/src/runtime/scheduler/multi_thread/worker.rs:600:18
  56: with_budget<core::result::Result<alloc::boxed::Box<tokio::runtime::scheduler::multi_thread::worker::Core, alloc::alloc::Global>, ()>, tokio::runtime::scheduler::multi_thread::worker::{impl#1}::run_task::{closure_env#0}>
             at /home/jumoell/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.48.0/src/task/coop/mod.rs:167:5
  57: budget<core::result::Result<alloc::boxed::Box<tokio::runtime::scheduler::multi_thread::worker::Core, alloc::alloc::Global>, ()>, tokio::runtime::scheduler::multi_thread::worker::{impl#1}::run_task::{closure_env#0}>
             at /home/jumoell/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.48.0/src/task/coop/mod.rs:133:5
  58: run_task
             at /home/jumoell/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.48.0/src/runtime/scheduler/multi_thread/worker.rs:591:9
  59: run
             at /home/jumoell/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.48.0/src/runtime/scheduler/multi_thread/worker.rs:539:29
  60: {closure#0}
             at /home/jumoell/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.48.0/src/runtime/scheduler/multi_thread/worker.rs:504:24
  61: set<tokio::runtime::scheduler::Context, tokio::runtime::scheduler::multi_thread::worker::run::{closure#0}::{closure_env#0}, ()>
             at /home/jumoell/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.48.0/src/runtime/context/scoped.rs:40:9
  62: {closure#0}<(), tokio::runtime::scheduler::multi_thread::worker::run::{closure#0}::{closure_env#0}>
             at /home/jumoell/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.48.0/src/runtime/context.rs:176:38
  63: try_with<tokio::runtime::context::Context, tokio::runtime::context::set_scheduler::{closure_env#0}<(), tokio::runtime::scheduler::multi_thread::worker::run::{closure#0}::{closure_env#0}>, ()>
             at /nix/store/sbyxhn9dlw3iabbqq5v56q60c6xsfmnz-rust-mixed/lib/rustlib/src/rust/library/std/src/thread/local.rs:513:12
  64: with<tokio::runtime::context::Context, tokio::runtime::context::set_scheduler::{closure_env#0}<(), tokio::runtime::scheduler::multi_thread::worker::run::{closure#0}::{closure_env#0}>, ()>
             at /nix/store/sbyxhn9dlw3iabbqq5v56q60c6xsfmnz-rust-mixed/lib/rustlib/src/rust/library/std/src/thread/local.rs:477:20
  65: set_scheduler<(), tokio::runtime::scheduler::multi_thread::worker::run::{closure#0}::{closure_env#0}>
             at /home/jumoell/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.48.0/src/runtime/context.rs:176:17
  66: {closure#0}
             at /home/jumoell/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.48.0/src/runtime/scheduler/multi_thread/worker.rs:499:9
  67: enter_runtime<tokio::runtime::scheduler::multi_thread::worker::run::{closure_env#0}, ()>
             at /home/jumoell/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.48.0/src/runtime/context/runtime.rs:65:16
  68: run
             at /home/jumoell/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.48.0/src/runtime/scheduler/multi_thread/worker.rs:491:5
  69: {closure#0}
             at /home/jumoell/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.48.0/src/runtime/scheduler/multi_thread/worker.rs:457:45
  70: poll<tokio::runtime::scheduler::multi_thread::worker::{impl#0}::launch::{closure_env#0}, ()>
             at /home/jumoell/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.48.0/src/runtime/blocking/task.rs:42:21
  71: {closure#0}<tokio::runtime::blocking::task::BlockingTask<tokio::runtime::scheduler::multi_thread::worker::{impl#0}::launch::{closure_env#0}>, tokio::runtime::blocking::schedule::BlockingSchedule>
             at /home/jumoell/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.48.0/src/runtime/task/core.rs:365:24
  72: with_mut<tokio::runtime::task::core::Stage<tokio::runtime::blocking::task::BlockingTask<tokio::runtime::scheduler::multi_thread::worker::{impl#0}::launch::{closure_env#0}>>, core::task::poll::Poll<()>, tokio::runtime::task::core::{impl#6}::poll::{closure_env#0}<tokio::runtime::blocking::task::BlockingTask<tokio::runtime::scheduler::multi_thread::worker::{impl#0}::launch::{closure_env#0}>, tokio::runtime::blocking::schedule::BlockingSchedule>>
             at /home/jumoell/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.48.0/src/loom/std/unsafe_cell.rs:16:9
  73: poll<tokio::runtime::blocking::task::BlockingTask<tokio::runtime::scheduler::multi_thread::worker::{impl#0}::launch::{closure_env#0}>, tokio::runtime::blocking::schedule::BlockingSchedule>
             at /home/jumoell/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.48.0/src/runtime/task/core.rs:354:30
  74: {closure#0}<tokio::runtime::blocking::task::BlockingTask<tokio::runtime::scheduler::multi_thread::worker::{impl#0}::launch::{closure_env#0}>, tokio::runtime::blocking::schedule::BlockingSchedule>
             at /home/jumoell/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.48.0/src/runtime/task/harness.rs:535:30
  75: call_once<core::task::poll::Poll<()>, tokio::runtime::task::harness::poll_future::{closure_env#0}<tokio::runtime::blocking::task::BlockingTask<tokio::runtime::scheduler::multi_thread::worker::{impl#0}::launch::{closure_env#0}>, tokio::runtime::blocking::schedule::BlockingSchedule>>
             at /nix/store/sbyxhn9dlw3iabbqq5v56q60c6xsfmnz-rust-mixed/lib/rustlib/src/rust/library/core/src/panic/unwind_safe.rs:274:9
  76: do_call<core::panic::unwind_safe::AssertUnwindSafe<tokio::runtime::task::harness::poll_future::{closure_env#0}<tokio::runtime::blocking::task::BlockingTask<tokio::runtime::scheduler::multi_thread::worker::{impl#0}::launch::{closure_env#0}>, tokio::runtime::blocking::schedule::BlockingSchedule>>, core::task::poll::Poll<()>>
             at /nix/store/sbyxhn9dlw3iabbqq5v56q60c6xsfmnz-rust-mixed/lib/rustlib/src/rust/library/std/src/panicking.rs:581:40
  77: catch_unwind<core::task::poll::Poll<()>, core::panic::unwind_safe::AssertUnwindSafe<tokio::runtime::task::harness::poll_future::{closure_env#0}<tokio::runtime::blocking::task::BlockingTask<tokio::runtime::scheduler::multi_thread::worker::{impl#0}::launch::{closure_env#0}>, tokio::runtime::blocking::schedule::BlockingSchedule>>>
             at /nix/store/sbyxhn9dlw3iabbqq5v56q60c6xsfmnz-rust-mixed/lib/rustlib/src/rust/library/std/src/panicking.rs:544:19
  78: catch_unwind<core::panic::unwind_safe::AssertUnwindSafe<tokio::runtime::task::harness::poll_future::{closure_env#0}<tokio::runtime::blocking::task::BlockingTask<tokio::runtime::scheduler::multi_thread::worker::{impl#0}::launch::{closure_env#0}>, tokio::runtime::blocking::schedule::BlockingSchedule>>, core::task::poll::Poll<()>>
             at /nix/store/sbyxhn9dlw3iabbqq5v56q60c6xsfmnz-rust-mixed/lib/rustlib/src/rust/library/std/src/panic.rs:359:14
  79: poll_future<tokio::runtime::blocking::task::BlockingTask<tokio::runtime::scheduler::multi_thread::worker::{impl#0}::launch::{closure_env#0}>, tokio::runtime::blocking::schedule::BlockingSchedule>
             at /home/jumoell/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.48.0/src/runtime/task/harness.rs:523:18
  80: poll_inner<tokio::runtime::blocking::task::BlockingTask<tokio::runtime::scheduler::multi_thread::worker::{impl#0}::launch::{closure_env#0}>, tokio::runtime::blocking::schedule::BlockingSchedule>
             at /home/jumoell/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.48.0/src/runtime/task/harness.rs:210:27
  81: poll<tokio::runtime::blocking::task::BlockingTask<tokio::runtime::scheduler::multi_thread::worker::{impl#0}::launch::{closure_env#0}>, tokio::runtime::blocking::schedule::BlockingSchedule>
             at /home/jumoell/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.48.0/src/runtime/task/harness.rs:155:20
  82: poll<tokio::runtime::blocking::task::BlockingTask<tokio::runtime::scheduler::multi_thread::worker::{impl#0}::launch::{closure_env#0}>, tokio::runtime::blocking::schedule::BlockingSchedule>
             at /home/jumoell/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.48.0/src/runtime/task/raw.rs:325:13
  83: poll
             at /home/jumoell/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.48.0/src/runtime/task/raw.rs:255:18
  84: run<tokio::runtime::blocking::schedule::BlockingSchedule>
             at /home/jumoell/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.48.0/src/runtime/task/mod.rs:546:13
  85: run
             at /home/jumoell/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.48.0/src/runtime/blocking/pool.rs:161:19
  86: run
             at /home/jumoell/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.48.0/src/runtime/blocking/pool.rs:516:22
  87: {closure#0}
             at /home/jumoell/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.48.0/src/runtime/blocking/pool.rs:474:47
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
2026-05-19T20:44:44.016083Z  INFO fm::task: Task shut down uncleanly name=output-scanner
```

</details>