### PR TITLE
ci: reduce test-ci-all default parallelism

### DIFF
--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -349,16 +349,18 @@ if [ -z "${CI:-}" ] && [[ -t 1 ]] && [ -z "${FM_TEST_CI_ALL_DISABLE_ETA:-}" ]; t
   parallel_args+=(--eta)
 fi
 
+default_parallel_jobs=$(($(nproc) / 3 + 1))
+
 if [ -n "${FM_TEST_CI_ALL_JOBS:-}" ]; then
   # when specifically set, use the env var
   parallel_args+=(--jobs "${FM_TEST_CI_ALL_JOBS}")
 elif [ -n "${CI:-}" ] || [ "${CARGO_PROFILE:-}" == "ci" ]; then
-  parallel_args+=(--jobs $(($(nproc) / 2 + 1)))
+  # Devimint tests are process-heavy; stay below the machine becoming too overloaded to reliably run tests.
+  parallel_args+=(--jobs "${default_parallel_jobs}")
 else
-  # on dev computers default to `num_cpus / 2 + 1` max parallel jobs
-  parallel_args+=(--jobs "${FM_TEST_CI_ALL_JOBS:-$(($(nproc) / 2 + 1))}")
+  # on dev computers default to `num_cpus / 3 + 1` max parallel jobs
+  parallel_args+=(--jobs "${default_parallel_jobs}")
 fi
-
 parallel_args+=(--timeout "${FM_TEST_CI_ALL_TIMEOUT:-360}")
 
 parallel_args+=(--load "${FM_TEST_CI_ALL_MAX_LOAD:-$(($(nproc)))}")


### PR DESCRIPTION
*PR published by Tau/assistant*

## Summary

Reduce the default `test-ci-all` GNU parallel job count from `nproc / 2 + 1` to `nproc / 3 + 1`.

## Details

On large CI runners, `nproc / 2 + 1` can start many devimint tests at once. Each devimint test can spawn a federation, gateways, lightning nodes, and bitcoind, so CPU count alone overestimates safe parallelism. PR #8658 hit a likely starvation flake where walletv2 gateway pegin handling did not complete before the 60s poll timeout while CI was running up to 49 test jobs concurrently: https://github.com/fedimint/fedimint/actions/runs/26663325154/job/78590965701

This keeps the explicit `FM_TEST_CI_ALL_JOBS` override unchanged and applies the lower default to both CI and local default runs.

## Testing

Run `bash -n scripts/tests/test-ci-all.sh`.
