### PR TITLE
chore: make receive_fee public

### DIFF
--- a/modules/fedimint-walletv2-client/src/lib.rs
+++ b/modules/fedimint-walletv2-client/src/lib.rs
@@ -261,6 +261,14 @@ impl WalletClientModule {
             .ok_or(SendError::NoConsensusFeerateAvailable)
     }
 
+    /// Fetch the current fee required to claim an onchain deposit (peg-in).
+    pub async fn receive_fee(&self) -> anyhow::Result<bitcoin::Amount> {
+        self.module_api
+            .receive_fee()
+            .await?
+            .ok_or_else(|| anyhow!("No consensus feerate is available"))
+    }
+
     /// Send an onchain payment with the given fee.
     pub async fn send(
         &self,


### PR DESCRIPTION
For Ecash App, I would like to show users ahead of time an estimate of the fee that they would be charged on peg-ins. `receive_fee` is not currently public, this PR adds the function and makes it public.