### PR TITLE
feat: add custom meta to wallet v2 send

### DIFF
--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -425,7 +425,12 @@ async fn withdraw_v2(
     };
 
     let operation_id = wallet_module
-        .send(address.as_unchecked().clone(), withdraw_amount, Some(fee))
+        .send(
+            address.as_unchecked().clone(),
+            withdraw_amount,
+            Some(fee),
+            serde_json::Value::Null,
+        )
         .await
         .map_err(|e| AdminGatewayError::WithdrawError {
             failure_reason: e.to_string(),

--- a/modules/fedimint-walletv2-client/src/cli.rs
+++ b/modules/fedimint-walletv2-client/src/cli.rs
@@ -61,7 +61,11 @@ pub(crate) async fn handle_cli_command(
             fee,
         } => json(
             wallet
-                .await_final_send_operation_state(wallet.send(address, value, fee).await?)
+                .await_final_send_operation_state(
+                    wallet
+                        .send(address, value, fee, serde_json::Value::Null)
+                        .await?,
+                )
                 .await?,
         ),
         Opts::Receive => json(wallet.receive().await),

--- a/modules/fedimint-walletv2-client/src/lib.rs
+++ b/modules/fedimint-walletv2-client/src/lib.rs
@@ -77,6 +77,8 @@ pub struct SendMeta {
     pub address: Address<NetworkUnchecked>,
     pub value: bitcoin::Amount,
     pub fee: bitcoin::Amount,
+    #[serde(default)]
+    pub custom_meta: serde_json::Value,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -275,6 +277,7 @@ impl WalletClientModule {
         address: Address<NetworkUnchecked>,
         value: bitcoin::Amount,
         fee: Option<bitcoin::Amount>,
+        custom_meta: serde_json::Value,
     ) -> Result<OperationId, SendError> {
         if !address.is_valid_for_network(self.cfg.network) {
             return Err(SendError::WrongNetwork);
@@ -342,6 +345,7 @@ impl WalletClientModule {
                         address: address_clone.clone(),
                         value,
                         fee,
+                        custom_meta: custom_meta.clone(),
                     })
                 },
                 TransactionBuilder::new().with_outputs(client_output_bundle),

--- a/modules/fedimint-walletv2-tests/tests/tests.rs
+++ b/modules/fedimint-walletv2-tests/tests/tests.rs
@@ -206,7 +206,12 @@ async fn fee_exceeds_one_bitcoin_with_many_pending_txs() -> anyhow::Result<()> {
 
         let send_op = client
             .get_first_module::<WalletClientModule>()?
-            .send(address.clone(), Amount::from_sat(10_000), None)
+            .send(
+                address.clone(),
+                Amount::from_sat(10_000),
+                None,
+                serde_json::Value::Null,
+            )
             .await?;
 
         let state = client


### PR DESCRIPTION
WalletV2 does not have any custom meta field. Seems to be an oversight. This PR adds it.