### PR TITLE
feat: invite codes with expiration dates and user limits

### DIFF
--- a/fedimint-api-client/src/api/tests.rs
+++ b/fedimint-api-client/src/api/tests.rs
@@ -1,10 +1,8 @@
-use std::collections::BTreeMap;
 use std::str::FromStr as _;
 
+use fedimint_core::PeerId;
 use fedimint_core::config::FederationId;
 use fedimint_core::invite_code::InviteCode;
-use fedimint_core::util::SafeUrl;
-use fedimint_core::{NumPeersExt as _, PeerId};
 
 #[test]
 fn converts_invite_code() {
@@ -24,23 +22,4 @@ fn converts_invite_code() {
     assert_eq!(connect_as_string, bech32);
     let connect_parsed_json: InviteCode = serde_json::from_str(&json).unwrap();
     assert_eq!(connect_parsed_json, connect_parsed);
-}
-
-#[test]
-fn creates_essential_guardians_invite_code() {
-    let mut peer_to_url_map = BTreeMap::new();
-    peer_to_url_map.insert(PeerId::from(0), "ws://test1".parse().expect("URL fail"));
-    peer_to_url_map.insert(PeerId::from(1), "ws://test2".parse().expect("URL fail"));
-    peer_to_url_map.insert(PeerId::from(2), "ws://test3".parse().expect("URL fail"));
-    peer_to_url_map.insert(PeerId::from(3), "ws://test4".parse().expect("URL fail"));
-    let max_size = peer_to_url_map.to_num_peers().max_evil() + 1;
-
-    let code =
-        InviteCode::new_with_essential_num_guardians(&peer_to_url_map, FederationId::dummy());
-
-    assert_eq!(FederationId::dummy(), code.federation_id());
-
-    let expected_map: BTreeMap<PeerId, SafeUrl> =
-        peer_to_url_map.into_iter().take(max_size).collect();
-    assert_eq!(expected_map, code.peers());
 }

--- a/fedimint-api-client/src/lib.rs
+++ b/fedimint-api-client/src/lib.rs
@@ -8,14 +8,12 @@
 use anyhow::{Context as _, bail};
 use api::{DynGlobalApi, FederationApiExt as _};
 use fedimint_connectors::ConnectorRegistry;
-use fedimint_connectors::error::ServerError;
 use fedimint_core::config::{ClientConfig, FederationId};
 use fedimint_core::endpoint_constants::CLIENT_CONFIG_ENDPOINT;
 use fedimint_core::invite_code::InviteCode;
 use fedimint_core::module::ApiRequestErased;
 use fedimint_core::util::backoff_util;
 use fedimint_logging::LOG_CLIENT_NET;
-use query::FilterMap;
 use tracing::debug;
 
 pub mod api;
@@ -32,7 +30,6 @@ pub async fn download_from_invite_code(
     debug!(
         target: LOG_CLIENT_NET,
         %invite,
-        peers = ?invite.peers(),
         "Downloading client config via invite code"
     );
 
@@ -44,6 +41,7 @@ pub async fn download_from_invite_code(
     )?;
     let api_secret = invite.api_secret();
     let invite_id = invite.invite_id();
+    let peer = invite.peer();
 
     fedimint_core::util::retry(
         "Downloading client config",
@@ -55,6 +53,7 @@ pub async fn download_from_invite_code(
                 federation_id,
                 api_secret.clone(),
                 invite_id,
+                peer,
             )
         },
     )
@@ -69,31 +68,28 @@ pub async fn try_download_client_config(
     federation_id: FederationId,
     api_secret: Option<String>,
     invite_id: Option<[u8; 16]>,
+    peer: fedimint_core::PeerId,
 ) -> anyhow::Result<(ClientConfig, DynGlobalApi)> {
-    debug!(target: LOG_CLIENT_NET, "Downloading client config from peer");
-    // TODO: use new download approach based on guardian PKs
-    let query_strategy = FilterMap::new(move |cfg: ClientConfig| {
-        if federation_id != cfg.global.calculate_federation_id() {
-            return Err(ServerError::ConditionFailed(anyhow::anyhow!(
-                "FederationId in invite code does not match client config"
-            )));
-        }
+    debug!(target: LOG_CLIENT_NET, "Downloading client config from the guardian in the invite code");
 
-        Ok(cfg.global.api_endpoints)
-    });
-
-    // The invite id is only sent to the guardians in the invite code; its
-    // issuer counts the download towards the invite code's user limit
-    let api_endpoints = api_from_invite
-        .request_with_strategy(
-            query_strategy,
+    // The invite id is sent only to the guardian in the invite code; as its
+    // issuer it counts the download towards the invite code's user limit
+    let config = api_from_invite
+        .request_single_peer::<ClientConfig>(
             CLIENT_CONFIG_ENDPOINT.to_owned(),
             ApiRequestErased::new(invite_id),
+            peer,
         )
         .await?;
 
+    if config.global.calculate_federation_id() != federation_id {
+        bail!("FederationId in invite code does not match client config");
+    }
+
     // now we can build an api for all guardians and download the client config
-    let api_endpoints = api_endpoints
+    let api_endpoints = config
+        .global
+        .api_endpoints
         .into_iter()
         .map(|(peer, url)| (peer, url.url))
         .collect();

--- a/fedimint-api-client/src/lib.rs
+++ b/fedimint-api-client/src/lib.rs
@@ -43,6 +43,7 @@ pub async fn download_from_invite_code(
         invite.api_secret().as_deref(),
     )?;
     let api_secret = invite.api_secret();
+    let invite_id = invite.invite_id();
 
     fedimint_core::util::retry(
         "Downloading client config",
@@ -53,6 +54,7 @@ pub async fn download_from_invite_code(
                 &api_from_invite,
                 federation_id,
                 api_secret.clone(),
+                invite_id,
             )
         },
     )
@@ -66,6 +68,7 @@ pub async fn try_download_client_config(
     api_from_invite: &DynGlobalApi,
     federation_id: FederationId,
     api_secret: Option<String>,
+    invite_id: Option<[u8; 16]>,
 ) -> anyhow::Result<(ClientConfig, DynGlobalApi)> {
     debug!(target: LOG_CLIENT_NET, "Downloading client config from peer");
     // TODO: use new download approach based on guardian PKs
@@ -79,11 +82,13 @@ pub async fn try_download_client_config(
         Ok(cfg.global.api_endpoints)
     });
 
+    // The invite id is only sent to the guardians in the invite code; its
+    // issuer counts the download towards the invite code's user limit
     let api_endpoints = api_from_invite
         .request_with_strategy(
             query_strategy,
             CLIENT_CONFIG_ENDPOINT.to_owned(),
-            ApiRequestErased::default(),
+            ApiRequestErased::new(invite_id),
         )
         .await?;
 

--- a/fedimint-cli/src/cli.rs
+++ b/fedimint-cli/src/cli.rs
@@ -88,11 +88,6 @@ pub(crate) enum Command {
     #[clap(subcommand)]
     Dev(DevCmd),
 
-    /// Config enabling client to establish websocket connection to federation
-    InviteCode {
-        peer: PeerId,
-    },
-
     /// Join a federation using its InviteCode
     #[clap(alias = "join-federation")]
     Join {

--- a/fedimint-cli/src/client.rs
+++ b/fedimint-cli/src/client.rs
@@ -100,10 +100,6 @@ pub enum ClientCmd {
         /// hasn't been redeemed by the recipient. Defaults to one week.
         #[clap(long, default_value_t = 60 * 60 * 24 * 7)]
         timeout: u64,
-        /// If the necessary information to join the federation the e-cash
-        /// belongs to should be included in the serialized notes
-        #[clap(long)]
-        include_invite: bool,
     },
     /// Splits a string containing multiple e-cash notes (e.g. from the `spend`
     /// command) into ones that contain exactly one.
@@ -255,7 +251,6 @@ pub async fn handle_command(
             amount,
             allow_overpay,
             timeout,
-            include_invite,
         } => {
             warn!(
                 target: LOG_CLIENT,
@@ -270,13 +265,7 @@ pub async fn handle_command(
             let timeout = Duration::from_secs(timeout);
             let (operation, notes) = if allow_overpay {
                 let (operation, notes) = mint_module
-                    .spend_notes_with_selector(
-                        &SelectNotesWithAtleastAmount,
-                        amount,
-                        timeout,
-                        include_invite,
-                        (),
-                    )
+                    .spend_notes_with_selector(&SelectNotesWithAtleastAmount, amount, timeout, ())
                     .await?;
 
                 let overspend_amount = notes.total_amount().saturating_sub(amount);
@@ -291,13 +280,7 @@ pub async fn handle_command(
                 (operation, notes)
             } else {
                 mint_module
-                    .spend_notes_with_selector(
-                        &SelectNotesWithExactAmount,
-                        amount,
-                        timeout,
-                        include_invite,
-                        (),
-                    )
+                    .spend_notes_with_selector(&SelectNotesWithExactAmount, amount, timeout, ())
                     .await?
             };
             info!(target: LOG_CLIENT, "Spend e-cash operation: {}", operation.fmt_short());

--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -590,16 +590,6 @@ impl FedimintCli {
         }
 
         match cli.command.clone() {
-            Command::InviteCode { peer } => {
-                let client = self.client_open(&cli).await?;
-
-                let invite_code = client
-                    .invite_code(peer)
-                    .await
-                    .ok_or_cli_msg("peer not found")?;
-
-                Ok(CliOutput::InviteCode { invite_code })
-            }
             Command::Join { invite_code } => {
                 {
                     let invite_code: InviteCode = InviteCode::from_str(&invite_code)

--- a/fedimint-client-module/src/lib.rs
+++ b/fedimint-client-module/src/lib.rs
@@ -442,11 +442,6 @@ where
         self.module
     }
 }
-#[derive(Deserialize)]
-pub struct GetInviteCodeRequest {
-    pub peer: PeerId,
-}
-
 pub struct TransactionUpdates {
     pub update_stream: BoxStream<'static, TxSubmissionStatesSM>,
 }

--- a/fedimint-client-module/src/module/mod.rs
+++ b/fedimint-client-module/src/module/mod.rs
@@ -15,13 +15,12 @@ use fedimint_core::core::{
     OperationId,
 };
 use fedimint_core::db::{Database, DatabaseTransaction, GlobalDBTxAccessToken, NonCommittable};
-use fedimint_core::invite_code::InviteCode;
 use fedimint_core::module::registry::{ModuleDecoderRegistry, ModuleRegistry};
 use fedimint_core::module::{AmountUnit, Amounts, CommonModuleInit, ModuleCommon, ModuleInit};
 use fedimint_core::task::{MaybeSend, MaybeSync};
 use fedimint_core::util::BoxStream;
 use fedimint_core::{
-    Amount, OutPoint, PeerId, apply, async_trait_maybe_send, dyn_newtype_define, maybe_add_send,
+    Amount, OutPoint, apply, async_trait_maybe_send, dyn_newtype_define, maybe_add_send,
     maybe_add_send_sync,
 };
 use fedimint_eventlog::{Event, EventKind, EventPersistence};
@@ -102,8 +101,6 @@ pub trait ClientContextIface: MaybeSend + MaybeSync {
     fn db(&self) -> &Database;
 
     fn executor(&self) -> &(maybe_add_send_sync!(dyn IExecutor + 'static));
-
-    async fn invite_code(&self, peer: PeerId) -> Option<InviteCode>;
 
     fn get_internal_payment_markers(&self) -> anyhow::Result<(PublicKey, u64)>;
 
@@ -492,22 +489,6 @@ where
 
     pub async fn get_config(&self) -> ClientConfig {
         self.client.get().config().await
-    }
-
-    /// Returns an invite code for the federation that points to an arbitrary
-    /// guardian server for fetching the config
-    pub async fn get_invite_code(&self) -> InviteCode {
-        let cfg = self.get_config().await.global;
-        self.client
-            .get()
-            .invite_code(
-                *cfg.api_endpoints
-                    .keys()
-                    .next()
-                    .expect("A federation always has at least one guardian"),
-            )
-            .await
-            .expect("The guardian we requested an invite code for exists")
     }
 
     pub fn get_internal_payment_markers(&self) -> anyhow::Result<(PublicKey, u64)> {

--- a/fedimint-client/src/client.rs
+++ b/fedimint-client/src/client.rs
@@ -30,8 +30,8 @@ use fedimint_client_module::transaction::{
     TxSubmissionStatesSM,
 };
 use fedimint_client_module::{
-    AddStateMachinesResult, ClientModuleInstance, GetInviteCodeRequest, ModuleGlobalContextGen,
-    ModuleRecoveryCompleted, TransactionUpdates, TxCreatedEvent,
+    AddStateMachinesResult, ClientModuleInstance, ModuleGlobalContextGen, ModuleRecoveryCompleted,
+    TransactionUpdates, TxCreatedEvent,
 };
 use fedimint_connectors::{ConnectorRegistry, PeerStatus};
 use fedimint_core::config::{
@@ -45,7 +45,6 @@ use fedimint_core::db::{
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::endpoint_constants::{CLIENT_CONFIG_ENDPOINT, VERSION_ENDPOINT};
 use fedimint_core::envs::is_running_in_test_env;
-use fedimint_core::invite_code::InviteCode;
 use fedimint_core::module::registry::{ModuleDecoderRegistry, ModuleRegistry};
 use fedimint_core::module::{
     AmountUnit, Amounts, ApiRequestErased, ApiVersion, MultiApiVersion,
@@ -1856,23 +1855,6 @@ impl Client {
         get_api_urls(&self.db, &self.config().await).await
     }
 
-    /// Create an invite code with the api endpoint of the given peer which can
-    /// be used to download this client config
-    pub async fn invite_code(&self, peer: PeerId) -> Option<InviteCode> {
-        self.get_peer_urls()
-            .await
-            .into_iter()
-            .find_map(|(peer_id, url)| (peer == peer_id).then_some(url))
-            .map(|peer_url| {
-                InviteCode::new(
-                    peer_url.clone(),
-                    peer,
-                    self.federation_id(),
-                    self.api_secret.clone(),
-                )
-            })
-    }
-
     /// Blocks till the client has synced the guardian public key set
     /// (introduced in version 0.4) and returns it. Once it has been fetched
     /// once this function is guaranteed to return immediately.
@@ -1983,11 +1965,6 @@ impl Client {
                 "get_federation_id" => {
                     let federation_id = self.federation_id();
                     yield serde_json::to_value(federation_id)?;
-                }
-                "get_invite_code" => {
-                    let req: GetInviteCodeRequest = serde_json::from_value(params)?;
-                    let invite_code = self.invite_code(req.peer).await;
-                    yield serde_json::to_value(invite_code)?;
                 }
                 "get_operation" => {
                     let req: GetOperationIdRequest = serde_json::from_value(params)?;
@@ -2398,10 +2375,6 @@ impl ClientContextIface for Client {
 
     fn executor(&self) -> &(maybe_add_send_sync!(dyn IExecutor + 'static)) {
         Client::executor(self)
-    }
-
-    async fn invite_code(&self, peer: PeerId) -> Option<InviteCode> {
-        Client::invite_code(self, peer).await
     }
 
     fn get_internal_payment_markers(&self) -> anyhow::Result<(PublicKey, u64)> {

--- a/fedimint-core/src/invite_code.rs
+++ b/fedimint-core/src/invite_code.rs
@@ -171,6 +171,23 @@ impl InviteCode {
             })
             .expect("Ensured by constructor")
     }
+
+    /// Opaque id identifying this invite code to the issuing guardian, if one
+    /// was set.
+    pub fn invite_id(&self) -> Option<[u8; 16]> {
+        self.0.iter().find_map(|data| match data {
+            InviteCodePart::InviteId(invite_id) => Some(*invite_id),
+            _ => None,
+        })
+    }
+
+    /// Sets the invite id, replacing any previously set one.
+    pub fn with_invite_id(mut self, invite_id: [u8; 16]) -> Self {
+        self.0
+            .retain(|data| !matches!(data, InviteCodePart::InviteId(_)));
+        self.0.push(InviteCodePart::InviteId(invite_id));
+        self
+    }
 }
 
 /// For extendability [`InviteCode`] consists of parts, where client can ignore
@@ -196,6 +213,11 @@ enum InviteCodePart {
 
     /// Api secret to use
     ApiSecret(String),
+
+    /// Opaque id identifying this invite code to the issuing guardian, which
+    /// tracks metadata such as the expiration date and user limit for it in
+    /// its local database
+    InviteId([u8; 16]),
 
     /// Unknown invite code fields to be defined in the future
     #[encodable_default]

--- a/fedimint-core/src/invite_code.rs
+++ b/fedimint-core/src/invite_code.rs
@@ -9,12 +9,12 @@ use anyhow::ensure;
 use bech32::{Bech32m, Hrp};
 use serde::{Deserialize, Serialize};
 
+use crate::PeerId;
 use crate::base32::FEDIMINT_PREFIX;
 use crate::config::FederationId;
 use crate::encoding::{Decodable, DecodeError, Encodable};
 use crate::module::registry::{ModuleDecoderRegistry, ModuleRegistry};
 use crate::util::SafeUrl;
-use crate::{NumPeersExt, PeerId};
 
 /// Information required for client to join Federation
 ///
@@ -73,50 +73,6 @@ impl InviteCode {
         }
 
         s
-    }
-
-    pub fn from_map(
-        peer_to_url_map: &BTreeMap<PeerId, SafeUrl>,
-        federation_id: FederationId,
-        api_secret: Option<String>,
-    ) -> Self {
-        let max_size = peer_to_url_map.to_num_peers().max_evil() + 1;
-        let mut code_vec: Vec<InviteCodePart> = peer_to_url_map
-            .iter()
-            .take(max_size)
-            .map(|(peer, url)| InviteCodePart::Api {
-                url: url.clone(),
-                peer: *peer,
-            })
-            .collect();
-
-        code_vec.push(InviteCodePart::FederationId(federation_id));
-
-        if let Some(api_secret) = api_secret {
-            code_vec.push(InviteCodePart::ApiSecret(api_secret));
-        }
-
-        Self(code_vec)
-    }
-
-    /// Constructs an [`InviteCode`] which contains as many guardian URLs as
-    /// needed to always be able to join a working federation
-    pub fn new_with_essential_num_guardians(
-        peer_to_url_map: &BTreeMap<PeerId, SafeUrl>,
-        federation_id: FederationId,
-    ) -> Self {
-        let max_size = peer_to_url_map.to_num_peers().max_evil() + 1;
-        let mut code_vec: Vec<InviteCodePart> = peer_to_url_map
-            .iter()
-            .take(max_size)
-            .map(|(peer, url)| InviteCodePart::Api {
-                url: url.clone(),
-                peer: *peer,
-            })
-            .collect();
-        code_vec.push(InviteCodePart::FederationId(federation_id));
-
-        Self(code_vec)
     }
 
     /// Returns the API URL of one of the guardians.

--- a/fedimint-dbtool/src/dump.rs
+++ b/fedimint-dbtool/src/dump.rs
@@ -341,6 +341,26 @@ impl DatabaseDump {
                     "Guardian Metadata"
                 );
             }
+            server_db::DbKeyPrefix::InviteId => {
+                push_db_pair_items_no_serde!(
+                    dbtx,
+                    server_db::InviteIdKeyPrefix,
+                    server_db::InviteIdKey,
+                    fedimint_server::db::InviteIdMeta,
+                    consensus,
+                    "Invite Ids"
+                );
+            }
+            server_db::DbKeyPrefix::InviteUserCount => {
+                push_db_pair_items_no_serde!(
+                    dbtx,
+                    server_db::InviteUserCountKeyPrefix,
+                    server_db::InviteUserCountKey,
+                    u64,
+                    consensus,
+                    "Invite User Counts"
+                );
+            }
         }
     }
     async fn write_serialized_client_operation_log(

--- a/fedimint-load-test-tool/src/common.rs
+++ b/fedimint-load-test-tool/src/common.rs
@@ -18,7 +18,7 @@ use fedimint_core::module::CommonModuleInit;
 use fedimint_core::module::registry::ModuleRegistry;
 use fedimint_core::util::backoff_util::aggressive_backoff;
 use fedimint_core::util::retry;
-use fedimint_core::{Amount, OutPoint, PeerId, TieredCounts, secp256k1};
+use fedimint_core::{Amount, OutPoint, TieredCounts, secp256k1};
 use fedimint_ln_client::{
     LightningClientInit, LightningClientModule, LnPayState, OutgoingLightningPayment,
 };
@@ -33,14 +33,6 @@ use tokio::sync::mpsc;
 use tracing::{info, warn};
 
 use crate::MetricEvent;
-
-pub async fn get_invite_code_cli(peer: PeerId) -> anyhow::Result<InviteCode> {
-    cmd!(FedimintCli, "invite-code", peer).out_json().await?["invite_code"]
-        .as_str()
-        .map(InviteCode::from_str)
-        .transpose()?
-        .context("missing invite code")
-}
 
 pub async fn get_notes_cli(amount: &Amount) -> anyhow::Result<OOBNotes> {
     cmd!(FedimintCli, "spend", amount.msats.to_string())
@@ -99,7 +91,6 @@ pub async fn do_spend_notes(
             &SelectNotesWithAtleastAmount,
             amount,
             Duration::from_mins(10),
-            false,
             (),
         )
         .await?;

--- a/fedimint-load-test-tool/src/main.rs
+++ b/fedimint-load-test-tool/src/main.rs
@@ -41,9 +41,7 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufWriter};
 use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
 
-use crate::common::{
-    build_client, do_spend_notes, get_invite_code_cli, remint_denomination, try_get_notes_cli,
-};
+use crate::common::{build_client, do_spend_notes, remint_denomination, try_get_notes_cli};
 pub mod common;
 
 #[derive(Parser, Clone)]
@@ -329,7 +327,7 @@ async fn main() -> anyhow::Result<()> {
             test_download_config(&connectors, &invite_code, opts.users, &event_sender.clone())
         }
         Command::LoadTest(args) => {
-            let invite_code = invite_code_or_fallback(args.invite_code).await;
+            let invite_code = invite_code_or_fallback(args.invite_code);
 
             let gateway_id = if let Some(gateway_id) = args.gateway_id {
                 Some(gateway_id)
@@ -376,7 +374,7 @@ async fn main() -> anyhow::Result<()> {
             .await?
         }
         Command::LnCircularLoadTest(args) => {
-            let invite_code = invite_code_or_fallback(args.invite_code).await;
+            let invite_code = invite_code_or_fallback(args.invite_code);
             run_ln_circular_load_test(
                 opts.archive_dir,
                 opts.users,
@@ -411,21 +409,12 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn invite_code_or_fallback(invite_code: Option<InviteCode>) -> Option<InviteCode> {
-    if let Some(invite_code) = invite_code {
-        Some(invite_code)
-    } else {
-        // Try to get an invite code through cli in a best effort basis
-        match get_invite_code_cli(0.into()).await {
-            Ok(invite_code) => Some(invite_code),
-            Err(e) => {
-                info!(
-                    "No invite code provided and failed to get one with '{e}' error, will try to proceed without one..."
-                );
-                None
-            }
-        }
+fn invite_code_or_fallback(invite_code: Option<InviteCode>) -> Option<InviteCode> {
+    if invite_code.is_none() {
+        info!("No invite code provided, will try to proceed without one...");
     }
+
+    invite_code
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/fedimint-server-core/src/dashboard_ui.rs
+++ b/fedimint-server-core/src/dashboard_ui.rs
@@ -69,6 +69,10 @@ pub trait IDashboardApi {
     /// Get the federation invite code to share with users
     async fn federation_invite_code(&self) -> String;
 
+    /// Create an invite code with an expiration date and user limit,
+    /// registering its invite id in the guardian's local database
+    async fn create_invite_code(&self, expires_at: u64, user_limit: u64) -> String;
+
     /// Get the federation audit summary
     async fn federation_audit(&self) -> AuditSummary;
 

--- a/fedimint-server-tests/tests/migration.rs
+++ b/fedimint-server-tests/tests/migration.rs
@@ -28,7 +28,7 @@ use fedimint_server::consensus::db::{
     SignedSessionOutcomePrefix, get_global_database_migrations,
 };
 use fedimint_server::core::ServerModule;
-use fedimint_server::db::DbKeyPrefix;
+use fedimint_server::db::{DbKeyPrefix, InviteIdKeyPrefix, InviteUserCountKeyPrefix};
 use fedimint_server::net::api::announcement::{ApiAnnouncementKey, ApiAnnouncementPrefix};
 use fedimint_server::net::api::guardian_metadata::GuardianMetadataPrefix;
 use fedimint_testing_core::db::{
@@ -224,6 +224,22 @@ async fn test_server_db_migrations() -> anyhow::Result<()> {
                         // Guardian metadata is optional, just verify we can query it
                         let _metadata = dbtx
                             .find_by_prefix(&GuardianMetadataPrefix)
+                            .await
+                            .collect::<Vec<_>>()
+                            .await;
+                    }
+                    DbKeyPrefix::InviteId => {
+                        // Invite ids are optional, just verify we can query them
+                        let _invite_ids = dbtx
+                            .find_by_prefix(&InviteIdKeyPrefix)
+                            .await
+                            .collect::<Vec<_>>()
+                            .await;
+                    }
+                    DbKeyPrefix::InviteUserCount => {
+                        // Invite user counts are optional, just verify we can query them
+                        let _user_counts = dbtx
+                            .find_by_prefix(&InviteUserCountKeyPrefix)
                             .await
                             .collect::<Vec<_>>()
                             .await;

--- a/fedimint-server-ui/src/dashboard/invite.rs
+++ b/fedimint-server-ui/src/dashboard/invite.rs
@@ -1,44 +1,133 @@
-use fedimint_ui_common::copiable_text;
+use axum::extract::{Form, State};
+use axum::response::{Html, IntoResponse};
+use chrono::Utc;
+use fedimint_server_core::dashboard_ui::DynDashboardApi;
+use fedimint_ui_common::auth::UserAuth;
+use fedimint_ui_common::{UiState, copiable_text};
 use maud::{Markup, PreEscaped, html};
 use qrcode::QrCode;
+use serde::Deserialize;
 
-// Card with invite code text and copy button
-pub fn render(invite_code: &str, session_count: u64) -> Markup {
+pub const INVITE_CREATE_ROUTE: &str = "/invite/create";
+
+// Card with a form to generate invite codes with an expiration date and user
+// limit
+pub fn render(session_count: u64) -> Markup {
     html! {
         div class="card h-100" {
             div class="card-header dashboard-header" { "Invite Code" }
             div class="card-body" {
                 @if session_count == 0 {
                     div class="alert alert-warning" {
-                        "The invite code will be available once the federation has completed its first consensus session."
+                        "Invite codes will be available once the federation has completed its first consensus session."
                     }
                 } @else {
-                    @let observer_link = format!("https://observer.fedimint.org/nostr?check={invite_code}");
-                    @let qr_svg = QrCode::new(invite_code)
-                        .expect("Failed to generate QR code")
-                        .render::<qrcode::render::svg::Color>()
-                        .build();
-
-                    p { "Share this with users to onboard them to your federation." }
-
-                    // QR Code
-                    div class="text-center mb-3" {
-                        div class="border rounded p-2 bg-white d-inline-block" style="width: 250px; max-width: 100%;" {
-                            div style="width: 100%; height: auto; overflow: hidden;" {
-                                (PreEscaped(format!(r#"<div style="width: 100%; height: auto;">{}</div>"#, qr_svg.replace("width=", "data-width=").replace("height=", "data-height=").replace("<svg", r#"<svg style="width: 100%; height: auto; display: block;""#))))
-                            }
-                        }
-                    }
-
-                    div class="mb-3" {
-                        (copiable_text(invite_code))
-                    }
-
-                    a href=(observer_link) target="_blank" class="btn btn-outline-success w-100 py-2" {
-                        "Announce on Nostr"
+                    div id="invite-container" {
+                        (invite_form())
                     }
                 }
             }
         }
     }
+}
+
+// Form to select the expiration and user limit of a new invite code; the
+// generated invite code replaces it via htmx
+fn invite_form() -> Markup {
+    html! {
+        div class="alert alert-info" {
+            "Generate an invite code to onboard users to your federation. Every invite code has an expiration date and a limit on the number of users that can join with it."
+        }
+
+        form hx-post=(INVITE_CREATE_ROUTE) hx-target="#invite-container" hx-swap="innerHTML" {
+            div class="form-group mb-3" {
+                label for="expires_in" class="form-label" { "Expires in Days" }
+                input type="number" class="form-control" id="expires_in" name="expires_in" min="1" value="30" required;
+            }
+            div class="form-group mb-3" {
+                label for="user_limit" class="form-label" { "User Limit" }
+                input type="number" class="form-control" id="user_limit" name="user_limit" min="1" value="50" required;
+            }
+            button type="submit" class="btn btn-primary w-100 py-2" { "Generate Invite Code" }
+        }
+    }
+}
+
+// QR Code
+fn qr_code(data: &str) -> Markup {
+    let qr_svg = QrCode::new(data)
+        .expect("Failed to generate QR code")
+        .render::<qrcode::render::svg::Color>()
+        .build();
+
+    html! {
+        div class="text-center mb-3" {
+            div class="border rounded p-2 bg-white d-inline-block" style="width: 250px; max-width: 100%;" {
+                div style="width: 100%; height: auto; overflow: hidden;" {
+                    (PreEscaped(format!(r#"<div style="width: 100%; height: auto;">{}</div>"#, qr_svg.replace("width=", "data-width=").replace("height=", "data-height=").replace("<svg", r#"<svg style="width: 100%; height: auto; display: block;""#))))
+                }
+            }
+        }
+    }
+}
+
+// Re-renders the form with an error alert below it so the user can retry
+fn form_with_error(message: &str) -> Markup {
+    html! {
+        (invite_form())
+
+        div class="alert alert-danger mt-3" { (message) }
+    }
+}
+
+#[derive(Deserialize)]
+pub struct CreateInviteInput {
+    pub expires_in: u64,
+    pub user_limit: u64,
+}
+
+// Creates an invite code with the selected expiration and user limit and
+// returns the fragment htmx swaps into the invite card
+pub async fn post_create_invite(
+    State(state): State<UiState<DynDashboardApi>>,
+    _auth: UserAuth,
+    Form(input): Form<CreateInviteInput>,
+) -> impl IntoResponse {
+    if input.expires_in == 0 {
+        return Html(
+            form_with_error("The invite code needs to be valid for at least one day").into_string(),
+        );
+    }
+
+    if input.user_limit == 0 {
+        return Html(form_with_error("The user limit needs to be at least one").into_string());
+    }
+
+    let Some(expires_at) = Utc::now().checked_add_days(chrono::Days::new(input.expires_in)) else {
+        return Html(form_with_error("Could not compute the expiration date").into_string());
+    };
+
+    let expiry = u64::try_from(expires_at.timestamp())
+        .expect("Timestamp is positive since it is in the future");
+
+    let invite_code = state.api.create_invite_code(expiry, input.user_limit).await;
+
+    Html(
+        html! {
+            (qr_code(&invite_code))
+
+            div class="mb-3" {
+                (copiable_text(&invite_code))
+            }
+
+            div class="alert alert-info" {
+                "This invite code expires on "
+                (expires_at.format("%Y-%m-%d %H:%M UTC"))
+                " and can be used by up to "
+                (input.user_limit)
+                " users."
+            }
+        }
+        .into_string(),
+    )
 }

--- a/fedimint-server-ui/src/dashboard/mod.rs
+++ b/fedimint-server-ui/src/dashboard/mod.rs
@@ -196,7 +196,6 @@ async fn dashboard_view(
     let fedimintd_version_hash = state.api.fedimintd_version_hash().await;
     let consensus_ord_latency = state.api.consensus_ord_latency().await;
     let p2p_connection_status = state.api.p2p_connection_status().await;
-    let invite_code = state.api.federation_invite_code().await;
     let audit_summary = state.api.federation_audit().await;
     let bitcoin_rpc_url = state.api.bitcoin_rpc_url().await;
     let bitcoin_rpc_status = state.api.bitcoin_rpc_status().await;
@@ -208,7 +207,7 @@ async fn dashboard_view(
             }
 
             div class="col-md-6" {
-                (invite::render(&invite_code, session_count))
+                (invite::render(session_count))
             }
         }
 
@@ -334,6 +333,10 @@ pub fn router(api: DynDashboardApi) -> Router {
         .route(EXPLORER_IDX_ROUTE, get(consensus_explorer_view))
         .route(DOWNLOAD_BACKUP_ROUTE, get(download_backup))
         .route(CHANGE_PASSWORD_ROUTE, post(change_password))
+        .route(
+            invite::INVITE_CREATE_ROUTE,
+            post(invite::post_create_invite),
+        )
         .route(METRICS_ROUTE, get(metrics_handler))
         .route(
             CONNECTIVITY_CHECK_ROUTE,

--- a/fedimint-server/src/consensus/api.rs
+++ b/fedimint-server/src/consensus/api.rs
@@ -76,6 +76,7 @@ use crate::config::{ServerConfig, legacy_consensus_config_hash};
 use crate::consensus::db::{AcceptedItemPrefix, AcceptedTransactionKey, SignedSessionOutcomeKey};
 use crate::consensus::engine::get_finished_session_count_static;
 use crate::consensus::transaction::{TxProcessingMode, process_transaction_with_dbtx};
+use crate::db::{InviteIdKey, InviteIdMeta, InviteUserCountKey};
 use crate::metrics::{BACKUP_WRITE_SIZE_BYTES, STORED_BACKUPS_COUNT};
 use crate::net::api::HasApiContext;
 use crate::net::api::announcement::{ApiAnnouncementKey, ApiAnnouncementPrefix, get_api_urls};
@@ -681,6 +682,39 @@ impl ConsensusApi {
             api_secret,
         )
     }
+
+    /// Checks the expiration date and user limit of the invite code with this
+    /// invite id and counts the download towards its user limit.
+    async fn register_config_download(&self, invite_id: [u8; 16]) -> Result<(), ApiError> {
+        let mut dbtx = self.db.begin_transaction().await;
+
+        let meta = dbtx
+            .get_value(&InviteIdKey(invite_id))
+            .await
+            .ok_or_else(|| ApiError::bad_request("Unknown invite id".to_string()))?;
+
+        if meta.expires_at <= fedimint_core::time::duration_since_epoch().as_secs() {
+            return Err(ApiError::bad_request("Invite code is expired".to_string()));
+        }
+
+        let users = dbtx
+            .get_value(&InviteUserCountKey(invite_id))
+            .await
+            .unwrap_or(0);
+
+        if users >= meta.user_limit {
+            return Err(ApiError::bad_request(
+                "Invite code has reached its user limit".to_string(),
+            ));
+        }
+
+        dbtx.insert_entry(&InviteUserCountKey(invite_id), &(users + 1))
+            .await;
+
+        dbtx.commit_tx_result()
+            .await
+            .map_err(|_| ApiError::server_error("Failed to count config download".to_string()))
+    }
 }
 
 #[async_trait]
@@ -773,6 +807,24 @@ impl IDashboardApi for ConsensusApi {
     async fn federation_invite_code(&self) -> String {
         self.get_invite_code(self.get_active_api_secret())
             .await
+            .to_string()
+    }
+
+    async fn create_invite_code(&self, expires_at: u64, user_limit: u64) -> String {
+        let invite_id = rand::random::<[u8; 16]>();
+
+        let meta = InviteIdMeta {
+            expires_at,
+            user_limit,
+        };
+
+        let mut dbtx = self.db.begin_transaction().await;
+        dbtx.insert_new_entry(&InviteIdKey(invite_id), &meta).await;
+        dbtx.commit_tx().await;
+
+        self.get_invite_code(self.get_active_api_secret())
+            .await
+            .with_invite_id(invite_id)
             .to_string()
     }
 
@@ -905,7 +957,15 @@ pub fn server_endpoints() -> Vec<ApiEndpoint<ConsensusApi>> {
         api_endpoint! {
             CLIENT_CONFIG_ENDPOINT,
             ApiVersion::new(0, 0),
-            async |fedimint: &ConsensusApi, _context, _v: ()| -> ClientConfig {
+            // The invite id is optional only to remain compatible with
+            // clients that do not send one yet; once those are sufficiently
+            // deployed it becomes required so every invite code's expiration
+            // date and user limit are enforced
+            async |fedimint: &ConsensusApi, _context, invite_id: Option<[u8; 16]>| -> ClientConfig {
+                if let Some(invite_id) = invite_id {
+                    fedimint.register_config_download(invite_id).await?;
+                }
+
                 Ok(fedimint.client_cfg.clone())
             }
         },

--- a/fedimint-server/src/db.rs
+++ b/fedimint-server/src/db.rs
@@ -5,7 +5,7 @@ use fedimint_core::db::{
     DatabaseTransaction, IDatabaseTransactionOpsCore as _, MODULE_GLOBAL_PREFIX,
 };
 use fedimint_core::encoding::{Decodable, Encodable};
-use fedimint_core::impl_db_record;
+use fedimint_core::{impl_db_lookup, impl_db_record};
 use futures::StreamExt as _;
 use strum::{EnumIter, IntoEnumIterator as _};
 
@@ -20,6 +20,8 @@ pub enum DbKeyPrefix {
     ApiAnnouncements = 0x06,
     ServerInfo = 0x07,
     GuardianMetadata = 0x08,
+    InviteId = 0x09,
+    InviteUserCount = 0x0a,
 
     DatabaseVersion = fedimint_core::db::DbKeyPrefix::DatabaseVersion as u8,
     ClientBackup = fedimint_core::db::DbKeyPrefix::ClientBackup as u8,
@@ -67,4 +69,47 @@ impl_db_record!(
     value = ServerInfo,
     db_prefix = DbKeyPrefix::ServerInfo,
     notify_on_modify = false,
+);
+
+#[derive(Clone, Debug, Encodable, Decodable)]
+pub struct InviteIdKey(pub [u8; 16]);
+
+#[derive(Clone, Debug, Encodable, Decodable)]
+pub struct InviteIdKeyPrefix;
+
+#[derive(Clone, Debug, Encodable, Decodable)]
+pub struct InviteIdMeta {
+    /// Unix timestamp in seconds after which the invite code is expired
+    pub expires_at: u64,
+    /// Maximum number of users that may join via this invite code
+    pub user_limit: u64,
+}
+
+impl_db_record!(
+    key = InviteIdKey,
+    value = InviteIdMeta,
+    db_prefix = DbKeyPrefix::InviteId,
+    notify_on_modify = false,
+);
+
+impl_db_lookup!(key = InviteIdKey, query_prefix = InviteIdKeyPrefix);
+
+/// Number of users that have joined via the invite code with this invite id so
+/// far; a missing entry means zero
+#[derive(Clone, Debug, Encodable, Decodable)]
+pub struct InviteUserCountKey(pub [u8; 16]);
+
+#[derive(Clone, Debug, Encodable, Decodable)]
+pub struct InviteUserCountKeyPrefix;
+
+impl_db_record!(
+    key = InviteUserCountKey,
+    value = u64,
+    db_prefix = DbKeyPrefix::InviteUserCount,
+    notify_on_modify = false,
+);
+
+impl_db_lookup!(
+    key = InviteUserCountKey,
+    query_prefix = InviteUserCountKeyPrefix
 );

--- a/fedimint-wasm-tests/src/lib.rs
+++ b/fedimint-wasm-tests/src/lib.rs
@@ -275,7 +275,6 @@ mod tests {
                 &SelectNotesWithAtleastAmount,
                 Amount::from_sats(11),
                 Duration::from_secs(10000),
-                false,
                 (),
             )
             .await?;
@@ -310,7 +309,6 @@ mod tests {
                     &SelectNotesWithAtleastAmount,
                     amount,
                     Duration::from_secs(10000),
-                    false,
                     (),
                 )
                 .await?;

--- a/gateway/fedimint-gateway-client/src/lib.rs
+++ b/gateway/fedimint-gateway-client/src/lib.rs
@@ -3,7 +3,6 @@ use std::collections::BTreeMap;
 use bitcoin::address::NetworkUnchecked;
 use bitcoin::{Address, Txid};
 use fedimint_connectors::ServerResult;
-use fedimint_core::PeerId;
 use fedimint_core::config::FederationId;
 use fedimint_core::invite_code::InviteCode;
 use fedimint_core::util::SafeUrl;
@@ -419,9 +418,9 @@ pub async fn set_mnemonic(
 pub async fn get_invite_codes(
     client: &GatewayApi,
     base_url: &SafeUrl,
-) -> ServerResult<BTreeMap<FederationId, BTreeMap<PeerId, (String, InviteCode)>>> {
+) -> ServerResult<BTreeMap<FederationId, InviteCode>> {
     client
-        .request::<(), BTreeMap<FederationId, BTreeMap<PeerId, (String, InviteCode)>>>(
+        .request::<(), BTreeMap<FederationId, InviteCode>>(
             base_url,
             Method::GET,
             INVITE_CODES_ENDPOINT,

--- a/gateway/fedimint-gateway-client/src/main.rs
+++ b/gateway/fedimint-gateway-client/src/main.rs
@@ -15,7 +15,6 @@ use config_commands::ConfigCommands;
 use ecash_commands::EcashCommands;
 use fedimint_connectors::ConnectorRegistry;
 use fedimint_connectors::error::ServerError;
-use fedimint_core::PeerId;
 use fedimint_core::config::FederationId;
 use fedimint_core::invite_code::InviteCode;
 use fedimint_core::util::SafeUrl;
@@ -47,7 +46,7 @@ pub enum CliOutput {
     Mnemonic(MnemonicResponse),
     PaymentLog(PaymentLogResponse),
     PaymentSummary(PaymentSummaryResponse),
-    InviteCodes(BTreeMap<FederationId, BTreeMap<PeerId, (String, InviteCode)>>),
+    InviteCodes(BTreeMap<FederationId, InviteCode>),
     PasswordHash(String),
 
     // Lightning commands

--- a/gateway/fedimint-gateway-server/src/federation_manager.rs
+++ b/gateway/fedimint-gateway-server/src/federation_manager.rs
@@ -5,11 +5,10 @@ use std::time::SystemTime;
 
 use bitcoin::secp256k1::Keypair;
 use fedimint_client::ClientHandleArc;
+use fedimint_core::TieredCounts;
 use fedimint_core::config::{FederationId, FederationIdPrefix, JsonClientConfig};
 use fedimint_core::db::{Committable, DatabaseTransaction, NonCommittable};
-use fedimint_core::invite_code::InviteCode;
 use fedimint_core::util::{FmtCompactAnyhow as _, Spanned};
-use fedimint_core::{PeerId, TieredCounts};
 use fedimint_gateway_common::FederationInfo;
 use fedimint_gateway_server_db::GatewayDbtxNcExt as _;
 use fedimint_gw_client::GatewayClientModule;
@@ -343,28 +342,6 @@ impl FederationManager {
                 info!(federation_id = %federation_id, "Successfully backed up federation");
             }
         }
-    }
-
-    pub async fn all_invite_codes(
-        &self,
-    ) -> BTreeMap<FederationId, BTreeMap<PeerId, (String, InviteCode)>> {
-        let mut invite_codes = BTreeMap::new();
-
-        for (federation_id, client) in &self.clients {
-            let config = client.value().config().await;
-            let api_endpoints = &config.global.api_endpoints;
-
-            let mut fed_invite_codes = BTreeMap::new();
-            for (peer_id, peer_url) in api_endpoints {
-                if let Some(code) = client.value().invite_code(*peer_id).await {
-                    fed_invite_codes.insert(*peer_id, (peer_url.name.clone(), code));
-                }
-            }
-
-            invite_codes.insert(*federation_id, fed_invite_codes);
-        }
-
-        invite_codes
     }
 
     pub async fn get_note_summary(

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -67,7 +67,7 @@ use fedimint_core::time::duration_since_epoch;
 use fedimint_core::util::backoff_util::fibonacci_max_one_hour;
 use fedimint_core::util::{FmtCompact, FmtCompactAnyhow, SafeUrl, Spanned, retry};
 use fedimint_core::{
-    Amount, BitcoinAmountOrAll, PeerId, TieredCounts, crit, fedimint_build_code_version_env,
+    Amount, BitcoinAmountOrAll, TieredCounts, crit, fedimint_build_code_version_env,
     get_network_for_address,
 };
 use fedimint_eventlog::{DBTransactionEventLogExt, EventLogId, StructuredPaymentEvents};
@@ -2526,7 +2526,7 @@ impl IAdminGateway for Gateway {
             })
         } else if let Ok(mint_module) = client.get_first_module::<MintV2ClientModule>() {
             let ecash = mint_module
-                .send(payload.amount, serde_json::Value::Null, true)
+                .send(payload.amount, serde_json::Value::Null)
                 .await
                 .map_err(|e| AdminGatewayError::Unexpected(e.into()))?;
 
@@ -2892,12 +2892,15 @@ impl IAdminGateway for Gateway {
     }
 
     /// Returns a `BTreeMap` that is keyed by the `FederationId` and contains
-    /// all the invite codes (with peer names) for the federation.
-    async fn handle_export_invite_codes(
-        &self,
-    ) -> BTreeMap<FederationId, BTreeMap<PeerId, (String, InviteCode)>> {
-        let fed_manager = self.federation_manager.read().await;
-        fed_manager.all_invite_codes().await
+    /// the invite code the gateway used to join the federation.
+    async fn handle_export_invite_codes(&self) -> BTreeMap<FederationId, InviteCode> {
+        let mut dbtx = self.gateway_db.begin_transaction_nc().await;
+
+        dbtx.load_federation_configs()
+            .await
+            .into_iter()
+            .map(|(federation_id, config)| (federation_id, config.invite_code))
+            .collect()
     }
 
     /// Returns `TieredCounts` which describes the breakdown of notes in the

--- a/gateway/fedimint-gateway-ui/src/federation.rs
+++ b/gateway/fedimint-gateway-ui/src/federation.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeMap;
 use std::fmt::Display;
 use std::str::FromStr;
 use std::time::{Duration, SystemTime};
@@ -11,7 +10,7 @@ use bitcoin::address::NetworkUnchecked;
 use fedimint_core::base32::{self, FEDIMINT_PREFIX};
 use fedimint_core::config::FederationId;
 use fedimint_core::invite_code::InviteCode;
-use fedimint_core::{Amount, BitcoinAmountOrAll, PeerId, TieredCounts};
+use fedimint_core::{Amount, BitcoinAmountOrAll, TieredCounts};
 use fedimint_gateway_common::{
     DepositAddressPayload, FederationInfo, LeaveFedPayload, ReceiveEcashPayload, SetFeesPayload,
     SpendEcashPayload, WithdrawPayload, WithdrawPreviewPayload,
@@ -145,7 +144,7 @@ pub fn scripts() -> Markup {
 
 pub fn render<E: Display>(
     fed: &FederationInfo,
-    invite_codes: &BTreeMap<PeerId, (String, InviteCode)>,
+    invite_code: Option<&InviteCode>,
     note_summary: &Result<TieredCounts, E>,
 ) -> Markup {
     html!(
@@ -534,70 +533,54 @@ pub fn render<E: Display>(
                                 role="tabpanel"
                                 aria-labelledby=(format!("peers-tab-{}", fed.federation_id))
                             {
-                                @if invite_codes.is_empty() {
-                                    div class="alert alert-secondary" {
-                                        "No invite codes found for this federation."
-                                    }
-                                } @else {
-                                    table class="table table-sm" {
-                                        thead {
-                                            tr {
-                                                th { "Peer ID" }
-                                                th { "Name" }
-                                                th { "Invite Code" }
-                                            }
+                                @match invite_code {
+                                    None => {
+                                        div class="alert alert-secondary" {
+                                            "No invite code found for this federation."
                                         }
-                                        tbody {
-                                            @for (peer_id, (name, code)) in invite_codes {
-                                                @let code_str = code.to_string();
-                                                @let modal_id = format!("qr-modal-{}-{}", fed.federation_id, peer_id);
-                                                @let qr = QrCode::new(code_str.as_bytes()).expect("Failed to generate QR code");
-                                                @let qr_svg = qr.render::<svg::Color>().build();
-                                                tr {
-                                                    td { (peer_id) }
-                                                    td { (name) }
-                                                    td {
-                                                        div class="d-flex align-items-center gap-1" {
-                                                            input type="text"
-                                                                class="form-control form-control-sm"
-                                                                value=(code_str)
-                                                                readonly
-                                                                onclick="copyText(this)"
-                                                                style="cursor: pointer; font-size: 0.75rem;";
-                                                            button type="button"
-                                                                class="btn btn-sm btn-outline-secondary"
-                                                                data-bs-toggle="modal"
-                                                                data-bs-target=(format!("#{}", modal_id))
-                                                                title="Show QR Code"
-                                                            { "QR" }
-                                                        }
+                                    }
+                                    Some(code) => {
+                                        @let code_str = code.to_string();
+                                        @let modal_id = format!("qr-modal-{}", fed.federation_id);
+                                        @let qr = QrCode::new(code_str.as_bytes()).expect("Failed to generate QR code");
+                                        @let qr_svg = qr.render::<svg::Color>().build();
+                                        div class="d-flex align-items-center gap-1" {
+                                            input type="text"
+                                                class="form-control form-control-sm"
+                                                value=(code_str)
+                                                readonly
+                                                onclick="copyText(this)"
+                                                style="cursor: pointer; font-size: 0.75rem;";
+                                            button type="button"
+                                                class="btn btn-sm btn-outline-secondary"
+                                                data-bs-toggle="modal"
+                                                data-bs-target=(format!("#{}", modal_id))
+                                                title="Show QR Code"
+                                            { "QR" }
+                                        }
 
-                                                        // QR Code Modal
-                                                        div class="modal fade"
-                                                            id=(modal_id)
-                                                            tabindex="-1"
-                                                            aria-hidden="true"
+                                        // QR Code Modal
+                                        div class="modal fade"
+                                            id=(modal_id)
+                                            tabindex="-1"
+                                            aria-hidden="true"
+                                        {
+                                            div class="modal-dialog modal-dialog-centered" {
+                                                div class="modal-content" {
+                                                    div class="modal-header" {
+                                                        h5 class="modal-title" {
+                                                            "Invite Code"
+                                                        }
+                                                        button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" {}
+                                                    }
+                                                    div class="modal-body d-flex justify-content-center" {
+                                                        div class="border rounded p-2 bg-white"
+                                                            style="width: 300px; height: 300px;"
                                                         {
-                                                            div class="modal-dialog modal-dialog-centered" {
-                                                                div class="modal-content" {
-                                                                    div class="modal-header" {
-                                                                        h5 class="modal-title" {
-                                                                            "Invite Code — Peer " (peer_id) " (" (name) ")"
-                                                                        }
-                                                                        button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" {}
-                                                                    }
-                                                                    div class="modal-body d-flex justify-content-center" {
-                                                                        div class="border rounded p-2 bg-white"
-                                                                            style="width: 300px; height: 300px;"
-                                                                        {
-                                                                            (PreEscaped(format!(
-                                                                                r#"<svg style="width: 100%; height: 100%; display: block;">{}</svg>"#,
-                                                                                qr_svg.replace("width=", "data-width=").replace("height=", "data-height=")
-                                                                            )))
-                                                                        }
-                                                                    }
-                                                                }
-                                                            }
+                                                            (PreEscaped(format!(
+                                                                r#"<svg style="width: 100%; height: 100%; display: block;">{}</svg>"#,
+                                                                qr_svg.replace("width=", "data-width=").replace("height=", "data-height=")
+                                                            )))
                                                         }
                                                     }
                                                 }

--- a/gateway/fedimint-gateway-ui/src/lib.rs
+++ b/gateway/fedimint-gateway-ui/src/lib.rs
@@ -21,12 +21,12 @@ use axum::routing::{get, post};
 use axum::{Form, Router};
 use axum_extra::extract::CookieJar;
 use axum_extra::extract::cookie::{Cookie, SameSite};
+use fedimint_core::TieredCounts;
 use fedimint_core::bitcoin::Network;
 use fedimint_core::config::FederationId;
 use fedimint_core::invite_code::InviteCode;
 use fedimint_core::secp256k1::serde::Deserialize;
 use fedimint_core::task::TaskGroup;
-use fedimint_core::{PeerId, TieredCounts};
 use fedimint_gateway_common::{
     ChainSource, CloseChannelsWithPeerRequest, CloseChannelsWithPeerResponse, ConnectFedPayload,
     CreateInvoiceForOperatorPayload, CreateOfferPayload, CreateOfferResponse,
@@ -231,9 +231,7 @@ pub trait IAdminGateway {
         payload: PaymentLogPayload,
     ) -> Result<PaymentLogResponse, Self::Error>;
 
-    async fn handle_export_invite_codes(
-        &self,
-    ) -> BTreeMap<FederationId, BTreeMap<PeerId, (String, InviteCode)>>;
+    async fn handle_export_invite_codes(&self) -> BTreeMap<FederationId, InviteCode>;
 
     fn get_password_hash(&self) -> String;
 
@@ -398,12 +396,11 @@ where
         }
 
         @let invite_codes = state.api.handle_export_invite_codes().await;
-        @let empty_map = BTreeMap::new();
 
         @for fed in &gateway_info.federations {
-            @let fed_codes = invite_codes.get(&fed.federation_id).unwrap_or(&empty_map);
+            @let invite_code = invite_codes.get(&fed.federation_id);
             @let note_summary = state.api.handle_get_note_summary_msg(&fed.federation_id).await;
-            (federation::render(fed, fed_codes, &note_summary))
+            (federation::render(fed, invite_code, &note_summary))
         }
     };
 
@@ -439,10 +436,7 @@ where
         .handle_export_invite_codes()
         .await
         .into_iter()
-        .map(|(fed_id, peers)| {
-            let codes = peers.into_values().map(|(_, code)| code).collect();
-            (fed_id, codes)
-        })
+        .map(|(fed_id, code)| (fed_id, vec![code]))
         .collect();
     let json = match serde_json::to_string_pretty(&invite_codes) {
         Ok(json) => json,

--- a/modules/fedimint-mint-client/src/cli.rs
+++ b/modules/fedimint-mint-client/src/cli.rs
@@ -31,10 +31,6 @@ enum Opts {
         /// hasn't been redeemed by the recipient. Defaults to one week.
         #[clap(long, default_value_t = 60 * 60 * 24 * 7)]
         timeout: u64,
-        /// If the necessary information to join the federation the e-cash
-        /// belongs to should be included in the serialized notes
-        #[clap(long)]
-        include_invite: bool,
     },
     /// Splits a string containing multiple e-cash notes (e.g. from the `spend`
     /// command) into ones that contain exactly one.
@@ -61,7 +57,6 @@ async fn spend(
     amount: Amount,
     allow_overpay: bool,
     timeout: u64,
-    include_invite: bool,
 ) -> anyhow::Result<serde_json::Value> {
     warn!(
         "The client will try to double-spend these notes after the timeout to reclaim \
@@ -71,13 +66,7 @@ async fn spend(
     let timeout = Duration::from_secs(timeout);
     let (operation, notes) = if allow_overpay {
         let (operation, notes) = mint
-            .spend_notes_with_selector(
-                &SelectNotesWithAtleastAmount,
-                amount,
-                timeout,
-                include_invite,
-                (),
-            )
+            .spend_notes_with_selector(&SelectNotesWithAtleastAmount, amount, timeout, ())
             .await?;
 
         let overspend_amount = notes.total_amount().saturating_sub(amount);
@@ -87,14 +76,8 @@ async fn spend(
 
         (operation, notes)
     } else {
-        mint.spend_notes_with_selector(
-            &SelectNotesWithExactAmount,
-            amount,
-            timeout,
-            include_invite,
-            (),
-        )
-        .await?
+        mint.spend_notes_with_selector(&SelectNotesWithExactAmount, amount, timeout, ())
+            .await?
     };
     info!("Spend e-cash operation: {}", operation.fmt_short());
 
@@ -177,8 +160,7 @@ pub(crate) async fn handle_cli_command(
             amount,
             allow_overpay,
             timeout,
-            include_invite,
-        } => spend(mint, amount, allow_overpay, timeout, include_invite).await,
+        } => spend(mint, amount, allow_overpay, timeout).await,
         Opts::Split { oob_notes } => Ok(split(&oob_notes)),
         Opts::Combine { oob_notes } => combine(&oob_notes),
         Opts::Validate { oob_notes, online } => {

--- a/modules/fedimint-mint-client/src/events.rs
+++ b/modules/fedimint-mint-client/src/events.rs
@@ -45,10 +45,6 @@ pub struct OOBNotesSpent {
 
     /// The timeout before attempting to refund
     pub timeout: Duration,
-
-    /// Boolean that indicates if the invite code was included in the note
-    /// serialization
-    pub include_invite: bool,
 }
 
 impl Event for OOBNotesSpent {

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -1137,7 +1137,6 @@ impl ClientModule for MintClientModule {
                         &SelectNotesWithExactAmount,
                         req.amount,
                         req.try_cancel_after,
-                        req.include_invite,
                         req.extra_meta
                     ).await?;
                     yield serde_json::to_value(result)?;
@@ -1148,7 +1147,6 @@ impl ClientModule for MintClientModule {
                         &SelectNotesWithAtleastAmount,
                         req.min_amount,
                         req.try_cancel_after,
-                        req.include_invite,
                         req.extra_meta
                     ).await?;
                     yield serde_json::to_value(result)?;
@@ -1206,7 +1204,6 @@ struct SubscribeReissueExternalNotesRequest {
 struct SpendNotesExpertRequest {
     min_amount: Amount,
     try_cancel_after: Duration,
-    include_invite: bool,
     extra_meta: serde_json::Value,
 }
 
@@ -1214,7 +1211,6 @@ struct SpendNotesExpertRequest {
 struct SpendNotesRequest {
     amount: Amount,
     try_cancel_after: Duration,
-    include_invite: bool,
     extra_meta: serde_json::Value,
 }
 
@@ -1920,14 +1916,12 @@ impl MintClientModule {
         &self,
         min_amount: Amount,
         try_cancel_after: Duration,
-        include_invite: bool,
         extra_meta: M,
     ) -> anyhow::Result<(OperationId, OOBNotes)> {
         self.spend_notes_with_selector(
             &SelectNotesWithAtleastAmount,
             min_amount,
             try_cancel_after,
-            include_invite,
             extra_meta,
         )
         .await
@@ -1953,7 +1947,6 @@ impl MintClientModule {
         notes_selector: &impl NotesSelector,
         requested_amount: Amount,
         try_cancel_after: Duration,
-        include_invite: bool,
         extra_meta: M,
     ) -> anyhow::Result<(OperationId, OOBNotes)> {
         let federation_id_prefix = self.federation_id.to_prefix();
@@ -1975,14 +1968,7 @@ impl MintClientModule {
                             )
                             .await?;
 
-                        let oob_notes = if include_invite {
-                            OOBNotes::new_with_invite(
-                                notes,
-                                &self.client_ctx.get_invite_code().await,
-                            )
-                        } else {
-                            OOBNotes::new(federation_id_prefix, notes)
-                        };
+                        let oob_notes = OOBNotes::new(federation_id_prefix, notes);
 
                         self.client_ctx
                             .add_state_machines_dbtx(
@@ -2012,7 +1998,6 @@ impl MintClientModule {
                                     requested_amount,
                                     spent_amount: oob_notes.total_amount(),
                                     timeout: try_cancel_after,
-                                    include_invite,
                                 },
                             )
                             .await;

--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -131,7 +131,7 @@ async fn sends_ecash_out_of_band() -> anyhow::Result<()> {
     let client2_mint = client2.get_first_module::<MintClientModule>()?;
     info!("### SPEND NOTES");
     let (op, notes) = client1_mint
-        .spend_notes_with_selector(&SelectNotesWithAtleastAmount, sats(750), TIMEOUT, false, ())
+        .spend_notes_with_selector(&SelectNotesWithAtleastAmount, sats(750), TIMEOUT, ())
         .await?;
     let sub1 = &mut client1_mint.subscribe_spend_notes(op).await?.into_stream();
     assert_eq!(sub1.ok().await?, SpendOOBState::Created);
@@ -288,7 +288,6 @@ async fn sends_ecash_oob_highly_parallel() -> anyhow::Result<()> {
                         &SelectNotesWithAtleastAmount,
                         sats(30),
                         ECASH_TIMEOUT,
-                        false,
                         (),
                     )
                     .await
@@ -421,7 +420,7 @@ async fn sends_ecash_out_of_band_cancel() -> anyhow::Result<()> {
     // Spend from client1 to client2
     let mint_module = client.get_first_module::<MintClientModule>()?;
     let (op, _) = mint_module
-        .spend_notes_with_selector(&SelectNotesWithAtleastAmount, sats(750), TIMEOUT, false, ())
+        .spend_notes_with_selector(&SelectNotesWithAtleastAmount, sats(750), TIMEOUT, ())
         .await?;
     let sub1 = &mut mint_module.subscribe_spend_notes(op).await?.into_stream();
     assert_eq!(sub1.ok().await?, SpendOOBState::Created);
@@ -459,13 +458,7 @@ async fn sends_ecash_out_of_band_cancel_partial() -> anyhow::Result<()> {
     info!("### SPEND NOTES");
     let mint_module = client.get_first_module::<MintClientModule>()?;
     let (spend_op, notes) = mint_module
-        .spend_notes_with_selector(
-            &SelectNotesWithAtleastAmount,
-            sats(750),
-            TIMEOUT * 3,
-            false,
-            (),
-        )
+        .spend_notes_with_selector(&SelectNotesWithAtleastAmount, sats(750), TIMEOUT * 3, ())
         .await?;
     let sub1 = &mut mint_module
         .subscribe_spend_notes(spend_op)
@@ -534,13 +527,7 @@ async fn error_zero_value_oob_spend() -> anyhow::Result<()> {
     // Spend from client1 to client2
     let err_msg = client1
         .get_first_module::<MintClientModule>()?
-        .spend_notes_with_selector(
-            &SelectNotesWithAtleastAmount,
-            Amount::ZERO,
-            TIMEOUT,
-            false,
-            (),
-        )
+        .spend_notes_with_selector(&SelectNotesWithAtleastAmount, Amount::ZERO, TIMEOUT, ())
         .await
         .expect_err("Zero-amount spends should be forbidden")
         .to_string();
@@ -766,7 +753,6 @@ async fn repair_wallet() -> anyhow::Result<()> {
                 &SelectNotesWithExactAmount,
                 Amount::from_msats(1),
                 TIMEOUT,
-                false,
                 (),
             )
             .await?;

--- a/modules/fedimint-mintv2-client/src/cli.rs
+++ b/modules/fedimint-mintv2-client/src/cli.rs
@@ -13,13 +13,7 @@ enum Opts {
     /// Count the `ECash` notes in the client's database by denomination.
     Count,
     /// Send `ECash` for the given amount.
-    Send {
-        amount: Amount,
-        /// Embed the federation's invite code in the serialized ecash so a
-        /// recipient that hasn't joined the federation can do so from it.
-        #[clap(long)]
-        include_invite: bool,
-    },
+    Send { amount: Amount },
     /// Receive the `ECash` by reissuing the notes and return the amount.
     Receive { ecash: String },
 }
@@ -32,12 +26,9 @@ pub(crate) async fn handle_cli_command(
 
     match opts {
         Opts::Count => Ok(json(mint.get_count_by_denomination().await)),
-        Opts::Send {
-            amount,
-            include_invite,
-        } => {
+        Opts::Send { amount } => {
             let ecash = mint
-                .send(amount, Value::Null, include_invite)
+                .send(amount, Value::Null)
                 .await
                 .map(|ecash| base32::encode_prefixed(FEDIMINT_PREFIX, &ecash))?;
 

--- a/modules/fedimint-mintv2-client/src/lib.rs
+++ b/modules/fedimint-mintv2-client/src/lib.rs
@@ -766,30 +766,14 @@ impl MintClientModule {
     /// before the reissue is complete in which case the reissued notes are
     /// returned to the regular balance. To cancel a successful ecash send
     /// simply receive it yourself.
-    ///
-    /// If `include_invite` is set, the federation's invite code is embedded in
-    /// the returned ecash so a recipient that has not joined the federation can
-    /// do so directly from the received ecash.
-    pub async fn send(
-        &self,
-        amount: Amount,
-        custom_meta: Value,
-        include_invite: bool,
-    ) -> Result<ECash, SendECashError> {
+    pub async fn send(&self, amount: Amount, custom_meta: Value) -> Result<ECash, SendECashError> {
         let amount = round_to_multiple(amount, client_denominations().next().unwrap().amount());
 
         if let Some(ecash) = self
             .client_ctx
             .module_db()
             .autocommit(
-                |dbtx, _| {
-                    Box::pin(self.send_ecash_dbtx(
-                        dbtx,
-                        amount,
-                        custom_meta.clone(),
-                        include_invite,
-                    ))
-                },
+                |dbtx, _| Box::pin(self.send_ecash_dbtx(dbtx, amount, custom_meta.clone())),
                 Some(100),
             )
             .await
@@ -833,7 +817,7 @@ impl MintClientModule {
                 .map_err(|_| SendECashError::Failure)?;
         }
 
-        Box::pin(self.send(amount, custom_meta, include_invite)).await
+        Box::pin(self.send(amount, custom_meta)).await
     }
 
     async fn send_ecash_dbtx(
@@ -841,7 +825,6 @@ impl MintClientModule {
         dbtx: &mut DatabaseTransaction<'_>,
         mut remaining_amount: Amount,
         custom_meta: Value,
-        include_invite: bool,
     ) -> Result<Option<ECash>, Infallible> {
         let mut stream = dbtx
             .find_by_prefix_sorted_descending(&SpendableNotePrefix)
@@ -869,12 +852,7 @@ impl MintClientModule {
             self.remove_spendable_note(dbtx, spendable_note).await;
         }
 
-        let ecash = if include_invite {
-            let invite = self.client_ctx.get_invite_code().await;
-            ECash::new_with_invite(notes, &invite)
-        } else {
-            ECash::new(self.federation_id, notes)
-        };
+        let ecash = ECash::new(self.federation_id, notes);
         let amount = ecash.amount();
         let operation_id = OperationId::new_random();
 

--- a/modules/fedimint-mintv2-tests/tests/tests.rs
+++ b/modules/fedimint-mintv2-tests/tests/tests.rs
@@ -127,12 +127,9 @@ async fn send_and_receive() -> anyhow::Result<()> {
     for i in 0..10 {
         tracing::info!("Sending ecash payment {i} of 10");
 
-        // Exercise both with and without the optional invite code.
-        let include_invite = i % 2 == 0;
-
         let ecash = client_send
             .get_first_module::<MintClientModule>()?
-            .send(Amount::from_sats(1_000), Value::Null, include_invite)
+            .send(Amount::from_sats(1_000), Value::Null)
             .await?;
 
         let Some(MintEvent::Send(_)) = send_events.next().await else {
@@ -143,15 +140,8 @@ async fn send_and_receive() -> anyhow::Result<()> {
 
         let ecash: ECash = base32::decode_prefixed(FEDIMINT_PREFIX, &ecash).unwrap();
 
-        // When requested, the sender embeds the federation invite code so a
-        // recipient can join the issuing federation directly from the received
-        // ecash. Otherwise no invite is present.
-        assert_eq!(
-            ecash
-                .federation_invite()
-                .map(|invite| invite.federation_id()),
-            include_invite.then(|| client_send.federation_id()),
-        );
+        // Clients cannot mint invite codes, hence no invite is embedded.
+        assert!(ecash.federation_invite().is_none());
 
         let operation_id = client_receive
             .get_first_module::<MintClientModule>()?
@@ -237,7 +227,7 @@ async fn double_spend_is_rejected() -> anyhow::Result<()> {
 
     let ecash = client_send
         .get_first_module::<MintClientModule>()?
-        .send(Amount::from_sats(1_000), Value::Null, false)
+        .send(Amount::from_sats(1_000), Value::Null)
         .await?;
 
     let Some(MintEvent::Send(_)) = send_events.next().await else {
@@ -306,7 +296,7 @@ async fn transaction_with_invalid_signature_is_rejected() -> anyhow::Result<()> 
 
     let ecash = client
         .get_first_module::<MintClientModule>()?
-        .send(Amount::from_sats(1_000), Value::Null, false)
+        .send(Amount::from_sats(1_000), Value::Null)
         .await?;
 
     let Some(MintEvent::Send(_)) = events.next().await else {


### PR DESCRIPTION
## Summary

Guardians now generate invite codes from the dashboard by choosing how many days the code is valid (default 30) and how many users may join with it (default 50). Each generated code carries an opaque invite id; the issuing guardian stores the expiration date, user limit, and a download counter for that id in its local database and enforces all three when serving the client config.

## Details

The dashboard no longer displays a static invite code. Instead the invite card shows a form (days valid + user limit); submitting it creates the invite via htmx and swaps the QR code, copiable invite string, and an expiry/limit summary into the card in place of the form.

Mechanically:

- `InviteCodePart::InviteId([u8; 16])` is a new invite code part holding an opaque random id. Old clients ignore it via the `#[encodable_default]` catch-all, so plain invite codes remain fully compatible in both directions.
- The issuing guardian stores `InviteIdKey -> InviteIdMeta { expires_at, user_limit }` plus a separate `InviteUserCountKey -> u64` download counter (missing entry means zero) under two new local, non-consensus db prefixes. No migration is needed; the dbtool dump and migration test matches were extended.
- A new `IDashboardApi::create_invite_code(expires_at, user_limit)` generates the id, persists the metadata, and returns the invite code with the id appended.
- The `client_config` endpoint now takes `Option<[u8; 16]>`. When an id is present the guardian rejects unknown ids, expired codes, and codes at their user limit, and otherwise increments the counter in the same transaction. Requests without an id are served as before.
- The client sends the invite id only on the initial config fetch, which goes to the guardians listed in the invite code. Since generated invites contain only the issuing guardian's endpoint, enforcement happens exactly once per join, at the issuer.

Enforcement is deliberately guardian-local: the issuer counts config downloads against the limit, as metadata lives only in its database. A modified client that strips the id, or anyone who already holds the config, is not stopped — this raises the bar against casual over-sharing through standard clients rather than acting as a cryptographic gate. Note that `client_config_json`, the admin UI helper endpoint, still serves the config without a check.

## Compatibility

All four version combinations keep working:

- **Old invite code, any client, new guardian**: a code without an id results in `null` params, which the new endpoint deserializes to `None` and serves as before.
- **Old invite code, new client, old guardian**: `ApiRequestErased::new(None)` serializes to `null` params, byte-identical to the previous request, so old guardians are unaffected.
- **New invite code, old client, new guardian**: old clients decode the unknown invite code part into the `#[encodable_default]` catch-all and ignore it; the join succeeds.
- **New invite code, new client, mixed federation**: only the issuing guardian receives the id; the verification fetch to all peers sends `null`, which old guardians deserialize as `()` successfully.

The known caveat: an old client joining via a limited invite is invisible to enforcement — it never presents the id, so it is not counted and expiry does not apply to it. Limits only bite for clients new enough to send the id.

The `Option` is transitional. The plan is to eventually make the invite id required on the server side so limits are always enforced: once clients that send the id are sufficiently deployed, the endpoint flips from `Option<[u8; 16]>` to `[u8; 16]` (with an API version bump) and guardians reject config downloads without a valid id. At that point every invite code has an enforced expiration date and user limit, matching the dashboard UX which already presents them as mandatory.

## Follow-up cleanup commits

Two additional commits tighten the model:

- **Single-peer config download**: invite codes are bound to a single guardian now, so the initial config fetch is a single request to that guardian instead of a query strategy over multiple peers. The unused multi-peer invite code constructors (`from_map`, `new_with_essential_num_guardians`) are removed; decoding old multi-peer invites still works.
- **No more client-side invite generation**: clients could mint id-less invite codes from their stored config, which would bypass (and later break under) enforcement. Removed: `ClientHandle::invite_code`, the `get_invite_code` client rpc, the `fedimint-cli invite-code` command, and the mint and mintv2 modules' `include_invite` options for embedding invites in out-of-band ecash (receiving such ecash remains supported). The gateway's invite code export now returns the stored invite code each federation was joined with, instead of deriving one per guardian; the exported `gateway-invite-codes.json` format is unchanged (one code per federation instead of several).

The consequence of the last commit: guardians are the only source of invite codes, so e-cash strings no longer carry join information and receivers must already be members or obtain a guardian-issued invite. Note this includes reverting the sender side of the recently merged #8667, which added invite embedding to mintv2 ecash.

A fail-fast for guardian-rejected config downloads (avoiding the ~35s retry loop on expired invites) was dropped from this PR for now and can follow separately.

## Reviewing

- The compatibility story above, in particular whether the transitional `Option` and the eventual hard requirement are the right migration path.
- Whether counting config downloads (including re-downloads and seed recovery re-joins) is an acceptable proxy for users.
- The concurrent-download race on the counter resolves via `commit_tx_result` plus the client's retry loop.
- Whether removing `include_invite` (mint and mintv2) is acceptable for downstream wallets that embed invites in e-cash strings.

## Testing

All touched crates compile and `just final-lint` passes. Manual testing: spawn a devimint env, open the guardian dashboard, generate an invite with a short expiry and limit of one, then join with `fedimint-cli` twice — the second join must be rejected, as must joins after expiry. Automated coverage for the join-flow enforcement is still to be added; happy to extend devimint tests if the direction is agreed on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
