### PR TITLE
test(mint): cover duplicate blind nonce rejection

### DIFF
--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -203,6 +203,59 @@ async fn blind_nonce_index() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn duplicate_blind_nonce_index_rejected() -> anyhow::Result<()> {
+    let fed = fixtures().new_fed_degraded().await;
+    let client = fed.new_client().await;
+    issue_ecash(&client, sats(1000)).await?;
+
+    let client_mint = client.get_first_module::<MintClientModule>()?;
+    let mut dbtx = client_mint.db.begin_transaction().await;
+    let operation_id = OperationId::new_random();
+    let issuance_req = client_mint
+        .create_output(&mut dbtx.to_ref_nc(), operation_id, 1, Amount::from_sats(1))
+        .await;
+    dbtx.commit_tx().await;
+
+    let blind_nonce = issuance_req
+        .outputs()
+        .first()
+        .expect("There should be at least one note in here")
+        .output
+        .ensure_v0_ref()?
+        .blind_nonce;
+
+    assert!(
+        !client_mint.api.check_blind_nonce_used(blind_nonce).await?,
+        "Blind nonce should not be used yet"
+    );
+
+    let duplicate_bundle = fedimint_client_module::transaction::ClientOutputBundle::new_no_sm(
+        issuance_req.outputs().to_vec(),
+    );
+    let tx = TransactionBuilder::new()
+        .with_outputs(client_mint.client_ctx.make_dyn(issuance_req))
+        .with_outputs(client_mint.client_ctx.make_dyn(duplicate_bundle));
+
+    let change_range = client_mint
+        .client_ctx
+        .finalize_and_submit_transaction(operation_id, "mint", |_| (), tx)
+        .await?;
+
+    let err = client
+        .transaction_updates(operation_id)
+        .await
+        .await_tx_accepted(change_range.txid())
+        .await
+        .expect_err("transaction with duplicate blind nonce should be rejected");
+    assert!(
+        err.contains("blind nonce was already used"),
+        "unexpected rejection: {err}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 #[ignore] // TODO: flaky https://github.com/fedimint/fedimint/issues/4508
 async fn sends_ecash_oob_highly_parallel() -> anyhow::Result<()> {
     // Give client1 initial balance


### PR DESCRIPTION
*PR published by Tau/OpenAI*

## Summary

Adds a small non-happy-path companion to the existing `blind_nonce_index` test. The new test constructs a transaction with two mint outputs sharing the same blind nonce and asserts the federation rejects it with the expected duplicate blind nonce error.

## Details

The test uses `ClientOutputBundle::new_no_sm` for the duplicated output bundle so the client-side state machine duplication does not panic before the transaction reaches submission. This intentionally documents the current end-to-end behavior: duplicate blind nonce outputs submitted through the client transaction path are rejected, while the existing adjacent test continues to cover the successful single-output index population path.

## Testing

Run `cargo test -p fedimint-mint-tests duplicate_blind_nonce_index_rejected`.
