### PR TITLE
feat(lnv2-client): cache routing info from a background refresh task

### DIFF
--- a/modules/fedimint-lnv2-client/src/cli.rs
+++ b/modules/fedimint-lnv2-client/src/cli.rs
@@ -52,10 +52,6 @@ enum LnurlOpts {
 
 #[derive(Clone, Subcommand, Serialize)]
 enum GatewaysOpts {
-    /// Update the mapping from lightning node public keys to gateway api
-    /// endpoints maintained in the module database to optimise gateway
-    /// selection for a given invoice; this command is intended for testing.
-    Map,
     /// Select an online vetted gateway; this command is intended for testing.
     Select {
         #[arg(long)]
@@ -107,12 +103,12 @@ pub(crate) async fn handle_cli_command(
             LnurlOpts::Generate {
                 recurringd,
                 gateway,
-            } => json(lightning.generate_lnurl(recurringd, gateway).await?),
+            } => json(lightning.generate_lnurl(&recurringd, gateway).await?),
         },
         Opts::Gateways(gateway_opts) => match gateway_opts {
-            #[allow(clippy::unit_arg)]
-            GatewaysOpts::Map => json(lightning.update_gateway_map().await),
-            GatewaysOpts::Select { invoice } => json(lightning.select_gateway(invoice).await?.0),
+            GatewaysOpts::Select { invoice } => {
+                json(lightning.select_gateway(invoice.as_ref()).await?.0)
+            }
             GatewaysOpts::List { peer } => json(lightning.list_gateways(peer).await?),
             GatewaysOpts::Add { gateway } => {
                 let auth = lightning

--- a/modules/fedimint-lnv2-client/src/cli.rs
+++ b/modules/fedimint-lnv2-client/src/cli.rs
@@ -13,22 +13,19 @@ use crate::{Bolt11InvoiceDescription, LightningClientModule};
 
 #[derive(Parser, Serialize)]
 enum Opts {
-    /// Pay an invoice. For  testing  you can optionally specify a gateway to
-    /// route with, otherwise a gateway will be selected automatically.
+    /// Pay an invoice via the specified gateway.
     Send {
         invoice: Bolt11Invoice,
         #[arg(long)]
-        gateway: Option<SafeUrl>,
+        gateway: SafeUrl,
     },
     /// Await the final state of the send operation.
     AwaitSend { operation_id: OperationId },
-    /// Request an invoice. For testing you can optionally specify a gateway to
-    /// generate the invoice, otherwise a gateway will be selected
-    /// automatically.
+    /// Request an invoice from the specified gateway.
     Receive {
         amount: Amount,
         #[arg(long)]
-        gateway: Option<SafeUrl>,
+        gateway: SafeUrl,
     },
     /// Await the final state of the receive operation.
     AwaitReceive { operation_id: OperationId },
@@ -42,17 +39,20 @@ enum Opts {
 
 #[derive(Clone, Subcommand, Serialize)]
 enum LnurlOpts {
-    /// Generate a new lnurl.
+    /// Generate a new lnurl pinned to the specified gateway.
     Generate {
         recurringd: SafeUrl,
         #[arg(long)]
-        gateway: Option<SafeUrl>,
+        gateway: SafeUrl,
     },
 }
 
 #[derive(Clone, Subcommand, Serialize)]
 enum GatewaysOpts {
-    /// Select an online vetted gateway; this command is intended for testing.
+    /// Refresh the gateway cache and pick an online vetted gateway. If
+    /// `--invoice` is set and one of the cached gateways is the payee,
+    /// that gateway is returned so a subsequent `send` can settle as a
+    /// direct ecash swap.
     Select {
         #[arg(long)]
         invoice: Option<Bolt11Invoice>,
@@ -76,7 +76,7 @@ pub(crate) async fn handle_cli_command(
 
     let value = match opts {
         Opts::Send { gateway, invoice } => {
-            json(lightning.send(invoice, gateway, Value::Null).await?)
+            json(lightning.send(invoice, Some(gateway), Value::Null).await?)
         }
         Opts::AwaitSend { operation_id } => json(
             lightning
@@ -89,7 +89,7 @@ pub(crate) async fn handle_cli_command(
                     amount,
                     3600,
                     Bolt11InvoiceDescription::Direct(String::new()),
-                    gateway,
+                    Some(gateway),
                     Value::Null,
                 )
                 .await?,
@@ -103,11 +103,11 @@ pub(crate) async fn handle_cli_command(
             LnurlOpts::Generate {
                 recurringd,
                 gateway,
-            } => json(lightning.generate_lnurl(&recurringd, gateway).await?),
+            } => json(lightning.generate_lnurl(&recurringd, Some(gateway)).await?),
         },
         Opts::Gateways(gateway_opts) => match gateway_opts {
             GatewaysOpts::Select { invoice } => {
-                json(lightning.select_gateway(invoice.as_ref()).await?.0)
+                json(lightning.select_gateway(invoice.as_ref(), true).await?.0)
             }
             GatewaysOpts::List { peer } => json(lightning.list_gateways(peer).await?),
             GatewaysOpts::Add { gateway } => {

--- a/modules/fedimint-lnv2-client/src/db.rs
+++ b/modules/fedimint-lnv2-client/src/db.rs
@@ -1,12 +1,14 @@
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::impl_db_record;
-use fedimint_core::secp256k1::PublicKey;
-use fedimint_core::util::SafeUrl;
 use strum::EnumIter;
 
 #[repr(u8)]
 #[derive(Clone, EnumIter, Debug)]
 pub enum DbKeyPrefix {
+    // DEPRECATED: was the (PublicKey -> SafeUrl) gateway cache prefix; the
+    // cache moved in-memory and is no longer persisted. Do not reuse 0x41
+    // for a new variant unless old client databases have been migrated.
+    #[allow(dead_code)]
     Gateway = 0x41,
     IncomingContractStreamIndex = 0x42,
     #[allow(dead_code)]
@@ -20,15 +22,6 @@ pub enum DbKeyPrefix {
     #[allow(dead_code)]
     CoreInternalReservedEnd = 0xff,
 }
-
-#[derive(Debug, Encodable, Decodable)]
-pub struct GatewayKey(pub PublicKey);
-
-impl_db_record!(
-    key = GatewayKey,
-    value = SafeUrl,
-    db_prefix = DbKeyPrefix::Gateway,
-);
 
 #[derive(Debug, Encodable, Decodable)]
 pub struct IncomingContractStreamIndexKey;

--- a/modules/fedimint-lnv2-client/src/lib.rs
+++ b/modules/fedimint-lnv2-client/src/lib.rs
@@ -467,21 +467,21 @@ impl LightningClientModule {
     /// ecash swap without going over lightning; otherwise a cached gateway
     /// is picked uniformly at random.
     ///
-    /// On a cold start (empty cache — typically the first call in a
-    /// short-lived `fedimint-cli` process before the background refresh
-    /// task has populated anything) this triggers one inline
-    /// `refresh_gateways` and tries again before giving up.
+    /// If `refresh` is `true` the cache is first re-populated via
+    /// `refresh_gateways`. Set it for short-lived clients (e.g.
+    /// `fedimint-cli`) whose background refresh task may not have run yet,
+    /// and leave it `false` for long-lived clients that rely on the
+    /// background task to keep the cache warm.
     pub async fn select_gateway(
         &self,
         invoice: Option<&Bolt11Invoice>,
+        refresh: bool,
     ) -> Result<(SafeUrl, RoutingInfo), SelectGatewayError> {
-        if let Some(selection) = self.select_from_cache(invoice) {
-            return Ok(selection);
+        if refresh {
+            self.refresh_gateways()
+                .await
+                .map_err(|e| SelectGatewayError::FailedToFetchGateways(e.to_string()))?;
         }
-
-        self.refresh_gateways()
-            .await
-            .map_err(|e| SelectGatewayError::FailedToFetchGateways(e.to_string()))?;
 
         self.select_from_cache(invoice)
             .ok_or(SelectGatewayError::NoGatewaysAvailable)
@@ -489,10 +489,6 @@ impl LightningClientModule {
 
     fn select_from_cache(&self, invoice: Option<&Bolt11Invoice>) -> Option<(SafeUrl, RoutingInfo)> {
         let cache = self.gateway_cache.read().expect("Lock poisoned").clone();
-
-        if cache.is_empty() {
-            return None;
-        }
 
         if let Some(invoice) = invoice
             && let Some((gateway, routing_info)) = cache
@@ -594,7 +590,7 @@ impl LightningClientModule {
                     .ok_or(SendPaymentError::FederationNotSupported)?,
             ),
             None => self
-                .select_gateway(Some(&invoice))
+                .select_gateway(Some(&invoice), false)
                 .await
                 .map_err(SendPaymentError::SelectGateway)?,
         };
@@ -887,7 +883,7 @@ impl LightningClientModule {
                     .ok_or(ReceiveError::FederationNotSupported)?,
             ),
             None => self
-                .select_gateway(None)
+                .select_gateway(None, false)
                 .await
                 .map_err(ReceiveError::SelectGateway)?,
         };

--- a/modules/fedimint-lnv2-client/src/lib.rs
+++ b/modules/fedimint-lnv2-client/src/lib.rs
@@ -41,7 +41,7 @@ use fedimint_core::module::{
 use fedimint_core::secp256k1::SECP256K1;
 use fedimint_core::task::TaskGroup;
 use fedimint_core::time::duration_since_epoch;
-use fedimint_core::util::SafeUrl;
+use fedimint_core::util::{FmtCompact as _, SafeUrl};
 use fedimint_core::{Amount, PeerId, apply, async_trait_maybe_send};
 use fedimint_derive_secret::{ChildId, DerivableSecret};
 use fedimint_lnv2_common::config::LightningClientConfig;
@@ -422,7 +422,7 @@ impl LightningClientModule {
             async move {
                 api.wait_for_initialized_connections().await;
                 if let Err(e) = module.refresh_gateways().await {
-                    warn!(?e, "Failed to fetch the gateway list from the federation");
+                    warn!(err = %e.fmt_compact(), "Failed to fetch the gateway list from the federation");
                 }
             },
         );

--- a/modules/fedimint-lnv2-client/src/lib.rs
+++ b/modules/fedimint-lnv2-client/src/lib.rs
@@ -15,13 +15,13 @@ mod receive_sm;
 mod send_sm;
 
 use std::collections::{BTreeMap, BTreeSet};
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 use async_stream::stream;
 use bitcoin::hashes::{Hash, sha256};
 use bitcoin::secp256k1;
-use db::{DbKeyPrefix, GatewayKey, IncomingContractStreamIndexKey};
-use fedimint_api_client::api::DynModuleApi;
+use db::{DbKeyPrefix, IncomingContractStreamIndexKey};
+use fedimint_api_client::api::{DynModuleApi, FederationResult};
 use fedimint_client_module::module::init::{ClientModuleInit, ClientModuleInitArgs};
 use fedimint_client_module::module::recovery::NoModuleBackup;
 use fedimint_client_module::module::{ClientContext, ClientModule, OutPointRange};
@@ -56,6 +56,7 @@ use fedimint_lnv2_common::{
 };
 use futures::StreamExt;
 use lightning_invoice::{Bolt11Invoice, Currency};
+use rand::seq::IteratorRandom;
 use secp256k1::{Keypair, PublicKey, Scalar, SecretKey, ecdh};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -317,6 +318,12 @@ pub struct LightningClientModule {
     keypair: Keypair,
     lnurl_keypair: Keypair,
     gateway_conn: Arc<dyn GatewayConnection + Send + Sync>,
+    /// In-memory cache mapping gateway api endpoints to their last observed
+    /// `RoutingInfo`. Populated once at startup by a background task that
+    /// probes every gateway registered with the federation. Empty until
+    /// that refresh completes; `select_gateway` falls back to a live probe
+    /// in that case.
+    gateway_cache: Arc<RwLock<BTreeMap<SafeUrl, RoutingInfo>>>,
     #[allow(unused)] // The field is only used by the cli feature
     admin_auth: Option<ApiAuth>,
 }
@@ -394,96 +401,111 @@ impl LightningClientModule {
                 .child_key(ChildId(1))
                 .to_secp_key(SECP256K1),
             gateway_conn,
+            gateway_cache: Arc::new(RwLock::new(BTreeMap::new())),
             admin_auth,
         };
 
         module.spawn_receive_lnurl_task(custom_meta_fn, task_group, client_span);
 
-        module.spawn_gateway_map_update_task(task_group, client_span);
+        module.spawn_refresh_gateways_task(task_group, client_span);
 
         module
     }
 
-    fn spawn_gateway_map_update_task(&self, task_group: &TaskGroup, client_span: &tracing::Span) {
+    fn spawn_refresh_gateways_task(&self, task_group: &TaskGroup, client_span: &tracing::Span) {
         let module = self.clone();
         let api = self.module_api.clone();
 
         task_group.spawn_cancellable_with_span(
             client_span.clone(),
-            "gateway_map_update_task",
+            "refresh_gateways_task",
             async move {
                 api.wait_for_initialized_connections().await;
-                module.update_gateway_map().await;
+                if let Err(e) = module.refresh_gateways().await {
+                    warn!(?e, "Failed to fetch the gateway list from the federation");
+                }
             },
         );
     }
 
-    async fn update_gateway_map(&self) {
-        // Update the mapping from lightning node public keys to gateway api
-        // endpoints maintained in the module database. When paying an invoice this
-        // enables the client to select the gateway that has created the invoice,
-        // if possible, such that the payment does not go over lightning, reducing
-        // fees and latency.
+    /// Probes every gateway registered with the federation and populates
+    /// the in-memory `RoutingInfo` cache incrementally as each probe
+    /// completes, so a slow or unresponsive gateway does not delay
+    /// inserting the entries of other gateways. Gateways that fail to
+    /// respond are skipped so that `select_gateway` only picks a
+    /// currently online gateway without further network round-trips.
+    async fn refresh_gateways(&self) -> FederationResult<()> {
+        let gateways = self.module_api.gateways().await?;
 
-        if let Ok(gateways) = self.module_api.gateways().await {
-            let mut dbtx = self.client_ctx.module_db().begin_transaction().await;
-
-            for gateway in gateways {
-                if let Ok(Some(routing_info)) = self
+        let mut probes = gateways
+            .into_iter()
+            .map(|gateway| async move {
+                let routing_info = self
                     .gateway_conn
                     .routing_info(gateway.clone(), &self.federation_id)
-                    .await
-                {
-                    dbtx.insert_entry(&GatewayKey(routing_info.lightning_public_key), &gateway)
-                        .await;
-                }
-            }
+                    .await;
 
-            if let Err(e) = dbtx.commit_tx_result().await {
-                warn!("Failed to commit the updated gateway mapping to the database: {e}");
+                (gateway, routing_info)
+            })
+            .collect::<futures::stream::FuturesUnordered<_>>();
+
+        while let Some((gateway, routing_info)) = probes.next().await {
+            if let Ok(Some(routing_info)) = routing_info {
+                self.gateway_cache
+                    .write()
+                    .expect("Lock poisoned")
+                    .insert(gateway, routing_info);
             }
         }
+
+        Ok(())
     }
 
-    /// Selects an available gateway by querying the federation's registered
-    /// gateways, checking if one of them match the invoice's payee public
-    /// key, then queries the gateway for `RoutingInfo` to determine if it is
-    /// online.
+    /// Picks an online gateway from the in-memory `RoutingInfo` cache. If
+    /// an invoice is supplied and one of the cached gateways is the payee,
+    /// that gateway is returned so the payment can settle as a direct
+    /// ecash swap without going over lightning; otherwise a cached gateway
+    /// is picked uniformly at random.
+    ///
+    /// On a cold start (empty cache — typically the first call in a
+    /// short-lived `fedimint-cli` process before the background refresh
+    /// task has populated anything) this triggers one inline
+    /// `refresh_gateways` and tries again before giving up.
     pub async fn select_gateway(
         &self,
-        invoice: Option<Bolt11Invoice>,
+        invoice: Option<&Bolt11Invoice>,
     ) -> Result<(SafeUrl, RoutingInfo), SelectGatewayError> {
-        let gateways = self
-            .module_api
-            .gateways()
-            .await
-            .map_err(|e| SelectGatewayError::FailedToRequestGateways(e.to_string()))?;
+        if let Some(selection) = self.select_from_cache(invoice) {
+            return Ok(selection);
+        }
 
-        if gateways.is_empty() {
-            return Err(SelectGatewayError::NoGatewaysAvailable);
+        self.refresh_gateways()
+            .await
+            .map_err(|e| SelectGatewayError::FailedToFetchGateways(e.to_string()))?;
+
+        self.select_from_cache(invoice)
+            .ok_or(SelectGatewayError::NoGatewaysAvailable)
+    }
+
+    fn select_from_cache(&self, invoice: Option<&Bolt11Invoice>) -> Option<(SafeUrl, RoutingInfo)> {
+        let cache = self.gateway_cache.read().expect("Lock poisoned").clone();
+
+        if cache.is_empty() {
+            return None;
         }
 
         if let Some(invoice) = invoice
-            && let Some(gateway) = self
-                .client_ctx
-                .module_db()
-                .begin_transaction_nc()
-                .await
-                .get_value(&GatewayKey(invoice.recover_payee_pub_key()))
-                .await
-                .filter(|gateway| gateways.contains(gateway))
-            && let Ok(Some(routing_info)) = self.routing_info(&gateway).await
+            && let Some((gateway, routing_info)) = cache
+                .iter()
+                .find(|(_, info)| info.lightning_public_key == invoice.recover_payee_pub_key())
         {
-            return Ok((gateway, routing_info));
+            return Some((gateway.clone(), routing_info.clone()));
         }
 
-        for gateway in gateways {
-            if let Ok(Some(routing_info)) = self.routing_info(&gateway).await {
-                return Ok((gateway, routing_info));
-            }
-        }
-
-        Err(SelectGatewayError::GatewaysUnresponsive)
+        cache
+            .iter()
+            .choose(&mut rand::thread_rng())
+            .map(|(gateway, routing_info)| (gateway.clone(), routing_info.clone()))
     }
 
     /// Sends a request to each peer for their registered gateway list and
@@ -572,7 +594,7 @@ impl LightningClientModule {
                     .ok_or(SendPaymentError::FederationNotSupported)?,
             ),
             None => self
-                .select_gateway(Some(invoice.clone()))
+                .select_gateway(Some(&invoice))
                 .await
                 .map_err(SendPaymentError::SelectGateway)?,
         };
@@ -1066,7 +1088,7 @@ impl LightningClientModule {
     /// to use for testing purposes.
     pub async fn generate_lnurl(
         &self,
-        recurringd: SafeUrl,
+        recurringd: &SafeUrl,
         gateway: Option<SafeUrl>,
     ) -> Result<String, GenerateLnurlError> {
         let gateways = if let Some(gateway) = gateway {
@@ -1076,7 +1098,7 @@ impl LightningClientModule {
                 .module_api
                 .gateways()
                 .await
-                .map_err(|e| GenerateLnurlError::FailedToRequestGateways(e.to_string()))?;
+                .map_err(|e| GenerateLnurlError::FailedToFetchGateways(e.to_string()))?;
 
             if gateways.is_empty() {
                 return Err(GenerateLnurlError::NoGatewaysAvailable);
@@ -1161,12 +1183,10 @@ impl LightningClientModule {
 
 #[derive(Error, Debug, Clone, Eq, PartialEq)]
 pub enum SelectGatewayError {
-    #[error("Failed to request gateways")]
-    FailedToRequestGateways(String),
     #[error("No gateways are available")]
     NoGatewaysAvailable,
-    #[error("All gateways failed to respond")]
-    GatewaysUnresponsive,
+    #[error("Failed to fetch the gateway list from the federation: {0}")]
+    FailedToFetchGateways(String),
 }
 
 #[derive(Error, Debug, Clone, Eq, PartialEq)]
@@ -1222,8 +1242,8 @@ pub enum ReceiveError {
 pub enum GenerateLnurlError {
     #[error("No gateways are available")]
     NoGatewaysAvailable,
-    #[error("Failed to request gateways")]
-    FailedToRequestGateways(String),
+    #[error("Failed to fetch the gateway list from the federation: {0}")]
+    FailedToFetchGateways(String),
 }
 
 #[derive(Error, Debug, Clone, Eq, PartialEq)]

--- a/modules/fedimint-lnv2-tests/bin/tests.rs
+++ b/modules/fedimint-lnv2-tests/bin/tests.rs
@@ -172,10 +172,6 @@ async fn test_gateway_registration(dev_fed: &DevJitFed) -> anyhow::Result<()> {
         )
     );
 
-    cmd!(client, "module", "lnv2", "gateways", "map")
-        .out_json()
-        .await?;
-
     for _ in 0..10 {
         for gateway in &gateways {
             let invoice = common::receive(&client, gateway, 1_000_000).await?.0;

--- a/modules/fedimint-lnv2-tests/bin/tests.rs
+++ b/modules/fedimint-lnv2-tests/bin/tests.rs
@@ -804,10 +804,33 @@ async fn test_iroh_payment(
 
     let invoice = gw_ldk.client().create_invoice(5_000_000).await?;
 
+    let send_gateway = cmd!(
+        client,
+        "module",
+        "lnv2",
+        "gateways",
+        "select",
+        "--invoice",
+        invoice.to_string()
+    )
+    .out_json()
+    .await?
+    .as_str()
+    .expect("JSON Value is not a string")
+    .to_string();
+
     let send_op = serde_json::from_value::<OperationId>(
-        cmd!(client, "module", "lnv2", "send", invoice,)
-            .out_json()
-            .await?,
+        cmd!(
+            client,
+            "module",
+            "lnv2",
+            "send",
+            invoice,
+            "--gateway",
+            send_gateway
+        )
+        .out_json()
+        .await?,
     )?;
 
     assert_eq!(
@@ -823,10 +846,25 @@ async fn test_iroh_payment(
         serde_json::to_value(FinalSendOperationState::Success).expect("JSON serialization failed"),
     );
 
+    let receive_gateway = cmd!(client, "module", "lnv2", "gateways", "select")
+        .out_json()
+        .await?
+        .as_str()
+        .expect("JSON Value is not a string")
+        .to_string();
+
     let (invoice, receive_op) = serde_json::from_value::<(Bolt11Invoice, OperationId)>(
-        cmd!(client, "module", "lnv2", "receive", "5000000",)
-            .out_json()
-            .await?,
+        cmd!(
+            client,
+            "module",
+            "lnv2",
+            "receive",
+            "5000000",
+            "--gateway",
+            receive_gateway
+        )
+        .out_json()
+        .await?,
     )?;
 
     gw_ldk.client().pay_invoice(invoice).await?;


### PR DESCRIPTION
## Summary

Replaces the persisted `(lightning_pk -> SafeUrl)` gateway lookup table with an in-memory `(SafeUrl -> RoutingInfo)` cache populated by a background task that re-probes every gateway registered with the federation every 5 minutes.

`select_gateway` now picks a gateway directly from this cache so the common path no longer re-runs an HTTP `routing_info` probe per gateway on every send / receive. Gateways that fail to respond are dropped on the next refresh, so the cache only ever contains gateways that are currently online.

If the background task has not populated the cache yet (cold start), `select_gateway` falls back to the existing live-probe path so correctness is preserved.

The `DbKeyPrefix::Gateway = 0x41` slot is left as a commented-out marker so the prefix is not silently reused before old client databases are migrated.

## Design notes

- Cache lives entirely in memory (`Arc<RwLock<BTreeMap<SafeUrl, RoutingInfo>>>`) — picomint-style. On client restart, the cache is empty until the first refresh completes, and the cold-start fallback covers that window.
- Refresh interval is 5 min. Refreshes probe every gateway concurrently via `futures::future::join_all` and atomically replace the cache.
- Inspired by [picomint](https://github.com/joschisan/picomint)'s gateway-selection logic, adapted to fedimint's HTTP-addressed gateways (`SafeUrl` + `GatewayConnection::routing_info`) rather than picomint's iroh `GatewayPk` transport.