### PR TITLE
feat(dev): report binary sizes in compilation bench

### DIFF
--- a/scripts/bench-compilation.sh
+++ b/scripts/bench-compilation.sh
@@ -45,7 +45,51 @@ fi
 time_pipe_path="$CARGO_BUILD_TARGET_DIR/time.out"
 time_fmt='%e\t%U\t%S'
 
-echo -e "                       total    user     sys"
+bin_path() {
+  local profile=$1
+  local bin=$2
+  local target_profile=$profile
+
+  if [ "$target_profile" = "dev" ]; then
+    target_profile="debug"
+  fi
+
+  echo "$CARGO_BUILD_TARGET_DIR/$target_profile/$bin"
+}
+
+bin_size() {
+  local profile=$1
+  local bin=$2
+  local path
+
+  path=$(bin_path "$profile" "$bin")
+
+  if [ -f "$path" ]; then
+    stat --printf=%s "$path"
+  else
+    echo "-"
+  fi
+}
+
+print_result() {
+  local command=$1
+  local profile=$2
+  local fedimintd_size=-
+  local fedimint_cli_size=-
+
+  if [ "$command" = "build" ]; then
+    fedimintd_size=$(bin_size "$profile" fedimintd)
+    fedimint_cli_size=$(bin_size "$profile" fedimint-cli)
+  fi
+
+  awk \
+    -v fedimintd_size="$fedimintd_size" \
+    -v fedimint_cli_size="$fedimint_cli_size" \
+    'BEGIN {FS="\t"} {printf "%8.2f%8.2f%8.2f%12s%16s\n", $1, $2, $3, fedimintd_size, fedimint_cli_size}' \
+    < "$time_pipe_path"
+}
+
+echo -e "                       total    user     sys   fedimintd    fedimint-cli"
 for profile in dev release ; do
   for command in check build ; do
 
@@ -71,14 +115,14 @@ for profile in dev release ; do
       printf "Full %6s %7s:" "$command" "$profile_human"
       command time --format="$time_fmt" -o "$time_pipe_path" -- \
         cargo $command --profile $profile -q  1>"$cmd_out_path" 2>&1
-      awk 'BEGIN {FS="\t"} {printf "%8.2f%8.2f%8.2f\n", $1, $2, $3}' < "$time_pipe_path"
+      print_result "$command" "$profile"
     fi
 
     printf "Incr %6s %7s:" "$command" "$profile_human"
     find "${BENCH_COMP_TOUCH_DIR:-fedimint-core}" -type f -exec touch {} +
     command time --format="$time_fmt" -o "$time_pipe_path" -- \
       cargo $command --profile $profile -q 1>"$cmd_out_path" 2>&1
-    awk 'BEGIN {FS="\t"} {printf "%8.2f%8.2f%8.2f\n", $1, $2, $3}' < "$time_pipe_path"
+    print_result "$command" "$profile"
 
   done
 done


### PR DESCRIPTION
Report the fedimintd and fedimint-cli binary sizes next to the existing compilation timing columns. Sizes are emitted in bytes for build rows, while check rows show '-' because cargo check does not produce binaries.

This makes just bench-compilation capture the binary size output needed to compare generated artifacts alongside compilation timings.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
