### PR TITLE
fix(gw-client): make gateway_handle_intercepted_htlc idempotent on replay

### DIFF
--- a/modules/fedimint-gw-client/src/lib.rs
+++ b/modules/fedimint-gw-client/src/lib.rs
@@ -477,36 +477,20 @@ impl GatewayClientModule {
 
     /// Attempt fulfill HTLC by buying preimage from the federation.
     ///
-    /// Idempotent across replays: the `operation_id` is derived
-    /// deterministically from the HTLC's payment hash, so if the gateway's
-    /// LND HTLC interceptor stream reconnects and LND replays a
-    /// still-pending HTLC, this returns the existing `operation_id` instead
-    /// of failing to re-submit the transaction, leaving the in-flight
-    /// completion state machine responsible for resolving the HTLC.
+    /// LND can replay a still-pending HTLC after interceptor reconnect or
+    /// gatewayd restart. Since the operation id is deterministic from the
+    /// payment hash, the replay must not re-fetch the consumed federation offer
+    /// or submit the same funding transaction again.
     ///
-    /// The short-circuit fires only while an active *completion* state machine
-    /// (`GatewayCompleteStateMachine`) is handling this exact HTLC circuit
-    /// (matching `operation_id` plus `incoming_chan_id`/`htlc_id`), not merely
-    /// when the operation exists or has any active state. Cases that fall
-    /// through and are failed back via the unmatched-HTLC path instead of being
-    /// left pending until timeout:
-    ///
-    /// - a replay whose original operation already reached a terminal state
-    /// - a payment hash whose active operation is a direct swap (no completion
-    ///   SM)
-    /// - a different circuit for the same payment hash (an MPP part or sender
-    ///   retry), which the existing completion SM would not resolve
-    ///
-    /// Re-emitting a terminal operation's original outcome (settling a success
-    /// on the new circuit instead of cancelling) is a follow-up.
+    /// We only short-circuit if an active `GatewayCompleteStateMachine` is
+    /// handling the exact same LND circuit. Terminal operations, direct swaps
+    /// with the same payment hash, and different circuits fall through to the
+    /// normal failure/cancel path.
     pub async fn gateway_handle_intercepted_htlc(&self, htlc: Htlc) -> anyhow::Result<OperationId> {
         debug!("Handling intercepted HTLC {htlc:?}");
 
-        // Check this BEFORE `create_funding_incoming_contract_output_from_htlc`:
-        // the first handling consumes the federation offer, so a replay that
-        // re-fetches it fails with "Timed out fetching the offer" otherwise. We
-        // match the full circuit key, not just `operation_id`; see the doc
-        // comment above for why narrower predicates are wrong.
+        // Check before the funding helper: the first handling consumes the
+        // federation offer. Match the full circuit key, not just `operation_id`.
         let operation_id = OperationId(htlc.payment_hash.to_byte_array());
         let replay_of_active_circuit = self
             .client_ctx
@@ -535,13 +519,8 @@ impl GatewayClientModule {
         let (op_id_from_funding, amount, client_output, client_output_sm, contract_id) = self
             .create_funding_incoming_contract_output_from_htlc(htlc.clone())
             .await?;
-        // The two derivations MUST stay in sync (`OperationId(htlc.payment_hash
-        // .to_byte_array())` in both places); a divergence would submit the
-        // transaction under one id while the caller observes another. Nothing has
-        // been submitted yet at this point, so we `ensure!` (propagates an error
-        // that the caller turns into a clean cancel/fail-back) rather than
-        // `assert!`, which would panic this spawned HTLC task and strand the HTLC
-        // until LND times it out.
+        // Keep the direct derivation above in sync with the funding helper. Return
+        // an error instead of panicking so the caller can fail back the HTLC cleanly.
         anyhow::ensure!(
             op_id_from_funding == operation_id,
             "operation id derivation must match: {op_id_from_funding:?} != {operation_id:?}"
@@ -556,17 +535,9 @@ impl GatewayClientModule {
             ClientOutputBundle::new(vec![output], vec![client_output_sm]),
         ));
         let operation_meta_gen = |_: OutPointRange| GatewayMeta::Receive;
-        // The replay check above is a best-effort fast path, not the correctness
-        // boundary: gatewayd handles HTLCs concurrently (one task per HTLC), so
-        // this atomic operation-exists guard is what actually prevents
-        // double-funding.
-        //
-        // Pre-existing limitation, narrowed (not closed) by the fast path: if the
-        // SAME circuit is replayed while the original handler is still between its
-        // scan and this commit, both miss the fast path, the loser fails here, and
-        // the caller cancels that circuit, racing the winner's settle on the same
-        // circuit. Fully closing it (treat a duplicate-operation error for this
-        // circuit as a replay, or serialize per payment hash) is a follow-up.
+        // The replay check above is only a fast path. Concurrent duplicate
+        // submissions are rejected here; avoiding the resulting cancel/settle race
+        // for the same circuit is a follow-up.
         self.client_ctx
             .finalize_and_submit_transaction(operation_id, KIND.as_str(), operation_meta_gen, tx)
             .await?;

--- a/modules/fedimint-gw-client/src/lib.rs
+++ b/modules/fedimint-gw-client/src/lib.rs
@@ -475,12 +475,77 @@ impl GatewayClientModule {
         Ok(())
     }
 
-    /// Attempt fulfill HTLC by buying preimage from the federation
+    /// Attempt fulfill HTLC by buying preimage from the federation.
+    ///
+    /// Idempotent across replays: the `operation_id` is derived
+    /// deterministically from the HTLC's payment hash, so if the gateway's
+    /// LND HTLC interceptor stream reconnects and LND replays a
+    /// still-pending HTLC, this returns the existing `operation_id` instead
+    /// of failing to re-submit the transaction, leaving the in-flight
+    /// completion state machine responsible for resolving the HTLC.
+    ///
+    /// The short-circuit fires only while an active *completion* state machine
+    /// (`GatewayCompleteStateMachine`) is handling this exact HTLC circuit
+    /// (matching `operation_id` plus `incoming_chan_id`/`htlc_id`), not merely
+    /// when the operation exists or has any active state. Cases that fall
+    /// through and are failed back via the unmatched-HTLC path instead of being
+    /// left pending until timeout:
+    ///
+    /// - a replay whose original operation already reached a terminal state
+    /// - a payment hash whose active operation is a direct swap (no completion
+    ///   SM)
+    /// - a different circuit for the same payment hash (an MPP part or sender
+    ///   retry), which the existing completion SM would not resolve
+    ///
+    /// Re-emitting a terminal operation's original outcome (settling a success
+    /// on the new circuit instead of cancelling) is a follow-up.
     pub async fn gateway_handle_intercepted_htlc(&self, htlc: Htlc) -> anyhow::Result<OperationId> {
         debug!("Handling intercepted HTLC {htlc:?}");
-        let (operation_id, amount, client_output, client_output_sm, contract_id) = self
+
+        // Check this BEFORE `create_funding_incoming_contract_output_from_htlc`:
+        // the first handling consumes the federation offer, so a replay that
+        // re-fetches it fails with "Timed out fetching the offer" otherwise. We
+        // match the full circuit key, not just `operation_id`; see the doc
+        // comment above for why narrower predicates are wrong.
+        let operation_id = OperationId(htlc.payment_hash.to_byte_array());
+        let replay_of_active_circuit = self
+            .client_ctx
+            .get_own_active_states()
+            .await
+            .into_iter()
+            .any(|(state, _)| {
+                matches!(
+                    state,
+                    GatewayClientStateMachines::Complete(sm)
+                        if sm.common.operation_id == operation_id
+                            && sm.common.incoming_chan_id == htlc.incoming_chan_id
+                            && sm.common.htlc_id == htlc.htlc_id
+                )
+            });
+        if replay_of_active_circuit {
+            debug!(
+                ?operation_id,
+                incoming_chan_id = htlc.incoming_chan_id,
+                htlc_id = htlc.htlc_id,
+                "HTLC circuit already being handled by an active completion state machine, treating as in-flight (likely an LND stream-reconnect replay)"
+            );
+            return Ok(operation_id);
+        }
+
+        let (op_id_from_funding, amount, client_output, client_output_sm, contract_id) = self
             .create_funding_incoming_contract_output_from_htlc(htlc.clone())
             .await?;
+        // The two derivations MUST stay in sync (`OperationId(htlc.payment_hash
+        // .to_byte_array())` in both places); a divergence would submit the
+        // transaction under one id while the caller observes another. Nothing has
+        // been submitted yet at this point, so we `ensure!` (propagates an error
+        // that the caller turns into a clean cancel/fail-back) rather than
+        // `assert!`, which would panic this spawned HTLC task and strand the HTLC
+        // until LND times it out.
+        anyhow::ensure!(
+            op_id_from_funding == operation_id,
+            "operation id derivation must match: {op_id_from_funding:?} != {operation_id:?}"
+        );
 
         let output = ClientOutput {
             output: LightningOutput::V0(client_output.output),
@@ -491,6 +556,17 @@ impl GatewayClientModule {
             ClientOutputBundle::new(vec![output], vec![client_output_sm]),
         ));
         let operation_meta_gen = |_: OutPointRange| GatewayMeta::Receive;
+        // The replay check above is a best-effort fast path, not the correctness
+        // boundary: gatewayd handles HTLCs concurrently (one task per HTLC), so
+        // this atomic operation-exists guard is what actually prevents
+        // double-funding.
+        //
+        // Pre-existing limitation, narrowed (not closed) by the fast path: if the
+        // SAME circuit is replayed while the original handler is still between its
+        // scan and this commit, both miss the fast path, the loser fails here, and
+        // the caller cancels that circuit, racing the winner's settle on the same
+        // circuit. Fully closing it (treat a duplicate-operation error for this
+        // circuit as a replay, or serialize per payment hash) is a follow-up.
         self.client_ctx
             .finalize_and_submit_transaction(operation_id, KIND.as_str(), operation_meta_gen, tx)
             .await?;


### PR DESCRIPTION
## Summary

Makes `gateway_handle_intercepted_htlc` (LNv1) idempotent when LND replays a still-pending HTLC. This is extracted from #8615 as a standalone, mechanism-independent correctness fix: it is needed regardless of whether reconnect is implemented by #8615's in-stream retry loop or #8653's task-group-shutdown approach, because any reconnect or gatewayd restart can make LND replay pending HTLCs on a fresh interceptor stream.

## The bug

The `operation_id` is derived deterministically from the HTLC payment hash. When the same HTLC is delivered twice while the original handler is still active:

- `create_funding_incoming_contract_output_from_htlc` fails on replay because the federation offer was already consumed by the first funding transaction.
- That error propagates through `try_handle_lightning_payment_ln_legacy` -> `handle_lightning_payment`, which treats the payment as unmatched.
- For a federation scid, the unmatched path now cancels the HTLC (#8625), racing the original completion state machine that is still legitimately resolving the same circuit.

## The fix

Add a replay check at the top of `gateway_handle_intercepted_htlc`, before the funding helper re-fetches the consumed federation offer:

- Derive `operation_id` directly from the payment hash up front.
- Look for an active `GatewayCompleteStateMachine` with the same `operation_id`, `incoming_chan_id`, and `htlc_id`.
- Only that exact active completion circuit short-circuits as an in-flight replay.
- Replays of terminal operations, direct-swap operations with the same payment hash, or different circuits fall through to the existing failure/cancel path instead of being left pending.
- Keep the two `operation_id` derivations in sync with `anyhow::ensure!`, so a mismatch is reported as an error instead of panicking a spawned HTLC task.

The replay scan is a best-effort fast path. The atomic correctness boundary remains `finalize_and_submit_transaction`, which prevents duplicate funding under the same operation id.

## Known limitations / follow-ups

- Terminal success replay: if the original operation bought the preimage but its `complete_htlc` response to LND was lost, this PR fails the replayed circuit back instead of re-settling it with the stored preimage. Re-emitting terminal outcomes crosses the gw-client/gateway-server boundary and is left for a follow-up.
- Same-circuit scan-to-commit race: if the same circuit is replayed while the original handler is still between the active-state scan and operation commit, both handlers can miss the fast path. Tracked in #8681.

## Notes

- The broader interceptor-stream reconnect work is intentionally out of scope here; see #8653.
- This PR narrows replay handling without attempting to serialize all intercepted HTLC processing.

## Test plan

- [x] CI passes
- [ ] Manual: restart gatewayd with an HTLC in flight at LND; confirm the replayed HTLC is recognized as in-flight (`HTLC circuit already being handled by an active completion state machine ...`) and is not cancelled out from under the active completion state machine
- [ ] Manual: force the original completion to a terminal state with the LND response lost, then replay; confirm the HTLC is failed back promptly instead of hanging until timeout
- [ ] Manual: send a normal LNv1 payment to confirm the non-replay path is unchanged
