### PR TITLE
test(mint): add regression test for duplicate blind nonce

### DIFF
--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -203,6 +203,62 @@ async fn blind_nonce_index() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn duplicate_blind_nonce_index() -> anyhow::Result<()> {
+    // Give client initial balance
+    let fed = fixtures().new_fed_degraded().await;
+    let client = fed.new_client().await;
+    issue_ecash(&client, sats(1000)).await?;
+
+    // Issue e-cash and duplicate the output bundle to test the duplicate blind nonce panic fix
+    let client_mint = client.get_first_module::<MintClientModule>()?;
+
+    let mut dbtx = client_mint.db.begin_transaction().await;
+    let operation_id = OperationId::new_random();
+    let issuance_req = client_mint
+        .create_output(&mut dbtx.to_ref_nc(), operation_id, 1, Amount::from_sats(1))
+        .await;
+    dbtx.commit_tx().await;
+
+    let blind_nonce = issuance_req
+        .outputs()
+        .first()
+        .expect("There should be at least one note in here")
+        .output
+        .ensure_v0_ref()?
+        .blind_nonce;
+
+    assert!(
+        !client_mint.api.check_blind_nonce_used(blind_nonce).await?,
+        "Blind nonce should not be used yet"
+    );
+
+    // Create a duplicate output bundle without state machines to avoid client-side state machine duplicate panic
+    let duplicate_bundle = fedimint_client_module::transaction::ClientOutputBundle::new_no_sm(issuance_req.outputs().to_vec());
+
+    let tx = TransactionBuilder::new()
+        .with_outputs(client_mint.client_ctx.make_dyn(issuance_req))
+        .with_outputs(client_mint.client_ctx.make_dyn(duplicate_bundle));
+
+    let change_range = client_mint
+        .client_ctx
+        .finalize_and_submit_transaction(operation_id, "mint", |_| (), tx)
+        .await?;
+
+    let await_res = client
+        .transaction_updates(operation_id)
+        .await
+        .await_tx_accepted(change_range.txid())
+        .await;
+
+    assert!(
+        await_res.is_err(),
+        "Transaction with duplicate blind nonce index should not be accepted"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 #[ignore] // TODO: flaky https://github.com/fedimint/fedimint/issues/4508
 async fn sends_ecash_oob_highly_parallel() -> anyhow::Result<()> {
     // Give client1 initial balance

--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -233,12 +233,17 @@ async fn duplicate_blind_nonce_index() -> anyhow::Result<()> {
     );
 
     // Create a duplicate output bundle without state machines to avoid client-side state machine duplicate panic
-    let duplicate_bundle = fedimint_client_module::transaction::ClientOutputBundle::new_no_sm(issuance_req.outputs().to_vec());
+    let outputs_vec = issuance_req.outputs().to_vec();
+    let duplicate_bundle =
+        fedimint_client_module::transaction::ClientOutputBundle::new_no_sm(outputs_vec);
 
     let tx = TransactionBuilder::new()
         .with_outputs(client_mint.client_ctx.make_dyn(issuance_req))
         .with_outputs(client_mint.client_ctx.make_dyn(duplicate_bundle));
 
+    // Since we stripped the state machines from the duplicate bundle, the client
+    // won't panic locally. This submission should succeed client-side and properly
+    // reach the federation, where it will be rejected server-side.
     let change_range = client_mint
         .client_ctx
         .finalize_and_submit_transaction(operation_id, "mint", |_| (), tx)

--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -249,15 +249,16 @@ async fn duplicate_blind_nonce_index() -> anyhow::Result<()> {
         .finalize_and_submit_transaction(operation_id, "mint", |_| (), tx)
         .await?;
 
-    let await_res = client
+    client
         .transaction_updates(operation_id)
         .await
         .await_tx_accepted(change_range.txid())
-        .await;
+        .await
+        .expect("Transaction with duplicate blind nonce should be accepted (money burned)");
 
     assert!(
-        await_res.is_err(),
-        "Transaction with duplicate blind nonce index should not be accepted"
+        client_mint.api.check_blind_nonce_used(blind_nonce).await?,
+        "Blind nonce should be marked as used after being processed"
     );
 
     Ok(())
@@ -1219,6 +1220,81 @@ async fn test_send_oob_notes() -> anyhow::Result<()> {
             .send_oob_notes(Amount::from_sats(100), ())
             .await?;
     }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_migrate_db_v2_duplicate_blind_nonce() -> anyhow::Result<()> {
+    use fedimint_core::OutPoint;
+    use fedimint_core::core::ModuleInstanceId;
+    use fedimint_core::db::mem_impl::MemDatabase;
+    use fedimint_core::db::{Database, DatabaseTransaction};
+    use fedimint_core::module::registry::ModuleDecoderRegistry;
+    use fedimint_core::transaction::TransactionId;
+    use fedimint_core::util::BoxStream;
+    use fedimint_mint_common::{BlindNonce, MintOutput, MintOutputV0};
+    use fedimint_mint_server::MintInit;
+    use fedimint_server_core::ServerModuleInit;
+    use fedimint_server_core::migration::{
+        DynModuleHistoryItem, IServerDbMigrationContext, apply_migrations_server,
+    };
+    use std::sync::Arc;
+    use tbs::{BlindingKey, Message, blind_message};
+
+    struct MockServerDbMigrationContext {
+        history: Vec<DynModuleHistoryItem>,
+    }
+
+    #[async_trait::async_trait]
+    impl IServerDbMigrationContext for MockServerDbMigrationContext {
+        async fn get_module_history_stream<'s, 'tx>(
+            &'s self,
+            _module_id: ModuleInstanceId,
+            _dbtx: &'s mut DatabaseTransaction<'tx>,
+        ) -> BoxStream<'s, DynModuleHistoryItem> {
+            Box::pin(futures::stream::iter(self.history.clone()))
+        }
+    }
+
+    let blinding_key = BlindingKey::random();
+    let message = Message::from_bytes(&[0; 8]);
+    let blinded_message = blind_message(message, blinding_key);
+    let blind_nonce = BlindNonce(blinded_message);
+
+    let output1 = MintOutput::V0(MintOutputV0 {
+        amount: fedimint_core::Amount::from_sats(1),
+        blind_nonce,
+    });
+    let output2 = MintOutput::V0(MintOutputV0 {
+        amount: fedimint_core::Amount::from_sats(2),
+        blind_nonce,
+    });
+
+    let txid = TransactionId::from_slice(&[0; 32]).unwrap();
+
+    let history = vec![
+        DynModuleHistoryItem::Output(
+            fedimint_core::core::DynOutput::from_typed(0, output1),
+            OutPoint { txid, out_idx: 0 },
+        ),
+        DynModuleHistoryItem::Output(
+            fedimint_core::core::DynOutput::from_typed(0, output2),
+            OutPoint { txid, out_idx: 1 },
+        ),
+    ];
+
+    let ctx = Arc::new(MockServerDbMigrationContext { history })
+        as Arc<dyn IServerDbMigrationContext + Send + Sync>;
+    let decoders = ModuleDecoderRegistry::from_iter([(0, MintInit::kind(), MintInit.decoder())]);
+    let db = Database::new(MemDatabase::new(), decoders);
+
+    let migrations = MintInit.get_database_migrations();
+
+    // Applying migrations up to v2, which should run migrate_db_v2.
+    // If the panic is not fixed, this will panic because the duplicate
+    // blind nonce will trigger `insert_new_entry` failure.
+    apply_migrations_server(ctx, &db, "mint".to_string(), migrations).await?;
 
     Ok(())
 }


### PR DESCRIPTION
### summary
fixes #8582
adds a regression test for the duplicate blind nonce panic fixed in v0.11.1.
### details
this pr adds test coverage for the duplicate blind nonce paths. the bug, which caused the guardian to panic on duplicate blind nonces due to incorrect usage of `insert_new_entry`, was fixed in v0.11.1 but lacked regression tests.

this pr adds:
1. `test_migrate_db_v2_duplicate_blind_nonce`: tests the migration backfill panic by synthetically mocking a module history containing duplicate blind nonces and applying `migrate_db_v2`.
2. `duplicate_blind_nonce_index`: drives the live duplicate path end-to-end via `finalize_and_submit_transaction` with two outputs sharing a blind nonce. it asserts that the guardian does not panic, the transaction successfully transitions to an accepted state (exercising the "money was burned" warning path), and `check_blind_nonce_used` correctly returns true.

run `cargo test -p fedimint-mint-tests duplicate_blind_nonce` to check.