### PR TITLE
ci: add codex debug bot workflow

### DIFF
--- a/.github/scripts/run-codex-ci-debug.sh
+++ b/.github/scripts/run-codex-ci-debug.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+require_env() {
+  local name="$1"
+  if [ -z "${!name:-}" ]; then
+    echo "Missing required environment variable: ${name}" >&2
+    exit 1
+  fi
+}
+
+require_env BACKPORT_TOKEN
+require_env CI_DEBUG_RUN_ID
+require_env CI_DEBUG_RUN_URL
+require_env GITHUB_ACTOR
+require_env GITHUB_EVENT_NAME
+require_env GITHUB_EVENT_PATH
+require_env GITHUB_REPOSITORY
+require_env GITHUB_WORKSPACE
+require_env PPQ_KEY
+require_env PPQ_MODEL
+require_env RUNNER_TEMP
+
+# Workflow-dispatch runs intentionally leave some CI_DEBUG_* values empty.
+# Only require the fields needed to identify and fetch the target run.
+
+agent_root="${RUNNER_TEMP}/codex-ci-debug"
+agent_home="${agent_root}/home"
+codex_home="${agent_root}/codex-home"
+context_dir="${agent_root}/context"
+
+rm -rf "${agent_root}"
+mkdir -p \
+  "${agent_home}" \
+  "${codex_home}" \
+  "${context_dir}"
+
+path_toml=$(jq -Rn --arg value "${PATH}" '$value')
+
+cat > "${codex_home}/config.toml" <<EOF
+model = "${PPQ_MODEL}"
+model_provider = "ppq"
+sandbox_mode = "danger-full-access"
+approval_policy = "never"
+
+[model_providers.ppq]
+name = "PPQ"
+base_url = "https://api.ppq.ai/v1"
+env_key = "PPQ_KEY"
+wire_api = "responses"
+
+[shell_environment_policy]
+inherit = "all"
+ignore_default_excludes = true
+set = { PATH = ${path_toml} }
+include_only = [
+  "PATH",
+  "HOME",
+  "CODEX_HOME",
+  "GH_TOKEN",
+  "GITHUB_API_URL",
+  "GITHUB_ACTOR",
+  "GITHUB_EVENT_NAME",
+  "GITHUB_GRAPHQL_URL",
+  "GITHUB_REPOSITORY",
+  "GITHUB_RUN_ID",
+  "GITHUB_SERVER_URL",
+  "GITHUB_WORKSPACE",
+  "RUNNER_TEMP",
+  "CI_DEBUG_RUN_ID",
+  "CI_DEBUG_RUN_URL",
+  "CI_DEBUG_WORKFLOW_NAME",
+  "CI_DEBUG_WORKFLOW_EVENT",
+  "CI_DEBUG_HEAD_BRANCH",
+  "CI_DEBUG_HEAD_SHA",
+  "IN_NIX_SHELL",
+  "REPO_ROOT",
+  "CARGO_*",
+  "RUST*",
+  "CLIPPY_ARGS",
+  "FM_*",
+  "FLAKEBOX_*",
+  "NIX_*",
+  "NIXPKGS_*",
+  "CC*",
+  "CXX*",
+  "CFLAGS*",
+  "CPPFLAGS",
+  "CMAKE_*",
+  "PKG_CONFIG*",
+  "PROTOC*",
+  "AR*",
+  "AS",
+  "LD",
+  "LD_*",
+  "LD_LIBRARY_PATH",
+  "LIBCLANG_PATH",
+  "LLVM_CONFIG_PATH*",
+  "NM",
+  "OBJCOPY",
+  "OBJDUMP",
+  "RANLIB",
+  "READELF",
+  "SIZE",
+  "STRINGS",
+  "STRIP",
+  "ROCKSDB_*",
+  "SNAPPY_*",
+  "SQLITE3_*",
+  "SQLCIPHER_*",
+  "CONFIG_SHELL",
+  "SHELL",
+  "LANG",
+  "LC_*",
+  "LOCALE_ARCHIVE",
+  "TERM",
+  "TERMINFO_DIRS",
+  "TMPDIR",
+  "TEMP",
+  "TMP",
+  "TEMPDIR",
+  "PYTHON*",
+  "PERL5LIB",
+  "XDG_CONFIG_DIRS",
+  "XDG_DATA_DIRS",
+  "DETERMINISTIC_BUILD",
+  "SOURCE_DATE_EPOCH",
+  "SSL_CERT_FILE",
+  "NIX_SSL_CERT_FILE",
+]
+EOF
+
+jq '{
+  action,
+  repository: env.GITHUB_REPOSITORY,
+  event_name: env.GITHUB_EVENT_NAME,
+  actor: env.GITHUB_ACTOR,
+  workflow_run: .workflow_run,
+  inputs: .inputs
+}' "${GITHUB_EVENT_PATH}" > "${context_dir}/event.json"
+
+cat > "${context_dir}/prompt.md" <<'EOF'
+You are fedimint-bot, an automation agent for failed Fedimint CI runs.
+A GitHub Actions workflow failed on the merge queue or on the master branch.
+Investigate the failure and either comment on the culprit pull request,
+document unresolved findings in a GitHub issue, or open a draft pull request
+with a small, well-scoped fix.
+
+Target run:
+- Run id: $CI_DEBUG_RUN_ID
+- Run URL: $CI_DEBUG_RUN_URL
+- Workflow: $CI_DEBUG_WORKFLOW_NAME
+- Event: $CI_DEBUG_WORKFLOW_EVENT
+- Head branch: $CI_DEBUG_HEAD_BRANCH
+- Head SHA: $CI_DEBUG_HEAD_SHA
+
+Use the GitHub event payload at:
+$RUNNER_TEMP/codex-ci-debug/context/event.json
+
+Available tools:
+- `gh`, authenticated as fedimint-bot via `GH_TOKEN`;
+- `git`;
+- normal shell tools including `bash`, `curl`, `jq`, `rg`, `sed`, and `awk`;
+- the Fedimint Nix development shell, including its Rust toolchain and helper
+  environment, is active for commands you run.
+
+Baseline investigation:
+- Start with `gh run view "$CI_DEBUG_RUN_ID" --repo "$GITHUB_REPOSITORY"` and
+  `gh api repos/:owner/:repo/actions/runs/$CI_DEBUG_RUN_ID/jobs --paginate`.
+- Find the real failed job/step. Ignore aggregate status jobs such as
+  `Status (MQ)` unless every upstream job was unavailable.
+- Fetch focused logs for the failing jobs with `gh run view --job <job-id> --log`.
+  Search for `## FAILED`, `Some tests failed`, `panicked`, `error:`,
+  `timed out`, and the failing test or derivation name.
+- For merge queue runs, parse the queue branch name like
+  `gh-readonly-queue/master/pr-8652-...` to identify the PR when present. Do
+  not push to queue refs or contributor branches. Compare the failure with the
+  queued PR changes before deciding whether this is a repository-level failure
+  or a legitimate bug in the queued PR.
+- Check recent history for the same failure using `gh run list`,
+  `gh issue list/search`, and `gh pr list/search` before opening duplicate
+  issues or PRs.
+- Always search for existing GitHub issues tracking the same failure before
+  opening a new issue. Update the existing issue instead when there is a clear
+  match.
+
+Common patterns from the last month of master and merge-queue CI failures:
+- Merge queue failures were dominated by `CI (nix)` failing in `Build on linux`,
+  usually the `Tests` or `Tests (5 times more)` step. Representative flakes:
+  `bckn_esplora` with LNv2 and iroh timing out after one test was still running,
+  and backcompat `recurringd_test` with an old gateway failing with
+  `No gateway found`.
+- Backwards-compatibility failures were the second most common category and
+  often involved sampled devimint/backcompat combinations rather than compile
+  errors.
+- The only failed master push run in the sampled month was `Upgrade Tests` on
+  2026-05-17, caused by repeated GitHub archive HTTP 502 responses while Nix was
+  fetching a historical Fedimint tag. Treat clear upstream HTTP 5xx fetch
+  failures as transient unless they recur enough to justify a retry/caching fix.
+- A cargo audit failure can appear in `CI (nix)`, but the `audit` job is
+  intentionally allowed to fail in the workflow. Do inspect it, but do not call
+  it the root cause of a red required status unless the run has no other failing
+  blocking job.
+- Nixpkgs age can fail through the `Check NixOS/nixpkgs on ...` jobs; if that is
+  the only cause, open an issue for runner maintenance instead of a code PR.
+
+Decision rules:
+- Open a draft PR only when the fix is concrete, low-risk, and can be validated
+  with a focused command. Create a branch named
+  `fedimint-bot/ci-debug-<short-topic>-$CI_DEBUG_RUN_ID`.
+- A flaky failure still needs to be debugged and fixed when there is a
+  high-confidence cause. Do not open an issue merely because a failure is flaky.
+- Open an issue only when the investigation cannot establish a high-confidence
+  cause or actionable fix, when the cause is external/operational and needs
+  tracking rather than a code change, or when maintainer input is required.
+  Include the failing run URL, failed job and step, concise log excerpts, and a
+  concrete next action.
+- Reuse or update an existing issue/PR when one already clearly tracks the same
+  failure. Avoid duplicate issues.
+- If a merge queue failure is caused by a legitimate bug in the queued PR, do
+  not open a repository issue or a new fix PR. Instead, comment on that PR with
+  the failed run URL, failing job and step, concise evidence, and what needs to
+  be fixed before it can merge.
+- If a merge queue failure is not caused by the queued PR, handle it as a
+  repository-level CI failure and either fix it with a draft PR or document the
+  unresolved cause in an issue using the rules above.
+- Run `just format` after code changes when available, plus the smallest useful
+  check. Report any checks that were skipped and why in the issue or PR.
+- Avoid broad refactors and do not change unrelated code.
+- Do not mention secrets or environment variable values in comments, issues,
+  commits, branches, or PR descriptions.
+- Before finishing, comment on the culprit PR, open or update a GitHub issue,
+  or open a draft PR. If you cannot complete one of those actions, open an issue
+  explaining the blocker.
+EOF
+
+envsubst < "${context_dir}/prompt.md" > "${context_dir}/prompt.expanded.md"
+
+export HOME="${agent_home}"
+export CODEX_HOME="${codex_home}"
+export GH_TOKEN="${BACKPORT_TOKEN}"
+
+git config --global --add safe.directory "${GITHUB_WORKSPACE}"
+git config --global user.name fedimint-bot
+git config --global user.email fedimint-bot@users.noreply.github.com
+gh auth status >/dev/null
+gh auth setup-git
+
+cd "${GITHUB_WORKSPACE}"
+exec codex exec \
+  --ephemeral \
+  --dangerously-bypass-approvals-and-sandbox \
+  "$(cat "${context_dir}/prompt.expanded.md")"

--- a/.github/workflows/codex-ci-debug.yml
+++ b/.github/workflows/codex-ci-debug.yml
@@ -1,0 +1,130 @@
+name: "Codex CI Debug"
+
+on:
+  workflow_run:
+    workflows:
+      - "CI (nix)"
+      - "Backwards-Compatibility"
+      - "Upgrade Tests"
+      - "Publish docs"
+      - "Markdown Link Check"
+      - "Crate ownership check"
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: "GitHub Actions run id to debug"
+        required: true
+      reason:
+        description: "Optional context for the manual debug run"
+        required: false
+        default: ""
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.id || inputs.run_id }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  debug:
+    name: Debug failed CI run
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 120
+    if: >-
+      github.repository == 'fedimint/fedimint' &&
+      (
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.event.workflow_run.conclusion == 'failure' &&
+          (
+            github.event.workflow_run.event == 'merge_group' ||
+            (
+              github.event.workflow_run.event == 'push' &&
+              github.event.workflow_run.head_branch == 'master'
+            )
+          )
+        )
+      )
+
+    steps:
+      - name: Select failed run
+        id: target
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
+          WORKFLOW_RUN_URL: ${{ github.event.workflow_run.html_url }}
+          WORKFLOW_RUN_NAME: ${{ github.event.workflow_run.name }}
+          WORKFLOW_RUN_EVENT: ${{ github.event.workflow_run.event }}
+          WORKFLOW_RUN_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          WORKFLOW_DISPATCH_RUN_ID: ${{ inputs.run_id }}
+          WORKFLOW_DISPATCH_REASON: ${{ inputs.reason }}
+        run: |
+          set -euo pipefail
+
+          if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
+            run_id="${WORKFLOW_DISPATCH_RUN_ID}"
+            run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${run_id}"
+            run_name="manual"
+            run_event="manual"
+            head_branch=""
+            head_sha=""
+          else
+            run_id="${WORKFLOW_RUN_ID}"
+            run_url="${WORKFLOW_RUN_URL}"
+            run_name="${WORKFLOW_RUN_NAME}"
+            run_event="${WORKFLOW_RUN_EVENT}"
+            head_branch="${WORKFLOW_RUN_HEAD_BRANCH}"
+            head_sha="${WORKFLOW_RUN_HEAD_SHA}"
+          fi
+
+          {
+            echo "run_id=${run_id}"
+            echo "run_url=${run_url}"
+            echo "run_name=${run_name}"
+            echo "run_event=${run_event}"
+            echo "head_branch=${head_branch}"
+            echo "head_sha=${head_sha}"
+          } >> "${GITHUB_OUTPUT}"
+
+          echo "Selected CI run ${run_id}: ${run_url}"
+          if [ -n "${WORKFLOW_DISPATCH_REASON}" ]; then
+            echo "Manual context: ${WORKFLOW_DISPATCH_REASON}"
+          fi
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: master
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Run Codex CI debugger
+        env:
+          BACKPORT_TOKEN: ${{ secrets.BACKPORT_TOKEN }}
+          CI_DEBUG_RUN_ID: ${{ steps.target.outputs.run_id }}
+          CI_DEBUG_RUN_URL: ${{ steps.target.outputs.run_url }}
+          CI_DEBUG_WORKFLOW_NAME: ${{ steps.target.outputs.run_name }}
+          CI_DEBUG_WORKFLOW_EVENT: ${{ steps.target.outputs.run_event }}
+          CI_DEBUG_HEAD_BRANCH: ${{ steps.target.outputs.head_branch }}
+          CI_DEBUG_HEAD_SHA: ${{ steps.target.outputs.head_sha }}
+          PPQ_KEY: ${{ secrets.PPQ_KEY }}
+          PPQ_MODEL: ${{ vars.PPQ_MODEL || 'openai/gpt-5.5' }}
+        run: |
+          set -euo pipefail
+          nix --extra-experimental-features 'nix-command flakes' \
+            --accept-flake-config \
+            develop \
+            .#default \
+            --command \
+            nix --extra-experimental-features 'nix-command flakes' \
+            --accept-flake-config \
+            shell \
+            github:numtide/llm-agents.nix/24ec6b7b1ddf8896ac8df3b65dc564575e0a1928#codex \
+            nixpkgs#gh \
+            nixpkgs#ripgrep \
+            nixpkgs#curl \
+            nixpkgs#jq \
+            nixpkgs#gettext \
+            -c bash .github/scripts/run-codex-ci-debug.sh


### PR DESCRIPTION
Summary

Adds a Codex-powered CI debug workflow that triggers after failed merge queue or master CI runs and can be run manually against a specific run id.

Details

The workflow watches the main blocking CI workflows through `workflow_run`, filters to merge queue failures and `master` push failures, and invokes a dedicated script that sets up the Codex agent environment using the integration pattern from #8679.

The agent prompt includes the past-month failure patterns I found: merge queue failures were mostly `CI (nix)` linux test/backcompat failures, including devimint-style flakes such as LNv2/iroh timeouts and recurringd/gateway backcompat failures; the sampled master failure was an `Upgrade Tests` Nix fetch failure caused by GitHub archive HTTP 502s. It also notes that `cargo audit` is currently allowed to fail, so an audit-only failure does not make the overall workflow red.

The decision policy is: fix flakes when there is a high-confidence cause, open issues only for unresolved or non-actionable findings, and comment on the queued PR instead of opening an issue or PR when the merge queue failure is caused by a legitimate bug in that PR.

Testing

- `bash -n .github/scripts/run-codex-ci-debug.sh`
- `nix --extra-experimental-features 'nix-command flakes' run nixpkgs#actionlint -- .github/workflows/codex-ci-debug.yml`
- `just format`

`just final-lint` was attempted but failed before running lint because this checkout points the lint recipe at an absolute pre-commit hook path from another local checkout: `/home/user/projects/elsirion/minimint/.git/hooks/pre-commit`.
