### PR TITLE
feat(iroh): use elsirion relays as default when none configured

### DIFF
--- a/fedimint-core/src/net/iroh.rs
+++ b/fedimint-core/src/net/iroh.rs
@@ -8,12 +8,18 @@ use iroh::discovery::pkarr::{PkarrPublisher, PkarrResolver};
 use iroh::{Endpoint, RelayMode, RelayNode, RelayUrl, SecretKey};
 use iroh_relay::RelayQuicConfig;
 use tracing::{debug, info, warn};
+use url::Url;
 
 use crate::envs::{
     FM_IROH_DHT_ENABLE_ENV, FM_IROH_N0_DISCOVERY_ENABLE_ENV, FM_IROH_PKARR_PUBLISHER_ENABLE_ENV,
     FM_IROH_PKARR_RESOLVER_ENABLE_ENV, FM_IROH_RELAYS_ENABLE_ENV, is_env_var_set,
     is_env_var_set_opt,
 };
+
+const DEFAULT_IROH_RELAYS: [&str; 2] = [
+    "https://euc1-1.relay.elsirion.fedimint.iroh.link/",
+    "https://use1-1.relay.elsirion.fedimint.iroh.link/",
+];
 
 pub async fn build_iroh_endpoint(
     secret_key: SecretKey,
@@ -29,17 +35,19 @@ pub async fn build_iroh_endpoint(
         );
         RelayMode::Disabled
     } else if iroh_relays.is_empty() {
-        RelayMode::Default
+        RelayMode::Custom(
+            DEFAULT_IROH_RELAYS
+                .into_iter()
+                .map(|url| {
+                    relay_node_from_url(Url::parse(url).expect("default Iroh relay URL is valid"))
+                })
+                .collect(),
+        )
     } else {
         RelayMode::Custom(
             iroh_relays
                 .into_iter()
-                .map(|url| RelayNode {
-                    url: RelayUrl::from(url.to_unsafe()),
-                    stun_only: false,
-                    stun_port: DEFAULT_STUN_PORT,
-                    quic: Some(RelayQuicConfig::default()),
-                })
+                .map(|url| relay_node_from_url(url.to_unsafe()))
                 .collect(),
         )
     };
@@ -118,4 +126,25 @@ pub async fn build_iroh_endpoint(
     );
 
     Ok(endpoint)
+}
+
+fn relay_node_from_url(url: Url) -> RelayNode {
+    RelayNode {
+        url: RelayUrl::from(url),
+        stun_only: false,
+        stun_port: DEFAULT_STUN_PORT,
+        quic: Some(RelayQuicConfig::default()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_iroh_relays_are_valid_urls() {
+        for relay in DEFAULT_IROH_RELAYS {
+            Url::parse(relay).expect("default Iroh relay URL is valid");
+        }
+    }
 }


### PR DESCRIPTION
## Summary

When `iroh_relays` is not configured, fall back to a hardcoded pair of
elsirion-operated relays (`euc1-1` and `use1-1` under
`relay.elsirion.fedimint.iroh.link`) instead of iroh's built-in
`RelayMode::Default`, which points at n0's public relay infrastructure.

## Details

Up to now, federations that left `iroh_relays` unset would silently
depend on n0's public relays — an external service we don't control or
operate. This change keeps the explicit-config path unchanged but
routes the default through our own relays, so the out-of-the-box
behavior matches what the federation operator actually expects.

The two `RelayMode::Custom` arms now share a small
`relay_node_from_url` helper to avoid duplicating the `RelayNode`
construction.

## Reviewing

- Worth a quick sanity check on the two relay hostnames; they're
  hardcoded and would need a follow-up PR to change.
- `FM_IROH_DISABLE_RELAYS_ENV` still disables relays entirely, so the
  escape hatch is preserved.

## Testing

- New unit test `default_iroh_relays_are_valid_urls` asserts that the
  hardcoded relay URLs parse cleanly, so an accidental typo trips CI.
- `just clippy` and `just format` clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)