### PR TITLE
test(walletv2): scan initial regtest blocks

### DIFF
--- a/modules/fedimint-walletv2-server/src/lib.rs
+++ b/modules/fedimint-walletv2-server/src/lib.rs
@@ -966,8 +966,12 @@ impl Wallet {
             "Processed block count vote"
         );
 
-        // We do not sync blocks that predate the federation itself.
-        if old_consensus_block_count == 0 {
+        // Outside regtest, do not sync blocks that predate the federation itself.
+        // Regtest starts from scratch, so scan from genesis to avoid races where
+        // test deposits are mined before the first walletv2 block count
+        // transition is processed.
+        let scan_from_genesis = self.cfg.consensus.network == bitcoin::Network::Regtest;
+        if old_consensus_block_count == 0 && !scan_from_genesis {
             return Ok(());
         }
 


### PR DESCRIPTION
*PR published by Tau/gpt-5.1*

Summary

Avoid a walletv2 regtest startup race by scanning from genesis when the first walletv2 block-count transition is processed on regtest. Non-regtest behavior is unchanged and still skips pre-federation blocks when the previous consensus block count is zero.

Details

This was investigated after the hourly CI failure in https://github.com/fedimint/fedimint/actions/runs/27226525459/job/80395076898. The failing test was `gw_liquidity_test_walletv2` and the immediate symptom was:

```text
Polling gateway pegin failed after 54 retries (timeout: 60s)
Gateway balance 0 has not reached expected 900000000 (initial: 0)
```

The same master SHA passed in surrounding hourly runs, so this looked flaky rather than a deterministic regression. The key timing in the failing log was that devimint started a degraded 3/4 federation, then walletv2 gateway peg-in deposits were sent/mined before fedimintd session 0 finished processing:

```text
18:20:30 Pegging-in gateway funds
18:20:31 Reached Aleph BFT round limit ... session_index=0
18:20:32 Completed consensus session session_index=0
```

The suspicious walletv2 code skips scanning entirely when `old_consensus_block_count == 0`, to avoid syncing pre-federation chain history. On regtest, however, bitcoind starts from scratch and deposits can be mined before the first walletv2 block-count transition is fully processed. If that first transition jumps past the deposit block, the skip means the deposit output is never recorded, the gateway's walletv2 scanner never sees it, and the gateway balance stays at zero forever.

We considered adding an explicit consensus activation/scan-start height, but that is a larger consensus/config change. This PR takes the minimal deterministic fix for the test/regtest setup: on regtest, scan from block zero on the initial transition. The branch is based on the consensus network from config, not a runtime env var, so all peers make the same decision.

Testing

Reviewers can reproduce the relevant check with:

```bash
cargo check -q -p fedimint-walletv2-server
```
