### PR TITLE
test(walletv2): add peg-in diagnostics

### DIFF
--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -863,22 +863,41 @@ impl Federation {
 
         for gw in gateways.clone() {
             let pegin_addr = gw.client().get_pegin_addr(&fed_id).await?;
+            debug!(
+                gateway = %gw.gw_name,
+                ln = %gw.ln.ln_type(),
+                address = %pegin_addr,
+                amount_sats = amount + deposit_fees,
+                uses_walletv2,
+                "Sending gateway pegin"
+            );
             self.bitcoind
                 .send_to(pegin_addr, amount + deposit_fees)
                 .await?;
         }
 
+        let pegin_start = Instant::now();
         self.bitcoind.mine_blocks(21).await?;
         let bitcoind_block_height: u64 = self.bitcoind.get_block_count().await? - 1;
+        debug!(
+            bitcoind_block_height,
+            elapsed_ms = %pegin_start.elapsed().as_millis(),
+            "Mined gateway pegin blocks"
+        );
+
         try_join_all(gateways.into_iter().enumerate().map(|(i, gw)| {
             let initial_balance = if uses_walletv2 {
                 initial_balances[i]
             } else {
                 0
             };
+            let gateway_name = gw.gw_name.clone();
+            let gateway_ln = gw.ln.ln_type().to_string();
             let fed_id = fed_id.clone();
             poll("gateway pegin", move || {
                 let fed_id = fed_id.clone();
+                let gateway_name = gateway_name.clone();
+                let gateway_ln = gateway_ln.clone();
                 async move {
                     let gw_info = gw
                         .client()
@@ -897,6 +916,14 @@ impl Federation {
                     };
 
                     if bitcoind_block_height != block_height {
+                        debug!(
+                            gateway = %gateway_name,
+                            ln = %gateway_ln,
+                            bitcoind_block_height,
+                            gateway_block_height = block_height,
+                            elapsed_ms = %pegin_start.elapsed().as_millis(),
+                            "Waiting for gateway pegin block sync"
+                        );
                         return Err(std::ops::ControlFlow::Continue(anyhow::anyhow!(
                             "gateway block height is not synced"
                         )));
@@ -913,7 +940,16 @@ impl Federation {
                         // the expected amount. Use 90% threshold to account
                         // for mintv2 fees (same as pegin_client).
                         let expected = initial_balance + (amount * 1000 * 9 / 10);
-                        if gateway_balance >= expected {
+                        debug!(
+                            gateway = %gateway_name,
+                            ln = %gateway_ln,
+                            gateway_balance_msats = gateway_balance,
+                            expected_msats = expected,
+                            initial_balance_msats = initial_balance,
+                            elapsed_ms = %pegin_start.elapsed().as_millis(),
+                            "Checked walletv2 gateway pegin balance"
+                        );
+                        if expected <= gateway_balance {
                             Ok(())
                         } else {
                             Err(ControlFlow::Continue(anyhow::anyhow!(

--- a/modules/fedimint-walletv2-client/src/lib.rs
+++ b/modules/fedimint-walletv2-client/src/lib.rs
@@ -50,8 +50,8 @@ use fedimint_derive_secret::{ChildId, DerivableSecret};
 use fedimint_logging::LOG_CLIENT_MODULE_WALLETV2;
 use fedimint_walletv2_common::config::WalletClientConfig;
 use fedimint_walletv2_common::{
-    KIND, StandardScript, TxInfo, WalletCommonInit, WalletInput, WalletInputV0, WalletModuleTypes,
-    WalletOutput, WalletOutputV0, descriptor, is_potential_receive,
+    KIND, OutputInfo, StandardScript, TxInfo, WalletCommonInit, WalletInput, WalletInputV0,
+    WalletModuleTypes, WalletOutput, WalletOutputV0, descriptor, is_potential_receive,
 };
 use futures::StreamExt;
 use receive_sm::{ReceiveSMCommon, ReceiveSMState, ReceiveStateMachine};
@@ -668,37 +668,8 @@ impl WalletClientModule {
                     address_map.insert(self.derive_address(index).script_pubkey(), index);
                 }
 
-                if !output.spent {
-                    // In order to not overpay on fees we choose to wait,
-                    // the congestion will clear up within a few blocks.
-                    if self.module_api.pending_tx_chain().await?.len() >= 3 {
-                        return Ok(false);
-                    }
-
-                    let receive_fee = self
-                        .module_api
-                        .receive_fee()
-                        .await?
-                        .ok_or(anyhow!("No consensus feerate is available"))?;
-
-                    if output.value > receive_fee {
-                        let (operation_id, txid) = self
-                            .receive_output(
-                                output.index,
-                                output.value,
-                                address_index,
-                                receive_fee,
-                                output.outpoint,
-                            )
-                            .await;
-
-                        self.client_ctx
-                            .transaction_updates(operation_id)
-                            .await
-                            .await_tx_accepted(txid)
-                            .await
-                            .map_err(|e| anyhow!("Claim transaction was rejected: {e}"))?;
-                    }
+                if !output.spent && !self.process_unspent_output(output, address_index).await? {
+                    return Ok(false);
                 }
             }
 
@@ -720,6 +691,90 @@ impl WalletClientModule {
         );
 
         Ok(!outputs.is_empty())
+    }
+
+    async fn process_unspent_output(
+        &self,
+        output: &OutputInfo,
+        address_index: u64,
+    ) -> anyhow::Result<bool> {
+        debug!(
+            target: LOG_CLIENT_MODULE_WALLETV2,
+            output_index = output.index,
+            value_sat = output.value.to_sat(),
+            address_index,
+            outpoint = ?output.outpoint,
+            "Discovered unspent walletv2 receive output"
+        );
+
+        // In order to not overpay on fees we choose to wait,
+        // the congestion will clear up within a few blocks.
+        let pending_tx_chain_len = self.module_api.pending_tx_chain().await?.len();
+        if 3 <= pending_tx_chain_len {
+            debug!(
+                target: LOG_CLIENT_MODULE_WALLETV2,
+                output_index = output.index,
+                pending_tx_chain_len,
+                "Delaying walletv2 receive claim because pending transaction chain is full"
+            );
+            return Ok(false);
+        }
+
+        let receive_fee = self
+            .module_api
+            .receive_fee()
+            .await?
+            .ok_or(anyhow!("No consensus feerate is available"))?;
+
+        if receive_fee < output.value {
+            debug!(
+                target: LOG_CLIENT_MODULE_WALLETV2,
+                output_index = output.index,
+                value_sat = output.value.to_sat(),
+                fee_sat = receive_fee.to_sat(),
+                "Submitting walletv2 receive claim"
+            );
+            let (operation_id, txid) = self
+                .receive_output(
+                    output.index,
+                    output.value,
+                    address_index,
+                    receive_fee,
+                    output.outpoint,
+                )
+                .await;
+
+            debug!(
+                target: LOG_CLIENT_MODULE_WALLETV2,
+                output_index = output.index,
+                ?operation_id,
+                %txid,
+                "Waiting for walletv2 receive claim acceptance"
+            );
+            self.client_ctx
+                .transaction_updates(operation_id)
+                .await
+                .await_tx_accepted(txid)
+                .await
+                .map_err(|e| anyhow!("Claim transaction was rejected: {e}"))?;
+            debug!(
+                target: LOG_CLIENT_MODULE_WALLETV2,
+                output_index = output.index,
+                ?operation_id,
+                %txid,
+                "Walletv2 receive claim accepted"
+            );
+        } else {
+            debug!(
+                target: LOG_CLIENT_MODULE_WALLETV2,
+                output_index = output.index,
+                value_sat = output.value.to_sat(),
+                fee_sat = receive_fee.to_sat(),
+                "Skipping walletv2 receive output because fee meets or exceeds value"
+            );
+        }
+
+        Ok(true)
     }
 }
 

--- a/modules/fedimint-walletv2-server/src/lib.rs
+++ b/modules/fedimint-walletv2-server/src/lib.rs
@@ -1044,7 +1044,7 @@ impl Wallet {
                             %outpoint,
                             value_sat = tx_out.value.to_sat(),
                             height,
-                            "Recorded potential receive"
+                            "Recorded potential walletv2 receive"
                         );
 
                         potential_receives_num += 1;

--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -94,7 +94,13 @@ export -f gw_liquidity_test
 function gw_liquidity_test_walletv2() {
   # walletv2 is not supported by older versions, so we skip for backwards-compatibility tests
   if [ -z "${FM_BACKWARDS_COMPATIBILITY_TEST:-}" ]; then
-    fm-run-test "${FUNCNAME[0]}" env FM_ENABLE_MODULE_WALLETV2=true FM_ENABLE_MODULE_WALLET=false ./scripts/tests/gateway-module-test.sh liquidity-test
+    # Keep walletv2 peg-in diagnostics visible for CI flake investigation:
+    # https://github.com/fedimint/fedimint/pull/8702
+    fm-run-test "${FUNCNAME[0]}" env \
+      RUST_LOG="fm::devimint=debug,fm::client::module::walletv2=debug,fm::module::walletv2=debug,${RUST_LOG:-}" \
+      FM_ENABLE_MODULE_WALLETV2=true \
+      FM_ENABLE_MODULE_WALLET=false \
+      ./scripts/tests/gateway-module-test.sh liquidity-test
   fi
 }
 export -f gw_liquidity_test_walletv2


### PR DESCRIPTION
*PR published by Tau*

## Summary

Adds targeted `debug!` diagnostics around the walletv2 gateway peg-in path used by `gw_liquidity_test_walletv2`, and enables those debug targets only for that CI test.

## Details

We are investigating this CI flake:

- failing job: https://github.com/fedimint/fedimint/actions/runs/27471735902/job/81203771567
- related earlier diagnostics PR: https://github.com/fedimint/fedimint/pull/8682

The failed job timed out in `gw_liquidity_test_walletv2` while waiting for a gateway peg-in balance to reach `900000000` msats. The final error only showed the gateway balance stayed at zero after the existing polling deadline, which was not enough to tell which phase was slow or stuck.

Current investigation:

- The CI path is `test-ci-all.sh` → `gateway-module-test.sh liquidity-test` with walletv2 enabled.
- CI currently sets `RUST_LOG="fm::test=debug,info,..."`, so `debug!` logs from `fm::devimint`, `fm::client::module::walletv2`, and `fm::module::walletv2` would not show up by default.
- Local repeated runs passed, so this does not look like a deterministic failure.
- Local timings showed that the walletv2 server usually records the potential receive output quickly after the peg-in.
- The slower and more variable part was the gateway walletv2 client auto-claim flow, especially around discovering the output, submitting the claim, and waiting for claim acceptance.
- Existing CI logs did not make it clear whether the failed run stalled before output discovery, during claim submission, while waiting for consensus acceptance, or while polling the gateway balance.

This PR adds per-stage `debug!` logs for:

- gateway peg-in submission, including gateway identity, LN backend, address, amount, and whether walletv2 is used;
- blocks mined after the peg-in;
- gateway block-sync polling;
- walletv2 gateway balance polling, including gateway identity and msat-denominated balances;
- walletv2 server recording potential receive outputs;
- walletv2 client output discovery, pending-chain backpressure, claim submission, claim-acceptance wait, accepted claims, and fee-based skips.

To keep default output less noisy while still capturing the diagnostics in CI, `gw_liquidity_test_walletv2` now runs with these extra `RUST_LOG` directives:

- `fm::devimint=debug`
- `fm::client::module::walletv2=debug`
- `fm::module::walletv2=debug`

The goal is not to change timing or behavior. The goal is to make the next occurrence actionable: the logs should show which gateway is affected and whether the delay is in block sync, receive-output indexing, claim creation, transaction acceptance, or final balance observation.

## Reviewing

Diagnostics-only behavior change, plus a test-specific logging override. Please check that the added logs are useful but not too noisy, and that they do not include secrets. Addresses, outpoints, txids, values, and gateway identity are intentionally included as correlation metadata for this CI-only investigation.

## Testing

- `rustfmt --edition 2024 --check devimint/src/federation.rs modules/fedimint-walletv2-client/src/lib.rs modules/fedimint-walletv2-server/src/lib.rs`
- `cargo check -q -p devimint -p fedimint-walletv2-client -p fedimint-walletv2-server`
- `just final-lint`
- local `gw_liquidity_test_walletv2` run with walletv2 enabled passed during investigation
