### PR TITLE
feat(wallet): track on-chain receives as per-UTXO operations

### DIFF
--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -36,7 +36,7 @@ use crate::cli::{CommonArgs, cleanup_on_exit, exec_user_command, setup};
 use crate::envs::{FM_DATA_DIR_ENV, FM_DEVIMINT_RUN_DEPRECATED_TESTS_ENV, FM_PASSWORD_ENV};
 use crate::federation::Client;
 use crate::util::{LoadTestTool, ProcessManager, almost_equal, poll};
-use crate::version_constants::{VERSION_0_10_0_ALPHA, VERSION_0_11_0_ALPHA};
+use crate::version_constants::{VERSION_0_10_0_ALPHA, VERSION_0_11_0_ALPHA, VERSION_0_12_0_ALPHA};
 use crate::{DevFed, Gatewayd, LightningNode, Lnd, cmd, dev_fed};
 
 pub struct Stats {
@@ -616,6 +616,215 @@ pub struct UpgradeClients {
     fm_pay_client: Client,
 }
 
+/// Wallet clients/data prepared with an old `fedimint-cli` to exercise the
+/// on-chain receive operation backfill after upgrading the client binary.
+struct WalletReceiveUpgradeClients {
+    allocated_client: Client,
+    allocated_operation_id: String,
+    allocated_address: String,
+    claimed_client: Client,
+    claimed_operation_id: String,
+    pending_client: Client,
+    pending_operation_id: String,
+}
+
+async fn prepare_wallet_receive_upgrade_clients(
+    dev_fed: &DevFed,
+) -> anyhow::Result<WalletReceiveUpgradeClients> {
+    let allocated_client = dev_fed
+        .fed
+        .new_joined_client("wallet-upgrade-allocated-client")
+        .await?;
+    let (allocated_address, allocated_operation_id) = allocated_client.get_deposit_addr().await?;
+
+    let claimed_client = dev_fed
+        .fed
+        .new_joined_client("wallet-upgrade-claimed-client")
+        .await?;
+    let (claimed_address, claimed_operation_id) = claimed_client.get_deposit_addr().await?;
+    fund_deposit_address_no_wait(dev_fed, &claimed_address).await?;
+    fund_deposit_address_no_wait(dev_fed, &claimed_address).await?;
+    cmd!(
+        claimed_client,
+        "module",
+        "wallet",
+        "await-deposit",
+        "--operation-id",
+        &claimed_operation_id,
+        "--num",
+        "2"
+    )
+    .run()
+    .await?;
+
+    let pending_client = dev_fed
+        .fed
+        .new_joined_client("wallet-upgrade-pending-client")
+        .await?;
+    let pending_operation_id = dev_fed
+        .fed
+        .pegin_client_no_wait(10_000, &pending_client)
+        .await?;
+
+    Ok(WalletReceiveUpgradeClients {
+        allocated_client,
+        allocated_operation_id,
+        allocated_address,
+        claimed_client,
+        claimed_operation_id,
+        pending_client,
+        pending_operation_id,
+    })
+}
+
+async fn wallet_receive_upgrade_test(
+    dev_fed: &DevFed,
+    clients: &WalletReceiveUpgradeClients,
+) -> anyhow::Result<()> {
+    assert_wallet_receive_operations(
+        &clients.claimed_client,
+        &clients.claimed_operation_id,
+        false,
+        2,
+    )
+    .await
+    .context("multiple claimed legacy deposits to the same address should be backfilled as receive operations")?;
+
+    let outcome = cmd!(
+        clients.claimed_client,
+        "module",
+        "wallet",
+        "legacy-deposit-outcome",
+        "--operation-id",
+        &clients.claimed_operation_id,
+    )
+    .out_json()
+    .await?;
+    anyhow::ensure!(
+        outcome.is_null(),
+        "v0.11 legacy address operation should still have no cached legacy outcome after receive backfill, got {outcome}"
+    );
+
+    assert_wallet_receive_operations(
+        &clients.allocated_client,
+        &clients.allocated_operation_id,
+        true,
+        0,
+    )
+    .await
+    .context("allocated-but-unfunded legacy address should not be backfilled")?;
+
+    fund_deposit_address_no_wait(dev_fed, &clients.allocated_address)
+        .await
+        .context("funding legacy allocated address after upgrade")?;
+    clients
+        .allocated_client
+        .await_deposit(&clients.allocated_operation_id)
+        .await
+        .context("claiming legacy allocated address after upgrade")?;
+    assert_wallet_receive_operations(
+        &clients.allocated_client,
+        &clients.allocated_operation_id,
+        true,
+        1,
+    )
+    .await
+    .context("post-upgrade funding should create a live receive operation")?;
+
+    clients
+        .pending_client
+        .await_deposit(&clients.pending_operation_id)
+        .await
+        .context("claiming pre-upgrade funded deposit after upgrade")?;
+    assert_wallet_receive_operations(
+        &clients.pending_client,
+        &clients.pending_operation_id,
+        true,
+        1,
+    )
+    .await
+    .context("pre-upgrade funded deposit claimed after upgrade should use receive operation")?;
+
+    Ok(())
+}
+
+async fn fund_deposit_address_no_wait(dev_fed: &DevFed, address: &str) -> anyhow::Result<()> {
+    let deposit_fees_msat = dev_fed.fed.deposit_fees()?.msats;
+    assert_eq!(
+        deposit_fees_msat % 1000,
+        0,
+        "Deposit fees expected to be whole sats in test suite"
+    );
+
+    dev_fed
+        .bitcoind
+        .send_to(address.to_owned(), 10_000 + deposit_fees_msat / 1000)
+        .await?;
+    dev_fed.bitcoind.mine_blocks(21).await?;
+    Ok(())
+}
+
+async fn assert_wallet_receive_operations(
+    client: &Client,
+    address_operation_id: &str,
+    claim_owned_by_receive_operation: bool,
+    expected_count: usize,
+) -> anyhow::Result<()> {
+    let receives = wallet_receive_operations_for_address(client, address_operation_id).await?;
+    anyhow::ensure!(
+        receives.len() == expected_count,
+        "expected {expected_count} receive operation(s) for address operation {address_operation_id}, found {receives:?}"
+    );
+
+    for (receive_operation_id, receive) in receives {
+        let claim_operation_id = receive["claim_operation_id"]
+            .as_str()
+            .context("receive operation must have claim_operation_id")?;
+
+        let expected_claim_operation_id = if claim_owned_by_receive_operation {
+            receive_operation_id.as_str()
+        } else {
+            address_operation_id
+        };
+        anyhow::ensure!(
+            claim_operation_id == expected_claim_operation_id,
+            "unexpected receive claim operation id"
+        );
+    }
+
+    Ok(())
+}
+
+async fn wallet_receive_operations_for_address(
+    client: &Client,
+    address_operation_id: &str,
+) -> anyhow::Result<Vec<(String, serde_json::Value)>> {
+    let operations = cmd!(client, "list-operations", "--limit", "100")
+        .out_json()
+        .await?;
+
+    Ok(operations["operations"]
+        .as_array()
+        .context("operations must be an array")?
+        .iter()
+        .filter_map(|operation| {
+            let receive = operation["operation_meta"]["variant"]["receive"].as_object()?;
+            if receive
+                .get("address_operation_id")
+                .and_then(|id| id.as_str())
+                == Some(address_operation_id)
+            {
+                Some((
+                    operation["id"].as_str()?.to_owned(),
+                    serde_json::Value::Object(receive.clone()),
+                ))
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>())
+}
+
 async fn stress_test_fed(dev_fed: &DevFed, clients: Option<&UpgradeClients>) -> anyhow::Result<()> {
     use futures::FutureExt;
 
@@ -753,6 +962,21 @@ pub async fn upgrade_tests(process_mgr: &ProcessManager, binary: UpgradeTest) ->
                 ln_receive_client: dev_fed.fed.new_joined_client("ln-receive-client").await?,
                 fm_pay_client: dev_fed.fed.new_joined_client("fm-pay-client").await?,
             };
+            let mut wallet_receive_upgrade_clients = if fedimint_cli_version < *VERSION_0_12_0_ALPHA
+                && paths.len() > 1
+            {
+                Some(
+                    prepare_wallet_receive_upgrade_clients(&dev_fed)
+                        .await
+                        .context("preparing wallet receive upgrade clients")?,
+                )
+            } else {
+                info!(
+                    %fedimint_cli_version,
+                    "Skipping wallet receive upgrade test because the initial fedimint-cli version is not legacy"
+                );
+                None
+            };
 
             try_join!(
                 stress_test_fed(&dev_fed, Some(&reusable_upgrade_clients)),
@@ -763,6 +987,14 @@ pub async fn upgrade_tests(process_mgr: &ProcessManager, binary: UpgradeTest) ->
                 set_fedimint_cli_path(path);
                 let fedimint_cli_version = crate::util::FedimintCli::version_or_default().await;
                 info!("upgraded fedimint-cli to version: {}", fedimint_cli_version);
+                if fedimint_cli_version >= *VERSION_0_12_0_ALPHA
+                    && let Some(wallet_receive_upgrade_clients) =
+                        wallet_receive_upgrade_clients.take()
+                {
+                    wallet_receive_upgrade_test(&dev_fed, &wallet_receive_upgrade_clients)
+                        .await
+                        .context("wallet receive operation upgrade test")?;
+                }
                 try_join!(
                     stress_test_fed(&dev_fed, Some(&reusable_upgrade_clients)),
                     wait_session_client.wait_session()

--- a/fedimint-client-module/src/module/mod.rs
+++ b/fedimint-client-module/src/module/mod.rs
@@ -4,6 +4,7 @@ use std::collections::BTreeSet;
 use std::fmt::Debug;
 use std::pin::Pin;
 use std::sync::{Arc, Weak};
+use std::time::SystemTime;
 use std::{ffi, marker, ops};
 
 use anyhow::{anyhow, bail};
@@ -24,7 +25,10 @@ use fedimint_core::{
     Amount, OutPoint, PeerId, apply, async_trait_maybe_send, dyn_newtype_define, maybe_add_send,
     maybe_add_send_sync,
 };
-use fedimint_eventlog::{Event, EventKind, EventPersistence};
+use fedimint_eventlog::{
+    DBTransactionEventLogExt as _, Event, EventKind, EventLogId, EventPersistence,
+    PersistedLogEntry,
+};
 use fedimint_logging::LOG_CLIENT;
 use futures::Stream;
 use serde::Serialize;
@@ -461,12 +465,46 @@ where
         &self.module_db
     }
 
+    pub async fn get_event_log_dbtx(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        pos: Option<EventLogId>,
+        limit: u64,
+    ) -> Vec<PersistedLogEntry> {
+        dbtx.global_dbtx(self.global_dbtx_access_token)
+            .get_event_log(pos, limit)
+            .await
+    }
+
     pub async fn has_active_states(&self, op_id: OperationId) -> bool {
         self.client.get().has_active_states(op_id).await
     }
 
     pub async fn operation_exists(&self, op_id: OperationId) -> bool {
         self.client.get().operation_exists(op_id).await
+    }
+
+    pub async fn operation_log_entry_exists(&self, op_id: OperationId) -> bool {
+        self.client
+            .get()
+            .operation_log()
+            .operation_log_entry_exists(op_id)
+            .await
+    }
+
+    pub async fn operation_log_entry_exists_dbtx(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        op_id: OperationId,
+    ) -> bool {
+        self.client
+            .get()
+            .operation_log()
+            .operation_log_entry_exists_dbtx(
+                &mut dbtx.global_dbtx(self.global_dbtx_access_token),
+                op_id,
+            )
+            .await
     }
 
     pub async fn get_own_active_states(&self) -> Vec<(M::States, ActiveStateMeta)> {
@@ -705,6 +743,27 @@ where
                 operation_id,
                 operation_type,
                 serde_json::to_value(operation_meta).expect("Can't fail"),
+            )
+            .await;
+    }
+
+    pub async fn add_operation_log_entry_dbtx_with_creation_time(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        operation_id: OperationId,
+        operation_type: &str,
+        operation_meta: impl serde::Serialize,
+        creation_time: SystemTime,
+    ) {
+        self.client
+            .get()
+            .operation_log()
+            .add_operation_log_entry_dbtx_with_creation_time(
+                &mut dbtx.global_dbtx(self.global_dbtx_access_token),
+                operation_id,
+                operation_type,
+                serde_json::to_value(operation_meta).expect("Can't fail"),
+                creation_time,
             )
             .await;
     }

--- a/fedimint-client-module/src/oplog.rs
+++ b/fedimint-client-module/src/oplog.rs
@@ -46,12 +46,37 @@ pub trait IOperationLog {
         operation_id: OperationId,
     ) -> Option<OperationLogEntry>;
 
+    /// Returns `true` if an operation log entry for `operation_id` exists.
+    ///
+    /// Unlike `Client::operation_exists`, this checks for the operation *log
+    /// entry* itself, not for any state machines belonging to the operation.
+    /// Operations whose log entry is written before (or without) any state
+    /// machines must use this to test for existence.
+    async fn operation_log_entry_exists(&self, operation_id: OperationId) -> bool;
+
+    /// Same as [`IOperationLog::operation_log_entry_exists`], but reads through
+    /// an existing transaction so uncommitted entries are visible.
+    async fn operation_log_entry_exists_dbtx(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        operation_id: OperationId,
+    ) -> bool;
+
     async fn add_operation_log_entry_dbtx(
         &self,
         dbtx: &mut DatabaseTransaction<'_>,
         operation_id: OperationId,
         operation_type: &str,
         operation_meta: serde_json::Value,
+    );
+
+    async fn add_operation_log_entry_dbtx_with_creation_time(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        operation_id: OperationId,
+        operation_type: &str,
+        operation_meta: serde_json::Value,
+        creation_time: SystemTime,
     );
 
     fn outcome_or_updates(

--- a/fedimint-client/src/client/builder.rs
+++ b/fedimint-client/src/client/builder.rs
@@ -1138,11 +1138,13 @@ impl ClientBuilder {
 
         let client_arc = ClientHandle::new(client_inner);
 
+        // Must be set before starting modules: `module.start()` (e.g. the
+        // wallet's receive-operation backfill) may access the final client.
+        final_client.set(client_iface.clone());
+
         for (_, _, module) in client_arc.modules.iter_modules() {
             module.start().await;
         }
-
-        final_client.set(client_iface.clone());
 
         if !module_recoveries.is_empty() {
             client_arc.spawn_module_recoveries_task(

--- a/fedimint-client/src/oplog.rs
+++ b/fedimint-client/src/oplog.rs
@@ -1,7 +1,8 @@
 use std::collections::HashSet;
 use std::fmt::Debug;
 use std::ops::Range;
-use std::time::Duration;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, SystemTime};
 
 use fedimint_client_module::oplog::{
     IOperationLog, JsonStringed, OperationLogEntry, OperationOutcome, UpdateStreamOrOutcome,
@@ -16,7 +17,6 @@ use fedimint_logging::LOG_CLIENT;
 use futures::StreamExt as _;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
-use tokio::sync::OnceCell;
 use tracing::{error, instrument, warn};
 
 use crate::db::{ChronologicalOperationLogKey, OperationLogKey};
@@ -27,34 +27,41 @@ mod tests;
 #[derive(Debug, Clone)]
 pub struct OperationLog {
     db: Database,
-    oldest_entry: tokio::sync::OnceCell<ChronologicalOperationLogKey>,
+    oldest_entry: Arc<Mutex<Option<ChronologicalOperationLogKey>>>,
 }
 
 impl OperationLog {
     pub fn new(db: Database) -> Self {
         Self {
             db,
-            oldest_entry: OnceCell::new(),
+            oldest_entry: Arc::new(Mutex::new(None)),
         }
     }
 
     /// Will return the oldest operation log key in the database and cache the
     /// result. If no entry exists yet the DB will be queried on each call till
-    /// an entry is present.
+    /// an entry is present. Historical inserts can move the cached value
+    /// backwards.
     async fn get_oldest_operation_log_key(&self) -> Option<ChronologicalOperationLogKey> {
-        let mut dbtx = self.db.begin_transaction_nc().await;
-        self.oldest_entry
-            .get_or_try_init(move || async move {
-                dbtx.find_by_prefix(&crate::db::ChronologicalOperationLogKeyPrefix)
-                    .await
-                    .map(|(key, ())| key)
-                    .next()
-                    .await
-                    .ok_or(())
-            })
+        if let Some(oldest_entry) = *self.oldest_entry.lock().expect("mutex poisoned") {
+            return Some(oldest_entry);
+        }
+
+        let oldest_entry = self
+            .db
+            .begin_transaction_nc()
             .await
-            .ok()
-            .copied()
+            .find_by_prefix(&crate::db::ChronologicalOperationLogKeyPrefix)
+            .await
+            .map(|(key, ())| key)
+            .next()
+            .await;
+
+        if let Some(oldest_entry) = oldest_entry {
+            *self.oldest_entry.lock().expect("mutex poisoned") = Some(oldest_entry);
+        }
+
+        oldest_entry
     }
 
     pub async fn add_operation_log_entry_dbtx(
@@ -63,6 +70,24 @@ impl OperationLog {
         operation_id: OperationId,
         operation_type: &str,
         operation_meta: impl serde::Serialize,
+    ) {
+        self.add_operation_log_entry_dbtx_with_creation_time(
+            dbtx,
+            operation_id,
+            operation_type,
+            operation_meta,
+            now(),
+        )
+        .await;
+    }
+
+    pub async fn add_operation_log_entry_dbtx_with_creation_time(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        operation_id: OperationId,
+        operation_type: &str,
+        operation_meta: impl serde::Serialize,
+        creation_time: SystemTime,
     ) {
         dbtx.insert_new_entry(
             &OperationLogKey { operation_id },
@@ -76,14 +101,24 @@ impl OperationLog {
             ),
         )
         .await;
-        dbtx.insert_new_entry(
-            &ChronologicalOperationLogKey {
-                creation_time: now(),
-                operation_id,
-            },
-            &(),
-        )
-        .await;
+        let chronological_key = ChronologicalOperationLogKey {
+            creation_time,
+            operation_id,
+        };
+        dbtx.insert_new_entry(&chronological_key, &()).await;
+
+        let oldest_entry = Arc::clone(&self.oldest_entry);
+        dbtx.on_commit(move || {
+            let mut cached_oldest_entry = oldest_entry.lock().expect("mutex poisoned");
+            if cached_oldest_entry.is_none_or(|cached_key| {
+                (
+                    chronological_key.creation_time,
+                    chronological_key.operation_id.0,
+                ) < (cached_key.creation_time, cached_key.operation_id.0)
+            }) {
+                *cached_oldest_entry = Some(chronological_key);
+            }
+        });
     }
 
     #[deprecated(since = "0.6.0", note = "Use `paginate_operations_rev` instead")]
@@ -175,6 +210,23 @@ impl OperationLog {
         dbtx.get_value(&OperationLogKey { operation_id }).await
     }
 
+    pub async fn operation_log_entry_exists(&self, operation_id: OperationId) -> bool {
+        Self::operation_log_entry_exists_dbtx(
+            &mut self.db.begin_transaction_nc().await.into_nc(),
+            operation_id,
+        )
+        .await
+    }
+
+    pub async fn operation_log_entry_exists_dbtx(
+        dbtx: &mut DatabaseTransaction<'_>,
+        operation_id: OperationId,
+    ) -> bool {
+        dbtx.get_value(&OperationLogKey { operation_id })
+            .await
+            .is_some()
+    }
+
     /// Sets the outcome of an operation
     #[instrument(target = LOG_CLIENT, skip(db), level = "debug")]
     pub async fn set_operation_outcome(
@@ -256,6 +308,18 @@ impl IOperationLog for OperationLog {
         OperationLog::get_operation_dbtx(dbtx, operation_id).await
     }
 
+    async fn operation_log_entry_exists(&self, operation_id: OperationId) -> bool {
+        OperationLog::operation_log_entry_exists(self, operation_id).await
+    }
+
+    async fn operation_log_entry_exists_dbtx(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        operation_id: OperationId,
+    ) -> bool {
+        OperationLog::operation_log_entry_exists_dbtx(dbtx, operation_id).await
+    }
+
     async fn add_operation_log_entry_dbtx(
         &self,
         dbtx: &mut DatabaseTransaction<'_>,
@@ -269,6 +333,25 @@ impl IOperationLog for OperationLog {
             operation_id,
             operation_type,
             operation_meta,
+        )
+        .await
+    }
+
+    async fn add_operation_log_entry_dbtx_with_creation_time(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        operation_id: OperationId,
+        operation_type: &str,
+        operation_meta: serde_json::Value,
+        creation_time: SystemTime,
+    ) {
+        OperationLog::add_operation_log_entry_dbtx_with_creation_time(
+            self,
+            dbtx,
+            operation_id,
+            operation_type,
+            operation_meta,
+            creation_time,
         )
         .await
     }

--- a/fedimint-client/src/oplog/tests.rs
+++ b/fedimint-client/src/oplog/tests.rs
@@ -295,3 +295,49 @@ async fn test_pagination_empty_then_not() {
     let page = op_log.paginate_operations_rev(10, None).await;
     assert_eq!(page.len(), 1);
 }
+
+#[tokio::test]
+async fn test_pagination_sees_historical_insert_after_oldest_cache_is_initialized() {
+    let db = Database::new(MemDatabase::new(), ModuleRegistry::default());
+    let op_log = OperationLog::new(db.clone());
+
+    let recent_op_id = OperationId([1; 32]);
+    let older_op_id = OperationId([2; 32]);
+    let recent_time = SystemTime::UNIX_EPOCH + Duration::from_secs(60 * 60 * 24 * 14);
+    let older_time = SystemTime::UNIX_EPOCH + Duration::from_secs(60 * 60 * 24 * 7);
+
+    let mut dbtx = db.begin_transaction().await;
+    op_log
+        .add_operation_log_entry_dbtx_with_creation_time(
+            &mut dbtx.to_ref_nc(),
+            recent_op_id,
+            "foo",
+            "recent",
+            recent_time,
+        )
+        .await;
+    dbtx.commit_tx().await;
+
+    let page = op_log.paginate_operations_rev(10, None).await;
+    assert_eq!(page.len(), 1);
+
+    let mut dbtx = db.begin_transaction().await;
+    op_log
+        .add_operation_log_entry_dbtx_with_creation_time(
+            &mut dbtx.to_ref_nc(),
+            older_op_id,
+            "foo",
+            "older",
+            older_time,
+        )
+        .await;
+    dbtx.commit_tx().await;
+
+    let page = op_log.paginate_operations_rev(10, None).await;
+    assert_eq!(
+        page.iter()
+            .map(|(key, _entry)| key.operation_id)
+            .collect::<Vec<_>>(),
+        vec![recent_op_id, older_op_id]
+    );
+}

--- a/modules/fedimint-wallet-client/src/cli.rs
+++ b/modules/fedimint-wallet-client/src/cli.rs
@@ -29,6 +29,11 @@ enum Opts {
         #[arg(long, default_value = "1")]
         num: usize,
     },
+    /// Return the final outcome for an old deposit-address operation
+    LegacyDepositOutcome {
+        #[arg(long)]
+        operation_id: OperationId,
+    },
     GetConsensusBlockCount,
     /// Returns the Bitcoin RPC kind
     GetBitcoinRpcKind {
@@ -157,6 +162,10 @@ pub(crate) async fn handle_cli_command(
         } => {
             await_deposit(module, addr, operation_id, tweak_idx, num).await?;
             serde_json::Value::Bool(true)
+        }
+        Opts::LegacyDepositOutcome { operation_id } => {
+            serde_json::to_value(module.get_legacy_deposit_outcome(operation_id).await?)
+                .expect("JSON serialization failed")
         }
         Opts::GetBitcoinRpcKind { peer_id } => {
             let kind = module

--- a/modules/fedimint-wallet-client/src/client_db.rs
+++ b/modules/fedimint-wallet-client/src/client_db.rs
@@ -21,6 +21,7 @@ pub enum DbKeyPrefix {
     RecoveryState = 0x30,
     SupportsSafeDeposit = 0x31,
     PegInPoolCursor = 0x32,
+    ReceiveOperationsBackfilled = 0x33,
     /// Prefixes between 0xb0..=0xcf shall all be considered allocated for
     /// historical and future external use
     ExternalReservedStart = 0xb0,
@@ -210,6 +211,18 @@ impl_db_record!(
 impl_db_lookup!(
     key = SupportsSafeDepositKey,
     query_prefix = SupportsSafeDepositPrefix
+);
+
+/// Marker set once the one-time backfill of per-UTXO receive operation log
+/// entries (see `WalletClientModule::backfill_receive_operations`) has
+/// completed.
+#[derive(Clone, Debug, Encodable, Decodable, Serialize)]
+pub struct ReceiveOperationsBackfilledKey;
+
+impl_db_record!(
+    key = ReceiveOperationsBackfilledKey,
+    value = (),
+    db_prefix = DbKeyPrefix::ReceiveOperationsBackfilled,
 );
 
 /// Round-robin cursor for

--- a/modules/fedimint-wallet-client/src/events.rs
+++ b/modules/fedimint-wallet-client/src/events.rs
@@ -76,7 +76,12 @@ impl Event for SendPaymentStatusEvent {
 // Emitted when a deposit is confirmed
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct ReceivePaymentEvent {
-    pub operation_id: OperationId,
+    /// Operation id of the deposit address allocation.
+    // Renamed from `operation_id` in 0.12.
+    #[serde(alias = "operation_id")]
+    pub address_operation_id: OperationId,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub receive_operation_id: Option<OperationId>,
     pub amount: Amount,
     pub txid: Txid,
 }

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -16,15 +16,15 @@ pub mod client_db;
 /// but retained for time being to ensure existing peg-ins complete.
 mod deposit;
 pub mod events;
-use events::SendPaymentEvent;
+use events::{DepositConfirmed, SendPaymentEvent};
 /// Peg-in monitor: a task monitoring deposit addresses for peg-ins.
 mod pegin_monitor;
 mod withdraw;
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::future;
 use std::sync::Arc;
-use std::time::{Duration, SystemTime};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context as AnyhowContext, anyhow, bail, ensure};
 use async_stream::{stream, try_stream};
@@ -57,13 +57,13 @@ use fedimint_core::module::{
     ModuleInit, MultiApiVersion,
 };
 use fedimint_core::task::{MaybeSend, MaybeSync, TaskGroup, sleep};
-use fedimint_core::util::backoff_util::background_backoff;
-use fedimint_core::util::{BoxStream, backoff_util, retry};
+use fedimint_core::util::{BoxStream, FmtCompactAnyhow as _, backoff_util};
 use fedimint_core::{
     BitcoinHash, OutPoint, TransactionId, apply, async_trait_maybe_send, push_db_pair_items,
     runtime, secp256k1,
 };
 use fedimint_derive_secret::{ChildId, DerivableSecret};
+use fedimint_eventlog::Event as _;
 use fedimint_logging::LOG_CLIENT_MODULE_WALLET;
 pub use fedimint_wallet_common as common;
 use fedimint_wallet_common::config::{FeeConsensus, WalletClientConfig};
@@ -81,35 +81,18 @@ use crate::api::WalletFederationApi;
 use crate::backup::{FEDERATION_RECOVER_MAX_GAP, RecoveryStateV2, WalletRecovery};
 use crate::client_db::{
     ClaimedPegInData, ClaimedPegInKey, ClaimedPegInPrefix, NextPegInTweakIndexKey,
-    PegInPoolCursorKey, PegInTweakIndexData, PegInTweakIndexPrefix, RecoveryFinalizedKey,
-    RecoveryStateKey, SupportsSafeDepositPrefix,
+    PegInPoolCursorKey, PegInTweakIndexData, PegInTweakIndexPrefix, ReceiveOperationsBackfilledKey,
+    RecoveryFinalizedKey, RecoveryStateKey, SupportsSafeDepositPrefix,
 };
 use crate::deposit::DepositStateMachine;
 use crate::withdraw::{CreatedWithdrawState, WithdrawStateMachine, WithdrawStates};
 
 const WALLET_TWEAK_CHILD_ID: ChildId = ChildId(0);
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
-pub struct BitcoinTransactionData {
-    /// The bitcoin transaction is saved as soon as we see it so the transaction
-    /// can be re-transmitted if it's evicted from the mempool.
-    pub btc_transaction: bitcoin::Transaction,
-    /// Index of the deposit output
-    pub out_idx: u32,
-}
-
+/// State of a single on-chain receive (peg-in of one UTXO), as streamed by
+/// [`WalletClientModule::subscribe_receive`].
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
-pub enum DepositStateV1 {
-    WaitingForTransaction,
-    WaitingForConfirmation(BitcoinTransactionData),
-    Confirmed(BitcoinTransactionData),
-    Claimed(BitcoinTransactionData),
-    Failed(String),
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
-pub enum DepositStateV2 {
-    WaitingForTransaction,
+pub enum ReceiveState {
     WaitingForConfirmation {
         #[serde(with = "bitcoin::amount::serde::as_sat")]
         btc_deposited: bitcoin::Amount,
@@ -125,6 +108,32 @@ pub enum DepositStateV2 {
         btc_deposited: bitcoin::Amount,
         btc_out_point: bitcoin::OutPoint,
     },
+    IgnoredDust {
+        #[serde(with = "bitcoin::amount::serde::as_sat")]
+        btc_deposited: bitcoin::Amount,
+        btc_out_point: bitcoin::OutPoint,
+    },
+    Failed(String),
+}
+
+/// Final state of a legacy deposit, returned by
+/// [`WalletClientModule::get_legacy_deposit_outcome`]. Legacy deposits only
+/// ever reached a claimed or failed terminal state, so only those are
+/// represented here.
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LegacyDepositOutcome {
+    /// This deposit's UTXO has been migrated to a per-UTXO `Receive` operation.
+    /// Pass `receive_operation_id` to [`WalletClientModule::subscribe_receive`]
+    /// instead of reading the legacy outcome.
+    Migrated { receive_operation_id: OperationId },
+    /// The deposit was claimed.
+    Claimed {
+        #[serde(with = "bitcoin::amount::serde::as_sat")]
+        btc_deposited: bitcoin::Amount,
+        btc_out_point: bitcoin::OutPoint,
+    },
+    /// The deposit failed.
     Failed(String),
 }
 
@@ -329,6 +338,12 @@ impl ModuleInit for WalletClientInit {
                         wallet_client_items.insert("PegInPoolCursor".to_string(), Box::new(cursor));
                     }
                 }
+                DbKeyPrefix::ReceiveOperationsBackfilled => {
+                    if let Some(val) = dbtx.get_value(&ReceiveOperationsBackfilledKey).await {
+                        wallet_client_items
+                            .insert("ReceiveOperationsBackfilled".to_string(), Box::new(val));
+                    }
+                }
                 DbKeyPrefix::RecoveryState
                 | DbKeyPrefix::ExternalReservedStart
                 | DbKeyPrefix::CoreInternalReservedStart
@@ -459,7 +474,9 @@ pub struct WalletOperationMeta {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum WalletOperationMetaVariant {
-    Deposit {
+    // Renamed from `deposit` in 0.12.
+    #[serde(alias = "deposit")]
+    DepositAddress {
         address: Address<NetworkUnchecked>,
         /// Added in 0.4.2, can be `None` for old deposits or `Some` for ones
         /// using the pegin monitor. The value is the child index of the key
@@ -469,6 +486,19 @@ pub enum WalletOperationMetaVariant {
         tweak_idx: Option<TweakIdx>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         expires_at: Option<SystemTime>,
+    },
+    Receive {
+        /// Operation for the static address allocation this receive belongs to.
+        address_operation_id: OperationId,
+        /// Operation that owns the claim transaction/state machines. For new
+        /// receives this is the receive operation itself. For receives
+        /// backfilled from old storage this can be the address operation id.
+        claim_operation_id: OperationId,
+        address: Address<NetworkUnchecked>,
+        tweak_idx: TweakIdx,
+        btc_out_point: bitcoin::OutPoint,
+        #[serde(with = "bitcoin::amount::serde::as_sat")]
+        btc_deposited: bitcoin::Amount,
     },
     Withdraw {
         address: Address<NetworkUnchecked>,
@@ -492,6 +522,17 @@ pub struct WalletClientModuleData {
 }
 
 impl WalletClientModuleData {
+    pub(crate) fn receive_operation_id(
+        address_operation_id: OperationId,
+        btc_out_point: bitcoin::OutPoint,
+    ) -> OperationId {
+        OperationId::from_encodable(&(
+            b"wallet-v1-receive".to_vec(),
+            address_operation_id,
+            btc_out_point,
+        ))
+    }
+
     fn derive_deposit_address(
         &self,
         idx: TweakIdx,
@@ -575,6 +616,14 @@ impl ClientModule for WalletClientModule {
     }
 
     async fn start(&self) {
+        if let Err(error) = self.backfill_receive_operations().await {
+            tracing::warn!(
+                target: LOG_CLIENT_MODULE_WALLET,
+                err = %error.fmt_compact_anyhow(),
+                "Failed to backfill wallet receive operation log entries"
+            );
+        }
+
         self.task_group
             .spawn_cancellable_with_span(self.client_span.clone(), "peg-in monitor", {
                 let client_ctx = self.client_ctx.clone();
@@ -692,9 +741,9 @@ impl ClientModule for WalletClientModule {
                     let result = serde_json::to_value(&response)?;
                     yield result;
                 },
-                "subscribe_deposit" => {
-                    let req: SubscribeDepositRequest = serde_json::from_value(request)?;
-                    for await state in self.subscribe_deposit(req.operation_id).await?.into_stream() {
+                "subscribe_receive" => {
+                    let req: SubscribeReceiveRequest = serde_json::from_value(request)?;
+                    for await state in self.subscribe_receive(req.operation_id).await?.into_stream() {
                         yield serde_json::to_value(state)?;
                     }
                 },
@@ -738,7 +787,7 @@ pub struct PegInRequest {
 }
 
 #[derive(Deserialize)]
-struct SubscribeDepositRequest {
+struct SubscribeReceiveRequest {
     operation_id: OperationId,
 }
 
@@ -799,6 +848,122 @@ impl WalletClientModule {
 
     pub fn get_fee_consensus(&self) -> FeeConsensus {
         self.cfg().fee_consensus
+    }
+
+    /// One-time migration that creates a per-UTXO
+    /// [`WalletOperationMetaVariant::Receive`] operation-log entry for deposits
+    /// that were already claimed before receive operations were tracked
+    /// individually.
+    async fn backfill_receive_operations(&self) -> anyhow::Result<()> {
+        /// Scans the event log for [`DepositConfirmed`] events, returning the
+        /// deposited amount and confirmation time keyed by the on-chain
+        /// outpoint. Walking the whole (potentially large) event log is
+        /// acceptable because the backfill only runs once.
+        async fn collect_deposit_confirmed_amounts(
+            dbtx: &mut DatabaseTransaction<'_>,
+            client_ctx: &ClientContext<WalletClientModule>,
+        ) -> anyhow::Result<HashMap<bitcoin::OutPoint, (bitcoin::Amount, SystemTime)>> {
+            const PAGE_SIZE: u64 = 1000;
+
+            let mut cursor = None;
+            let mut amounts = HashMap::new();
+
+            loop {
+                let events = client_ctx.get_event_log_dbtx(dbtx, cursor, PAGE_SIZE).await;
+                if events.is_empty() {
+                    break;
+                }
+
+                for entry in &events {
+                    let entry = entry.as_raw();
+                    if entry.kind == DepositConfirmed::KIND
+                        && entry.module_kind() == DepositConfirmed::MODULE.as_ref()
+                        && let Some(event) = entry.to_event::<DepositConfirmed>()
+                    {
+                        amounts.insert(
+                            bitcoin::OutPoint {
+                                txid: event.txid,
+                                vout: event.out_idx,
+                            },
+                            (
+                                bitcoin::Amount::from_sat(event.amount.try_into_sats()?),
+                                UNIX_EPOCH + Duration::from_micros(entry.ts_usecs),
+                            ),
+                        );
+                    }
+                }
+
+                cursor = events.last().map(|entry| entry.id().next());
+            }
+
+            Ok(amounts)
+        }
+
+        let mut dbtx = self.db.begin_transaction().await;
+
+        if dbtx
+            .get_value(&ReceiveOperationsBackfilledKey)
+            .await
+            .is_some()
+        {
+            return Ok(());
+        }
+
+        let deposit_amounts =
+            collect_deposit_confirmed_amounts(&mut dbtx.to_ref_nc(), &self.client_ctx).await?;
+
+        let peg_in_entries = dbtx
+            .find_by_prefix(&PegInTweakIndexPrefix)
+            .await
+            .collect::<Vec<_>>()
+            .await;
+
+        for (key, peg_in_data) in peg_in_entries {
+            let tweak_idx = key.0;
+            let (_script, address, _tweak_key, derived_address_operation_id) =
+                self.data.derive_peg_in_script(tweak_idx);
+            debug_assert_eq!(derived_address_operation_id, peg_in_data.operation_id);
+
+            for btc_out_point in peg_in_data.claimed {
+                // Dust deposits are never claimed and don't emit a
+                // `DepositConfirmed` event, so a missing entry here also filters
+                // them out (just like the live path's `IgnoredDust` handling).
+                let Some((btc_deposited, creation_time)) =
+                    deposit_amounts.get(&btc_out_point).copied()
+                else {
+                    continue;
+                };
+
+                let receive_operation_id = WalletClientModuleData::receive_operation_id(
+                    peg_in_data.operation_id,
+                    btc_out_point,
+                );
+
+                pegin_monitor::ensure_receive_operation(
+                    &mut dbtx.to_ref_nc(),
+                    &self.client_ctx,
+                    receive_operation_id,
+                    WalletOperationMetaVariant::Receive {
+                        address_operation_id: peg_in_data.operation_id,
+                        // Old claims ran under the address operation, so that's
+                        // the operation that owns the claim transaction.
+                        claim_operation_id: peg_in_data.operation_id,
+                        address: address.clone().into_unchecked(),
+                        tweak_idx,
+                        btc_out_point,
+                        btc_deposited,
+                    },
+                    creation_time,
+                )
+                .await;
+            }
+        }
+
+        dbtx.insert_entry(&ReceiveOperationsBackfilledKey, &())
+            .await;
+        dbtx.commit_tx().await;
+
+        Ok(())
     }
 
     async fn allocate_deposit_address_inner(
@@ -1055,7 +1220,7 @@ impl WalletClientModule {
                                 deposit_address.operation_id,
                                 WalletCommonInit::KIND.as_str(),
                                 WalletOperationMeta {
-                                    variant: WalletOperationMetaVariant::Deposit {
+                                    variant: WalletOperationMetaVariant::DepositAddress {
                                         address: deposit_address.address.clone().into_unchecked(),
                                         tweak_idx: Some(deposit_address.tweak_idx),
                                         expires_at: None,
@@ -1181,7 +1346,7 @@ impl WalletClientModule {
                                 deposit_address.operation_id,
                                 WalletCommonInit::KIND.as_str(),
                                 WalletOperationMeta {
-                                    variant: WalletOperationMetaVariant::Deposit {
+                                    variant: WalletOperationMetaVariant::DepositAddress {
                                         address: deposit_address.address.clone().into_unchecked(),
                                         tweak_idx: Some(deposit_address.tweak_idx),
                                         expires_at: None,
@@ -1369,15 +1534,11 @@ impl WalletClientModule {
         Ok(result)
     }
 
-    /// Returns a stream of updates about an ongoing deposit operation created
-    /// with [`WalletClientModule::allocate_deposit_address_expert_only`].
-    /// Returns an error for old deposit operations created prior to the 0.4
-    /// release and not driven to completion yet. This should be rare enough
-    /// that an indeterminate state is ok here.
-    pub async fn subscribe_deposit(
+    /// Returns a stream of updates about a concrete receive operation.
+    pub async fn subscribe_receive(
         &self,
         operation_id: OperationId,
-    ) -> anyhow::Result<UpdateStreamOrOutcome<DepositStateV2>> {
+    ) -> anyhow::Result<UpdateStreamOrOutcome<ReceiveState>> {
         let operation = self
             .client_ctx
             .get_operation(operation_id)
@@ -1390,100 +1551,182 @@ impl WalletClientModule {
 
         let operation_meta = operation.meta::<WalletOperationMeta>();
 
-        let WalletOperationMetaVariant::Deposit {
-            address, tweak_idx, ..
+        let WalletOperationMetaVariant::Receive {
+            claim_operation_id,
+            tweak_idx,
+            btc_out_point,
+            btc_deposited,
+            ..
         } = operation_meta.variant
         else {
-            bail!("Operation is not a deposit operation");
-        };
-
-        let address = address.require_network(self.cfg().network.0)?;
-
-        // The old deposit operations don't have tweak_idx set
-        let Some(tweak_idx) = tweak_idx else {
-            // In case we are dealing with an old deposit that still uses state machines we
-            // don't have the logic here anymore to subscribe to updates. We can still read
-            // the final state though if it reached any.
-            let outcome_v1 = operation
-                .outcome::<DepositStateV1>()
-                .context("Old pending deposit, can't subscribe to updates")?;
-
-            let outcome_v2 = match outcome_v1 {
-                DepositStateV1::Claimed(tx_info) => DepositStateV2::Claimed {
-                    btc_deposited: tx_info.btc_transaction.output[tx_info.out_idx as usize].value,
-                    btc_out_point: bitcoin::OutPoint {
-                        txid: tx_info.btc_transaction.compute_txid(),
-                        vout: tx_info.out_idx,
-                    },
-                },
-                DepositStateV1::Failed(error) => DepositStateV2::Failed(error),
-                _ => bail!("Non-final outcome in operation log"),
-            };
-
-            return Ok(UpdateStreamOrOutcome::Outcome(outcome_v2));
+            bail!("Operation is not a receive operation");
         };
 
         Ok(self.client_ctx.outcome_or_updates(operation, operation_id, {
-            let stream_rpc = self.rpc.clone();
             let stream_client_ctx = self.client_ctx.clone();
-            let stream_script_pub_key = address.script_pubkey();
             move || {
 
             stream! {
-                yield DepositStateV2::WaitingForTransaction;
-
-                retry(
-                    "subscribe script history",
-                    background_backoff(),
-                    || stream_rpc.watch_script_history(&stream_script_pub_key)
-                ).await.expect("Will never give up");
-                let (btc_out_point, btc_deposited) = retry(
-                    "fetch history",
-                    background_backoff(),
-                    || async {
-                        let history = stream_rpc.get_script_history(&stream_script_pub_key).await?;
-                        history.first().and_then(|tx| {
-                            let (out_idx, amount) = tx.output
-                                .iter()
-                                .enumerate()
-                                .find_map(|(idx, output)| (output.script_pubkey == stream_script_pub_key).then_some((idx, output.value)))?;
-                            let txid = tx.compute_txid();
-
-                            Some((
-                                bitcoin::OutPoint {
-                                    txid,
-                                    vout: out_idx as u32,
-                                },
-                                amount
-                            ))
-                        }).context("No deposit transaction found")
-                    }
-                ).await.expect("Will never give up");
-
-                yield DepositStateV2::WaitingForConfirmation {
-                    btc_deposited,
-                    btc_out_point
-                };
-
-                let claim_data = stream_client_ctx.module_db().wait_key_exists(&ClaimedPegInKey {
+                let claimed_peg_in_key = ClaimedPegInKey {
                     peg_in_index: tweak_idx,
                     btc_out_point,
-                }).await;
+                };
 
-                yield DepositStateV2::Confirmed {
+                yield ReceiveState::WaitingForConfirmation {
                     btc_deposited,
                     btc_out_point
                 };
 
-                match stream_client_ctx.await_primary_module_outputs(operation_id, claim_data.change).await {
-                    Ok(()) => yield DepositStateV2::Claimed {
+                let claim_data = stream_client_ctx.module_db().wait_key_exists(&claimed_peg_in_key).await;
+
+                if claim_data.claim_txid == TransactionId::from_byte_array([0; 32]) && claim_data.change.is_empty() {
+                    yield ReceiveState::IgnoredDust {
+                        btc_deposited,
+                        btc_out_point
+                    };
+                    return;
+                }
+
+                yield ReceiveState::Confirmed {
+                    btc_deposited,
+                    btc_out_point
+                };
+
+                match stream_client_ctx.await_primary_module_outputs(claim_operation_id, claim_data.change).await {
+                    Ok(()) => yield ReceiveState::Claimed {
                         btc_deposited,
                         btc_out_point
                     },
-                    Err(e) => yield DepositStateV2::Failed(e.to_string())
+                    Err(e) => yield ReceiveState::Failed(e.to_string())
                 }
             }
         }}))
+    }
+
+    /// Reads the final outcome of a *legacy* deposit operation — a
+    /// [`WalletOperationMetaVariant::DepositAddress`] operation from before
+    /// receives were tracked as their own per-UTXO operations.
+    ///
+    /// This is the back-compat counterpart to [`Self::subscribe_receive`] for
+    /// older deposits that predate per-UTXO receive operations and so can't be
+    /// subscribed to. Such a deposit can no longer be driven to completion, but
+    /// the final state it reached can still be surfaced.
+    ///
+    /// If this deposit's UTXO has since been migrated to a per-UTXO `Receive`
+    /// operation, returns [`LegacyDepositOutcome::Migrated`] with the operation
+    /// id to pass to [`Self::subscribe_receive`] instead.
+    ///
+    /// Returns `Ok(None)` if the deposit has no recorded final outcome (e.g. an
+    /// old deposit that never completed), and an error if `operation_id` is not
+    /// a legacy deposit operation.
+    pub async fn get_legacy_deposit_outcome(
+        &self,
+        operation_id: OperationId,
+    ) -> anyhow::Result<Option<LegacyDepositOutcome>> {
+        // Pre-0.4.2 state-machine deposit outcome. Only the terminal variants
+        // we can act on are kept; anything else fails to decode and is treated
+        // as "no usable outcome".
+        #[derive(Deserialize)]
+        enum DepositFinalStateV1 {
+            Claimed {
+                btc_transaction: bitcoin::Transaction,
+                out_idx: u32,
+            },
+            Failed(String),
+        }
+
+        // 0.4.2–0.5 pegin-monitor deposit outcome (the pre-rename
+        // `DepositStateV2`), again only the terminal variants.
+        #[derive(Deserialize)]
+        enum DepositFinalStateV2 {
+            Claimed {
+                #[serde(with = "bitcoin::amount::serde::as_sat")]
+                btc_deposited: bitcoin::Amount,
+                btc_out_point: bitcoin::OutPoint,
+            },
+            Failed(String),
+        }
+
+        let operation = self
+            .client_ctx
+            .get_operation(operation_id)
+            .await
+            .with_context(|| anyhow!("Operation not found: {}", operation_id.fmt_short()))?;
+
+        let WalletOperationMetaVariant::DepositAddress { .. } =
+            operation.meta::<WalletOperationMeta>().variant
+        else {
+            bail!("Operation is not a legacy deposit operation");
+        };
+
+        // 0.5–0.11 deposits cached a `DepositStateV2` outcome; pre-0.4.2
+        // state-machine deposits cached a `DepositStateV1` outcome (which fails
+        // to decode as the former and falls through to the conversion below).
+        let outcome = if let Ok(Some(outcome)) = operation.try_outcome::<DepositFinalStateV2>() {
+            match outcome {
+                DepositFinalStateV2::Claimed {
+                    btc_deposited,
+                    btc_out_point,
+                } => LegacyDepositOutcome::Claimed {
+                    btc_deposited,
+                    btc_out_point,
+                },
+                DepositFinalStateV2::Failed(error) => LegacyDepositOutcome::Failed(error),
+            }
+        } else {
+            // No cached outcome means the deposit never reached a terminal
+            // state we recorded.
+            let Some(outcome) = operation
+                .try_outcome::<DepositFinalStateV1>()
+                .context("Failed to decode legacy deposit outcome")?
+            else {
+                return Ok(None);
+            };
+
+            match outcome {
+                DepositFinalStateV1::Claimed {
+                    btc_transaction,
+                    out_idx,
+                } => {
+                    let txid = btc_transaction.compute_txid();
+                    let btc_deposited = btc_transaction
+                        .output
+                        .get(out_idx as usize)
+                        .with_context(|| {
+                            format!("Legacy deposit outcome references missing output {out_idx} of {txid}")
+                        })?
+                        .value;
+
+                    LegacyDepositOutcome::Claimed {
+                        btc_deposited,
+                        btc_out_point: bitcoin::OutPoint {
+                            txid,
+                            vout: out_idx,
+                        },
+                    }
+                }
+                DepositFinalStateV1::Failed(error) => LegacyDepositOutcome::Failed(error),
+            }
+        };
+
+        // If this deposit's own UTXO already has a per-UTXO `Receive` operation
+        // (created by the live monitor or the one-time backfill), the legacy
+        // outcome is superseded; point the caller at `subscribe_receive`.
+        if let LegacyDepositOutcome::Claimed { btc_out_point, .. } = &outcome {
+            let receive_operation_id =
+                WalletClientModuleData::receive_operation_id(operation_id, *btc_out_point);
+            if self
+                .client_ctx
+                .operation_log_entry_exists(receive_operation_id)
+                .await
+            {
+                return Ok(Some(LegacyDepositOutcome::Migrated {
+                    receive_operation_id,
+                }));
+            }
+        }
+
+        Ok(Some(outcome))
     }
 
     pub async fn list_peg_in_tweak_idxes(&self) -> BTreeMap<TweakIdx, PegInTweakIndexData> {
@@ -1694,14 +1937,31 @@ impl WalletClientModule {
 
             debug!(target: LOG_CLIENT_MODULE_WALLET, has=pegins.len(), "Enough deposits detected");
 
-            for (_outpoint, transaction_id, change) in pegins {
+            for (btc_out_point, transaction_id, change) in pegins {
                 if transaction_id == TransactionId::from_byte_array([0; 32]) && change.is_empty() {
                     debug!(target: LOG_CLIENT_MODULE_WALLET, "Deposited amount was too low, skipping");
                     continue;
                 }
 
+                let receive_operation_id =
+                    WalletClientModuleData::receive_operation_id(operation_id, btc_out_point);
+                let claim_operation_id = match self
+                    .client_ctx
+                    .get_operation(receive_operation_id)
+                    .await
+                    .map(|operation| operation.meta::<WalletOperationMeta>().variant)
+                {
+                    Ok(WalletOperationMetaVariant::Receive {
+                        claim_operation_id, ..
+                    }) => claim_operation_id,
+                    Ok(_) | Err(_) => operation_id,
+                };
+
                 debug!(target: LOG_CLIENT_MODULE_WALLET, out_points=?change, "Ensuring deposists claimed");
-                let tx_subscriber = self.client_ctx.transaction_updates(operation_id).await;
+                let tx_subscriber = self
+                    .client_ctx
+                    .transaction_updates(claim_operation_id)
+                    .await;
 
                 if let Err(e) = tx_subscriber.await_tx_accepted(transaction_id).await {
                     bail!("{e}");
@@ -1709,7 +1969,7 @@ impl WalletClientModule {
 
                 debug!(target: LOG_CLIENT_MODULE_WALLET, out_points=?change, "Ensuring outputs claimed");
                 self.client_ctx
-                    .await_primary_module_outputs(operation_id, change)
+                    .await_primary_module_outputs(claim_operation_id, change)
                     .await
                     .expect("Cannot fail if tx was accepted and federation is honest");
             }

--- a/modules/fedimint-wallet-client/src/pegin_monitor.rs
+++ b/modules/fedimint-wallet-client/src/pegin_monitor.rs
@@ -31,7 +31,9 @@ use crate::client_db::{
     PegInTweakIndexPrefix, TweakIdx,
 };
 use crate::events::{DepositConfirmed, ReceivePaymentEvent};
-use crate::{WalletClientModule, WalletClientModuleData};
+use crate::{
+    WalletClientModule, WalletClientModuleData, WalletOperationMeta, WalletOperationMetaVariant,
+};
 
 /// A helper struct meant to combined data from all addresses/records
 /// into a single struct with all actionable data.
@@ -373,7 +375,7 @@ async fn check_idx_pegins(
     client_ctx: &ClientContext<WalletClientModule>,
 ) -> Result<Vec<CheckOutcome>, anyhow::Error> {
     let current_consensus_block_count = module_rpc.fetch_consensus_block_count().await?;
-    let (script, address, tweak_key, operation_id) = data.derive_peg_in_script(tweak_idx);
+    let (script, address, tweak_key, address_operation_id) = data.derive_peg_in_script(tweak_idx);
     btc_rpc.watch_script_history(&script).await?;
 
     let history = btc_rpc.get_script_history(&script).await?;
@@ -388,6 +390,8 @@ async fn check_idx_pegins(
             txid,
             vout: out_idx,
         };
+        let receive_operation_id =
+            WalletClientModuleData::receive_operation_id(address_operation_id, outpoint);
 
         let claimed_peg_in_key = ClaimedPegInKey {
             peg_in_index: tweak_idx,
@@ -405,6 +409,25 @@ async fn check_idx_pegins(
             outcomes.push(CheckOutcome::AlreadyClaimed);
             continue;
         }
+
+        let mut dbtx = db.begin_transaction().await;
+        ensure_receive_operation(
+            &mut dbtx.to_ref_nc(),
+            client_ctx,
+            receive_operation_id,
+            WalletOperationMetaVariant::Receive {
+                address_operation_id,
+                claim_operation_id: receive_operation_id,
+                address: address.clone().into_unchecked(),
+                tweak_idx,
+                btc_out_point: outpoint,
+                btc_deposited: transaction.output[out_idx as usize].value,
+            },
+            time::now(),
+        )
+        .await;
+        dbtx.commit_tx().await;
+
         let finality_delay = u64::from(data.cfg.finality_delay);
 
         let tx_block_count =
@@ -436,7 +459,8 @@ async fn check_idx_pegins(
             tweak_idx,
             tweak_key,
             &transaction,
-            operation_id,
+            address_operation_id,
+            receive_operation_id,
             outpoint,
             tx_out_proof,
             federation_knows_utxo,
@@ -447,13 +471,44 @@ async fn check_idx_pegins(
     Ok(outcomes)
 }
 
+/// Creates the receive operation-log entry for `receive_operation_id` (with
+/// metadata `variant` and the given `creation_time`) unless it already exists.
+pub(crate) async fn ensure_receive_operation(
+    dbtx: &mut DatabaseTransaction<'_>,
+    client_ctx: &ClientContext<WalletClientModule>,
+    receive_operation_id: OperationId,
+    variant: WalletOperationMetaVariant,
+    creation_time: SystemTime,
+) {
+    if client_ctx
+        .operation_log_entry_exists_dbtx(dbtx, receive_operation_id)
+        .await
+    {
+        return;
+    }
+
+    client_ctx
+        .add_operation_log_entry_dbtx_with_creation_time(
+            dbtx,
+            receive_operation_id,
+            fedimint_wallet_common::KIND.as_str(),
+            WalletOperationMeta {
+                variant,
+                extra_meta: serde_json::Value::Null,
+            },
+            creation_time,
+        )
+        .await;
+}
+
 #[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 async fn claim_peg_in(
     client_ctx: &ClientContext<WalletClientModule>,
     tweak_idx: TweakIdx,
     tweak_key: Keypair,
     transaction: &bitcoin::Transaction,
-    operation_id: OperationId,
+    address_operation_id: OperationId,
+    receive_operation_id: OperationId,
     out_point: bitcoin::OutPoint,
     tx_out_proof: TxOutProof,
     federation_knows_utxo: bool,
@@ -467,7 +522,8 @@ async fn claim_peg_in(
         out_idx: u32,
         tweak_key: Keypair,
         txout_proof: TxOutProof,
-        operation_id: OperationId,
+        address_operation_id: OperationId,
+        receive_operation_id: OperationId,
         federation_knows_utxo: bool,
     ) -> Option<OutPointRange> {
         let pegin_proof = PegInProof::new(
@@ -513,7 +569,8 @@ async fn claim_peg_in(
             .log_event(
                 dbtx,
                 ReceivePaymentEvent {
-                    operation_id,
+                    address_operation_id,
+                    receive_operation_id: Some(receive_operation_id),
                     amount,
                     txid,
                 },
@@ -525,7 +582,7 @@ async fn claim_peg_in(
                 .claim_inputs(
                     dbtx,
                     ClientInputBundle::new_no_sm(vec![client_input]),
-                    operation_id,
+                    receive_operation_id,
                 )
                 .await
                 .expect("Cannot claim input, additional funding needed"),
@@ -548,7 +605,8 @@ async fn claim_peg_in(
                         out_point.vout,
                         tweak_key,
                         tx_out_proof.clone(),
-                        operation_id,
+                        address_operation_id,
+                        receive_operation_id,
                         federation_knows_utxo,
                     )
                     .await;

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -27,8 +27,8 @@ use fedimint_testing::fixtures::Fixtures;
 use fedimint_testing_core::config::API_AUTH;
 use fedimint_wallet_client::api::WalletFederationApi;
 use fedimint_wallet_client::{
-    AllocateDepositOutcome, DepositStateV2, MaybeNewAddress, WalletClientInit, WalletClientModule,
-    WithdrawState,
+    AllocateDepositOutcome, MaybeNewAddress, ReceiveState, WalletClientInit, WalletClientModule,
+    WalletOperationMeta, WalletOperationMetaVariant, WithdrawState,
 };
 use fedimint_wallet_common::config::WalletConfig;
 use fedimint_wallet_common::tweakable::Tweakable;
@@ -37,7 +37,6 @@ use fedimint_wallet_common::{PegOutFees, Rbf, TxOutputSummary};
 use fedimint_wallet_server::WalletInit;
 use futures::stream::StreamExt;
 use secp256k1::rand::rngs::OsRng;
-use tokio::select;
 use tracing::{info, warn};
 
 fn fixtures() -> Fixtures {
@@ -286,20 +285,10 @@ async fn on_chain_peg_in_and_peg_out_happy_case() -> anyhow::Result<()> {
         deposit_operation
             .meta::<serde_json::Value>()
             .get("variant")
-            .and_then(|v| v.get("deposit"))
+            .and_then(|v| v.get("deposit_address"))
             .and_then(|d| d.get("address"))
             .is_some(),
         "Peg-in operation meta data should contain address"
-    );
-
-    // Test update stream returns expected updates
-    let mut deposit_updates = wallet_module
-        .subscribe_deposit(deposit_operation_id)
-        .await?
-        .into_stream();
-    assert_eq!(
-        deposit_updates.next().await.unwrap(),
-        DepositStateV2::WaitingForTransaction
     );
 
     info!(?address, "Peg-in address generated");
@@ -311,10 +300,31 @@ async fn on_chain_peg_in_and_peg_out_happy_case() -> anyhow::Result<()> {
         )
         .await;
 
-    info!("Waiting for confirmation");
+    wallet_module.recheck_pegin_address_by_op_id(op).await?;
+    let operations = client
+        .operation_log()
+        .paginate_operations_rev(10, None)
+        .await;
+    let (receive_operation_id, _) = operations
+        .iter()
+        .find(|(_, operation)| {
+            matches!(
+                operation.meta::<WalletOperationMeta>().variant,
+                WalletOperationMetaVariant::Receive { btc_out_point, .. }
+                    if btc_out_point.txid == tx.compute_txid()
+            )
+        })
+        .map(|(key, operation)| (key.operation_id, operation))
+        .expect("receive operation exists");
+
+    let mut receive_updates = wallet_module
+        .subscribe_receive(receive_operation_id)
+        .await?
+        .into_stream();
+
     assert_matches!(
-        deposit_updates.next().await.unwrap(),
-        DepositStateV2::WaitingForConfirmation { btc_out_point, .. } if btc_out_point.txid == tx.compute_txid()
+        receive_updates.next().await.unwrap(),
+        ReceiveState::WaitingForConfirmation { btc_out_point, .. } if btc_out_point.txid == tx.compute_txid()
     );
 
     bitcoin.mine_blocks(finality_delay).await;
@@ -327,25 +337,27 @@ async fn on_chain_peg_in_and_peg_out_happy_case() -> anyhow::Result<()> {
                 .recheck_pegin_address_by_op_id(op)
                 .await
                 .expect("Operation exists");
-            select! {
-                update = deposit_updates.next() => {
-                    break update;
-                },
-                _ = sleep_in_test("Waiting for address recheck", Duration::from_millis(100)) => { }
+            if wallet_module
+                .await_num_deposits_by_operation_id(op, 1)
+                .await
+                .is_ok()
+            {
+                break;
             }
+            sleep_in_test("Waiting for address recheck", Duration::from_millis(100)).await;
         }
     };
 
     info!("Waiting for claim tx");
-    assert_matches!(
-        await_update_while_rechecking.await.unwrap(),
-        DepositStateV2::Confirmed { btc_out_point, .. } if btc_out_point.txid == tx.compute_txid()
-    );
+    await_update_while_rechecking.await;
 
-    info!("Waiting for e-cash");
     assert_matches!(
-        deposit_updates.next().await.unwrap(),
-        DepositStateV2::Claimed { btc_out_point, .. } if btc_out_point.txid == tx.compute_txid()
+        receive_updates.next().await.unwrap(),
+        ReceiveState::Confirmed { btc_out_point, .. } if btc_out_point.txid == tx.compute_txid()
+    );
+    assert_matches!(
+        receive_updates.next().await.unwrap(),
+        ReceiveState::Claimed { btc_out_point, .. } if btc_out_point.txid == tx.compute_txid()
     );
 
     info!("Checking balance after deposit");
@@ -356,7 +368,7 @@ async fn on_chain_peg_in_and_peg_out_happy_case() -> anyhow::Result<()> {
     );
     assert_eq!(balance_sub.ok().await?, sats(PEG_IN_AMOUNT_SATS));
 
-    assert_eq!(deposit_updates.next().await, None);
+    assert_eq!(receive_updates.next().await, None);
 
     info!("Peg-in finished for test on_chain_peg_in_and_peg_out_happy_case");
     // Peg-out test, requires block to recognize change UTXOs
@@ -890,47 +902,40 @@ async fn dust_deposits_are_ignored() -> anyhow::Result<()> {
         )
         .await;
 
-    let mut deposit_updates = wallet_module.subscribe_deposit(op).await?.into_stream();
-    info!("Waiting for transaction");
-    assert_matches!(
-        deposit_updates.next().await.unwrap(),
-        DepositStateV2::WaitingForTransaction
-    );
-    info!("Waiting for confirmation");
-    assert_matches!(
-        deposit_updates.next().await.unwrap(),
-        DepositStateV2::WaitingForConfirmation { btc_out_point, .. } if btc_out_point.txid == tx.compute_txid()
-    );
-
     bitcoin.mine_blocks(finality_delay).await;
 
-    // Afaik technically not necessary, but useful to speed up test (should probably
-    // just poll more often in tests?)
-    let await_update_while_rechecking = async {
-        loop {
-            wallet_module
-                .recheck_pegin_address_by_op_id(op)
-                .await
-                .expect("Operation exists");
-            select! {
-                update = deposit_updates.next() => {
-                    break update;
-                },
-                _ = sleep_in_test("Waiting for address recheck", Duration::from_millis(100)) => { }
-            }
-        }
-    };
+    wallet_module
+        .await_num_deposits_by_operation_id(op, 1)
+        .await?;
 
-    info!("Waiting for claim tx");
+    let operations = client
+        .operation_log()
+        .paginate_operations_rev(10, None)
+        .await;
+    let (receive_operation_id, _) = operations
+        .iter()
+        .find(|(_, operation)| {
+            matches!(
+                operation.meta::<WalletOperationMeta>().variant,
+                WalletOperationMetaVariant::Receive { btc_out_point, .. }
+                    if btc_out_point.txid == tx.compute_txid()
+            )
+        })
+        .map(|(key, operation)| (key.operation_id, operation))
+        .expect("receive operation exists");
+
+    let mut receive_updates = wallet_module
+        .subscribe_receive(receive_operation_id)
+        .await?
+        .into_stream();
+
     assert_matches!(
-        await_update_while_rechecking.await.unwrap(),
-        DepositStateV2::Confirmed { btc_out_point, .. } if btc_out_point.txid == tx.compute_txid()
+        receive_updates.next().await.unwrap(),
+        ReceiveState::WaitingForConfirmation { btc_out_point, .. } if btc_out_point.txid == tx.compute_txid()
     );
-
-    info!("Waiting for e-cash");
     assert_matches!(
-        deposit_updates.next().await.unwrap(),
-        DepositStateV2::Claimed { btc_out_point, .. } if btc_out_point.txid == tx.compute_txid()
+        receive_updates.next().await.unwrap(),
+        ReceiveState::IgnoredDust { btc_out_point, .. } if btc_out_point.txid == tx.compute_txid()
     );
 
     info!("Checking balance after deposit");
@@ -1922,6 +1927,7 @@ mod fedimint_migration_tests {
                         client_db::DbKeyPrefix::RecoveryState => {}
                         client_db::DbKeyPrefix::SupportsSafeDeposit => {}
                         client_db::DbKeyPrefix::PegInPoolCursor => {}
+                        client_db::DbKeyPrefix::ReceiveOperationsBackfilled => {}
                         client_db::DbKeyPrefix::ExternalReservedStart
                         | client_db::DbKeyPrefix::CoreInternalReservedStart
                         | client_db::DbKeyPrefix::CoreInternalReservedEnd => {}


### PR DESCRIPTION
*PR published by Tau*

## Summary

Split the wallet client's deposit model into a deposit-address allocation and a separate per-UTXO "receive" operation, so each received on-chain UTXO has its own operation, lifecycle, and update stream instead of being conflated with the address that received it.

## Details

Previously a single deposit operation both allocated a deposit address and claimed whatever UTXO(s) later arrived on it, and its update stream (`subscribe_deposit`) re-derived progress by polling the chain. This reworks the model so that allocating an address and receiving a concrete UTXO are distinct operations:

- `WalletOperationMetaVariant::Deposit` becomes `DepositAddress` (address allocation only; `#[serde(alias = "deposit")]` keeps reading old metadata), and a new `Receive` variant carries the address op id, the claim op id, the outpoint, and the deposited amount.
- The peg-in monitor creates a `Receive` operation for every newly seen, not-yet-claimed UTXO before claiming it, and claims inputs/state machines under the receive op id. `ReceivePaymentEvent` records both the address and receive op ids.
- `subscribe_deposit`/`DepositStateV2` become `subscribe_receive`/ `ReceiveState`. The transient `WaitingForTransaction` state is dropped (a receive op only exists once a UTXO is seen) and a terminal `IgnoredDust` state is added for sub-fee deposits that are recorded but never claimed.
- `claim_operation_id` distinguishes who owns the claim transaction and state machines: for new receives it is the receive op itself; for receives recovered from old storage it is the original address op (whose state machines performed the historical claim). `subscribe_receive` and `await_num_deposits` route through it accordingly.
- A one-time, marker-gated migration (`backfill_receive_operations`, guarded by `ReceiveOperationsBackfilledKey`) synthesizes `Receive` operations for already-claimed deposits by scanning the event log for `DepositConfirmed` events, preserving each operation's original timestamp via a new `add_operation_log_entry_dbtx_with_creation_time`.
- `get_legacy_deposit_outcome` reads the terminal state of pre-migration deposits directly from the legacy `DepositStateV1`/`DepositStateV2` cached outcomes, returning `Migrated { receive_operation_id }` when that UTXO has since gained a per-UTXO receive op so callers use `subscribe_receive` instead.

## Design choices

- Receive op ids are content-derived (`hash(b"wallet-v1-receive", address op id, outpoint)`), so creation is idempotent across restarts and shared by the live and backfill paths.
- Existence is checked with a new `operation_log_entry_exists[_dbtx]` rather than `operation_exists`: a freshly written receive op has a log entry but no state machines, so the state-machine-based `operation_exists` would wrongly report it missing and defeat the idempotency guard.
- The legacy `DepositStateV1`/`DepositStateV2` shapes are decoded via frozen function-local types so the live `ReceiveState` enum can evolve without silently reinterpreting old on-disk data.
- The backfill keys off `DepositConfirmed`, which only exists from 0.6 onward; older claimed deposits are intentionally left to `get_legacy_deposit_outcome` rather than synthesized.
- The whole backfill runs in a single transaction; as a one-time, marker-gated migration a long transaction is acceptable.

## Breaking changes

- RPC method `subscribe_deposit` -> `subscribe_receive`.
- Public types `BitcoinTransactionData`, `DepositStateV1`, `DepositStateV2` removed (`DepositStateV2` effectively renamed to `ReceiveState`); `WalletOperationMetaVariant::Deposit` -> `DepositAddress`; `ReceivePaymentEvent::operation_id` -> `address_operation_id` plus an optional `receive_operation_id`.
- New on-disk metadata and the backfill marker are not understood by pre-this-change clients; this is a one-way migration.

## Testing

- Wallet integration tests updated to discover the receive op via the operation log and assert on `ReceiveState`; the dust path asserts `IgnoredDust`.
- Not yet covered: dedicated tests for `backfill_receive_operations` and `get_legacy_deposit_outcome`.

Assisted-By: Tau:gpt-5.5

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
