### PR TITLE
fix(mintv2-fedi-integration): persist receive terminal state to operation log

### DIFF
--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -1563,7 +1563,13 @@ impl Gateway {
                 })?;
 
             if payload.wait {
-                match mint.await_final_receive_operation_state(operation_id).await {
+                let final_state = mint
+                    .await_final_receive_operation_state(operation_id)
+                    .await
+                    .map_err(|e| PublicGatewayError::ReceiveEcashError {
+                        failure_reason: e.to_string(),
+                    })?;
+                match final_state {
                     fedimint_mintv2_client::FinalReceiveOperationState::Success => {}
                     fedimint_mintv2_client::FinalReceiveOperationState::Rejected => {
                         return Err(PublicGatewayError::ReceiveEcashError {

--- a/modules/fedimint-mintv2-client/src/cli.rs
+++ b/modules/fedimint-mintv2-client/src/cli.rs
@@ -39,7 +39,9 @@ pub(crate) async fn handle_cli_command(
 
             let operation_id = mint.receive(ecash, Value::Null).await?;
 
-            let state = mint.await_final_receive_operation_state(operation_id).await;
+            let state = mint
+                .await_final_receive_operation_state(operation_id)
+                .await?;
 
             Ok(json(state))
         }

--- a/modules/fedimint-mintv2-client/src/lib.rs
+++ b/modules/fedimint-mintv2-client/src/lib.rs
@@ -950,20 +950,40 @@ impl MintClientModule {
     pub async fn await_final_receive_operation_state(
         &self,
         operation_id: OperationId,
-    ) -> FinalReceiveOperationState {
+    ) -> anyhow::Result<FinalReceiveOperationState> {
+        let operation = self.client_ctx.get_operation(operation_id).await?;
         let mut stream = self.notifier.subscribe(operation_id).await;
 
-        loop {
-            let Some(MintClientStateMachines::Receive(state)) = stream.next().await else {
-                continue;
-            };
+        let mut stream = self
+            .client_ctx
+            .outcome_or_updates(operation, operation_id, move || {
+                async_stream::stream! {
+                    loop {
+                        if let Some(MintClientStateMachines::Receive(state)) = stream.next().await {
+                            match state.state {
+                                ReceiveSMState::Pending => {}
+                                ReceiveSMState::Success => {
+                                    yield FinalReceiveOperationState::Success;
+                                    return;
+                                }
+                                ReceiveSMState::Rejected(..) => {
+                                    yield FinalReceiveOperationState::Rejected;
+                                    return;
+                                }
+                            }
+                        }
+                    }
+                }
+            })
+            .into_stream();
 
-            match state.state {
-                ReceiveSMState::Pending => {}
-                ReceiveSMState::Success => return FinalReceiveOperationState::Success,
-                ReceiveSMState::Rejected(..) => return FinalReceiveOperationState::Rejected,
-            }
+        let mut final_state = None;
+
+        while let Some(state) = stream.next().await {
+            final_state = Some(state);
         }
+
+        Ok(final_state.expect("Stream contains one final state"))
     }
 
     async fn remove_spendable_note(

--- a/modules/fedimint-mintv2-tests/tests/tests.rs
+++ b/modules/fedimint-mintv2-tests/tests/tests.rs
@@ -148,7 +148,7 @@ async fn send_and_receive() -> anyhow::Result<()> {
         let state = client_receive
             .get_first_module::<MintClientModule>()?
             .await_final_receive_operation_state(operation_id)
-            .await;
+            .await?;
 
         assert_eq!(state, FinalReceiveOperationState::Success);
 
@@ -239,7 +239,7 @@ async fn double_spend_is_rejected() -> anyhow::Result<()> {
     let state = client_send
         .get_first_module::<MintClientModule>()?
         .await_final_receive_operation_state(operation_id)
-        .await;
+        .await?;
 
     assert_eq!(state, FinalReceiveOperationState::Success);
 
@@ -262,7 +262,7 @@ async fn double_spend_is_rejected() -> anyhow::Result<()> {
     let state = client_receive
         .get_first_module::<MintClientModule>()?
         .await_final_receive_operation_state(operation_id)
-        .await;
+        .await?;
 
     assert_eq!(state, FinalReceiveOperationState::Rejected);
 
@@ -316,7 +316,7 @@ async fn transaction_with_invalid_signature_is_rejected() -> anyhow::Result<()> 
     let state = client
         .get_first_module::<MintClientModule>()?
         .await_final_receive_operation_state(operation_id)
-        .await;
+        .await?;
 
     assert_eq!(state, FinalReceiveOperationState::Rejected);
 
@@ -341,7 +341,7 @@ async fn transaction_with_invalid_signature_is_rejected() -> anyhow::Result<()> 
     let state = client
         .get_first_module::<MintClientModule>()?
         .await_final_receive_operation_state(operation_id)
-        .await;
+        .await?;
 
     assert_eq!(state, FinalReceiveOperationState::Success);
 


### PR DESCRIPTION
## Summary

- `await_final_receive_operation_state` previously subscribed to the state machine notifier directly and never wrote the terminal state anywhere persistent. After the SM deregisters, the future has nothing to await and the operation log entry's `outcome` field stays empty — consumers that want to render past receive operations (e.g. a transaction history view) can't recover the outcome after restart.
- Wrap the stream in `client_ctx.outcome_or_updates` and drain it fully, matching the consumption pattern in `lnv2-client::await_final_send_operation_state`. `caching_operation_update_stream`'s post-loop `optimistically_set_operation_outcome` only writes the cached value after the inner stream ends, so the future has to consume past the terminal yield rather than short-circuit on the first item.
- Signature gains an `anyhow::Result` wrapper because looking up the operation log entry can fail. Updated CLI, integration tests, and the gateway server caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)