### PR TITLE
chore(ci): prevent script injection via PR title in claude-review

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -168,6 +168,8 @@ jobs:
           fi
 
       - name: Build review prompt
+        env:
+          PR_TITLE: ${{ steps.pr.outputs.title }}
         run: |
           IS_CONSENSUS="${{ steps.changed.outputs.consensus }}"
           TRUNCATED="${{ steps.diff.outputs.truncated }}"
@@ -199,11 +201,12 @@ jobs:
           PROMPT_HEADER
 
           # PR metadata
-          cat >> /tmp/review_prompt.txt <<PROMPT_META
+          cat >> /tmp/review_prompt.txt <<'PROMPT_META'
 
-          PR Title: ${{ steps.pr.outputs.title }}
-          Consensus-critical files changed: ${IS_CONSENSUS}
+          PR metadata:
           PROMPT_META
+          printf 'PR Title: %s\n' "$PR_TITLE" >> /tmp/review_prompt.txt
+          printf 'Consensus-critical files changed: %s\n' "$IS_CONSENSUS" >> /tmp/review_prompt.txt
 
           # Conditional instructions
           if [ "$IS_CONSENSUS" = "true" ]; then


### PR DESCRIPTION
## Summary
- The `claude-review` workflow interpolated `${{ steps.pr.outputs.title }}` directly inside a `bash` heredoc when building the review prompt. A PR title containing `$(...)`, backticks, or `${...}` would be expanded by the shell at heredoc-time, letting anyone who can open a PR execute arbitrary code on the runner.
- Route the title through a `PR_TITLE` env var (the standard GHA mitigation for untrusted-input → shell injection), switch the metadata heredoc to single-quoted (`'PROMPT_META'`) so nothing inside is expanded, and append the title/consensus values via `printf "%s" "$PR_TITLE"`. Continues the security-hardening series from #8549.

## Test plan
- [ ] Workflow YAML still parses (CI lint / actionlint).
- [ ] Trigger `claude-review` on a PR with a benign title and confirm the generated prompt still contains `PR Title: …` and `Consensus-critical files changed: …`.
- [ ] Trigger `claude-review` on a PR whose title contains `$(id)` and confirm the literal string ends up in the prompt rather than being executed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)