### PR TITLE
fix(walletv2-fedi-integration): persist send + receive terminal state to operation log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4901,6 +4901,7 @@ name = "fedimint-walletv2-client"
 version = "0.12.0-alpha"
 dependencies = [
  "anyhow",
+ "async-stream",
  "async-trait",
  "bitcoin",
  "clap",

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -433,7 +433,10 @@ async fn withdraw_v2(
 
     let result = wallet_module
         .await_final_send_operation_state(operation_id)
-        .await;
+        .await
+        .map_err(|e| AdminGatewayError::WithdrawError {
+            failure_reason: e.to_string(),
+        })?;
 
     let fees = PegOutFees::from_amount(fee);
 

--- a/modules/fedimint-walletv2-client/Cargo.toml
+++ b/modules/fedimint-walletv2-client/Cargo.toml
@@ -21,6 +21,7 @@ path = "src/lib.rs"
 
 [dependencies]
 anyhow = { workspace = true }
+async-stream = { workspace = true }
 async-trait = { workspace = true }
 bitcoin = { workspace = true }
 clap = { workspace = true, optional = true }

--- a/modules/fedimint-walletv2-client/src/cli.rs
+++ b/modules/fedimint-walletv2-client/src/cli.rs
@@ -62,7 +62,7 @@ pub(crate) async fn handle_cli_command(
         } => json(
             wallet
                 .await_final_send_operation_state(wallet.send(address, value, fee).await?)
-                .await,
+                .await?,
         ),
         Opts::Receive => json(wallet.receive().await),
     };

--- a/modules/fedimint-walletv2-client/src/lib.rs
+++ b/modules/fedimint-walletv2-client/src/lib.rs
@@ -97,6 +97,15 @@ pub enum FinalSendOperationState {
     Failure,
 }
 
+/// The final state of an operation receiving bitcoin onchain.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum FinalReceiveOperationState {
+    /// The federation accepted the claiming transaction.
+    Success,
+    /// The federation rejected the claiming transaction.
+    Aborted,
+}
+
 #[derive(Debug, Clone)]
 pub struct WalletClientModule {
     root_secret: DerivableSecret,
@@ -353,21 +362,84 @@ impl WalletClientModule {
     pub async fn await_final_send_operation_state(
         &self,
         operation_id: OperationId,
-    ) -> FinalSendOperationState {
+    ) -> anyhow::Result<FinalSendOperationState> {
+        let operation = self.client_ctx.get_operation(operation_id).await?;
         let mut stream = self.notifier.subscribe(operation_id).await;
 
-        loop {
-            let Some(WalletClientStateMachines::Send(state)) = stream.next().await else {
-                panic!("stream must produce a terminal send state");
-            };
+        let mut stream = self
+            .client_ctx
+            .outcome_or_updates(operation, operation_id, move || {
+                async_stream::stream! {
+                    loop {
+                        if let Some(WalletClientStateMachines::Send(state)) = stream.next().await {
+                            match state.state {
+                                SendSMState::Funding => {}
+                                SendSMState::Success(txid) => {
+                                    yield FinalSendOperationState::Success(txid);
+                                    return;
+                                }
+                                SendSMState::Aborted(..) => {
+                                    yield FinalSendOperationState::Aborted;
+                                    return;
+                                }
+                                SendSMState::Failure => {
+                                    yield FinalSendOperationState::Failure;
+                                    return;
+                                }
+                            }
+                        }
+                    }
+                }
+            })
+            .into_stream();
 
-            match state.state {
-                SendSMState::Funding => {}
-                SendSMState::Success(txid) => return FinalSendOperationState::Success(txid),
-                SendSMState::Aborted(..) => return FinalSendOperationState::Aborted,
-                SendSMState::Failure => return FinalSendOperationState::Failure,
-            }
+        let mut final_state = None;
+
+        while let Some(state) = stream.next().await {
+            final_state = Some(state);
         }
+
+        Ok(final_state.expect("Stream contains one final state"))
+    }
+
+    /// Await the final state of the receive operation.
+    pub async fn await_final_receive_operation_state(
+        &self,
+        operation_id: OperationId,
+    ) -> anyhow::Result<FinalReceiveOperationState> {
+        let operation = self.client_ctx.get_operation(operation_id).await?;
+        let mut stream = self.notifier.subscribe(operation_id).await;
+
+        let mut stream = self
+            .client_ctx
+            .outcome_or_updates(operation, operation_id, move || {
+                async_stream::stream! {
+                    loop {
+                        if let Some(WalletClientStateMachines::Receive(state)) = stream.next().await {
+                            match state.state {
+                                ReceiveSMState::Funding => {}
+                                ReceiveSMState::Success => {
+                                    yield FinalReceiveOperationState::Success;
+                                    return;
+                                }
+                                ReceiveSMState::Aborted(..) => {
+                                    yield FinalReceiveOperationState::Aborted;
+                                    return;
+                                }
+                            }
+                        }
+                    }
+                }
+            })
+            .into_stream();
+
+        let mut final_state = None;
+
+        while let Some(state) = stream.next().await {
+            final_state = Some(state);
+        }
+
+        Ok(final_state.expect("Stream contains one final state"))
     }
 
     /// Returns the next unused receive address, polling until the initial

--- a/modules/fedimint-walletv2-tests/tests/tests.rs
+++ b/modules/fedimint-walletv2-tests/tests/tests.rs
@@ -212,7 +212,7 @@ async fn fee_exceeds_one_bitcoin_with_many_pending_txs() -> anyhow::Result<()> {
         let state = client
             .get_first_module::<WalletClientModule>()?
             .await_final_send_operation_state(send_op)
-            .await;
+            .await?;
 
         assert!(matches!(state, FinalSendOperationState::Success(_)));
 


### PR DESCRIPTION
## Summary

- `await_final_send_operation_state` previously subscribed to the state machine notifier directly and never wrote the `FinalSendOperationState` (which carries the bitcoin txid in its `Success` variant) anywhere persistent. Consumers rendering past on-chain send operations had no way to recover the txid after restart — the op log entry's `outcome` stayed empty.
- Wrap the same stream in `client_ctx.outcome_or_updates` and drain the returned `UpdateStreamOrOutcome` fully (mirrors the consumption pattern in `lnv2-client` and the equivalent `mintv2-client` fix). The terminal state lands on disk via `caching_operation_update_stream`'s post-loop `optimistically_set_operation_outcome`.
- Adds a symmetric `await_final_receive_operation_state` + `FinalReceiveOperationState { Success, Aborted }` so receive ops gain the same persistent terminal-state surface.
- Signature gains an `anyhow::Result` wrapper because looking up the operation log entry can fail. Updated CLI, integration tests, and the gateway server caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)