### PR TITLE
feat: Mint Receive Fee Quote (v1 and v2)

### DIFF
--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -1246,6 +1246,22 @@ pub enum ReissueExternalNotesError {
     AlreadyReissued,
 }
 
+/// Breakdown of the fee reissuing external notes would incur, as computed by
+/// [`MintClientModule::reissue_fee_quote`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReissueFeeQuote {
+    /// Total fee: everything the reissued value does not become a net wallet
+    /// gain.
+    pub total: Amount,
+    /// Fees charged on the spent (input) notes — both the external notes and
+    /// any of the wallet's own notes pulled in by consolidation.
+    pub input: Amount,
+    /// Fees charged on the newly minted (output) notes.
+    pub output: Amount,
+    /// Sub-denomination remainder that cannot form a note and is lost.
+    pub dust: Amount,
+}
+
 impl MintClientModule {
     async fn create_sufficient_input(
         &self,
@@ -1747,6 +1763,82 @@ impl MintClientModule {
     ) -> (NoteIssuanceRequest, BlindNonce) {
         let secret = self.new_note_secret(amount, dbtx).await;
         NoteIssuanceRequest::new(&self.secp, &secret)
+    }
+
+    /// Computes the exact fee `reissue_external_notes(oob_notes)` would incur
+    /// given the wallet's current note inventory, without submitting anything.
+    ///
+    /// Runs the same change generation the real reissue does
+    /// (`create_final_inputs_and_outputs`, including note consolidation)
+    /// against a non-committable transaction that is dropped rather than
+    /// committed, so the wallet's notes are read but left untouched. The
+    /// quote is point-in-time: it depends on the current inventory and can
+    /// move as notes change.
+    pub async fn reissue_fee_quote(&self, oob_notes: &OOBNotes) -> anyhow::Result<ReissueFeeQuote> {
+        let input_amount = oob_notes.total_amount();
+        // The reissue's explicit inputs are the external notes; the federation's
+        // fees on those are the starting `output_amount` for change generation.
+        let external_input_fees: Amount = oob_notes
+            .notes()
+            .iter_items()
+            .map(|(amount, _)| self.cfg.fee_consensus.fee(amount))
+            .sum();
+
+        // Non-committable: writes are discarded on drop, so this is a pure
+        // dry-run over the real inventory.
+        let mut dbtx = self.client_ctx.module_db().begin_transaction_nc().await;
+        // Disambiguate from the blanket `IClientModule` method of the same name.
+        let (inputs, outputs) = ClientModule::create_final_inputs_and_outputs(
+            self,
+            &mut dbtx.to_ref_nc(),
+            OperationId::new_random(),
+            AmountUnit::BITCOIN,
+            input_amount,
+            external_input_fees,
+        )
+        .await?;
+        // This is a dry-run: the change generation writes to `dbtx` (e.g.
+        // removing consolidated notes), but we intentionally drop it without
+        // committing. Mark it so the commit tracker doesn't warn on drop.
+        dbtx.ignore_uncommitted();
+
+        // Consolidation may pull additional wallet notes in as inputs and mint
+        // additional outputs; all outputs become the user's new notes.
+        let consolidation_input: Amount = inputs
+            .inputs()
+            .iter()
+            .map(|i| i.amounts.get_bitcoin())
+            .sum();
+        let output_value: Amount = outputs
+            .outputs()
+            .iter()
+            .map(|o| o.amounts.get_bitcoin())
+            .sum();
+
+        let consolidation_input_fees: Amount = inputs
+            .inputs()
+            .iter()
+            .map(|i| self.cfg.fee_consensus.fee(i.amounts.get_bitcoin()))
+            .sum();
+        let output_fees: Amount = outputs
+            .outputs()
+            .iter()
+            .map(|o| self.cfg.fee_consensus.fee(o.amounts.get_bitcoin()))
+            .sum();
+
+        // Net wallet gain = minted outputs − wallet notes consumed. The total
+        // fee is everything the reissued value did not become a net gain;
+        // whatever is left after the explicit input/output fees is dust.
+        let total = (input_amount + consolidation_input).saturating_sub(output_value);
+        let input = external_input_fees + consolidation_input_fees;
+        let dust = total.saturating_sub(input + output_fees);
+
+        Ok(ReissueFeeQuote {
+            total,
+            input,
+            output: output_fees,
+            dust,
+        })
     }
 
     /// Try to reissue e-cash notes received from a third party to receive them

--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -156,6 +156,67 @@ async fn sends_ecash_out_of_band() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn reissue_fee_quote_matches_actual_fee() -> anyhow::Result<()> {
+    let fed = fixtures().new_fed_degraded().await;
+    let (client_send, client_receive) = fed.two_clients().await;
+    issue_ecash(&client_send, sats(11_000)).await?;
+
+    // Reissue several times so the receiver's note inventory — and therefore the
+    // consolidation-driven fee — differs between iterations (first into an empty
+    // wallet, then into a progressively more populated one).
+    for i in 0..5 {
+        let send_mint = client_send.get_first_module::<MintClientModule>()?;
+        let (spend_op, notes) = send_mint
+            .spend_notes_with_selector(
+                &SelectNotesWithAtleastAmount,
+                sats(1_000),
+                TIMEOUT,
+                false,
+                (),
+            )
+            .await?;
+        let mut send_sub = send_mint
+            .subscribe_spend_notes(spend_op)
+            .await?
+            .into_stream();
+        assert_eq!(send_sub.ok().await?, SpendOOBState::Created);
+
+        let receive_mint = client_receive.get_first_module::<MintClientModule>()?;
+        let reissued_value = notes.total_amount();
+
+        let quote = receive_mint.reissue_fee_quote(&notes).await?;
+        let before = client_receive.get_balance_for_btc().await?;
+
+        let op = receive_mint.reissue_external_notes(notes, ()).await?;
+        let mut sub = receive_mint
+            .subscribe_reissue_external_notes(op)
+            .await?
+            .into_stream();
+        assert_eq!(sub.ok().await?, ReissueExternalNotesState::Created);
+        assert_eq!(sub.ok().await?, ReissueExternalNotesState::Issuing);
+        // `Done` is reached once the reissued (and consolidation) notes have been
+        // issued, so the balance is settled by here.
+        assert_eq!(sub.ok().await?, ReissueExternalNotesState::Done);
+        assert_eq!(send_sub.ok().await?, SpendOOBState::Success);
+
+        let after = client_receive.get_balance_for_btc().await?;
+        let actual_fee = reissued_value - (after - before);
+
+        assert_eq!(
+            quote.total, actual_fee,
+            "iteration {i}: quoted fee {quote:?} != actual fee {actual_fee:?}"
+        );
+        assert_eq!(
+            quote.total,
+            quote.input + quote.output + quote.dust,
+            "iteration {i}: breakdown {quote:?} does not sum to total"
+        );
+    }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn blind_nonce_index() -> anyhow::Result<()> {
     // Give client initial balance
     let fed = fixtures().new_fed_degraded().await;

--- a/modules/fedimint-mintv2-client/src/lib.rs
+++ b/modules/fedimint-mintv2-client/src/lib.rs
@@ -128,6 +128,21 @@ pub enum MintOperationMeta {
     },
 }
 
+/// Breakdown of the fee a `receive` would incur, as computed by
+/// [`MintClientModule::receive_fee_quote`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReceiveFeeQuote {
+    /// Total fee: everything the ecash value does not become a net wallet gain.
+    pub total: Amount,
+    /// Fees charged on the spent (input) notes — both the ecash and any notes
+    /// pulled in by rebalancing.
+    pub input: Amount,
+    /// Fees charged on the newly minted (output) notes.
+    pub output: Amount,
+    /// Sub-denomination remainder that cannot form a note and is lost.
+    pub dust: Amount,
+}
+
 #[derive(Debug, Clone)]
 pub struct MintClientInit;
 
@@ -944,6 +959,76 @@ impl MintClientModule {
         dbtx.commit_tx().await;
 
         Ok(operation_id)
+    }
+
+    /// Computes the exact fee a `receive(ecash)` would incur given the client's
+    /// current note inventory, without submitting anything.
+    ///
+    /// This runs the same change generation the real receive does
+    /// (`create_final_inputs_and_outputs`, including funding selection and
+    /// rebalancing) against a non-committable transaction that is dropped
+    /// rather than committed, so the client's notes are read but left
+    /// untouched. The quote is point-in-time: it depends on the current
+    /// inventory and can move as notes change.
+    pub async fn receive_fee_quote(&self, ecash: &ECash) -> anyhow::Result<ReceiveFeeQuote> {
+        let notes = ecash.notes();
+        let input_amount: Amount = notes.iter().map(SpendableNote::amount).sum();
+        // The receive's explicit inputs are the ecash notes; the federation's
+        // fees on those are the starting `output_amount` for change generation.
+        let ecash_input_fees: Amount = notes
+            .iter()
+            .map(|note| self.cfg.fee_consensus.fee(note.amount()))
+            .sum();
+
+        // Non-committable: writes (remove_spendable_note, ...) are discarded on
+        // drop, so this is a pure dry-run over the real inventory.
+        let mut dbtx = self.client_ctx.module_db().begin_transaction_nc().await;
+        let (inputs, outputs) = self
+            .create_final_inputs_and_outputs(
+                &mut dbtx.to_ref_nc(),
+                OperationId::new_random(),
+                self.cfg.amount_unit,
+                input_amount,
+                ecash_input_fees,
+            )
+            .await?;
+
+        let unit = self.cfg.amount_unit;
+        let amount_of = |amounts: &Amounts| amounts.get(&unit).copied().unwrap_or_default();
+
+        // Rebalancing may pull additional existing notes in as inputs and mint
+        // additional outputs; all outputs become the user's new notes.
+        let rebalance_input: Amount = inputs.inputs().iter().map(|i| amount_of(&i.amounts)).sum();
+        let output_value: Amount = outputs
+            .outputs()
+            .iter()
+            .map(|o| amount_of(&o.amounts))
+            .sum();
+
+        let rebalance_input_fees: Amount = inputs
+            .inputs()
+            .iter()
+            .map(|i| self.cfg.fee_consensus.fee(amount_of(&i.amounts)))
+            .sum();
+        let output_fees: Amount = outputs
+            .outputs()
+            .iter()
+            .map(|o| self.cfg.fee_consensus.fee(amount_of(&o.amounts)))
+            .sum();
+
+        // Net wallet gain = minted outputs − existing notes consumed. The total
+        // fee is everything the ecash value did not become a net gain; whatever
+        // is left after the explicit input/output fees is sub-denomination dust.
+        let total = (input_amount + rebalance_input).saturating_sub(output_value);
+        let input = ecash_input_fees + rebalance_input_fees;
+        let dust = total.saturating_sub(input + output_fees);
+
+        Ok(ReceiveFeeQuote {
+            total,
+            input,
+            output: output_fees,
+            dust,
+        })
     }
 
     /// Await the final state of the receive operation.

--- a/modules/fedimint-mintv2-client/src/lib.rs
+++ b/modules/fedimint-mintv2-client/src/lib.rs
@@ -992,6 +992,10 @@ impl MintClientModule {
                 ecash_input_fees,
             )
             .await?;
+        // This is a dry-run: the change generation writes to `dbtx` (e.g.
+        // removing rebalanced notes), but we intentionally drop it without
+        // committing. Mark it so the commit tracker doesn't warn on drop.
+        dbtx.ignore_uncommitted();
 
         let unit = self.cfg.amount_unit;
         let amount_of = |amounts: &Amounts| amounts.get(&unit).copied().unwrap_or_default();

--- a/modules/fedimint-mintv2-tests/tests/tests.rs
+++ b/modules/fedimint-mintv2-tests/tests/tests.rs
@@ -13,8 +13,8 @@ use fedimint_dummy_client::{DummyClientInit, DummyClientModule};
 use fedimint_dummy_server::DummyInit;
 use fedimint_eventlog::{Event, EventLogEntry, EventLogId};
 use fedimint_mintv2_client::{
-    ECash, FinalReceiveOperationState, MintClientInit, MintClientModule, ReceivePaymentEvent,
-    ReceivePaymentStatus, ReceivePaymentUpdateEvent, SendPaymentEvent,
+    ECash, FinalReceiveOperationState, MintClientInit, MintClientModule, MintOperationMeta,
+    ReceivePaymentEvent, ReceivePaymentStatus, ReceivePaymentUpdateEvent, SendPaymentEvent,
 };
 use fedimint_mintv2_common::KIND;
 use fedimint_mintv2_server::MintInit;
@@ -168,6 +168,84 @@ async fn send_and_receive() -> anyhow::Result<()> {
     }
 
     ensure!(client_receive.get_balance_for_btc().await? >= Amount::from_sats(9900));
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn receive_fee_quote_matches_actual_fee() -> anyhow::Result<()> {
+    let fixtures = fixtures();
+    let fed = fixtures.new_fed_not_degraded().await;
+
+    let client_send = fed
+        .join_client_with_db(MemDatabase::new().into(), root_secret(&SEND_SK))
+        .await;
+    let client_receive = fed
+        .join_client_with_db(MemDatabase::new().into(), root_secret(&RECEIVE_SK))
+        .await;
+
+    issue_ecash(&client_send, Amount::from_sats(11_000)).await?;
+
+    // Receive several times so the receiver's note inventory — and therefore the
+    // rebalance-driven fee — differs between iterations (first into an empty
+    // wallet, then into a progressively more populated one).
+    for i in 0..5 {
+        let ecash = client_send
+            .get_first_module::<MintClientModule>()?
+            .send(Amount::from_sats(1_000), Value::Null)
+            .await?;
+        let ecash: ECash = base32::decode_prefixed(
+            FEDIMINT_PREFIX,
+            &base32::encode_prefixed(FEDIMINT_PREFIX, &ecash),
+        )
+        .unwrap();
+
+        let mint = client_receive.get_first_module::<MintClientModule>()?;
+        let ecash_value = ecash.amount();
+
+        let quote = mint.receive_fee_quote(&ecash).await?;
+        let before = client_receive.get_balance_for_btc().await?;
+
+        let operation_id = mint.receive(ecash, Value::Null).await?;
+        let state = mint
+            .await_final_receive_operation_state(operation_id)
+            .await?;
+        ensure!(state == FinalReceiveOperationState::Success);
+
+        // The receive state machine reports `Success` once the tx is accepted,
+        // but the reissued (change) notes are credited by the output state
+        // machines. Wait for those before reading the settled balance.
+        let MintOperationMeta::Receive {
+            change_outpoint_range,
+            ..
+        } = client_receive
+            .operation_log()
+            .get_operation(operation_id)
+            .await
+            .expect("operation exists")
+            .meta::<MintOperationMeta>()
+        else {
+            panic!("expected a receive operation");
+        };
+        client_receive
+            .await_primary_bitcoin_module_outputs(
+                operation_id,
+                change_outpoint_range.into_iter().collect(),
+            )
+            .await?;
+
+        let after = client_receive.get_balance_for_btc().await?;
+        let actual_fee = ecash_value - (after - before);
+
+        ensure!(
+            quote.total == actual_fee,
+            "iteration {i}: quoted fee {quote:?} != actual fee {actual_fee:?}"
+        );
+        ensure!(
+            quote.total == quote.input + quote.output + quote.dust,
+            "iteration {i}: breakdown {quote:?} does not sum to total"
+        );
+    }
 
     Ok(())
 }


### PR DESCRIPTION
With mint fees turned on, right now it is very difficult to predict what the fees are going to be for claiming those notes. I think this is a horrible user experience, apps either just don't show the fee at all or are forced to show what the fee policy is (i.e base/ppm), but can't show what will actually be taken out of the user's balance.

This PR tries to fix this for both mintv1 and mintv2 by adding `receive_fee_quote` which returns the total fee as well as a breakdown of the fee (input/output/dust). It does this by going through the steps to create a real transaction, but then not submitting it. These quotes are "point in time" because they are dependent on the state of the user's wallet. So if they receive ecash notes via lightning or some other mechanism, the quote will no longer be accurate. I think this is a fine tradeoff, most apps can show this before requesting confirmation that they would like to redeem.

Here's an example screenshot in Ecash App:

<img width="1249" height="1252" alt="image" src="https://github.com/user-attachments/assets/77cf9ea9-527d-4296-bdfb-229a020cd7e1" />
