### PR TITLE
feat(walletv2-fedi-integration): expose receive address and bitcoin outpoint on meta and event

### DIFF
--- a/modules/fedimint-walletv2-client/src/events.rs
+++ b/modules/fedimint-walletv2-client/src/events.rs
@@ -45,9 +45,10 @@ impl Event for SendPaymentUpdateEvent {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct ReceivePaymentEvent {
     pub operation_id: OperationId,
-    pub address: Address<NetworkUnchecked>,
     pub value: bitcoin::Amount,
     pub fee: bitcoin::Amount,
+    pub address: Address<NetworkUnchecked>,
+    pub outpoint: Option<bitcoin::OutPoint>,
 }
 
 impl Event for ReceivePaymentEvent {

--- a/modules/fedimint-walletv2-client/src/lib.rs
+++ b/modules/fedimint-walletv2-client/src/lib.rs
@@ -84,6 +84,8 @@ pub struct ReceiveMeta {
     pub change_outpoint_range: OutPointRange,
     pub value: bitcoin::Amount,
     pub fee: bitcoin::Amount,
+    pub address: Option<Address<NetworkUnchecked>>,
+    pub outpoint: Option<bitcoin::OutPoint>,
 }
 
 /// The final state of an operation sending bitcoin onchain.
@@ -423,6 +425,7 @@ impl WalletClientModule {
         value: bitcoin::Amount,
         address_index: u64,
         fee: bitcoin::Amount,
+        outpoint: Option<bitcoin::OutPoint>,
     ) -> (OperationId, TransactionId) {
         let operation_id = OperationId::new_random();
 
@@ -455,6 +458,9 @@ impl WalletClientModule {
             vec![client_input_sm],
         ));
 
+        let address = self.derive_address(address_index).as_unchecked().clone();
+
+        let meta_address = address.clone();
         let range = self
             .client_ctx
             .finalize_and_submit_transaction(
@@ -465,6 +471,8 @@ impl WalletClientModule {
                         change_outpoint_range,
                         value,
                         fee,
+                        address: Some(meta_address.clone()),
+                        outpoint,
                     })
                 },
                 TransactionBuilder::new().with_inputs(client_input_bundle),
@@ -479,9 +487,10 @@ impl WalletClientModule {
                 &mut dbtx,
                 ReceivePaymentEvent {
                     operation_id,
-                    address: self.derive_address(address_index).as_unchecked().clone(),
                     value,
                     fee,
+                    address,
+                    outpoint,
                 },
             )
             .await;
@@ -590,7 +599,13 @@ impl WalletClientModule {
 
                     if output.value > receive_fee {
                         let (operation_id, txid) = self
-                            .receive_output(output.index, output.value, address_index, receive_fee)
+                            .receive_output(
+                                output.index,
+                                output.value,
+                                address_index,
+                                receive_fee,
+                                output.outpoint,
+                            )
                             .await;
 
                         self.client_ctx

--- a/modules/fedimint-walletv2-common/src/lib.rs
+++ b/modules/fedimint-walletv2-common/src/lib.rs
@@ -101,6 +101,7 @@ pub struct OutputInfo {
     pub script: ScriptBuf,
     pub value: bitcoin::Amount,
     pub spent: bool,
+    pub outpoint: Option<bitcoin::OutPoint>,
 }
 
 #[derive(Debug)]

--- a/modules/fedimint-walletv2-server/src/lib.rs
+++ b/modules/fedimint-walletv2-server/src/lib.rs
@@ -1354,6 +1354,7 @@ impl Wallet {
                     script: entry.1.1.script_pubkey,
                     value: entry.1.1.value,
                     spent: spent.contains(&entry.0.0),
+                    outpoint: Some(entry.1.0),
                 }))
             })
             .collect()


### PR DESCRIPTION
## Summary
- Adds an optional `address` field to `ReceiveMeta` for consistency with the existing `ReceivePaymentEvent.address`.
- Adds an optional `outpoint` field (the funding bitcoin `OutPoint`) to both `ReceiveMeta` and `ReceivePaymentEvent`.
- Adds an optional `outpoint` field to `OutputInfo` returned by the `output_info_slice` scanning endpoint so the client can propagate it through the receive flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)