### PR TITLE
fix: make tx_chain and pending_tx_chain public

### DIFF
--- a/modules/fedimint-walletv2-client/src/lib.rs
+++ b/modules/fedimint-walletv2-client/src/lib.rs
@@ -243,12 +243,12 @@ impl WalletClientModule {
     }
 
     /// Fetch information on the chain of pending bitcoin transactions.
-    async fn pending_tx_chain(&self) -> FederationResult<Vec<TxInfo>> {
+    pub async fn pending_tx_chain(&self) -> FederationResult<Vec<TxInfo>> {
         self.module_api.pending_tx_chain().await
     }
 
     /// Display log of bitcoin transactions.
-    async fn tx_chain(&self) -> FederationResult<Vec<TxInfo>> {
+    pub async fn tx_chain(&self) -> FederationResult<Vec<TxInfo>> {
         self.module_api.tx_chain().await
     }
 


### PR DESCRIPTION
I want to use these in Ecash App. The CLI already exposes them, other wallets should be able to use them too.