### PR TITLE
Fix Codex receiver event payload path

### DIFF
--- a/.github/workflows/codex-agent-review-comment-receiver.yml
+++ b/.github/workflows/codex-agent-review-comment-receiver.yml
@@ -24,11 +24,9 @@ jobs:
     steps:
       - name: Capture sanitized event
         id: capture
-        env:
-          EVENT_PATH: ${{ github.event_path }}
         run: |
           set -euo pipefail
-          body=$(jq -r '.comment.body // ""' "${EVENT_PATH}")
+          body=$(jq -r '.comment.body // ""' "${GITHUB_EVENT_PATH}")
 
           if [[ "${body}" != *"@fedimint-bot"* ]]; then
             echo "upload=false" >> "${GITHUB_OUTPUT}"
@@ -67,7 +65,7 @@ jobs:
               }
             },
             sender: { login: .sender.login }
-          }' "${EVENT_PATH}" > "${RUNNER_TEMP}/codex-agent-review-comment/event.json"
+          }' "${GITHUB_EVENT_PATH}" > "${RUNNER_TEMP}/codex-agent-review-comment/event.json"
           echo "upload=true" >> "${GITHUB_OUTPUT}"
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2


### PR DESCRIPTION
Summary

Fix the Codex agent review-comment receiver so it reads the GitHub event payload from the built-in `GITHUB_EVENT_PATH` environment variable.

Details

The receiver workflow used `${{ github.event_path }}` to populate `EVENT_PATH`, but that expression resolved to an empty string in the failing run. As a result, the unprivileged receiver failed before uploading the sanitized event artifact, so the privileged `workflow_run` handler never had a chance to process the inline `@fedimint-bot` mention.

This removes the extra `EVENT_PATH` indirection and reads `${GITHUB_EVENT_PATH}` directly in the shell step.

Testing

- `actionlint .github/workflows/codex-agent-review-comment-receiver.yml .github/workflows/codex-agent.yml`
- `just format`
