### PR TITLE
feat(server-ui): show fedimintd version and git hash in footer

### DIFF
--- a/fedimint-core/src/version.rs
+++ b/fedimint-core/src/version.rs
@@ -12,3 +12,13 @@ pub fn cargo_pkg() -> &'static str {
 pub fn git_hash() -> &'static str {
     option_env!("FEDIMINT_BUILD_CODE_VERSION").unwrap_or("0000000000000000000000000000000000000001")
 }
+
+/// Returns the version hash if it is meaningful (i.e. not all zeros, which
+/// `fedimint-build` substitutes when no git information is available).
+pub fn non_zero_version_hash(hash: &str) -> Option<&str> {
+    if hash.bytes().all(|b| b == b'0') {
+        None
+    } else {
+        Some(hash)
+    }
+}

--- a/fedimint-server-core/src/dashboard_ui.rs
+++ b/fedimint-server-core/src/dashboard_ui.rs
@@ -91,6 +91,10 @@ pub trait IDashboardApi {
     /// Get the fedimintd version
     async fn fedimintd_version(&self) -> String;
 
+    /// Get the git hash of the fedimintd binary, or `None` if it is not
+    /// available (e.g. it was built outside a git checkout).
+    async fn fedimintd_version_hash(&self) -> Option<String>;
+
     /// Change the guardian password
     async fn change_password(
         &self,

--- a/fedimint-server-core/src/setup_ui.rs
+++ b/fedimint-server-core/src/setup_ui.rs
@@ -62,6 +62,13 @@ pub trait ISetupApi {
     /// Returns the enabled modules, if set by any setup code
     async fn cfg_enabled_modules(&self) -> Option<BTreeSet<ModuleKind>>;
 
+    /// Get the fedimintd version
+    async fn fedimintd_version(&self) -> String;
+
+    /// Get the git hash of the fedimintd binary, or `None` if it is not
+    /// available (e.g. it was built outside a git checkout).
+    async fn fedimintd_version_hash(&self) -> Option<String>;
+
     /// Create a trait object
     fn into_dyn(self) -> DynSetupApi
     where

--- a/fedimint-server-ui/src/dashboard/consensus_explorer.rs
+++ b/fedimint-server-ui/src/dashboard/consensus_explorer.rs
@@ -136,8 +136,9 @@ pub async fn consensus_explorer_view(
     };
 
     let version = state.api.fedimintd_version().await;
+    let version_hash = state.api.fedimintd_version_hash().await;
 
-    Html(dashboard_layout(content, &version).into_string()).into_response()
+    Html(dashboard_layout(content, &version, version_hash.as_deref()).into_string()).into_response()
 }
 
 /// Format the type of consensus item for display

--- a/fedimint-server-ui/src/dashboard/mod.rs
+++ b/fedimint-server-ui/src/dashboard/mod.rs
@@ -21,7 +21,7 @@ use fedimint_ui_common::auth::UserAuth;
 use fedimint_ui_common::{
     CONNECTIVITY_CHECK_ROUTE, LOGIN_ROUTE, LoginInput, ROOT_ROUTE, UiState,
     connectivity_check_handler, dashboard_layout, login_form, login_submit_response,
-    single_card_layout,
+    single_card_layout_with_version,
 };
 use maud::html;
 use {
@@ -35,8 +35,18 @@ use crate::{
 };
 
 // Dashboard login form handler
-async fn login_form_handler() -> impl IntoResponse {
-    Html(single_card_layout("Enter Password", login_form(None)).into_string())
+async fn login_form_handler(State(state): State<UiState<DynDashboardApi>>) -> impl IntoResponse {
+    let version = state.api.fedimintd_version().await;
+    let version_hash = state.api.fedimintd_version_hash().await;
+    Html(
+        single_card_layout_with_version(
+            "Enter Password",
+            login_form(None),
+            &version,
+            version_hash.as_deref(),
+        )
+        .into_string(),
+    )
 }
 
 // Dashboard login submit handler
@@ -103,6 +113,15 @@ async fn change_password(
     Form(input): Form<crate::PasswordChangeInput>,
 ) -> impl IntoResponse {
     let api_auth = state.api.auth().await;
+    let version = state.api.fedimintd_version().await;
+    let version_hash = state.api.fedimintd_version_hash().await;
+    let render = |header: &str, content| {
+        Html(
+            single_card_layout_with_version(header, content, &version, version_hash.as_deref())
+                .into_string(),
+        )
+        .into_response()
+    };
 
     // Verify current password
     if !api_auth.verify(&input.current_password) {
@@ -110,8 +129,7 @@ async fn change_password(
             div class="alert alert-danger" { "Current password is incorrect" }
             a href="/" class="btn btn-primary w-100 py-2" { "Return to Dashboard" }
         };
-        return Html(single_card_layout("Password Change Failed", content).into_string())
-            .into_response();
+        return render("Password Change Failed", content);
     }
 
     // Verify new password confirmation
@@ -120,8 +138,7 @@ async fn change_password(
             div class="alert alert-danger" { "New passwords do not match" }
             a href="/" class="btn btn-primary w-100 py-2" { "Return to Dashboard" }
         };
-        return Html(single_card_layout("Password Change Failed", content).into_string())
-            .into_response();
+        return render("Password Change Failed", content);
     }
 
     // Check that new password is not empty
@@ -130,8 +147,7 @@ async fn change_password(
             div class="alert alert-danger" { "New password cannot be empty" }
             a href="/" class="btn btn-primary w-100 py-2" { "Return to Dashboard" }
         };
-        return Html(single_card_layout("Password Change Failed", content).into_string())
-            .into_response();
+        return render("Password Change Failed", content);
     }
 
     // Call the API to change the password
@@ -154,7 +170,7 @@ async fn change_password(
                 }
                 a href="/login" class="btn btn-primary w-100 py-2" { "Go to Login" }
             };
-            Html(single_card_layout("Password Changed", content).into_string()).into_response()
+            render("Password Changed", content)
         }
         Err(err) => {
             let content = html! {
@@ -163,8 +179,7 @@ async fn change_password(
                 }
                 a href="/" class="btn btn-primary w-100 py-2" { "Return to Dashboard" }
             };
-            Html(single_card_layout("Password Change Failed", content).into_string())
-                .into_response()
+            render("Password Change Failed", content)
         }
     }
 }
@@ -178,6 +193,7 @@ async fn dashboard_view(
     let federation_name = state.api.federation_name().await;
     let session_count = state.api.session_count().await;
     let fedimintd_version = state.api.fedimintd_version().await;
+    let fedimintd_version_hash = state.api.fedimintd_version_hash().await;
     let consensus_ord_latency = state.api.consensus_ord_latency().await;
     let p2p_connection_status = state.api.p2p_connection_status().await;
     let invite_code = state.api.federation_invite_code().await;
@@ -299,7 +315,15 @@ async fn dashboard_view(
         }
     };
 
-    Html(dashboard_layout(content, &fedimintd_version).into_string()).into_response()
+    Html(
+        dashboard_layout(
+            content,
+            &fedimintd_version,
+            fedimintd_version_hash.as_deref(),
+        )
+        .into_string(),
+    )
+    .into_response()
 }
 
 pub fn router(api: DynDashboardApi) -> Router {

--- a/fedimint-server-ui/src/setup.rs
+++ b/fedimint-server-ui/src/setup.rs
@@ -14,7 +14,7 @@ use fedimint_ui_common::auth::UserAuth;
 use fedimint_ui_common::{
     CONNECTIVITY_CHECK_ROUTE, LOGIN_ROUTE, LoginInput, ROOT_ROUTE, UiState,
     connectivity_check_handler, copiable_text, login_form, login_submit_response,
-    single_card_layout,
+    single_card_layout_with_version,
 };
 use maud::{Markup, PreEscaped, html};
 use qrcode::QrCode;
@@ -307,8 +307,19 @@ async fn setup_form(State(state): State<UiState<DynSetupApi>>) -> impl IntoRespo
     let available_modules = state.api.available_modules();
     let default_modules = state.api.default_modules();
     let content = setup_form_content(&available_modules, &default_modules);
+    let version = state.api.fedimintd_version().await;
+    let version_hash = state.api.fedimintd_version_hash().await;
 
-    Html(single_card_layout("Guardian Setup", content).into_string()).into_response()
+    Html(
+        single_card_layout_with_version(
+            "Guardian Setup",
+            content,
+            &version,
+            version_hash.as_deref(),
+        )
+        .into_string(),
+    )
+    .into_response()
 }
 
 // POST handler for the /setup route (process the setup form)
@@ -385,7 +396,18 @@ async fn login_form_handler(State(state): State<UiState<DynSetupApi>>) -> impl I
         return Redirect::to(ROOT_ROUTE).into_response();
     }
 
-    Html(single_card_layout("Enter Password", login_form(None)).into_string()).into_response()
+    let version = state.api.fedimintd_version().await;
+    let version_hash = state.api.fedimintd_version_hash().await;
+    Html(
+        single_card_layout_with_version(
+            "Enter Password",
+            login_form(None),
+            &version,
+            version_hash.as_deref(),
+        )
+        .into_string(),
+    )
+    .into_response()
 }
 
 // POST handler for the /login route (authenticate and set session cookie)
@@ -420,6 +442,8 @@ async fn federation_setup(
         .await
         .expect("Successful authentication ensures that the local parameters have been set");
 
+    let version = state.api.fedimintd_version().await;
+    let version_hash = state.api.fedimintd_version_hash().await;
     let connected_peers = state.api.connected_peers().await;
     let federation_size = state.api.federation_size().await;
     let cfg_federation_name = state.api.cfg_federation_name().await;
@@ -550,7 +574,16 @@ async fn federation_setup(
         }
     };
 
-    Html(single_card_layout("Federation Setup", content).into_string()).into_response()
+    Html(
+        single_card_layout_with_version(
+            "Federation Setup",
+            content,
+            &version,
+            version_hash.as_deref(),
+        )
+        .into_string(),
+    )
+    .into_response()
 }
 
 // POST handler for adding peer connection info
@@ -587,6 +620,8 @@ async fn post_start_dkg(
     _auth: UserAuth,
 ) -> impl IntoResponse {
     let our_connection_info = state.api.setup_code().await;
+    let version = state.api.fedimintd_version().await;
+    let version_hash = state.api.fedimintd_version_hash().await;
 
     match state.api.start_dkg().await {
         Ok(()) => {
@@ -623,7 +658,15 @@ async fn post_start_dkg(
 
             (
                 [("HX-Retarget", "body"), ("HX-Reswap", "innerHTML")],
-                Html(single_card_layout("DKG Started", content).into_string()),
+                Html(
+                    single_card_layout_with_version(
+                        "DKG Started",
+                        content,
+                        &version,
+                        version_hash.as_deref(),
+                    )
+                    .into_string(),
+                ),
             )
                 .into_response()
         }

--- a/fedimint-server/src/config/setup.rs
+++ b/fedimint-server/src/config/setup.rs
@@ -99,15 +99,27 @@ pub struct SetupApi {
     db: Database,
     /// Triggers the distributed key generation
     sender: Sender<ConfigGenParams>,
+    /// Version of the running fedimintd binary
+    code_version_str: String,
+    /// Git hash of the running fedimintd binary
+    code_version_hash: String,
 }
 
 impl SetupApi {
-    pub fn new(settings: ConfigGenSettings, db: Database, sender: Sender<ConfigGenParams>) -> Self {
+    pub fn new(
+        settings: ConfigGenSettings,
+        db: Database,
+        sender: Sender<ConfigGenParams>,
+        code_version_str: String,
+        code_version_hash: String,
+    ) -> Self {
         Self {
             settings,
             state: Arc::new(Mutex::new(SetupState::default())),
             db,
             sender,
+            code_version_str,
+            code_version_hash,
         }
     }
 
@@ -499,6 +511,14 @@ impl ISetupApi for SetupApi {
             .chain(local_setup_code.iter())
             .find_map(|info| info.enabled_modules.clone())
     }
+
+    async fn fedimintd_version(&self) -> String {
+        self.code_version_str.clone()
+    }
+
+    async fn fedimintd_version_hash(&self) -> Option<String> {
+        fedimint_core::version::non_zero_version_hash(&self.code_version_hash).map(str::to_owned)
+    }
 }
 
 #[async_trait]
@@ -624,6 +644,8 @@ mod tests {
             },
             MemDatabase::new().into_database(),
             sender,
+            String::new(),
+            String::new(),
         )
     }
 

--- a/fedimint-server/src/consensus/api.rs
+++ b/fedimint-server/src/consensus/api.rs
@@ -56,6 +56,7 @@ use fedimint_core::transaction::{
     SerdeTransaction, Transaction, TransactionError, TransactionSubmissionOutcome,
 };
 use fedimint_core::util::{FmtCompact, SafeUrl};
+use fedimint_core::version::non_zero_version_hash;
 use fedimint_core::{ChainId, OutPoint, OutPointRange, PeerId, TransactionId, secp256k1};
 use fedimint_logging::LOG_NET_API;
 use fedimint_server_core::bitcoin_rpc::ServerBitcoinRpcMonitor;
@@ -103,6 +104,7 @@ pub struct ConsensusApi {
     pub bitcoin_rpc_connection: ServerBitcoinRpcMonitor,
     pub supported_api_versions: SupportedApiVersionsSummary,
     pub code_version_str: String,
+    pub code_version_hash: String,
     pub task_group: TaskGroup,
 }
 
@@ -810,6 +812,10 @@ impl IDashboardApi for ConsensusApi {
 
     async fn fedimintd_version(&self) -> String {
         self.code_version_str.clone()
+    }
+
+    async fn fedimintd_version_hash(&self) -> Option<String> {
+        non_zero_version_hash(&self.code_version_hash).map(str::to_owned)
     }
 
     async fn change_password(

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -75,6 +75,7 @@ pub async fn run(
     force_api_secrets: ApiSecrets,
     data_dir: PathBuf,
     code_version_str: String,
+    code_version_hash: String,
     dyn_server_bitcoin_rpc: DynServerBitcoinRpc,
     ui_bind: SocketAddr,
     dashboard_ui_router: DashboardUiRouter,
@@ -206,6 +207,7 @@ pub async fn run(
         bitcoin_rpc_connection: bitcoin_rpc_connection.clone(),
         force_api_secret: force_api_secrets.get_active(),
         code_version_str,
+        code_version_hash,
         task_group: task_group.clone(),
     };
 

--- a/fedimint-server/src/lib.rs
+++ b/fedimint-server/src/lib.rs
@@ -92,6 +92,7 @@ pub async fn run(
     settings: ConfigGenSettings,
     db: Database,
     code_version_str: String,
+    code_version_hash: String,
     module_init_registry: ServerModuleInitRegistry,
     task_group: TaskGroup,
     bitcoin_rpc: DynServerBitcoinRpc,
@@ -146,6 +147,7 @@ pub async fn run(
                 db.clone(),
                 &task_group,
                 code_version_str.clone(),
+                code_version_hash.clone(),
                 force_api_secrets.clone(),
                 setup_ui_router,
                 module_init_registry.clone(),
@@ -189,6 +191,7 @@ pub async fn run(
         force_api_secrets,
         data_dir,
         code_version_str,
+        code_version_hash,
         bitcoin_rpc,
         settings.ui_bind,
         dashboard_ui_router,
@@ -238,6 +241,7 @@ pub async fn run_config_gen(
     db: Database,
     task_group: &TaskGroup,
     code_version_str: String,
+    code_version_hash: String,
     api_secrets: ApiSecrets,
     setup_ui_handler: SetupUiRouter,
     module_init_registry: ServerModuleInitRegistry,
@@ -252,7 +256,13 @@ pub async fn run_config_gen(
 
     let (cgp_sender, mut cgp_receiver) = tokio::sync::mpsc::channel(1);
 
-    let setup_api = SetupApi::new(settings.clone(), db.clone(), cgp_sender);
+    let setup_api = SetupApi::new(
+        settings.clone(),
+        db.clone(),
+        cgp_sender,
+        code_version_str.clone(),
+        code_version_hash,
+    );
 
     let mut rpc_module = RpcModule::new(setup_api.clone());
 

--- a/fedimint-testing/src/federation.rs
+++ b/fedimint-testing/src/federation.rs
@@ -392,6 +392,7 @@ impl FederationTestBuilder {
                     ApiSecrets::default(),
                     checkpoint_dir,
                     code_version_str.to_string(),
+                    String::new(),
                     bitcoin_rpc_connection,
                     ui_bind,
                     Box::new(|_| axum::Router::new()),

--- a/fedimint-ui-common/src/lib.rs
+++ b/fedimint-ui-common/src/lib.rs
@@ -94,18 +94,34 @@ pub struct LoginInput {
 }
 
 pub fn single_card_layout(header: &str, content: Markup) -> Markup {
-    card_layout("col-md-8 col-lg-5 narrow-container", header, content)
+    card_layout("col-md-8 col-lg-5 narrow-container", header, content, None)
 }
 
-fn card_layout(col_class: &str, header: &str, content: Markup) -> Markup {
+/// Variant of [`single_card_layout`] that renders a version footer at the
+/// bottom of the page.
+pub fn single_card_layout_with_version(
+    header: &str,
+    content: Markup,
+    version: &str,
+    version_hash: Option<&str>,
+) -> Markup {
+    card_layout(
+        "col-md-8 col-lg-5 narrow-container",
+        header,
+        content,
+        Some(version_footer(version, version_hash)),
+    )
+}
+
+fn card_layout(col_class: &str, header: &str, content: Markup, footer: Option<Markup>) -> Markup {
     html! {
         (DOCTYPE)
         html {
             head {
                 (common_head("Fedimint"))
             }
-            body class="d-flex align-items-center min-vh-100" {
-                div class="container" {
+            body class="d-flex flex-column min-vh-100" {
+                div class="container my-auto" {
                     div class="row justify-content-center" {
                         div class=(col_class) {
                             div class="card" {
@@ -116,6 +132,9 @@ fn card_layout(col_class: &str, header: &str, content: Markup) -> Markup {
                             }
                         }
                     }
+                }
+                @if let Some(footer) = footer {
+                    (footer)
                 }
                 (connectivity_widget())
                 script src="/assets/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous" {}
@@ -172,7 +191,7 @@ pub fn login_submit_response(
     Html(login_form(Some("The password is invalid")).into_string()).into_response()
 }
 
-pub fn dashboard_layout(content: Markup, version: &str) -> Markup {
+pub fn dashboard_layout(content: Markup, version: &str, version_hash: Option<&str>) -> Markup {
     html! {
         (DOCTYPE)
         html {
@@ -182,13 +201,26 @@ pub fn dashboard_layout(content: Markup, version: &str) -> Markup {
             body {
                 div class="container" {
                     (content)
-
-                    div class="text-center mt-4 mb-3" {
-                        span class="text-muted" { "Version " (version) }
-                    }
                 }
+                (version_footer(version, version_hash))
                 (connectivity_widget())
                 script src="/assets/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous" {}
+            }
+        }
+    }
+}
+
+/// Renders the version line shown at the bottom of guardian admin pages.
+/// `version_hash` is rendered next to the version in monospace when present.
+pub fn version_footer(version: &str, version_hash: Option<&str>) -> Markup {
+    html! {
+        div class="text-center mt-4 mb-3" {
+            span class="text-muted" { "Version " (version) }
+            @if let Some(hash) = version_hash {
+                @let short_hash: String = hash.chars().take(7).collect();
+                span class="text-muted ms-2 font-monospace" style="font-size: 0.85em;" {
+                    "(" (short_hash) ")"
+                }
             }
         }
     }

--- a/fedimintd/src/lib.rs
+++ b/fedimintd/src/lib.rs
@@ -410,6 +410,7 @@ pub async fn run(
     install_crypto_provider().await;
 
     let task_group = root_task_group.clone();
+    let code_version_hash = code_version_hash.to_string();
     root_task_group.spawn_cancellable("main", async move {
         fedimint_server::run(
             server_opts.data_dir,
@@ -417,6 +418,7 @@ pub async fn run(
             settings,
             db,
             code_version_str,
+            code_version_hash,
             module_init_registry,
             task_group,
             dyn_server_bitcoin_rpc,

--- a/gateway/fedimint-gateway-ui/src/lib.rs
+++ b/gateway/fedimint-gateway-ui/src/lib.rs
@@ -318,7 +318,7 @@ where
                     (err.to_string())
                 }
             };
-            return Html(dashboard_layout(content, &gatewayd_version).into_string())
+            return Html(dashboard_layout(content, &gatewayd_version, None).into_string())
                 .into_response();
         }
     };
@@ -407,7 +407,7 @@ where
         }
     };
 
-    Html(dashboard_layout(content, &gatewayd_version).into_string()).into_response()
+    Html(dashboard_layout(content, &gatewayd_version, None).into_string()).into_response()
 }
 
 async fn stop_gateway_handler<E>(


### PR DESCRIPTION
## Summary

- Plumb the build's git hash through `fedimintd::run` → `fedimint_server::run` → both `ConsensusApi` and `SetupApi`, and expose it via new trait methods on `IDashboardApi` / `ISetupApi`.
- Render a version footer (e.g. `Version 0.12.0-alpha (af13de9)`) at the bottom of every guardian admin page — setup form, federation setup, login, DKG started, dashboard, password change, consensus explorer. The hash is hidden when it's all zeros (build with no git info).
- Refactor the single-card body to `flex-column min-vh-100` + `my-auto` so the card stays vertically centered with the new footer pinned below it. Gateway UI is unchanged (passes `None` for the hash; no footer on its card pages).

Closes #8638.

## Test plan

- [x] `just clippy`
- [x] `just format`
- [x] Visually verified setup page footer (pre-DKG) and dashboard footer (post-DKG) via devimint.