### PR TITLE
chore: release v0.11.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4733,6 +4733,7 @@ name = "fedimint-walletv2-client"
 version = "0.11.0-rc.1"
 dependencies = [
  "anyhow",
+ "async-stream",
  "async-trait",
  "bitcoin",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2248,7 +2248,7 @@ dependencies = [
 
 [[package]]
 name = "devimint"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -2708,7 +2708,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fedimint-aead"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "argon2",
@@ -2740,7 +2740,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-api-client"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2766,7 +2766,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-bip39"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "bip39",
  "fedimint-client",
@@ -2777,7 +2777,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-bitcoind"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2792,14 +2792,14 @@ dependencies = [
 
 [[package]]
 name = "fedimint-build"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "fedimint-cli"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2842,7 +2842,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2874,7 +2874,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client-module"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -2905,7 +2905,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client-rpc"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2933,7 +2933,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client-uniffi"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "fedimint-build",
@@ -2951,7 +2951,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client-wasm"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2969,7 +2969,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-connectors"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "arti-client",
@@ -3004,7 +3004,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-core"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3070,7 +3070,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-cursed-redb"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3090,7 +3090,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-db-locked"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3102,7 +3102,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dbtool"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3138,7 +3138,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-derive"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
@@ -3148,7 +3148,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-derive-secret"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",
@@ -3160,11 +3160,11 @@ dependencies = [
 
 [[package]]
 name = "fedimint-docs"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 
 [[package]]
 name = "fedimint-dummy-client"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3186,7 +3186,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dummy-common"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -3196,7 +3196,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dummy-server"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3212,7 +3212,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-empty-client"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3229,7 +3229,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-empty-common"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -3239,7 +3239,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-empty-server"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3255,7 +3255,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-eventlog"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3273,7 +3273,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-fountain"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3285,7 +3285,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-fuzz"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "fedimint-core",
  "fedimint-ln-common",
@@ -3298,7 +3298,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-client"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "bcrypt",
@@ -3323,7 +3323,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-common"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -3340,7 +3340,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-server"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3421,7 +3421,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-server-db"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -3449,7 +3449,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-ui"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "async-trait",
  "axum 0.8.8",
@@ -3481,7 +3481,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gw-client"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3511,7 +3511,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gwv2-client"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3538,7 +3538,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-hkdf"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "bitcoin_hashes",
 ]
@@ -3586,7 +3586,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lightning"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3613,7 +3613,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-client"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3647,7 +3647,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-common"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3670,7 +3670,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-server"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3695,7 +3695,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-tests"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3724,7 +3724,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnurl"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "bech32",
  "lightning-invoice",
@@ -3736,7 +3736,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-client"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3768,7 +3768,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-common"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3788,7 +3788,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-server"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3812,7 +3812,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-tests"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3849,7 +3849,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-load-test-tool"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -3877,7 +3877,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-logging"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "console-subscriber",
@@ -3890,7 +3890,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-client"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3911,7 +3911,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-common"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -3925,7 +3925,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-server"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3944,7 +3944,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-tests"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -3958,7 +3958,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-metrics"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -3970,7 +3970,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-client"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -4011,7 +4011,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-common"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",
@@ -4024,7 +4024,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-server"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4051,7 +4051,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-tests"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4085,7 +4085,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mintv2-client"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -4124,7 +4124,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mintv2-common"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",
@@ -4137,7 +4137,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mintv2-server"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4162,7 +4162,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mintv2-tests"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4195,7 +4195,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-portalloc"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "dirs",
@@ -4209,7 +4209,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-recoverytool"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -4232,7 +4232,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-recurringd"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -4261,7 +4261,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-recurringd-tests"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "devimint",
@@ -4275,7 +4275,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-recurringdv2"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -4296,7 +4296,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-rocksdb"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4313,7 +4313,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -4370,7 +4370,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server-bitcoin-rpc"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4386,7 +4386,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server-core"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4404,7 +4404,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server-tests"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "bitcoin",
  "fedimint-api-client",
@@ -4424,7 +4424,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server-ui"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4451,7 +4451,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-tbs"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "bls12_381",
  "criterion",
@@ -4466,7 +4466,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-testing"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4506,7 +4506,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-testing-core"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -4567,7 +4567,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-tpe"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "bitcoin_hashes",
  "bls12_381",
@@ -4581,7 +4581,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ui-common"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "axum 0.8.8",
  "axum-extra",
@@ -4593,7 +4593,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-unknown-common"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -4603,7 +4603,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-unknown-server"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4617,14 +4617,14 @@ dependencies = [
 
 [[package]]
 name = "fedimint-util-error"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "fedimint-wallet-client"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -4654,7 +4654,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-common"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -4670,7 +4670,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-server"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4697,7 +4697,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-tests"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4730,7 +4730,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-walletv2-client"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4758,7 +4758,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-walletv2-common"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -4771,7 +4771,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-walletv2-server"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4793,7 +4793,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-walletv2-tests"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4823,7 +4823,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wasm-tests"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "fedimint-client",
@@ -4844,7 +4844,7 @@ dependencies = [
 
 [[package]]
 name = "fedimintd"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -4881,7 +4881,7 @@ dependencies = [
 
 [[package]]
 name = "fedimintd-envs"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 
 [[package]]
 name = "ff"
@@ -5197,7 +5197,7 @@ dependencies = [
 
 [[package]]
 name = "gateway-tests"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,7 +107,7 @@ keywords = ["bitcoin", "lightning", "chaumian", "e-cash", "federated"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/fedimint/fedimint"
-version = "0.11.0-rc.1"
+version = "0.11.2"
 
 [workspace.metadata]
 authors = ["The Fedimint Developers"]
@@ -168,7 +168,7 @@ criterion = "0.5.1"
 # We need to pin this arti's `curve25519-dalek` dependency, due to `https://rustsec.org/advisories/RUSTSEC-2024-0344` vulnerability
 # It's been updated by https://gitlab.torproject.org/tpo/core/arti/-/merge_requests/2211, should be removed in next release.
 curve25519-dalek = ">=4.1.3"
-devimint = { path = "./devimint", version = "=0.11.0-rc.1" }
+devimint = { path = "./devimint", version = "=0.11.2" }
 dirs = "6.0.0"
 erased-serde = "0.4"
 esplora-client = { version = "0.12.3", default-features = false, features = [
@@ -178,70 +178,70 @@ esplora-client = { version = "0.12.3", default-features = false, features = [
 ] }
 tor-rtcompat = { version = "0.33.0" }
 
-fedimint-aead = { path = "./crypto/aead", version = "=0.11.0-rc.1" }
-fedimint-api-client = { path = "./fedimint-api-client", version = "=0.11.0-rc.1" }
-fedimint-bip39 = { path = "./fedimint-bip39", version = "=0.11.0-rc.1" }
-fedimint-bitcoind = { path = "./fedimint-bitcoind", version = "=0.11.0-rc.1" }
-fedimint-build = { path = "./fedimint-build", version = "=0.11.0-rc.1" }
-fedimint-client = { path = "./fedimint-client", version = "=0.11.0-rc.1" }
-fedimint-client-module = { path = "./fedimint-client-module", version = "=0.11.0-rc.1" }
-fedimint-client-rpc = { path = "./fedimint-client-rpc", version = "=0.11.0-rc.1" }
-fedimint-connectors = { path = "./fedimint-connectors", version = "=0.11.0-rc.1" }
-fedimint-core = { path = "./fedimint-core", version = "=0.11.0-rc.1" }
-fedimint-cursed-redb = { path = "./fedimint-cursed-redb", version = "=0.11.0-rc.1" }
-fedimint-db-locked = { path = "./fedimint-db-locked", version = "=0.11.0-rc.1" }
-fedimint-derive = { path = "./fedimint-derive", version = "=0.11.0-rc.1" }
-fedimint-derive-secret = { path = "./crypto/derive-secret", version = "=0.11.0-rc.1" }
-fedimint-dummy-client = { path = "./modules/fedimint-dummy-client", version = "=0.11.0-rc.1" }
-fedimint-dummy-common = { path = "./modules/fedimint-dummy-common", version = "=0.11.0-rc.1" }
-fedimint-dummy-server = { path = "./modules/fedimint-dummy-server", version = "=0.11.0-rc.1" }
-fedimint-empty-common = { path = "./modules/fedimint-empty-common", version = "=0.11.0-rc.1" }
-fedimint-eventlog = { path = "./fedimint-eventlog", version = "=0.11.0-rc.1" }
-fedimint-gateway-common = { package = "fedimint-gateway-common", path = "./gateway/fedimint-gateway-common", version = "=0.11.0-rc.1" }
-fedimint-gateway-server = { package = "fedimint-gateway-server", path = "./gateway/fedimint-gateway-server", version = "=0.11.0-rc.1" }
-fedimint-gateway-server-db = { package = "fedimint-gateway-server-db", path = "./gateway/fedimint-gateway-server-db", version = "=0.11.0-rc.1" }
-fedimint-gateway-ui = { package = "fedimint-gateway-ui", path = "./gateway/fedimint-gateway-ui", version = "=0.11.0-rc.1" }
-fedimint-gw-client = { path = "./modules/fedimint-gw-client", version = "=0.11.0-rc.1" }
-fedimint-gwv2-client = { path = "./modules/fedimint-gwv2-client", version = "=0.11.0-rc.1" }
-fedimint-lightning = { package = "fedimint-lightning", path = "./gateway/fedimint-lightning", version = "=0.11.0-rc.1" }
-fedimint-ln-client = { path = "./modules/fedimint-ln-client", version = "=0.11.0-rc.1" }
-fedimint-ln-common = { path = "./modules/fedimint-ln-common", version = "=0.11.0-rc.1" }
-fedimint-ln-server = { path = "./modules/fedimint-ln-server", version = "=0.11.0-rc.1" }
-fedimint-lnurl = { path = "./fedimint-lnurl", version = "=0.11.0-rc.1" }
-fedimint-lnv2-client = { path = "./modules/fedimint-lnv2-client", version = "=0.11.0-rc.1" }
-fedimint-lnv2-common = { path = "./modules/fedimint-lnv2-common", version = "=0.11.0-rc.1" }
-fedimint-lnv2-server = { path = "./modules/fedimint-lnv2-server", version = "=0.11.0-rc.1" }
-fedimint-logging = { path = "./fedimint-logging", version = "=0.11.0-rc.1" }
-fedimint-meta-client = { path = "./modules/fedimint-meta-client", version = "=0.11.0-rc.1" }
-fedimint-meta-common = { path = "./modules/fedimint-meta-common", version = "=0.11.0-rc.1" }
-fedimint-meta-server = { path = "./modules/fedimint-meta-server", version = "=0.11.0-rc.1" }
-fedimint-metrics = { path = "./fedimint-metrics", version = "=0.11.0-rc.1" }
-fedimint-mint-client = { path = "./modules/fedimint-mint-client", version = "=0.11.0-rc.1" }
-fedimint-mint-common = { path = "./modules/fedimint-mint-common", version = "=0.11.0-rc.1" }
-fedimint-mint-server = { path = "./modules/fedimint-mint-server", version = "=0.11.0-rc.1" }
-fedimint-mintv2-client = { path = "./modules/fedimint-mintv2-client", version = "=0.11.0-rc.1" }
-fedimint-mintv2-common = { path = "./modules/fedimint-mintv2-common", version = "=0.11.0-rc.1" }
-fedimint-mintv2-server = { path = "./modules/fedimint-mintv2-server", version = "=0.11.0-rc.1" }
-fedimint-portalloc = { path = "utils/portalloc", version = "=0.11.0-rc.1" }
-fedimint-rocksdb = { path = "./fedimint-rocksdb", version = "=0.11.0-rc.1" }
-fedimint-server = { path = "./fedimint-server", version = "=0.11.0-rc.1" }
-fedimint-server-bitcoin-rpc = { path = "./fedimint-server-bitcoin-rpc", version = "=0.11.0-rc.1" }
-fedimint-server-core = { path = "./fedimint-server-core", version = "=0.11.0-rc.1" }
-fedimint-server-ui = { path = "./fedimint-server-ui", version = "=0.11.0-rc.1" }
-fedimint-testing = { path = "./fedimint-testing", version = "=0.11.0-rc.1" }
-fedimint-testing-core = { path = "./fedimint-testing-core", version = "=0.11.0-rc.1" }
-fedimint-ui-common = { path = "./fedimint-ui-common", version = "=0.11.0-rc.1" }
-fedimint-unknown-common = { path = "./modules/fedimint-unknown-common", version = "=0.11.0-rc.1" }
-fedimint-unknown-server = { path = "./modules/fedimint-unknown-server", version = "=0.11.0-rc.1" }
-fedimint-util-error = { path = "./fedimint-util-error", version = "=0.11.0-rc.1" }
-fedimint-wallet-client = { path = "./modules/fedimint-wallet-client", version = "=0.11.0-rc.1" }
-fedimint-wallet-common = { path = "./modules/fedimint-wallet-common", version = "=0.11.0-rc.1" }
-fedimint-wallet-server = { path = "./modules/fedimint-wallet-server", version = "=0.11.0-rc.1" }
-fedimint-walletv2-client = { path = "./modules/fedimint-walletv2-client", version = "=0.11.0-rc.1" }
-fedimint-walletv2-common = { path = "./modules/fedimint-walletv2-common", version = "=0.11.0-rc.1" }
-fedimint-walletv2-server = { path = "./modules/fedimint-walletv2-server", version = "=0.11.0-rc.1" }
-fedimintd = { path = "./fedimintd", version = "=0.11.0-rc.1" }
-fedimintd-envs = { path = "./fedimintd-envs", version = "=0.11.0-rc.1" }
+fedimint-aead = { path = "./crypto/aead", version = "=0.11.2" }
+fedimint-api-client = { path = "./fedimint-api-client", version = "=0.11.2" }
+fedimint-bip39 = { path = "./fedimint-bip39", version = "=0.11.2" }
+fedimint-bitcoind = { path = "./fedimint-bitcoind", version = "=0.11.2" }
+fedimint-build = { path = "./fedimint-build", version = "=0.11.2" }
+fedimint-client = { path = "./fedimint-client", version = "=0.11.2" }
+fedimint-client-module = { path = "./fedimint-client-module", version = "=0.11.2" }
+fedimint-client-rpc = { path = "./fedimint-client-rpc", version = "=0.11.2" }
+fedimint-connectors = { path = "./fedimint-connectors", version = "=0.11.2" }
+fedimint-core = { path = "./fedimint-core", version = "=0.11.2" }
+fedimint-cursed-redb = { path = "./fedimint-cursed-redb", version = "=0.11.2" }
+fedimint-db-locked = { path = "./fedimint-db-locked", version = "=0.11.2" }
+fedimint-derive = { path = "./fedimint-derive", version = "=0.11.2" }
+fedimint-derive-secret = { path = "./crypto/derive-secret", version = "=0.11.2" }
+fedimint-dummy-client = { path = "./modules/fedimint-dummy-client", version = "=0.11.2" }
+fedimint-dummy-common = { path = "./modules/fedimint-dummy-common", version = "=0.11.2" }
+fedimint-dummy-server = { path = "./modules/fedimint-dummy-server", version = "=0.11.2" }
+fedimint-empty-common = { path = "./modules/fedimint-empty-common", version = "=0.11.2" }
+fedimint-eventlog = { path = "./fedimint-eventlog", version = "=0.11.2" }
+fedimint-gateway-common = { package = "fedimint-gateway-common", path = "./gateway/fedimint-gateway-common", version = "=0.11.2" }
+fedimint-gateway-server = { package = "fedimint-gateway-server", path = "./gateway/fedimint-gateway-server", version = "=0.11.2" }
+fedimint-gateway-server-db = { package = "fedimint-gateway-server-db", path = "./gateway/fedimint-gateway-server-db", version = "=0.11.2" }
+fedimint-gateway-ui = { package = "fedimint-gateway-ui", path = "./gateway/fedimint-gateway-ui", version = "=0.11.2" }
+fedimint-gw-client = { path = "./modules/fedimint-gw-client", version = "=0.11.2" }
+fedimint-gwv2-client = { path = "./modules/fedimint-gwv2-client", version = "=0.11.2" }
+fedimint-lightning = { package = "fedimint-lightning", path = "./gateway/fedimint-lightning", version = "=0.11.2" }
+fedimint-ln-client = { path = "./modules/fedimint-ln-client", version = "=0.11.2" }
+fedimint-ln-common = { path = "./modules/fedimint-ln-common", version = "=0.11.2" }
+fedimint-ln-server = { path = "./modules/fedimint-ln-server", version = "=0.11.2" }
+fedimint-lnurl = { path = "./fedimint-lnurl", version = "=0.11.2" }
+fedimint-lnv2-client = { path = "./modules/fedimint-lnv2-client", version = "=0.11.2" }
+fedimint-lnv2-common = { path = "./modules/fedimint-lnv2-common", version = "=0.11.2" }
+fedimint-lnv2-server = { path = "./modules/fedimint-lnv2-server", version = "=0.11.2" }
+fedimint-logging = { path = "./fedimint-logging", version = "=0.11.2" }
+fedimint-meta-client = { path = "./modules/fedimint-meta-client", version = "=0.11.2" }
+fedimint-meta-common = { path = "./modules/fedimint-meta-common", version = "=0.11.2" }
+fedimint-meta-server = { path = "./modules/fedimint-meta-server", version = "=0.11.2" }
+fedimint-metrics = { path = "./fedimint-metrics", version = "=0.11.2" }
+fedimint-mint-client = { path = "./modules/fedimint-mint-client", version = "=0.11.2" }
+fedimint-mint-common = { path = "./modules/fedimint-mint-common", version = "=0.11.2" }
+fedimint-mint-server = { path = "./modules/fedimint-mint-server", version = "=0.11.2" }
+fedimint-mintv2-client = { path = "./modules/fedimint-mintv2-client", version = "=0.11.2" }
+fedimint-mintv2-common = { path = "./modules/fedimint-mintv2-common", version = "=0.11.2" }
+fedimint-mintv2-server = { path = "./modules/fedimint-mintv2-server", version = "=0.11.2" }
+fedimint-portalloc = { path = "utils/portalloc", version = "=0.11.2" }
+fedimint-rocksdb = { path = "./fedimint-rocksdb", version = "=0.11.2" }
+fedimint-server = { path = "./fedimint-server", version = "=0.11.2" }
+fedimint-server-bitcoin-rpc = { path = "./fedimint-server-bitcoin-rpc", version = "=0.11.2" }
+fedimint-server-core = { path = "./fedimint-server-core", version = "=0.11.2" }
+fedimint-server-ui = { path = "./fedimint-server-ui", version = "=0.11.2" }
+fedimint-testing = { path = "./fedimint-testing", version = "=0.11.2" }
+fedimint-testing-core = { path = "./fedimint-testing-core", version = "=0.11.2" }
+fedimint-ui-common = { path = "./fedimint-ui-common", version = "=0.11.2" }
+fedimint-unknown-common = { path = "./modules/fedimint-unknown-common", version = "=0.11.2" }
+fedimint-unknown-server = { path = "./modules/fedimint-unknown-server", version = "=0.11.2" }
+fedimint-util-error = { path = "./fedimint-util-error", version = "=0.11.2" }
+fedimint-wallet-client = { path = "./modules/fedimint-wallet-client", version = "=0.11.2" }
+fedimint-wallet-common = { path = "./modules/fedimint-wallet-common", version = "=0.11.2" }
+fedimint-wallet-server = { path = "./modules/fedimint-wallet-server", version = "=0.11.2" }
+fedimint-walletv2-client = { path = "./modules/fedimint-walletv2-client", version = "=0.11.2" }
+fedimint-walletv2-common = { path = "./modules/fedimint-walletv2-common", version = "=0.11.2" }
+fedimint-walletv2-server = { path = "./modules/fedimint-walletv2-server", version = "=0.11.2" }
+fedimintd = { path = "./fedimintd", version = "=0.11.2" }
+fedimintd-envs = { path = "./fedimintd-envs", version = "=0.11.2" }
 ff = "0.13.1"
 fs-lock = "=0.1.10"
 fs2 = "0.4.3"
@@ -253,7 +253,7 @@ gloo-timers = "0.3.0"
 group = "0.13.0"
 hex = "0.4.3"
 hex-conservative = "1.0.0"
-hkdf = { package = "fedimint-hkdf", path = "./crypto/hkdf", version = "=0.11.0-rc.1" }
+hkdf = { package = "fedimint-hkdf", path = "./crypto/hkdf", version = "=0.11.2" }
 honggfuzz = { version = "=0.5.55", default-features = false } # needs to be pinned to the same version `cargo-fuzz` binary uses
 hyper = "1.6"
 imbl = "5.0.0"
@@ -330,7 +330,7 @@ substring = "1.4.5"
 subtle = "2.6.1"
 syn = "2.0"
 tar = "0.4.45"
-tbs = { package = "fedimint-tbs", path = "./crypto/tbs", version = "=0.11.0-rc.1" }
+tbs = { package = "fedimint-tbs", path = "./crypto/tbs", version = "=0.11.2" }
 tempfile = "3.20.0"
 test-log = { version = "0.2", features = ["trace"], default-features = false }
 thiserror = "2.0.18"
@@ -349,7 +349,7 @@ tonic_lnd = { version = "0.4.0", package = "fedimint-tonic-lnd", features = [
 ] }
 tower = { version = "0.4.13", default-features = false }
 tower-http = { version = "0.6.8", features = ["cors"] }
-tpe = { package = "fedimint-tpe", path = "./crypto/tpe", version = "=0.11.0-rc.1" }
+tpe = { package = "fedimint-tpe", path = "./crypto/tpe", version = "=0.11.2" }
 tracing = "0.1.44"
 tracing-opentelemetry = "0.29.0"
 tracing-subscriber = "0.3.22"

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -433,7 +433,10 @@ async fn withdraw_v2(
 
     let result = wallet_module
         .await_final_send_operation_state(operation_id)
-        .await;
+        .await
+        .map_err(|e| AdminGatewayError::WithdrawError {
+            failure_reason: e.to_string(),
+        })?;
 
     let fees = PegOutFees::from_amount(fee);
 

--- a/modules/fedimint-walletv2-client/Cargo.toml
+++ b/modules/fedimint-walletv2-client/Cargo.toml
@@ -21,6 +21,7 @@ path = "src/lib.rs"
 
 [dependencies]
 anyhow = { workspace = true }
+async-stream = { workspace = true }
 async-trait = { workspace = true }
 bitcoin = { workspace = true }
 clap = { workspace = true, optional = true }

--- a/modules/fedimint-walletv2-client/src/cli.rs
+++ b/modules/fedimint-walletv2-client/src/cli.rs
@@ -62,7 +62,7 @@ pub(crate) async fn handle_cli_command(
         } => json(
             wallet
                 .await_final_send_operation_state(wallet.send(address, value, fee).await?)
-                .await,
+                .await?,
         ),
         Opts::Receive => json(wallet.receive().await),
     };

--- a/modules/fedimint-walletv2-client/src/lib.rs
+++ b/modules/fedimint-walletv2-client/src/lib.rs
@@ -97,6 +97,15 @@ pub enum FinalSendOperationState {
     Failure,
 }
 
+/// The final state of an operation receiving bitcoin onchain.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum FinalReceiveOperationState {
+    /// The federation accepted the claiming transaction.
+    Success,
+    /// The federation rejected the claiming transaction.
+    Aborted,
+}
+
 #[derive(Debug, Clone)]
 pub struct WalletClientModule {
     root_secret: DerivableSecret,
@@ -353,21 +362,84 @@ impl WalletClientModule {
     pub async fn await_final_send_operation_state(
         &self,
         operation_id: OperationId,
-    ) -> FinalSendOperationState {
+    ) -> anyhow::Result<FinalSendOperationState> {
+        let operation = self.client_ctx.get_operation(operation_id).await?;
         let mut stream = self.notifier.subscribe(operation_id).await;
 
-        loop {
-            let Some(WalletClientStateMachines::Send(state)) = stream.next().await else {
-                panic!("stream must produce a terminal send state");
-            };
+        let mut stream = self
+            .client_ctx
+            .outcome_or_updates(operation, operation_id, move || {
+                async_stream::stream! {
+                    loop {
+                        if let Some(WalletClientStateMachines::Send(state)) = stream.next().await {
+                            match state.state {
+                                SendSMState::Funding => {}
+                                SendSMState::Success(txid) => {
+                                    yield FinalSendOperationState::Success(txid);
+                                    return;
+                                }
+                                SendSMState::Aborted(..) => {
+                                    yield FinalSendOperationState::Aborted;
+                                    return;
+                                }
+                                SendSMState::Failure => {
+                                    yield FinalSendOperationState::Failure;
+                                    return;
+                                }
+                            }
+                        }
+                    }
+                }
+            })
+            .into_stream();
 
-            match state.state {
-                SendSMState::Funding => {}
-                SendSMState::Success(txid) => return FinalSendOperationState::Success(txid),
-                SendSMState::Aborted(..) => return FinalSendOperationState::Aborted,
-                SendSMState::Failure => return FinalSendOperationState::Failure,
-            }
+        let mut final_state = None;
+
+        while let Some(state) = stream.next().await {
+            final_state = Some(state);
         }
+
+        Ok(final_state.expect("Stream contains one final state"))
+    }
+
+    /// Await the final state of the receive operation.
+    pub async fn await_final_receive_operation_state(
+        &self,
+        operation_id: OperationId,
+    ) -> anyhow::Result<FinalReceiveOperationState> {
+        let operation = self.client_ctx.get_operation(operation_id).await?;
+        let mut stream = self.notifier.subscribe(operation_id).await;
+
+        let mut stream = self
+            .client_ctx
+            .outcome_or_updates(operation, operation_id, move || {
+                async_stream::stream! {
+                    loop {
+                        if let Some(WalletClientStateMachines::Receive(state)) = stream.next().await {
+                            match state.state {
+                                ReceiveSMState::Funding => {}
+                                ReceiveSMState::Success => {
+                                    yield FinalReceiveOperationState::Success;
+                                    return;
+                                }
+                                ReceiveSMState::Aborted(..) => {
+                                    yield FinalReceiveOperationState::Aborted;
+                                    return;
+                                }
+                            }
+                        }
+                    }
+                }
+            })
+            .into_stream();
+
+        let mut final_state = None;
+
+        while let Some(state) = stream.next().await {
+            final_state = Some(state);
+        }
+
+        Ok(final_state.expect("Stream contains one final state"))
     }
 
     /// Returns the next unused receive address, polling until the initial

--- a/modules/fedimint-walletv2-tests/tests/tests.rs
+++ b/modules/fedimint-walletv2-tests/tests/tests.rs
@@ -212,7 +212,7 @@ async fn fee_exceeds_one_bitcoin_with_many_pending_txs() -> anyhow::Result<()> {
         let state = client
             .get_first_module::<WalletClientModule>()?
             .await_final_send_operation_state(send_op)
-            .await;
+            .await?;
 
         assert!(matches!(state, FinalSendOperationState::Success(_)));
 


### PR DESCRIPTION
## Summary

Prepare the v0.11.2 release branch by including the latest v0.11 backport and bumping all workspace crate versions to `0.11.2`.

## Details

This PR starts from `upstream/releases/v0.11` at #8664, which includes the latest merged v0.11 backport, then cherry-picks the still-open #8665 walletv2 operation outcome persistence backport so the release contains all currently labeled v0.11 backports.

The version bump was done with `just bump-version 0.11.0-rc.1 0.11.2`, and `Cargo.lock` was regenerated by running clippy rather than `cargo update` or `cargo generate-lockfile`. The lockfile diff only changes workspace crate versions from `0.11.0-rc.1` to `0.11.2`.

## Testing

- `cargo clippy --workspace --all-targets`
- `just format`
- `git diff --check`
- lockfile diff check for version-only changes
- `just clippy`

`just final-lint` is not available on this release branch. `just cargo-sort-check` and the generated pre-commit hook currently fail before checking files with `error: no file found at: /home/user/.local/share/workspaces/minimint/release-0.11.2`, which appears to be a local worktree/tooling issue.
