### PR TITLE
fix(gateway): cancel unmatched federation HTLCs instead of forwarding

### DIFF
--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -1049,8 +1049,11 @@ impl Gateway {
 
     /// Handles an intercepted lightning payment. If the payment is part of an
     /// incoming payment to a federation, spawns a state machine and hands the
-    /// payment off to it. Otherwise, forwards the payment to the next hop like
-    /// a normal lightning node.
+    /// payment off to it. If the payment's last-hop short channel id maps to
+    /// a known federation but no LNv1 or LNv2 offer matched, cancels (fails
+    /// back) the HTLC so the sender can retry rather than treating the
+    /// gateway as a dead route. Otherwise (real-channel forwards), resumes
+    /// the HTLC so LND can route it as a normal forward.
     ///
     /// Returns the outcome label for metrics tracking.
     async fn handle_lightning_payment(
@@ -1106,8 +1109,27 @@ impl Gateway {
             return "lnv1";
         }
 
-        Self::forward_lightning_payment(payment_request, lightning_context).await;
-        "forward"
+        // Neither LNv1 nor LNv2 matched. If the last-hop scid is one of our
+        // federation virtual scids, cancel so the sender gets a non-permanent
+        // failure (avoiding `UNKNOWN_NEXT_PEER` blacklisting). If the scid is
+        // for a real channel, resume so LND forwards normally.
+        let is_federation_scid = match payment_request.short_channel_id {
+            Some(scid) => self
+                .federation_manager
+                .read()
+                .await
+                .get_client_for_index(scid)
+                .is_some(),
+            None => false,
+        };
+
+        if is_federation_scid {
+            Self::cancel_unmatched_lightning_payment(payment_request, lightning_context).await;
+            "cancel"
+        } else {
+            Self::forward_lightning_payment(payment_request, lightning_context).await;
+            "forward"
+        }
     }
 
     /// Tries to handle a lightning payment using the LNv2 protocol.
@@ -1209,9 +1231,39 @@ impl Gateway {
             .await
     }
 
+    /// Cancels (fails back) a lightning payment whose last-hop scid maps to a
+    /// known federation but matched no LNv1 or LNv2 offer.
+    ///
+    /// Returning `PaymentAction::Forward` here would tell LND to resume the
+    /// HTLC as a normal forward, but the last-hop short channel id is a
+    /// virtual scid (no real channel exists), so LND would fail it back with
+    /// the permanent error `UNKNOWN_NEXT_PEER`. Senders' mission control
+    /// treats that as a permanent blacklist signal against the gateway,
+    /// breaking future payments across all federations.
+    ///
+    /// `PaymentAction::Cancel` maps to `ResolveHoldForwardAction::Fail`, which
+    /// fails the HTLC back with a non-permanent reason so the sender can
+    /// retry instead of blacklisting the gateway.
+    async fn cancel_unmatched_lightning_payment(
+        htlc_request: InterceptPaymentRequest,
+        lightning_context: &LightningContext,
+    ) {
+        let outcome = InterceptPaymentResponse {
+            action: PaymentAction::Cancel,
+            payment_hash: htlc_request.payment_hash,
+            incoming_chan_id: htlc_request.incoming_chan_id,
+            htlc_id: htlc_request.htlc_id,
+        };
+
+        if let Err(err) = lightning_context.lnrpc.complete_htlc(outcome).await {
+            warn!(target: LOG_GATEWAY, err = %err.fmt_compact(), "Error sending lightning payment response to lightning node");
+        }
+    }
+
     /// Forwards a lightning payment to the next hop like a normal lightning
-    /// node. Only necessary for LNv1, since LNv2 uses hold invoices instead
-    /// of HTLC interception for routing incoming payments.
+    /// node. Used when the intercepted HTLC is not destined for any federation
+    /// this gateway serves, so LND should route it normally over a real
+    /// channel.
     async fn forward_lightning_payment(
         htlc_request: InterceptPaymentRequest,
         lightning_context: &LightningContext,


### PR DESCRIPTION
## Summary

LND's HTLC interceptor forwards every HTLC to gatewayd, including normal Lightning forwards over real channels. When neither LNv1 nor LNv2 matched, gatewayd previously returned `PaymentAction::Forward` unconditionally, which maps to `ResolveHoldForwardAction::Resume` in LND.

For HTLCs whose last-hop scid is one of the gateway's virtual federation scids (no real channel), LND then fails the HTLC back with `UNKNOWN_NEXT_PEER` — a *permanent* BOLT-04 failure code. The correct response when the gateway can't honour an HTLC (because no `LightningOutputV0::Offer` matches the `payment_hash`) is a non-permanent failure like `INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS`. Today the gateway returns the wrong shape of failure, polluting sender mission control with permanent-failure entries against the gateway hop.

The trigger condition in practice is **pre-payment probes**: probing wallets construct probe HTLCs with synthetic `payment_hash`es that no federation offer can ever match, so every probe through an LNv1 Fedimint gateway today produces an `UNKNOWN_NEXT_PEER`. Different wallet strategies handle this differently; the user-visible outcome is non-deterministic but materially bad.

### Measured impact on a production gateway

Live tests with Blink → Henwen (LNv1) → Marigold federation, all 10 sat:

| | Outcome | What Blink did |
|---|---|---|
| 6 attempts | 3 SUCCESS / 3 FAIL | parallel probe + real on different channels → success; probe alone on one channel → failure |

3/6 attempts (50%) failed entirely — probe got `UNKNOWN_NEXT_PEER`, no follow-up real-payment HTLC sent. The original user-reported failure (`Unable to find a route for payment`) was one such case.

### What good looks like — the Beefy comparison

Same wallet, same federation, same amount, but a different gateway (Beefy):

- No probe HTLC at all.
- One real-payment HTLC, settled in <200 ms.

The reason isn't earned reputation. Blink has Beefy on an explicit allowlist that was set up specifically to bypass this exact probing problem. That mitigation worked for one gateway but is the wrong long-term answer — every new Fedimint gateway has to be individually whitelisted by every probing wallet, and until that's done it sees the 50% failure rate that Henwen has today. This PR fixes the underlying wrong-failure-code so no whitelisting is needed.

### Code change

This PR splits the fallback path based on whether the last-hop scid maps to a known federation:

- **Federation scid with no matching offer** → `PaymentAction::Cancel` (maps to `ResolveHoldForwardAction::Fail`) so the HTLC fails back with a non-permanent reason. Probes that hit the gateway will then see the appropriate failure code, and senders' mission control records the right kind of entry.
- **Any other scid (real channel)** → keep returning `PaymentAction::Forward` so LND continues to route non-Fedimint traffic normally.

Full investigation, code references, and reproduction traces: https://gist.github.com/douglaz/944a703a93bea36682085068c218c03f

## Changes

- Add `cancel_unmatched_lightning_payment` helper alongside the existing `forward_lightning_payment`.
- Branch `handle_lightning_payment` on `federation_manager.get_client_for_index(scid).is_some()` after both LNv1 and LNv2 attempts fail.
- Emit a new `"cancel"` metric label on `HTLC_HANDLING_DURATION_SECONDS` for the federation-scid case (existing `"forward"` label still used for real-channel forwards).
- Update doc comments to reflect the new behavior.

## Test plan

- [x] `cargo check -p fedimint-gateway-server`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt -p fedimint-gateway-server --check`
- [ ] Integration test on a devimint environment with an unmatched-offer HTLC: confirm LND returns a non-permanent failure reason rather than `UNKNOWN_NEXT_PEER`.
- [ ] Integration test on a node also acting as a normal Lightning router: confirm non-Fedimint forwards still complete.
- [ ] Repeat the live Blink reproduction post-deploy: confirm probe HTLCs return non-permanent failures and Blink stops probe-and-give-up failures.

## Notes

Companion fixes worth considering (not in this PR):

- Reduce the `fetch_and_validate_offer` 5 s timeout drastically — synthetic probe hashes will *never* materialise as `OfferKey`s in federation consensus, so waiting only adds latency.
- Log every interceptor verdict (settle / cancel / forward) at INFO with `payment_hash` and `federation_id`.
- Add a `gateway_interceptor_verdict_total{outcome, federation_id}` metric.

Behavioral assertions still need on-network verification, but the change compiles cleanly and passed an independent `codex review` pass.
