### PR TITLE
fix: Disconnect gateway when LNv1 or LNv2 tasks exit unexpectedly

### DIFF
--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -100,8 +100,8 @@ use fedimint_gwv2_client::{
 use fedimint_lightning::lnd::GatewayLndClient;
 use fedimint_lightning::{
     CreateInvoiceRequest, ILnRpcClient, InterceptPaymentRequest, InterceptPaymentResponse,
-    InvoiceDescription, LightningContext, LightningRpcError, LnRpcTracked, PayInvoiceResponse,
-    PaymentAction, RouteHtlcStream, ldk,
+    InvoiceDescription, LightningContext, LightningRpcError, LnRpcTracked, Lnv2HoldInvoiceFilter,
+    PayInvoiceResponse, PaymentAction, RouteHtlcStream, ldk,
 };
 use fedimint_ln_client::pay::PaymentData;
 use fedimint_ln_common::LightningCommonInit;
@@ -1885,13 +1885,33 @@ impl Gateway {
                 lnd_tls_cert,
                 lnd_macaroon,
                 lnd_time_pref,
-            } => Box::new(GatewayLndClient::new(
-                lnd_rpc_addr,
-                lnd_tls_cert,
-                lnd_macaroon,
-                lnd_time_pref,
-                None,
-            )),
+            } => {
+                // The LND backend uses this to ignore HOLD invoices on the
+                // shared LND node that aren't federation-bound. Returns true
+                // iff there is a registered LNv2 incoming contract for the
+                // given payment hash.
+                let gateway_db = self.gateway_db.clone();
+                let lnv2_filter: Lnv2HoldInvoiceFilter = Arc::new(move |hash| {
+                    let gateway_db = gateway_db.clone();
+                    Box::pin(async move {
+                        gateway_db
+                            .begin_transaction_nc()
+                            .await
+                            .load_registered_incoming_contract(PaymentImage::Hash(hash))
+                            .await
+                            .is_some()
+                    })
+                });
+
+                Box::new(GatewayLndClient::new(
+                    lnd_rpc_addr,
+                    lnd_tls_cert,
+                    lnd_macaroon,
+                    lnd_time_pref,
+                    None,
+                    lnv2_filter,
+                ))
+            }
             LightningMode::Ldk {
                 lightning_port,
                 alias,

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -880,6 +880,16 @@ impl Gateway {
                         Ok((stream, ln_client)) => (stream, ln_client),
                         Err(err) => {
                             warn!(target: LOG_GATEWAY, err = %err.fmt_compact(), "Failed to open lightning payment stream");
+                            // `route_htlcs` may have already spawned tasks into the
+                            // subgroup before failing (e.g. the LNv1 interceptor is
+                            // spawned before LNv2 setup, which can fail). Tear the
+                            // subgroup down so no stale task keeps owning the LND HTLC
+                            // stream, which would prevent the retry from taking over and
+                            // could cause it to cancel real HTLCs after `gateway_receiver`
+                            // is dropped.
+                            if let Err(err) = payment_stream_task_group.shutdown_join_all(None).await {
+                                crit!(target: LOG_GATEWAY, err = %err.fmt_compact_anyhow(), "Lightning payment stream task group shutdown");
+                            }
                             sleep(Duration::from_secs(PAYMENT_STREAM_RETRY_SECONDS)).await;
                             continue
                         }

--- a/gateway/fedimint-lightning/src/lib.rs
+++ b/gateway/fedimint-lightning/src/lib.rs
@@ -26,6 +26,7 @@ pub use fedimint_ln_common::contracts::Preimage;
 use fedimint_ln_common::route_hints::RouteHint;
 use fedimint_logging::LOG_LIGHTNING;
 use fedimint_metrics::HistogramExt as _;
+use futures::future::BoxFuture;
 use futures::stream::BoxStream;
 use lightning_invoice::Bolt11Invoice;
 use serde::{Deserialize, Serialize};
@@ -35,6 +36,14 @@ use tracing::{info, trace, warn};
 pub const MAX_LIGHTNING_RETRIES: u32 = 10;
 
 pub type RouteHtlcStream<'a> = BoxStream<'a, InterceptPaymentRequest>;
+
+/// Returns `true` if the given payment hash corresponds to a HOLD invoice that
+/// the gateway created on behalf of a federation. Used by the LND backend to
+/// ignore unrelated HOLD invoices on a shared LND node, which would otherwise
+/// be mistaken for federation-bound payments and produce invalid responses on
+/// LND's HTLC interceptor wire.
+pub type Lnv2HoldInvoiceFilter =
+    Arc<dyn Fn(sha256::Hash) -> BoxFuture<'static, bool> + Send + Sync + 'static>;
 
 #[derive(
     Error, Debug, Serialize, Deserialize, Encodable, Decodable, Clone, Eq, PartialEq, Hash,

--- a/gateway/fedimint-lightning/src/lnd.rs
+++ b/gateway/fedimint-lightning/src/lnd.rs
@@ -142,6 +142,7 @@ impl GatewayLndClient {
     async fn spawn_lnv2_hold_invoice_subscription(
         &self,
         task_group: &TaskGroup,
+        payment_stream_group: TaskGroup,
         gateway_sender: HtlcSubscriptionSender,
         payment_hash: Vec<u8>,
     ) -> Result<(), LightningRpcError> {
@@ -162,7 +163,8 @@ impl GatewayLndClient {
                     match stream {
                         Ok(stream) => stream.into_inner(),
                         Err(err) => {
-                            crit!(target: LOG_LIGHTNING, err = %err.fmt_compact(), "Failed to subscribe to hold invoice updates");
+                            crit!(target: LOG_LIGHTNING, err = %err.fmt_compact(), "Failed to subscribe to hold invoice updates, shutting down payment-stream subgroup to trigger gateway reconnect");
+                            payment_stream_group.shutdown();
                             return;
                         }
                     }
@@ -173,20 +175,30 @@ impl GatewayLndClient {
                 }
             };
 
-            while let Some(hold) = tokio::select! {
-                () = handle.make_shutdown_rx() => {
-                    None
-                }
-                hold_update = hold_stream.message() => {
-                    match hold_update {
-                        Ok(hold) => hold,
-                        Err(err) => {
-                            crit!(target: LOG_LIGHTNING, err = %err.fmt_compact(), "Error received over hold invoice update stream");
-                            None
+            loop {
+                let hold = tokio::select! {
+                    () = handle.make_shutdown_rx() => {
+                        info!(target: LOG_LIGHTNING, "LND HOLD Invoice Subscription received shutdown signal");
+                        break;
+                    }
+                    hold_update = hold_stream.message() => {
+                        match hold_update {
+                            Ok(Some(hold)) => hold,
+                            Ok(None) => {
+                                // LND closed the stream because the invoice
+                                // reached a terminal state (settled, canceled,
+                                // or expired).
+                                break;
+                            }
+                            Err(err) => {
+                                crit!(target: LOG_LIGHTNING, err = %err.fmt_compact(), "Error received over hold invoice update stream, shutting down payment-stream subgroup to trigger gateway reconnect");
+                                payment_stream_group.shutdown();
+                                break;
+                            }
                         }
                     }
-                }
-            } {
+                };
+
                 debug!(
                     target: LOG_LIGHTNING,
                     payment_hash = %PrettyPaymentHash(&r_hash),
@@ -342,17 +354,24 @@ impl GatewayLndClient {
                     if let Err(err) = self_copy
                         .spawn_lnv2_hold_invoice_subscription(
                             &hold_group,
+                            subgroup.clone(),
                             gateway_sender.clone(),
                             payment_hash.clone(),
                         )
                         .await
                     {
+                        // Spawning failed because `connect()` exhausted its
+                        // retries, a strong signal that LND is unreachable. We
+                        // can no longer observe this invoice's `Accepted`
+                        // update, so shut down the payment-stream subgroup to
+                        // force a gateway reconnect.
                         warn!(
                             target: LOG_LIGHTNING,
                             err = %err.fmt_compact(),
                             payment_hash = %PrettyPaymentHash(&payment_hash),
-                            "Failed to spawn HOLD invoice subscription task",
+                            "Failed to spawn HOLD invoice subscription task, shutting down payment-stream subgroup to trigger gateway reconnect",
                         );
+                        subgroup.shutdown();
                     }
                 }
             }

--- a/gateway/fedimint-lightning/src/lnd.rs
+++ b/gateway/fedimint-lightning/src/lnd.rs
@@ -269,7 +269,7 @@ impl GatewayLndClient {
         let mut client = self.connect().await?;
 
         // Compute the minimum `add_index` that we need to subscribe to updates for.
-        let add_index = client
+        let first_index_offset = client
             .lightning()
             .list_invoices(ListInvoiceRequest {
                 pending_only: true,
@@ -287,6 +287,14 @@ impl GatewayLndClient {
             })?
             .into_inner()
             .first_index_offset;
+
+        // `SubscribeInvoices` only replays invoices with an `add_index` strictly
+        // greater than `add_index`, so subscribing from `first_index_offset`
+        // directly would skip the add event of the oldest pending invoice and we
+        // would never spawn a monitor for it. Subtract one so that oldest pending
+        // invoice is replayed. `saturating_sub` keeps this correct in the
+        // empty-list case where `first_index_offset` is 0.
+        let add_index = first_index_offset.saturating_sub(1);
 
         let self_copy = self.clone();
         let hold_group = task_group.make_subgroup();

--- a/gateway/fedimint-lightning/src/lnd.rs
+++ b/gateway/fedimint-lightning/src/lnd.rs
@@ -49,8 +49,8 @@ use tonic_lnd::{Client as LndClient, connect};
 use tracing::{debug, info, trace, warn};
 
 use super::{
-    ChannelInfo, ILnRpcClient, LightningRpcError, ListChannelsResponse, MAX_LIGHTNING_RETRIES,
-    RouteHtlcStream,
+    ChannelInfo, ILnRpcClient, LightningRpcError, ListChannelsResponse, Lnv2HoldInvoiceFilter,
+    MAX_LIGHTNING_RETRIES, RouteHtlcStream,
 };
 use crate::{
     CloseChannelsWithPeerRequest, CloseChannelsWithPeerResponse, CreateInvoiceRequest,
@@ -73,6 +73,12 @@ pub struct GatewayLndClient {
     macaroon: String,
     time_pref: f64,
     lnd_sender: Option<mpsc::Sender<ForwardHtlcInterceptResponse>>,
+    /// Predicate used to distinguish HOLD invoices the gateway created
+    /// (federation-bound) from unrelated HOLD invoices on the same LND node.
+    /// Without this, every HOLD invoice on a shared LND would be intercepted
+    /// as if it were federation-bound, producing invalid LNv1 responses that
+    /// crash LND's htlc_interceptor stream.
+    lnv2_filter: Lnv2HoldInvoiceFilter,
 }
 
 impl GatewayLndClient {
@@ -82,6 +88,7 @@ impl GatewayLndClient {
         macaroon: String,
         time_pref: f64,
         lnd_sender: Option<mpsc::Sender<ForwardHtlcInterceptResponse>>,
+        lnv2_filter: Lnv2HoldInvoiceFilter,
     ) -> Self {
         info!(
             target: LOG_LIGHTNING,
@@ -97,6 +104,7 @@ impl GatewayLndClient {
             macaroon,
             time_pref,
             lnd_sender,
+            lnv2_filter,
         }
     }
 
@@ -187,6 +195,25 @@ impl GatewayLndClient {
                 );
 
                 if hold.state() == InvoiceState::Accepted {
+                    // Only forward HOLD invoices that the gateway created on
+                    // behalf of a federation. We check here (rather than at
+                    // the new-invoice add-event) because the contract is
+                    // saved to gateway_db *after* the HOLD invoice is created
+                    // on LND, so the add-event races registration. By the
+                    // time `Accepted` fires the HTLC has arrived, which means
+                    // the BOLT11 invoice was published and the contract is
+                    // committed.
+                    let hash = sha256::Hash::from_slice(&hold.r_hash)
+                        .expect("LND payment hashes are 32 bytes");
+                    if !(self_copy.lnv2_filter)(hash).await {
+                        trace!(
+                            target: LOG_LIGHTNING,
+                            payment_hash = %PrettyPaymentHash(&hold.r_hash),
+                            "Ignoring HOLD invoice not created by this gateway",
+                        );
+                        continue;
+                    }
+
                     let intercept = InterceptPaymentRequest {
                         payment_hash: Hash::from_slice(&hold.r_hash.clone())
                             .expect("Failed to convert to Hash"),
@@ -994,6 +1021,7 @@ impl ILnRpcClient for GatewayLndClient {
             macaroon: self.macaroon.clone(),
             time_pref: self.time_pref,
             lnd_sender: Some(lnd_sender.clone()),
+            lnv2_filter: self.lnv2_filter.clone(),
         });
         Ok((Box::pin(ReceiverStream::new(gateway_receiver)), new_client))
     }

--- a/gateway/fedimint-lightning/src/lnd.rs
+++ b/gateway/fedimint-lightning/src/lnd.rs
@@ -251,6 +251,10 @@ impl GatewayLndClient {
 
         let self_copy = self.clone();
         let hold_group = task_group.make_subgroup();
+        // See the matching comment in `spawn_lnv1_htlc_interceptor`: if this
+        // task exits unexpectedly we shut down the payment-stream subgroup so
+        // the gateway transitions to `Disconnected` and reconnects.
+        let subgroup = task_group.clone();
         task_group.spawn("LND Invoice Subscription", move |handle| async move {
             let future_stream = client.lightning().subscribe_invoices(InvoiceSubscription {
                 add_index,
@@ -262,6 +266,7 @@ impl GatewayLndClient {
                         Ok(stream) => stream.into_inner(),
                         Err(err) => {
                             warn!(target: LOG_LIGHTNING, err = %err.fmt_compact(), "Failed to subscribe to all invoice updates");
+                            subgroup.shutdown();
                             return;
                         }
                     }
@@ -324,6 +329,11 @@ impl GatewayLndClient {
                     }
                 }
             }
+
+            if !handle.is_shutting_down() {
+                warn!(target: LOG_LIGHTNING, "LND Invoice Subscription exited unexpectedly, shutting down payment-stream subgroup to trigger gateway reconnect");
+                subgroup.shutdown();
+            }
         });
 
         Ok(())
@@ -351,6 +361,12 @@ impl GatewayLndClient {
                 failure_reason: format!("Failed to get node info {status:?}"),
             })?;
 
+        // If the HTLC interceptor exits unexpectedly we shut down the
+        // payment-stream subgroup. That cascades to the lnv2 invoice
+        // subscription (and its hold-invoice subtasks), which drop their
+        // `gateway_sender` clones, closing the gateway's HTLC stream and
+        // driving the gateway back to `Disconnected` so it reconnects.
+        let subgroup = task_group.clone();
         task_group.spawn("LND HTLC Subscription", |handle| async move {
                 let future_stream = client
                     .router()
@@ -361,6 +377,7 @@ impl GatewayLndClient {
                             Ok(stream) => stream.into_inner(),
                             Err(e) => {
                                 crit!(target: LOG_LIGHTNING, err = %e.fmt_compact(), "Failed to establish htlc stream");
+                                subgroup.shutdown();
                                 return;
                             }
                         }
@@ -424,6 +441,13 @@ impl GatewayLndClient {
                                 });
                         }
                     }
+                }
+
+                // Loop exited because of an HTLC stream error or end-of-stream
+                // (the expected-shutdown case is handled above).
+                if !handle.is_shutting_down() {
+                    warn!(target: LOG_LIGHTNING, "LND HTLC Subscription exited unexpectedly, shutting down payment-stream subgroup to trigger gateway reconnect");
+                    subgroup.shutdown();
                 }
             });
 


### PR DESCRIPTION
Different approach to https://github.com/fedimint/fedimint/pull/8615

Fixes: https://github.com/fedimint/fedimint/issues/8008

When either the LNv1 or LNv2 spawned interceptor tasks exit, we shutdown the `TaskGroup` so that all background threads holding onto `gateway_sender` are exited. This allows the gateway to transition to `Disconnected`, after which it will re-try to connect back to LND, and respawn the background interceptor tasks.