### PR TITLE
chore(gateway): log lnv1/lnv2 error variants when cancelling unmatched HTLC

### DIFF
--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -1124,9 +1124,30 @@ impl Gateway {
         };
 
         if is_federation_scid {
+            // The HTLC targeted a federation we serve but we couldn't claim
+            // it (no LNv1 offer / no LNv2 contract / underfunded gateway /
+            // federation timeout / etc.). Surface the underlying error
+            // variants so operators can diagnose the cause; otherwise both
+            // `Err` values are dropped on the floor and the only visible
+            // signal is the metric label `"error"`.
+            warn!(
+                target: LOG_GATEWAY,
+                payment_hash = %payment_request.payment_hash,
+                short_channel_id = ?payment_request.short_channel_id,
+                amount_msat = payment_request.amount_msat,
+                incoming_chan_id = payment_request.incoming_chan_id,
+                htlc_id = payment_request.htlc_id,
+                lnv2_err = ?lnv2_result.as_ref().err(),
+                lnv1_err = ?lnv1_result.as_ref().err(),
+                "Unmatched lightning payment for federation scid: cancelling HTLC",
+            );
             Self::cancel_unmatched_lightning_payment(payment_request, lightning_context).await;
             "cancel"
         } else {
+            // Normal route-through traffic: the gateway's LND interceptor
+            // sees every HTLC, but only federation-scid HTLCs are ours to
+            // handle. Resume so LND forwards the rest as a regular routing
+            // node — no warning needed since this is the expected path.
             Self::forward_lightning_payment(payment_request, lightning_context).await;
             "forward"
         }


### PR DESCRIPTION
## Why

After PR #8625 the gateway correctly cancels HTLCs whose last-hop scid maps to a federation it serves but neither LNv1 nor LNv2 could claim. That fixes the `UNKNOWN_NEXT_PEER` failure mode, but it leaves operators blind to the *cause* of the cancellation: both `try_handle_lightning_payment_lnv2` and `try_handle_lightning_payment_ln_legacy` return rich `Err` values, and the previous code dropped them on the floor. The only externally-visible signal is the metric label `"error"` on `HTLC_LNV{1,2}_ATTEMPT_DURATION_SECONDS` — not enough to distinguish e.g. a missing offer from an underfunded gateway or a federation timeout.

This came up while diagnosing a live incident where multiple legitimate ~1.5M-sat payments from WoS to a Fedi user were failing on a Beefy-served federation. The bug-fix path was firing as expected (clean `Cancel` instead of `UnknownNextPeer`), but neither the live logs nor the persisted state machine DB revealed why the gw_client returned `Err` — the SM was never persisted because the error happened in `create_funding_incoming_contract_output_from_htlc`, before `finalize_and_submit_transaction`. The federation's offer endpoint confirmed the offer was registered correctly and amounts matched; the most likely cause turned out to be `InsufficientBalanceError` during contract funding, which we couldn't confirm without instrumenting.

## What

One `warn!` on the federation-scid cancel path that includes:

- `payment_hash`
- `short_channel_id`
- `amount_msat`
- `incoming_chan_id`
- `htlc_id`
- `lnv2_err` — debug-formatted `Err` from the LNv2 attempt
- `lnv1_err` — debug-formatted `Err` from the LNv1 attempt

## What this does *not* do

The `forward_lightning_payment` branch (normal route-through traffic) is left silent. The gateway's LND interceptor sees *every* HTLC and the gateway is supposed to resume the ones whose scid is a real channel — LNv1/LNv2 mismatch is the expected outcome there, so warning on every forwarded HTLC would be noisy and misleading. Codex review caught an earlier version of this PR that did warn on the forward branch; that's been corrected.

No control-flow or data-handling changes. Pure observability.

## Test plan

- `cargo check -p fedimint-gateway-server` — clean
- Visual inspection: warning fires only on `is_federation_scid == true` branch
- Will deploy alongside the same gatewayd image rollout that's bringing PR #8625 to operators