### PR TITLE
ci(codex): make agent checkout shallow

### DIFF
--- a/.github/scripts/run-codex-agent.sh
+++ b/.github/scripts/run-codex-agent.sh
@@ -188,6 +188,8 @@ Repository conventions:
 Operational rules:
 - The GitHub event payload is at `$RUNNER_TEMP/codex-agent/context/event.json`.
 - The checked out repository is at `$GITHUB_WORKSPACE`.
+- The checkout is intentionally shallow to keep CI startup fast. If you need
+  extra history, tags, or PR refs, fetch only the specific refs you need.
 - First inspect the normalized `event_name` field in the event payload to
   understand whether this is an issue event, issue comment, PR comment,
   submitted PR review, or inline PR review comment. Submitted PR reviews and

--- a/.github/workflows/codex-agent.yml
+++ b/.github/workflows/codex-agent.yml
@@ -361,7 +361,6 @@ jobs:
         if: steps.validate.outputs.run == 'true'
         with:
           ref: ${{ github.event.repository.default_branch }}
-          fetch-depth: 0
           persist-credentials: false
 
       - name: Run Codex in Fedimint dev shell


### PR DESCRIPTION
### Summary

Make the Codex Agent workflow use the default shallow checkout instead of fetching the repository's full history.

### Details

Recent Codex Agent runs spent roughly 50 seconds in `actions/checkout` because `fetch-depth: 0` caused the job to fetch all branches and tags. The agent normally only needs the checked-out working tree, and can fetch targeted history or refs on demand when a task requires it.

This removes the full-history checkout and documents the intentional shallow checkout in the agent prompt.

### Reviewing

Please check whether any common Codex Agent task depends on all refs being present before the agent starts. The prompt now tells the agent to fetch specific refs/history when needed.

### Testing

- `just format`
- `bash -n .github/scripts/run-codex-agent.sh`
- `git diff --check HEAD~1..HEAD`
