### PR TITLE
fix: include invite code in mintv2 ecash

### DIFF
--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -2526,7 +2526,7 @@ impl IAdminGateway for Gateway {
             })
         } else if let Ok(mint_module) = client.get_first_module::<MintV2ClientModule>() {
             let ecash = mint_module
-                .send(payload.amount, serde_json::Value::Null)
+                .send(payload.amount, serde_json::Value::Null, true)
                 .await
                 .map_err(|e| AdminGatewayError::Unexpected(e.into()))?;
 

--- a/modules/fedimint-mintv2-client/src/cli.rs
+++ b/modules/fedimint-mintv2-client/src/cli.rs
@@ -13,7 +13,13 @@ enum Opts {
     /// Count the `ECash` notes in the client's database by denomination.
     Count,
     /// Send `ECash` for the given amount.
-    Send { amount: Amount },
+    Send {
+        amount: Amount,
+        /// Embed the federation's invite code in the serialized ecash so a
+        /// recipient that hasn't joined the federation can do so from it.
+        #[clap(long)]
+        include_invite: bool,
+    },
     /// Receive the `ECash` by reissuing the notes and return the amount.
     Receive { ecash: String },
 }
@@ -26,9 +32,12 @@ pub(crate) async fn handle_cli_command(
 
     match opts {
         Opts::Count => Ok(json(mint.get_count_by_denomination().await)),
-        Opts::Send { amount } => {
+        Opts::Send {
+            amount,
+            include_invite,
+        } => {
             let ecash = mint
-                .send(amount, Value::Null)
+                .send(amount, Value::Null, include_invite)
                 .await
                 .map(|ecash| base32::encode_prefixed(FEDIMINT_PREFIX, &ecash))?;
 

--- a/modules/fedimint-mintv2-client/src/ecash.rs
+++ b/modules/fedimint-mintv2-client/src/ecash.rs
@@ -1,6 +1,8 @@
-use fedimint_core::Amount;
 use fedimint_core::config::FederationId;
 use fedimint_core::encoding::{Decodable, Encodable};
+use fedimint_core::invite_code::InviteCode;
+use fedimint_core::util::SafeUrl;
+use fedimint_core::{Amount, PeerId};
 
 use crate::SpendableNote;
 
@@ -11,6 +13,14 @@ pub struct ECash(Vec<ECashField>);
 enum ECashField {
     Mint(FederationId),
     Note(SpendableNote),
+    /// Invite code to join the federation by which the e-cash was issued. This
+    /// allows a recipient that has not yet joined the federation to do so
+    /// directly from the received ecash.
+    Invite {
+        peer_apis: Vec<(PeerId, SafeUrl)>,
+        federation_id: FederationId,
+    },
+    ApiSecret(String),
     #[encodable_default]
     Default {
         variant: u64,
@@ -25,6 +35,23 @@ impl ECash {
                 .chain(notes.into_iter().map(ECashField::Note))
                 .collect(),
         )
+    }
+
+    pub fn new_with_invite(notes: Vec<SpendableNote>, invite: &InviteCode) -> Self {
+        let mut fields = vec![ECashField::Mint(invite.federation_id())];
+
+        fields.extend(notes.into_iter().map(ECashField::Note));
+
+        fields.push(ECashField::Invite {
+            peer_apis: vec![(invite.peer(), invite.url())],
+            federation_id: invite.federation_id(),
+        });
+
+        if let Some(api_secret) = invite.api_secret() {
+            fields.push(ECashField::ApiSecret(api_secret));
+        }
+
+        Self(fields)
     }
 
     pub fn amount(&self) -> Amount {
@@ -52,5 +79,37 @@ impl ECash {
                 _ => None,
             })
             .collect()
+    }
+
+    /// The invite code of the federation by which this ecash was issued, if it
+    /// was included by the sender.
+    pub fn federation_invite(&self) -> Option<InviteCode> {
+        let api_secret = self.api_secret();
+
+        self.0.iter().find_map(|field| {
+            let ECashField::Invite {
+                peer_apis,
+                federation_id,
+            } = field
+            else {
+                return None;
+            };
+
+            let (peer_id, api) = peer_apis.first().cloned()?;
+
+            Some(InviteCode::new(
+                api,
+                peer_id,
+                *federation_id,
+                api_secret.clone(),
+            ))
+        })
+    }
+
+    fn api_secret(&self) -> Option<String> {
+        self.0.iter().find_map(|field| match field {
+            ECashField::ApiSecret(api_secret) => Some(api_secret.clone()),
+            _ => None,
+        })
     }
 }

--- a/modules/fedimint-mintv2-client/src/lib.rs
+++ b/modules/fedimint-mintv2-client/src/lib.rs
@@ -852,7 +852,8 @@ impl MintClientModule {
             self.remove_spendable_note(dbtx, spendable_note).await;
         }
 
-        let ecash = ECash::new(self.federation_id, notes);
+        let invite = self.client_ctx.get_invite_code().await;
+        let ecash = ECash::new_with_invite(notes, &invite);
         let amount = ecash.amount();
         let operation_id = OperationId::new_random();
 

--- a/modules/fedimint-mintv2-client/src/lib.rs
+++ b/modules/fedimint-mintv2-client/src/lib.rs
@@ -766,14 +766,30 @@ impl MintClientModule {
     /// before the reissue is complete in which case the reissued notes are
     /// returned to the regular balance. To cancel a successful ecash send
     /// simply receive it yourself.
-    pub async fn send(&self, amount: Amount, custom_meta: Value) -> Result<ECash, SendECashError> {
+    ///
+    /// If `include_invite` is set, the federation's invite code is embedded in
+    /// the returned ecash so a recipient that has not joined the federation can
+    /// do so directly from the received ecash.
+    pub async fn send(
+        &self,
+        amount: Amount,
+        custom_meta: Value,
+        include_invite: bool,
+    ) -> Result<ECash, SendECashError> {
         let amount = round_to_multiple(amount, client_denominations().next().unwrap().amount());
 
         if let Some(ecash) = self
             .client_ctx
             .module_db()
             .autocommit(
-                |dbtx, _| Box::pin(self.send_ecash_dbtx(dbtx, amount, custom_meta.clone())),
+                |dbtx, _| {
+                    Box::pin(self.send_ecash_dbtx(
+                        dbtx,
+                        amount,
+                        custom_meta.clone(),
+                        include_invite,
+                    ))
+                },
                 Some(100),
             )
             .await
@@ -817,7 +833,7 @@ impl MintClientModule {
                 .map_err(|_| SendECashError::Failure)?;
         }
 
-        Box::pin(self.send(amount, custom_meta)).await
+        Box::pin(self.send(amount, custom_meta, include_invite)).await
     }
 
     async fn send_ecash_dbtx(
@@ -825,6 +841,7 @@ impl MintClientModule {
         dbtx: &mut DatabaseTransaction<'_>,
         mut remaining_amount: Amount,
         custom_meta: Value,
+        include_invite: bool,
     ) -> Result<Option<ECash>, Infallible> {
         let mut stream = dbtx
             .find_by_prefix_sorted_descending(&SpendableNotePrefix)
@@ -852,8 +869,12 @@ impl MintClientModule {
             self.remove_spendable_note(dbtx, spendable_note).await;
         }
 
-        let invite = self.client_ctx.get_invite_code().await;
-        let ecash = ECash::new_with_invite(notes, &invite);
+        let ecash = if include_invite {
+            let invite = self.client_ctx.get_invite_code().await;
+            ECash::new_with_invite(notes, &invite)
+        } else {
+            ECash::new(self.federation_id, notes)
+        };
         let amount = ecash.amount();
         let operation_id = OperationId::new_random();
 

--- a/modules/fedimint-mintv2-tests/tests/tests.rs
+++ b/modules/fedimint-mintv2-tests/tests/tests.rs
@@ -127,9 +127,12 @@ async fn send_and_receive() -> anyhow::Result<()> {
     for i in 0..10 {
         tracing::info!("Sending ecash payment {i} of 10");
 
+        // Exercise both with and without the optional invite code.
+        let include_invite = i % 2 == 0;
+
         let ecash = client_send
             .get_first_module::<MintClientModule>()?
-            .send(Amount::from_sats(1_000), Value::Null)
+            .send(Amount::from_sats(1_000), Value::Null, include_invite)
             .await?;
 
         let Some(MintEvent::Send(_)) = send_events.next().await else {
@@ -140,13 +143,14 @@ async fn send_and_receive() -> anyhow::Result<()> {
 
         let ecash: ECash = base32::decode_prefixed(FEDIMINT_PREFIX, &ecash).unwrap();
 
-        // The sender embeds the federation invite code so a recipient can join
-        // the issuing federation directly from the received ecash.
+        // When requested, the sender embeds the federation invite code so a
+        // recipient can join the issuing federation directly from the received
+        // ecash. Otherwise no invite is present.
         assert_eq!(
             ecash
                 .federation_invite()
                 .map(|invite| invite.federation_id()),
-            Some(client_send.federation_id()),
+            include_invite.then(|| client_send.federation_id()),
         );
 
         let operation_id = client_receive
@@ -233,7 +237,7 @@ async fn double_spend_is_rejected() -> anyhow::Result<()> {
 
     let ecash = client_send
         .get_first_module::<MintClientModule>()?
-        .send(Amount::from_sats(1_000), Value::Null)
+        .send(Amount::from_sats(1_000), Value::Null, false)
         .await?;
 
     let Some(MintEvent::Send(_)) = send_events.next().await else {
@@ -302,7 +306,7 @@ async fn transaction_with_invalid_signature_is_rejected() -> anyhow::Result<()> 
 
     let ecash = client
         .get_first_module::<MintClientModule>()?
-        .send(Amount::from_sats(1_000), Value::Null)
+        .send(Amount::from_sats(1_000), Value::Null, false)
         .await?;
 
     let Some(MintEvent::Send(_)) = events.next().await else {

--- a/modules/fedimint-mintv2-tests/tests/tests.rs
+++ b/modules/fedimint-mintv2-tests/tests/tests.rs
@@ -140,6 +140,15 @@ async fn send_and_receive() -> anyhow::Result<()> {
 
         let ecash: ECash = base32::decode_prefixed(FEDIMINT_PREFIX, &ecash).unwrap();
 
+        // The sender embeds the federation invite code so a recipient can join
+        // the issuing federation directly from the received ecash.
+        assert_eq!(
+            ecash
+                .federation_invite()
+                .map(|invite| invite.federation_id()),
+            Some(client_send.federation_id()),
+        );
+
         let operation_id = client_receive
             .get_first_module::<MintClientModule>()?
             .receive(ecash, Value::Null)


### PR DESCRIPTION
Fixes: https://github.com/fedimint/fedimint/issues/8666

Mintv2 does not have the invite code embedded in the ecash. This is important for user experience because it allows a user to scan an OOB ecash note and immediately join the federation.