### PR TITLE
Include release version in setup codes

### DIFF
--- a/fedimint-core/src/setup_code.rs
+++ b/fedimint-core/src/setup_code.rs
@@ -26,6 +26,8 @@ pub struct PeerSetupCode {
     pub federation_size: Option<u32>,
     /// Bitcoin network configured locally by the guardian
     pub network: Network,
+    /// Fedimint `x.y.z` cargo release version running on this peer
+    pub fedimint_version: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Encodable, Decodable, Serialize)]

--- a/fedimint-core/src/version.rs
+++ b/fedimint-core/src/version.rs
@@ -3,6 +3,19 @@ pub fn cargo_pkg() -> &'static str {
     env!("CARGO_PKG_VERSION")
 }
 
+/// Get the `x.y.z` cargo release version of `fedimint-core`.
+pub fn cargo_pkg_release() -> &'static str {
+    release_version(cargo_pkg())
+}
+
+/// Return only the `x.y.z` release component of a cargo package version.
+pub fn release_version(version: &str) -> &str {
+    version
+        .split(['-', '+'])
+        .next()
+        .expect("split always returns at least one item")
+}
+
 /// Get the git hash version of `fedimint-core`
 ///
 /// Note, in certain situations this not be accurate (eg. might be all `0`s).
@@ -22,3 +35,6 @@ pub fn non_zero_version_hash(hash: &str) -> Option<&str> {
         Some(hash)
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/fedimint-core/src/version/tests.rs
+++ b/fedimint-core/src/version/tests.rs
@@ -1,0 +1,10 @@
+use super::release_version;
+
+#[test]
+fn release_version_ignores_pre_release_and_build_metadata() {
+    assert_eq!(release_version("1.2.3-alpha.1"), "1.2.3");
+    assert_eq!(release_version("1.2.3-beta"), "1.2.3");
+    assert_eq!(release_version("1.2.3-rc.1"), "1.2.3");
+    assert_eq!(release_version("1.2.3+vendor-a"), "1.2.3");
+    assert_eq!(release_version("1.2.3-alpha.1+vendor-a"), "1.2.3");
+}

--- a/fedimint-server/src/config/mod.rs
+++ b/fedimint-server/src/config/mod.rs
@@ -121,7 +121,8 @@ pub struct ServerConfigPrivate {
 
 #[derive(Debug, Clone, Serialize, Deserialize, Encodable)]
 pub struct ServerConfigConsensus {
-    /// The version of the binary code running
+    /// The normalized `x.y.z` release version used for consensus config
+    /// checksums
     pub code_version: String,
     /// Agreed on core consensus version
     pub version: CoreConsensusVersion,
@@ -323,7 +324,7 @@ impl ServerConfig {
         code_version: String,
     ) -> Self {
         let consensus = ServerConfigConsensus {
-            code_version,
+            code_version: fedimint_core::version::release_version(&code_version).to_owned(),
             version: CORE_CONSENSUS_VERSION,
             broadcast_public_keys,
             broadcast_rounds_per_session: if is_running_in_test_env() {

--- a/fedimint-server/src/config/setup.rs
+++ b/fedimint-server/src/config/setup.rs
@@ -72,6 +72,8 @@ pub struct LocalParams {
     federation_size: Option<u32>,
     /// Bitcoin network configured locally
     network: bitcoin::Network,
+    /// Fedimint `x.y.z` cargo release version configured locally
+    fedimint_version: String,
 }
 
 impl LocalParams {
@@ -84,8 +86,24 @@ impl LocalParams {
             enabled_modules: self.enabled_modules.clone(),
             federation_size: self.federation_size,
             network: self.network,
+            fedimint_version: self.fedimint_version.clone(),
         }
     }
+}
+
+fn ensure_fedimint_version_matches(
+    peer_setup_code: &PeerSetupCode,
+    local_fedimint_version: &str,
+) -> anyhow::Result<()> {
+    let peer_fedimint_version =
+        fedimint_core::version::release_version(&peer_setup_code.fedimint_version);
+
+    ensure!(
+        peer_fedimint_version == local_fedimint_version,
+        "Guardian uses Fedimint version {peer_fedimint_version} but we use {local_fedimint_version}",
+    );
+
+    Ok(())
 }
 
 /// Serves the config gen API endpoints
@@ -270,6 +288,8 @@ impl ISetupApi for SetupApi {
                 enabled_modules,
                 federation_size,
                 network: self.settings.network,
+                fedimint_version: fedimint_core::version::release_version(&self.code_version_str)
+                    .to_owned(),
             }
         } else {
             let (tls_cert, tls_key) =
@@ -300,6 +320,8 @@ impl ISetupApi for SetupApi {
                 enabled_modules,
                 federation_size,
                 network: self.settings.network,
+                fedimint_version: fedimint_core::version::release_version(&self.code_version_str)
+                    .to_owned(),
             }
         };
 
@@ -331,6 +353,8 @@ impl ISetupApi for SetupApi {
             discriminant(&info.endpoints) == discriminant(&local_params.endpoints),
             "Guardian has different endpoint variant (TCP/Iroh) than us.",
         );
+
+        ensure_fedimint_version_matches(&info, &local_params.fedimint_version)?;
 
         ensure!(
             info.network == local_params.network,
@@ -403,6 +427,10 @@ impl ISetupApi for SetupApi {
         let our_setup_code = local_params.setup_code();
 
         state.setup_codes.insert(our_setup_code.clone());
+
+        for setup_code in &state.setup_codes {
+            ensure_fedimint_version_matches(setup_code, &local_params.fedimint_version)?;
+        }
 
         ensure!(
             state.setup_codes.len() == 1 || 4 <= state.setup_codes.len(),
@@ -625,6 +653,10 @@ mod tests {
     use super::*;
 
     fn setup_api(network: Network) -> SetupApi {
+        setup_api_with_version(network, "1.2.3-alpha")
+    }
+
+    fn setup_api_with_version(network: Network, version: &str) -> SetupApi {
         let (sender, _receiver) = mpsc::channel(1);
         let bind = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0);
 
@@ -644,7 +676,7 @@ mod tests {
             },
             MemDatabase::new().into_database(),
             sender,
-            String::new(),
+            version.to_owned(),
             String::new(),
         )
     }
@@ -694,6 +726,64 @@ mod tests {
         assert!(
             err.to_string()
                 .contains("Guardian uses Bitcoin network signet but we use regtest")
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_peer_setup_code_with_different_fedimint_version() {
+        let api = setup_api_with_version(Network::Regtest, "1.2.3-alpha");
+        let peer_api = setup_api_with_version(Network::Regtest, "1.2.4-beta");
+
+        setup_code(&api, "local").await;
+        let peer_code = setup_code(&peer_api, "peer").await;
+
+        let err = api
+            .add_peer_setup_code(peer_code)
+            .await
+            .expect_err("peer setup code with different Fedimint version should be rejected");
+
+        assert!(
+            err.to_string()
+                .contains("Guardian uses Fedimint version 1.2.4 but we use 1.2.3")
+        );
+    }
+
+    #[tokio::test]
+    async fn accepts_peer_setup_code_with_same_release_fedimint_version() {
+        let api = setup_api_with_version(Network::Regtest, "1.2.3-alpha");
+        let peer_api = setup_api_with_version(Network::Regtest, "1.2.3-beta");
+
+        setup_code(&api, "local").await;
+        let peer_code = setup_code(&peer_api, "peer").await;
+
+        let added_peer = api
+            .add_peer_setup_code(peer_code)
+            .await
+            .expect("peer setup code with same Fedimint release version should be accepted");
+
+        assert_eq!(added_peer, "peer");
+    }
+
+    #[tokio::test]
+    async fn rejects_wrong_fedimint_version_during_dkg() {
+        let api = setup_api_with_version(Network::Regtest, "1.2.3-alpha");
+        let peer_api = setup_api_with_version(Network::Regtest, "1.2.4-beta");
+
+        setup_code(&api, "local").await;
+        let peer_code = setup_code(&peer_api, "peer").await;
+        let peer_code = base32::decode_prefixed(FEDIMINT_PREFIX, &peer_code)
+            .expect("peer setup code should decode");
+
+        api.state.lock().await.setup_codes.insert(peer_code);
+
+        let err = api
+            .start_dkg()
+            .await
+            .expect_err("DKG should reject peer setup code with different Fedimint version");
+
+        assert!(
+            err.to_string()
+                .contains("Guardian uses Fedimint version 1.2.4 but we use 1.2.3")
         );
     }
 }

--- a/fedimint-testing-core/src/config.rs
+++ b/fedimint-testing-core/src/config.rs
@@ -62,6 +62,7 @@ pub fn local_config_gen_params(
                 enabled_modules: None,
                 federation_size: None,
                 network: bitcoin::Network::Regtest,
+                fedimint_version: fedimint_core::version::cargo_pkg_release().to_owned(),
             };
             (*peer, params)
         })

--- a/fedimintd/src/lib.rs
+++ b/fedimintd/src/lib.rs
@@ -251,9 +251,9 @@ impl ServerOpts {
 ///
 /// * `code_version_vendor_suffix` - An optional suffix that will be appended to
 ///   the internal fedimint release version, to distinguish binaries built by
-///   different vendors, usually with a different set of modules. Currently DKG
-///   will enforce that the combined `code_version` is the same between all
-///   peers.
+///   different vendors, usually with a different set of modules. The suffix is
+///   informational in setup/DKG: compatibility and consensus config generation
+///   use the normalized `x.y.z` release version.
 #[allow(clippy::too_many_lines)]
 pub async fn run(
     module_init_registry: ServerModuleInitRegistry,


### PR DESCRIPTION
*PR published by Tau/OpenAI*

### Summary

Setup codes now include the Fedimint `x.y.z` cargo release version, and setup rejects guardians whose setup-code release version does not match the local fedimintd release. This addresses #8627.

### Details

`PeerSetupCode` now carries a `fedimint_version` field populated from the local fedimintd version during setup. The setup API rejects mismatched peer setup codes when they are added, and `start_dkg` checks all setup codes again so stale or injected mismatched setup state is rejected during DKG. Version comparison normalizes Cargo-style versions to the `x.y.z` release component, ignoring alpha, beta, rc, build, and vendor suffixes. Consensus config `code_version` is normalized the same way so setup acceptance and DKG checksum behavior agree.

### Reviewing

Please focus on setup/DKG behavior and the decision to normalize consensus config `code_version` to the release component.

### Testing

Added tests for version normalization, accepting same-release setup codes with different prerelease suffixes, rejecting mismatched setup-code versions when added, and rejecting mismatched setup-code versions during DKG.

Closes #8627.
