### PR TITLE
test(devimint): assert invite_code endpoint reflects guardian metadata override

### DIFF
--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -1083,8 +1083,14 @@ pub async fn cli_tests(dev_fed: DevFed) -> Result<()> {
 }
 
 pub async fn guardian_metadata_tests(dev_fed: DevFed) -> Result<()> {
+    use fedimint_api_client::api::{DynGlobalApi, FederationApiExt};
+    use fedimint_connectors::ConnectorRegistry;
     use fedimint_core::PeerId;
+    use fedimint_core::endpoint_constants::INVITE_CODE_ENDPOINT;
+    use fedimint_core::invite_code::InviteCode;
+    use fedimint_core::module::ApiRequestErased;
     use fedimint_core::net::guardian_metadata::SignedGuardianMetadata;
+    use fedimint_core::util::SafeUrl;
 
     log_binary_versions().await?;
 
@@ -1194,6 +1200,34 @@ pub async fn guardian_metadata_tests(dev_fed: DevFed) -> Result<()> {
     assert_eq!(
         metadata.pkarr_id_z32, TEST_PKARR_ID,
         "Pkarr ID did not propagate correctly"
+    );
+
+    info!("Checking invite_code endpoint reflects overridden guardian metadata URL...");
+    // Connect directly to peer 0 via its real configured URL — `dev api --peer-id
+    // 0` would resolve through the client's propagated peer-URL map, which now
+    // points at the fake TEST_API_URL and would fail to connect.
+    let peer_id = PeerId::from(0);
+    let peer0_real_url: SafeUrl = fed
+        .vars
+        .get(&0)
+        .expect("peer 0 vars must exist")
+        .FM_API_URL
+        .parse()
+        .expect("FM_API_URL must be a valid SafeUrl");
+    let connectors = ConnectorRegistry::build_from_testing_env()?.bind().await?;
+    let admin_api = DynGlobalApi::new_admin(connectors, peer_id, peer0_real_url, None)?;
+    let invite: InviteCode = admin_api
+        .request_single_peer(
+            INVITE_CODE_ENDPOINT.to_string(),
+            ApiRequestErased::default(),
+            peer_id,
+        )
+        .await
+        .expect("invite_code RPC request should succeed");
+    assert_eq!(
+        invite.url().to_string(),
+        TEST_API_URL,
+        "invite_code endpoint did not reflect overridden guardian metadata URL"
     );
 
     Ok(())

--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -36,7 +36,7 @@ use crate::cli::{CommonArgs, cleanup_on_exit, exec_user_command, setup};
 use crate::envs::{FM_DATA_DIR_ENV, FM_DEVIMINT_RUN_DEPRECATED_TESTS_ENV, FM_PASSWORD_ENV};
 use crate::federation::Client;
 use crate::util::{LoadTestTool, ProcessManager, almost_equal, poll};
-use crate::version_constants::{VERSION_0_10_0_ALPHA, VERSION_0_11_0_ALPHA};
+use crate::version_constants::{VERSION_0_10_0_ALPHA, VERSION_0_11_0_ALPHA, VERSION_0_12_0_ALPHA};
 use crate::{DevFed, Gatewayd, LightningNode, Lnd, cmd, dev_fed};
 
 pub struct Stats {
@@ -1202,10 +1202,16 @@ pub async fn guardian_metadata_tests(dev_fed: DevFed) -> Result<()> {
         "Pkarr ID did not propagate correctly"
     );
 
+    // `invite_code` only honors overridden API URLs since 0.12.0-alpha; skip
+    // against older fedimintd in backwards-compatibility tests.
+    if fedimintd_version < *VERSION_0_12_0_ALPHA {
+        info!("Skipping invite_code endpoint assertion: fedimintd < 0.12.0-alpha");
+        return Ok(());
+    }
+
     info!("Checking invite_code endpoint reflects overridden guardian metadata URL...");
-    // Connect directly to peer 0 via its real configured URL — `dev api --peer-id
-    // 0` would resolve through the client's propagated peer-URL map, which now
-    // points at the fake TEST_API_URL and would fail to connect.
+    // Query peer 0 directly: the client's peer-URL map now points at the fake
+    // override URL, so `dev api --peer-id 0` would fail to connect.
     let peer_id = PeerId::from(0);
     let peer0_real_url: SafeUrl = fed
         .vars

--- a/devimint/src/version_constants.rs
+++ b/devimint/src/version_constants.rs
@@ -6,3 +6,5 @@ pub static VERSION_0_10_0_ALPHA: LazyLock<Version> =
     LazyLock::new(|| Version::parse("0.10.0-alpha").expect("version is parsable"));
 pub static VERSION_0_11_0_ALPHA: LazyLock<Version> =
     LazyLock::new(|| Version::parse("0.11.0-alpha").expect("version is parsable"));
+pub static VERSION_0_12_0_ALPHA: LazyLock<Version> =
+    LazyLock::new(|| Version::parse("0.12.0-alpha").expect("version is parsable"));


### PR DESCRIPTION
Follow-up to #8618.

Asserts the `invite_code` endpoint reflects an override applied via `sign-guardian-metadata`. Connects directly to peer 0's configured URL via `DynGlobalApi::new_admin` — `dev api --peer-id 0` would route through the client's peer-URL map, which the test has just propagated to a dummy URL

Not included, `sign-api-announcement` path — shadowed by guardian metadata in `get_api_urls`.

Testing
- `./scripts/tests/guardian-metadata-test.sh` passes locally
- `just final-lint` clean