### PR TITLE
fix(iroh): add n0 pkarr resolver fallback

### DIFF
--- a/fedimint-connectors/src/iroh.rs
+++ b/fedimint-connectors/src/iroh.rs
@@ -170,10 +170,7 @@ impl IrohConnector {
                 // installs a publisher.
                 {
                     if is_env_var_set_opt(FM_IROH_PKARR_RESOLVER_ENABLE_ENV).unwrap_or(true) {
-                        #[cfg(target_family = "wasm")]
-                        {
-                            builder = builder.add_discovery(move |_| Some(PkarrResolver::n0_dns()));
-                        }
+                        builder = builder.add_discovery(move |_| Some(PkarrResolver::n0_dns()));
                     } else {
                         warn!(
                             target: LOG_NET_IROH,
@@ -229,12 +226,9 @@ impl IrohConnector {
             // Add only resolver services here; the iroh preset convenience also
             // installs a publisher.
             {
-                // Resolve using HTTPS requests to our DNS server's /pkarr path in browsers
-                #[cfg(target_family = "wasm")]
-                {
-                    builder =
-                        builder.address_lookup(iroh_next::address_lookup::PkarrResolver::n0_dns());
-                }
+                // Resolve using HTTPS requests to our DNS server's /pkarr path.
+                builder =
+                    builder.address_lookup(iroh_next::address_lookup::PkarrResolver::n0_dns());
                 // Resolve using DNS queries outside browsers.
                 #[cfg(not(target_family = "wasm"))]
                 {

--- a/fedimint-core/src/net/iroh.rs
+++ b/fedimint-core/src/net/iroh.rs
@@ -6,7 +6,7 @@ use fedimint_core::util::SafeUrl;
 use fedimint_logging::LOG_NET_IROH;
 use iroh::defaults::DEFAULT_STUN_PORT;
 use iroh::discovery::pkarr::{PkarrPublisher, PkarrResolver};
-use iroh::endpoint::TransportConfig;
+use iroh::endpoint::{Builder, TransportConfig};
 use iroh::{Endpoint, RelayMode, RelayNode, RelayUrl, SecretKey};
 use iroh_relay::RelayQuicConfig;
 use tracing::{debug, info, warn};
@@ -102,14 +102,7 @@ pub async fn build_iroh_endpoint(
         );
     }
 
-    if is_env_var_set_opt(FM_IROH_N0_DISCOVERY_ENABLE_ENV).unwrap_or(true) {
-        builder = builder.discovery_n0();
-    } else {
-        warn!(
-            target: LOG_NET_IROH,
-            "Iroh n0 discovery is disabled"
-        );
-    }
+    builder = add_n0_discovery(builder);
 
     let mut transport_config = TransportConfig::default();
     transport_config.max_idle_timeout(Some(
@@ -154,6 +147,34 @@ fn relay_node_from_url(url: Url) -> RelayNode {
         stun_port: DEFAULT_STUN_PORT,
         quic: Some(RelayQuicConfig::default()),
     }
+}
+
+fn add_n0_discovery(builder: Builder) -> Builder {
+    if is_env_var_set_opt(FM_IROH_N0_DISCOVERY_ENABLE_ENV).unwrap_or(true) {
+        return add_n0_pkarr_resolver(builder.discovery_n0());
+    }
+
+    warn!(target: LOG_NET_IROH, "Iroh n0 discovery is disabled");
+    builder
+}
+
+#[cfg(not(target_family = "wasm"))]
+fn add_n0_pkarr_resolver(builder: Builder) -> Builder {
+    // Native discovery_n0 only uses DNS TXT; add HTTPS pkarr fallback.
+    if is_env_var_set_opt(FM_IROH_PKARR_RESOLVER_ENABLE_ENV).unwrap_or(true) {
+        return builder.add_discovery(|_| Some(PkarrResolver::n0_dns()));
+    }
+
+    warn!(
+        target: LOG_NET_IROH,
+        "Iroh pkarr resolver is disabled"
+    );
+    builder
+}
+
+#[cfg(target_family = "wasm")]
+fn add_n0_pkarr_resolver(builder: Builder) -> Builder {
+    builder
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Add the n0 pkarr HTTPS resolver alongside DNS TXT discovery for Iroh endpoints, so native clients and servers have an HTTP-based fallback when DNS TXT lookup is unavailable or filtered.

Closes #8684.

## Details

`iroh` already had the n0 pkarr HTTPS resolver path, but Fedimint only enabled that resolver on wasm/browser paths. Native paths kept DNS TXT lookup for n0 discovery, which meant environments with broken TXT resolution could fail bare `NodeId` dialing even when HTTPS egress worked.

This keeps the existing code structure and simply stops limiting the n0 pkarr resolver to wasm/browser targets:

- server/gateway endpoint construction still uses `discovery_n0()`, then adds `PkarrResolver::n0_dns()` on native;
- stable client connector now always adds `PkarrResolver::n0_dns()` when pkarr resolution is enabled;
- `iroh_next` client connector now always adds the n0 pkarr address lookup, while retaining native DNS TXT lookup.

## Reviewing

The intended behavior change is narrow: native Iroh discovery should now try HTTPS pkarr resolution in addition to DNS TXT, without changing the surrounding discovery setup.

## Testing

- `just format`
- `cargo check -q -p fedimint-core`
- `cargo check -q -p fedimint-connectors`
- `cargo clippy -q --locked --offline -p fedimint-core -p fedimint-connectors --all-targets -- -D warnings`

Note: earlier revisions also passed the direct `just final-lint` components, but `just final-lint` itself is blocked in this worktree by a stale shared git hook symlink.
