### PR TITLE
chore(gateway): add HTLC context to LND interceptor warning logs

### DIFF
--- a/gateway/fedimint-lightning/src/lnd.rs
+++ b/gateway/fedimint-lightning/src/lnd.rs
@@ -396,12 +396,23 @@ impl GatewayLndClient {
                 } {
                     trace!(target: LOG_LIGHTNING, ?htlc, "LND Handling HTLC");
 
-                    if htlc.incoming_circuit_key.is_none() {
-                        warn!(target: LOG_LIGHTNING, "Cannot route htlc with None incoming_circuit_key");
+                    let Some(incoming_circuit_key) = htlc.incoming_circuit_key else {
+                        // We have no circuit key, so the HTLC cannot be cancelled
+                        // either; it will time out at LND. Log enough context to
+                        // correlate with the sender's invoice and the target
+                        // federation.
+                        warn!(
+                            target: LOG_LIGHTNING,
+                            payment_hash = %PrettyPaymentHash(&htlc.payment_hash),
+                            scid = htlc.outgoing_requested_chan_id,
+                            amount_msat = htlc.outgoing_amount_msat,
+                            "Cannot route HTLC: incoming_circuit_key is None"
+                        );
                         continue;
-                    }
+                    };
 
-                    let incoming_circuit_key = htlc.incoming_circuit_key.unwrap();
+                    let chan_id = incoming_circuit_key.chan_id;
+                    let htlc_id = incoming_circuit_key.htlc_id;
 
                     // Forward all HTLCs to gatewayd, gatewayd will filter them based on scid
                     let intercept = InterceptPaymentRequest {
@@ -409,18 +420,32 @@ impl GatewayLndClient {
                         amount_msat: htlc.outgoing_amount_msat,
                         expiry: htlc.incoming_expiry,
                         short_channel_id: Some(htlc.outgoing_requested_chan_id),
-                        incoming_chan_id: incoming_circuit_key.chan_id,
-                        htlc_id: incoming_circuit_key.htlc_id,
+                        incoming_chan_id: chan_id,
+                        htlc_id,
                     };
 
                     match gateway_sender.send(intercept).await {
                         Ok(()) => {}
                         Err(err) => {
-                            warn!(target: LOG_LIGHTNING, err = %err.fmt_compact(), "Failed to send HTLC to gatewayd for processing");
+                            warn!(
+                                target: LOG_LIGHTNING,
+                                err = %err.fmt_compact(),
+                                payment_hash = %PrettyPaymentHash(&htlc.payment_hash),
+                                scid = htlc.outgoing_requested_chan_id,
+                                amount_msat = htlc.outgoing_amount_msat,
+                                "Failed to send HTLC to gatewayd for processing"
+                            );
                             let _ = Self::cancel_htlc(incoming_circuit_key, lnd_sender.clone())
                                 .await
                                 .map_err(|err| {
-                                    warn!(target: LOG_LIGHTNING, err = %err.fmt_compact(), "Failed to cancel HTLC");
+                                    warn!(
+                                        target: LOG_LIGHTNING,
+                                        err = %err.fmt_compact(),
+                                        payment_hash = %PrettyPaymentHash(&htlc.payment_hash),
+                                        chan_id,
+                                        htlc_id,
+                                        "Failed to cancel HTLC"
+                                    );
                                 });
                         }
                     }


### PR DESCRIPTION
## Summary

Adds HTLC context to the LND interceptor's warning logs so operators can correlate a failure with a specific payment and target federation. Extracted from #8615 (which is being superseded by #8653 for recovery and #8655 for replay idempotency); this is the one piece of #8615 not carried by either of those, and it stands alone as an observability improvement.

## Changes

In `spawn_lnv1_htlc_interceptor` (`gateway/fedimint-lightning/src/lnd.rs`), the three warning sites previously logged only an error string with no payment/circuit identifiers:

- **"Cannot route HTLC: incoming_circuit_key is None"** — now logs `payment_hash`, `scid`, `amount_msat`. Also converts the `is_none()` + `unwrap()` to a `let-else`, removing an `unwrap()` from non-test code.
- **"Failed to send HTLC to gatewayd for processing"** — now logs `payment_hash`, `scid`, `amount_msat`.
- **"Failed to cancel HTLC"** — now logs `payment_hash`, `chan_id`, `htlc_id` (captured before the circuit key is moved into `cancel_htlc`).

No behavior change beyond logging and the equivalent `let-else` rewrite.

## Test plan

- [ ] CI passes
- [ ] Manual: trigger an interceptor warning (e.g. send an HTLC while gatewayd's receive loop is unavailable) and confirm the log line includes the payment hash / scid / circuit identifiers
