### PR TITLE
chore(net): improve p2p config-gen progress logs

### DIFF
--- a/fedimint-server/src/config/mod.rs
+++ b/fedimint-server/src/config/mod.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::net::SocketAddr;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use anyhow::{Context, bail, format_err};
 use bitcoin::hashes::sha256;
@@ -560,7 +560,7 @@ impl ServerConfig {
                 .iter_mut()
                 .filter_map(|(p, r)| {
                     r.mark_unchanged();
-                    r.borrow().is_none().then_some((*p, r.clone()))
+                    r.borrow().connected.is_none().then_some((*p, r.clone()))
                 })
                 .collect();
 
@@ -570,8 +570,12 @@ impl ServerConfig {
 
             let disconnected_peers = pending_connection_receivers
                 .iter()
-                .map(|entry| entry.0)
-                .collect::<Vec<PeerId>>();
+                .map(|(peer, receiver)| {
+                    let last_error = receiver.borrow().last_error.clone();
+
+                    (*peer, last_error)
+                })
+                .collect::<Vec<_>>();
 
             info!(
                 target: LOG_NET_PEER_DKG,
@@ -599,10 +603,12 @@ impl ServerConfig {
             .into_iter()
             .filter(|p| *p != params.identity)
         {
-            let peer_message = connections
-                .receive_from_peer(peer)
-                .await
-                .context("Unexpected shutdown of p2p connections")?;
+            let peer_message = receive_from_peer_with_progress(
+                &connections,
+                peer,
+                "connection code checksum message",
+            )
+            .await?;
 
             if peer_message != P2PMessage::Checksum(checksum) {
                 error!(
@@ -689,10 +695,9 @@ impl ServerConfig {
             .into_iter()
             .filter(|p| *p != params.identity)
         {
-            let peer_message = connections
-                .receive_from_peer(peer)
-                .await
-                .context("Unexpected shutdown of p2p connections")?;
+            let peer_message =
+                receive_from_peer_with_progress(&connections, peer, "consensus config checksum")
+                    .await?;
 
             if peer_message != P2PMessage::Checksum(checksum) {
                 warn!(
@@ -718,6 +723,34 @@ impl ServerConfig {
         );
 
         Ok(cfg)
+    }
+}
+
+async fn receive_from_peer_with_progress(
+    connections: &DynP2PConnections<P2PMessage>,
+    peer: PeerId,
+    message_description: &'static str,
+) -> anyhow::Result<P2PMessage> {
+    let start = Instant::now();
+
+    loop {
+        select! {
+            // Cancel-safe: `receive_from_peer` is backed by
+            // `async_channel::Receiver::recv`, so dropping this future on the
+            // periodic progress-log tick does not lose messages.
+            peer_message = connections.receive_from_peer(peer) => {
+                return peer_message.context("Unexpected shutdown of p2p connections");
+            }
+            () = sleep(Duration::from_secs(10)) => {
+                info!(
+                    target: LOG_NET_PEER_DKG,
+                    %peer,
+                    message = message_description,
+                    elapsed_secs = start.elapsed().as_secs(),
+                    "Still waiting for peer message"
+                );
+            }
+        }
     }
 }
 

--- a/fedimint-server/src/consensus/api.rs
+++ b/fedimint-server/src/consensus/api.rs
@@ -278,7 +278,7 @@ impl ConsensusApi {
                 let ci_receiver = self.ci_status_receivers.get(peer).unwrap();
 
                 let consensus_status = LegacyPeerStatus {
-                    connection_status: match *p2p_receiver.borrow() {
+                    connection_status: match p2p_receiver.borrow().connected {
                         Some(..) => LegacyP2PConnectionStatus::Connected,
                         None => LegacyP2PConnectionStatus::Disconnected,
                     },
@@ -766,7 +766,7 @@ impl IDashboardApi for ConsensusApi {
     async fn p2p_connection_status(&self) -> BTreeMap<PeerId, Option<P2PConnectionStatus>> {
         self.p2p_status_receivers
             .iter()
-            .map(|(peer, receiver)| (*peer, receiver.borrow().clone()))
+            .map(|(peer, receiver)| (*peer, receiver.borrow().connected.clone()))
             .collect()
     }
 
@@ -953,7 +953,7 @@ pub fn server_endpoints() -> Vec<ApiEndpoint<ConsensusApi>> {
             async |fedimint: &ConsensusApi, _c, _v: ()| -> BTreeMap<PeerId, Option<P2PConnectionStatus>> {
                 Ok(fedimint.p2p_status_receivers
                     .iter()
-                    .map(|(peer, receiver)| (*peer, receiver.borrow().clone()))
+                    .map(|(peer, receiver)| (*peer, receiver.borrow().connected.clone()))
                     .collect())
             }
         },

--- a/fedimint-server/src/net/p2p.rs
+++ b/fedimint-server/src/net/p2p.rs
@@ -25,15 +25,26 @@ use crate::metrics::{PEER_CONNECT_COUNT, PEER_DISCONNECT_COUNT, PEER_MESSAGES_CO
 use crate::net::p2p_connection::DynP2PConnection;
 use crate::net::p2p_connector::DynP2PConnector;
 
-pub type P2PStatusSenders = BTreeMap<PeerId, watch::Sender<Option<P2PConnectionStatus>>>;
-pub type P2PStatusReceivers = BTreeMap<PeerId, watch::Receiver<Option<P2PConnectionStatus>>>;
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct P2PConnectionState {
+    /// Current connection metadata, or `None` if disconnected.
+    pub connected: Option<P2PConnectionStatus>,
+    /// Last disconnect/connect error observed while disconnected.
+    pub last_error: Option<String>,
+}
+
+pub type P2PStatusSenders = BTreeMap<PeerId, watch::Sender<P2PConnectionState>>;
+pub type P2PStatusReceivers = BTreeMap<PeerId, watch::Receiver<P2PConnectionState>>;
 
 pub fn p2p_status_channels(peers: Vec<PeerId>) -> (P2PStatusSenders, P2PStatusReceivers) {
     let mut senders = BTreeMap::new();
     let mut receivers = BTreeMap::new();
 
     for peer in peers {
-        let (sender, receiver) = watch::channel(None);
+        let (sender, receiver) = watch::channel(P2PConnectionState {
+            connected: None,
+            last_error: None,
+        });
 
         senders.insert(peer, sender);
         receivers.insert(peer, receiver);
@@ -156,7 +167,7 @@ impl<M: Send + 'static> P2PConnection<M> {
         peer_id: PeerId,
         connector: DynP2PConnector<M>,
         incoming_connections: Receiver<DynP2PConnection<M>>,
-        status_sender: watch::Sender<Option<P2PConnectionStatus>>,
+        status_sender: watch::Sender<P2PConnectionState>,
         task_group: &TaskGroup,
     ) -> P2PConnection<M> {
         // We use small message queues here to avoid outdated messages such as requests
@@ -185,7 +196,10 @@ impl<M: Send + 'static> P2PConnection<M> {
                         incoming_connections,
                         status_sender,
                     },
-                    state: P2PConnectionSMState::Disconnected(api_networking_backoff()),
+                    state: P2PConnectionSMState::Disconnected {
+                        backoff: api_networking_backoff(),
+                        last_error: None,
+                    },
                 };
 
                 while let Some(sm) = state_machine.state_transition().await {
@@ -228,19 +242,28 @@ struct P2PConnectionSMCommon<M> {
     peer_id_str: String,
     connector: DynP2PConnector<M>,
     incoming_connections: Receiver<DynP2PConnection<M>>,
-    status_sender: watch::Sender<Option<P2PConnectionStatus>>,
+    status_sender: watch::Sender<P2PConnectionState>,
 }
 
 enum P2PConnectionSMState<M> {
-    Disconnected(FibonacciBackoff),
+    Disconnected {
+        backoff: FibonacciBackoff,
+        last_error: Option<String>,
+    },
     Connected(DynP2PConnection<M>),
 }
 
 impl<M: Send + 'static> P2PConnectionStateMachine<M> {
     async fn state_transition(mut self) -> Option<Self> {
         match self.state {
-            P2PConnectionSMState::Disconnected(backoff) => {
-                self.common.status_sender.send_replace(None);
+            P2PConnectionSMState::Disconnected {
+                backoff,
+                last_error,
+            } => {
+                self.common.status_sender.send_replace(P2PConnectionState {
+                    connected: None,
+                    last_error,
+                });
 
                 self.common.transition_disconnected(backoff).await
             }
@@ -250,7 +273,10 @@ impl<M: Send + 'static> P2PConnectionStateMachine<M> {
                     rtt: connection.rtt(),
                 };
 
-                self.common.status_sender.send_replace(Some(status));
+                self.common.status_sender.send_replace(P2PConnectionState {
+                    connected: Some(status),
+                    last_error: None,
+                });
 
                 self.common.transition_connected(connection).await
             }
@@ -301,13 +327,22 @@ impl<M: Send + 'static> P2PConnectionSMCommon<M> {
     }
 
     fn disconnect(&self, error: anyhow::Error) -> P2PConnectionSMState<M> {
-        info!(target: LOG_NET_PEER, "Disconnected from peer: {}",  error);
+        let last_error = error.fmt_compact_anyhow().to_string();
+
+        info!(
+            target: LOG_NET_PEER,
+            error = %last_error,
+            "Disconnected from peer"
+        );
 
         PEER_DISCONNECT_COUNT
             .with_label_values(&[&self.our_id_str, &self.peer_id_str])
             .inc();
 
-        P2PConnectionSMState::Disconnected(api_networking_backoff())
+        P2PConnectionSMState::Disconnected {
+            backoff: api_networking_backoff(),
+            last_error: Some(last_error),
+        }
     }
 
     async fn send_message(
@@ -346,11 +381,9 @@ impl<M: Send + 'static> P2PConnectionSMCommon<M> {
             },
             // to prevent "reconnection ping-pongs", only the side with lower PeerId reconnects
             () = sleep(backoff.next().expect("Unlimited retries")), if self.our_id < self.peer_id => {
-
-
                 info!(target: LOG_NET_PEER, "Attempting to reconnect to peer");
 
-                match  self.connector.connect(self.peer_id).await {
+                match self.connector.connect(self.peer_id).await {
                     Ok(connection) => {
                         PEER_CONNECT_COUNT
                             .with_label_values(&[self.our_id_str.as_str(), self.peer_id_str.as_str(), "outgoing"])
@@ -358,12 +391,23 @@ impl<M: Send + 'static> P2PConnectionSMCommon<M> {
 
                         info!(target: LOG_NET_PEER, "Connected to peer");
 
-                        return Some(P2PConnectionSMState::Connected(connection));
+                        Some(P2PConnectionSMState::Connected(connection))
                     }
-                    Err(e) => warn!(target: LOG_CONSENSUS, "Failed to connect to peer: {e}")
-                }
+                    Err(e) => {
+                        let last_error = e.fmt_compact_anyhow().to_string();
 
-                Some(P2PConnectionSMState::Disconnected(backoff))
+                        warn!(
+                            target: LOG_CONSENSUS,
+                            error = %last_error,
+                            "Failed to connect to peer"
+                        );
+
+                        Some(P2PConnectionSMState::Disconnected {
+                            backoff,
+                            last_error: Some(last_error),
+                        })
+                    }
+                }
             },
         }
     }


### PR DESCRIPTION
## Summary

Improve config-gen and p2p logs for Iroh discovery stalls like #8684 by recording the last p2p connection error per peer and periodically logging when DKG is waiting for peer messages.

## Details

The incident in #8684 showed two hard-to-distinguish phases: peers were initially disconnected because Iroh discovery returned `No addressing information`, then the local guardian had all p2p links but still waited several minutes for checksum messages from other guardians.

This PR keeps the existing public p2p status API shape, but stores richer internal p2p connection state so config-gen can include each disconnected peer's last connection error in its pending-peer logs. It also adds a small helper around config-gen peer receives that logs progress every 10 seconds while waiting for checksum messages.

This is intentionally observability-only. It does not change reconnect timing, peer selection, Iroh discovery configuration, or the API response type for p2p connection status.

## Reviewing

Please check that the richer internal watch state remains private to server internals and that existing API callers still receive `BTreeMap<PeerId, Option<P2PConnectionStatus>>`.

## Testing

- `just format`
- `just final-lint`
