### PR TITLE
docs: cryptographic scheme write-ups for tbs, tpe, and dkg

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ are:
 - [Fedimint Contributing Guidelines](CONTRIBUTING.md#) for information for contributors.
 - [Fedimint Developer Discord Server](https://discord.gg/cEVEmqCgWG): the best place to get help and ask questions.
 - [Fedimint Technical Reference Documentation](https://docs.fedimint.org)
+- [Fedimint Cryptographic Schemes](https://docs.fedimint.org/crypto/): self-contained write-ups of the pairing-based
+  cryptography behind Chaumian e-cash ([threshold blind signatures](https://docs.fedimint.org/crypto/tbs.html)),
+  Lightning v2 preimage encryption ([threshold point encryption](https://docs.fedimint.org/crypto/tpe.html)), and the
+  dealer-free [distributed key generation](https://docs.fedimint.org/crypto/dkg.html) that sets up a federation's keys.
 - [Fedimint Contributor Calendar](https://calendar.google.com/calendar/u/0/embed?src=fedimintcalendar@gmail.com): This
   calendar contains all the developer calls and events.
 - [Fedimint Developer Calls](https://meet.jit.si/fedimintdevcall): We have developer calls every Monday at 4PM UTC to

--- a/docs/crypto/dkg.html
+++ b/docs/crypto/dkg.html
@@ -1,0 +1,262 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Distributed Key Generation — fedimint-server</title>
+<script>
+MathJax = { tex: { inlineMath: [['$', '$'], ['\\(', '\\)']] } };
+</script>
+<script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" async></script>
+<style>
+  body {
+    font-family: -apple-system, "Segoe UI", Helvetica, Arial, sans-serif;
+    max-width: 880px;
+    margin: 0 auto;
+    padding: 2rem 1.5rem 6rem;
+    color: #1c1e21;
+    line-height: 1.6;
+  }
+  h1 { font-size: 1.9rem; border-bottom: 2px solid #e0e0e0; padding-bottom: .4rem; }
+  h2 { font-size: 1.4rem; margin-top: 2.4rem; border-bottom: 1px solid #ececec; padding-bottom: .3rem; }
+  h3 { font-size: 1.1rem; margin-top: 1.8rem; }
+  code { background: #f4f4f6; padding: .1em .35em; border-radius: 4px; font-size: .9em; }
+  .box {
+    background: #f8f9fb;
+    border: 1px solid #e3e6ea;
+    border-left: 4px solid #4a6fa5;
+    border-radius: 6px;
+    padding: .8rem 1.2rem;
+    margin: 1.2rem 0;
+  }
+  .warn { border-left-color: #c0883a; background: #fbf7f0; }
+  .role { color: #4a6fa5; font-weight: 600; }
+  .nav { font-size: .9rem; margin-bottom: 1.5rem; }
+  .nav a { color: #4a6fa5; text-decoration: none; }
+  table { border-collapse: collapse; margin: 1rem 0; }
+  td, th { border: 1px solid #ddd; padding: .4rem .8rem; text-align: left; }
+  th { background: #f4f4f6; }
+  footer { margin-top: 3rem; color: #888; font-size: .85rem; }
+</style>
+</head>
+<body>
+
+<div class="nav"><a href="./index.html">← Cryptographic schemes</a></div>
+
+<h1>Distributed Key Generation</h1>
+<p>
+This page describes the cryptographic ceremony implemented in
+<code>fedimint-server</code>'s configuration setup: a <strong>Pedersen distributed key
+generation</strong> (DKG) over BLS12-381. It is run once, when a federation is created, to
+produce the threshold keys used by the rest of the system <em>without any trusted
+dealer</em> — no single party ever holds the secret key. Concretely, the DKG produces
+exactly the Shamir-shared key that the
+<a href="./tbs.html">threshold blind signature</a> and
+<a href="./tpe.html">threshold point encryption</a> schemes take as given.
+</p>
+<div class="box">
+<strong>Two instances, one protocol.</strong>
+The ceremony is run separately for each pairing group: <code>run_dkg_g1</code> produces a
+key whose public material lives in $\mathbb{G}_1$ (as <a href="./tpe.html">tpe</a> needs),
+and <code>run_dkg_g2</code> produces one whose public material lives in $\mathbb{G}_2$ (as
+<a href="./tbs.html">tbs</a> needs). The two are identical line for line apart from the
+group in which commitments are formed, so we describe a single generic instance over a
+group $\mathbb{G}$ with generator $g$.
+</div>
+<div class="box">
+<strong>Where this is used.</strong>
+The ceremony runs once, during federation setup, before consensus begins. Each module that
+needs a threshold key drives one run per key: the mint module runs a $\mathbb{G}_2$ ceremony
+<em>per denomination tier</em> to obtain that tier's blind-signing key
+(<a href="./tbs.html">tbs</a>), and lnv2 runs a $\mathbb{G}_1$ ceremony for its decryption
+key (<a href="./tpe.html">tpe</a>). In each case the module's secret key exists only as the
+resulting threshold sharing — no guardian ever holds it.
+</div>
+
+<h2>1. Setting and notation</h2>
+<p>
+$K := \mathbb{Z}/p\mathbb{Z}$ is the field of integers modulo the prime $p$. Let
+$\mathbb{G}$ be one of the BLS12-381 groups of order $p$, written additively, with fixed
+generator $g \in \mathbb{G}$; scalar multiplication $\lambda \mapsto \lambda\,g$ is the map
+$K \to \mathbb{G}$ used throughout.
+</p>
+<div class="box">
+<strong>Groups as vector spaces.</strong>
+Since $|\mathbb{G}| = p$ is prime, $\mathbb{G}$ is a one-dimensional $K$-vector space, and
+$\lambda \mapsto \lambda\, g$ is a $K$-linear isomorphism $K \xrightarrow{\sim} \mathbb{G}$.
+Every operation below — committing to a polynomial, evaluating it, summing per-guardian
+contributions — is linear, so the whole ceremony is one extended exercise in carrying
+linear algebra "into the exponent".
+</div>
+<p>
+A federation has $n$ <span class="role">guardians</span>, indexed by $\mathsf{PeerId}$s.
+Guardian $i$ is assigned the evaluation point
+$$x_i \;=\; i + 1 \;\in\; K,$$
+shifting peer indices by one so that the point $0$ — which will carry the secret — is never
+an evaluation point. With at most $f = \lfloor (n-1)/3 \rfloor$ faulty guardians, the
+reconstruction threshold is
+$$t \;=\; n - f,$$
+and every guardian samples a secret polynomial of degree $t-1$ (i.e. $t$ coefficients), so
+that any $t$ shares determine it and any $t-1$ reveal nothing.
+</p>
+
+<h2>2. Committing to a secret polynomial</h2>
+<p>
+Each <span class="role">guardian</span> $i$ samples a uniformly random polynomial of
+degree $t-1$ over $K$,
+$$f_i(X) \;=\; \sum_{k=0}^{t-1} a_{i,k}\, X^k, \qquad a_{i,k} \stackrel{\$}{\leftarrow} K,$$
+and publishes a <strong>Feldman commitment</strong> to its coefficients — the coefficient
+vector mapped into the group:
+$$C_i \;=\; \bigl(C_{i,0}, \dots, C_{i,t-1}\bigr), \qquad C_{i,k} \;=\; a_{i,k}\, g \;\in\; \mathbb{G}.$$
+</p>
+<div class="box">
+<strong>What a Feldman commitment buys.</strong>
+Because $g$ is a generator, $a \mapsto a\,g$ is injective, so $C_i$ binds guardian $i$ to a
+unique polynomial. And because it is linear, the commitment to a polynomial
+<em>evaluated</em> at a point is the same linear combination of the $C_{i,k}$ — which lets
+any recipient check a privately received share against the public commitment (§3.3) without
+learning the polynomial.
+</div>
+
+<h2>3. The protocol</h2>
+<p>
+The ceremony runs in three message rounds over authenticated peer-to-peer links. Guardian
+$i$ tracks the others' hash commitments, full commitments, and the secret shares addressed
+to it; a round advances only once a message has been received from <em>every</em> guardian.
+</p>
+
+<h3>3.1 Round 1 — hash commitment</h3>
+<p>
+Each guardian first broadcasts only a hash of its commitment vector,
+$$h_i \;=\; \mathsf{SHA256}\bigl(\mathsf{encode}(C_i)\bigr),$$
+and waits until it holds $h_j$ from all $n$ guardians before revealing anything more.
+</p>
+<div class="box">
+<strong>Why commit to the commitment first?</strong>
+Broadcasting $h_i$ before any $C_j$ is revealed forces every guardian to fix its polynomial
+<em>before</em> seeing the others'. Without this round, a guardian who spoke last could
+choose its coefficients adaptively in response to everyone else's commitments and so bias
+the joint public key. The hash round removes that rushing advantage.
+</div>
+
+<h3>3.2 Round 2 — reveal and verify</h3>
+<p>
+Once all hashes are in, each guardian broadcasts its full commitment vector $C_i$. On
+receiving $C_j$, guardian $i$ checks that
+</p>
+<ul>
+  <li>it matches the earlier hash, $\mathsf{SHA256}(\mathsf{encode}(C_j)) = h_j$, and</li>
+  <li>it has the right length $t$ — i.e. $f_j$ has the agreed degree $t-1$.</li>
+</ul>
+<p>Any mismatch aborts the ceremony. The protocol proceeds once all $n$ commitments are in.</p>
+
+<h3>3.3 Round 3 — deal and verify shares</h3>
+<p>
+Each guardian $i$ now evaluates its polynomial at every guardian's point and sends the
+result privately:
+$$s_{i \to j} \;=\; f_i(x_j) \;\in\; K \qquad (\text{kept for } j = i,\ \text{sent over the private link otherwise}).$$
+On receiving the share $s_{j \to i}$ from guardian $j$, guardian $i$ verifies it against
+$j$'s public commitment with the Feldman check
+$$s_{j \to i}\, g \;\stackrel{?}{=}\; \sum_{k=0}^{t-1} x_i^{\,k}\, C_{j,k}.$$
+</p>
+<div class="box">
+<strong>Why the check works.</strong>
+The right-hand side is the commitment $C_j$ "evaluated at $x_i$ in the exponent":
+$$\sum_{k=0}^{t-1} x_i^{\,k}\, C_{j,k}
+ \;=\; \sum_{k=0}^{t-1} x_i^{\,k}\, a_{j,k}\, g
+ \;=\; \Bigl(\sum_{k=0}^{t-1} a_{j,k}\, x_i^{\,k}\Bigr) g
+ \;=\; f_j(x_i)\, g.$$
+So the check passes exactly when $s_{j\to i} = f_j(x_i)$ — a guardian cannot send a share
+inconsistent with the polynomial it already committed to.
+</div>
+
+<h3>3.4 Combine</h3>
+<p>
+After collecting a valid share from every guardian, guardian $i$ sums them into its secret
+key share, and sums the per-guardian commitments coefficient-wise into the public
+commitment:
+$$\mathsf{sk}_i \;=\; \sum_{j=1}^{n} s_{j \to i}, \qquad
+\mathsf{PK}_k \;=\; \sum_{j=1}^{n} C_{j,k} \quad (k = 0, \dots, t-1).$$
+</p>
+
+<h2>4. What the ceremony produces</h2>
+<p>
+Define the <em>joint secret polynomial</em> as the sum of all the guardians' polynomials,
+$$F(X) \;=\; \sum_{j=1}^{n} f_j(X) \;=\; \sum_{k=0}^{t-1} A_k\, X^k, \qquad A_k = \sum_{j=1}^{n} a_{j,k}.$$
+Then the outputs of §3.4 are exactly
+$$\mathsf{sk}_i \;=\; \sum_{j} f_j(x_i) \;=\; F(x_i), \qquad
+\mathsf{PK}_k \;=\; \sum_{j} a_{j,k}\, g \;=\; A_k\, g,$$
+i.e. each guardian holds the value of $F$ at its own point, and everyone holds the Feldman
+commitment $\mathsf{PK} = (A_0 g, \dots, A_{t-1} g)$ to $F$.
+</p>
+<div class="box">
+<strong>This is precisely the Shamir sharing the other schemes assume.</strong>
+The federation's secret key is $x = F(0) = \sum_j a_{j,0}$ — the sum of every guardian's
+constant term — which is <em>never reconstructed</em> anywhere. Its public key is
+$\mathsf{PK}_0 = x\, g$, and guardian $i$'s public key share is obtained by evaluating the
+public commitment at $x_i$,
+$$\mathsf{pk}_i \;=\; \sum_{k=0}^{t-1} x_i^{\,k}\, \mathsf{PK}_k \;=\; F(x_i)\, g \;=\; \mathsf{sk}_i\, g.$$
+Setting $f := F$, this is exactly the polynomial, shares $f(i)$, evaluation points $i+1$,
+and aggregate key of <a href="./tbs.html">tbs §5.1</a> and <a href="./tpe.html">tpe §6.1</a>
+— so signing or decryption shares produced afterwards interpolate to a signature or
+decryption key under the single aggregate public key $x\,g$.
+</div>
+
+<h2>5. Security properties (informal)</h2>
+<ul>
+  <li><strong>No dealer, no single point of trust</strong> — the secret $x = F(0)$ is a sum
+      of $n$ independently chosen constant terms and is never assembled; it exists only as
+      the threshold sharing $\{F(x_i)\}$.</li>
+  <li><strong>Secrecy</strong> — $F$ has degree $t-1$, so any coalition of fewer than $t$
+      guardians sees a set of shares consistent with every possible secret: $t-1$ shares
+      reveal nothing about $x$ (perfect secrecy of Shamir sharing). The public commitment
+      reveals $F$ only "in the exponent", i.e. $x\,g$ but not $x$.</li>
+  <li><strong>Verifiability</strong> — the Feldman check (§3.3) lets every guardian confirm
+      each received share is consistent with the sender's committed polynomial, and the
+      hash round (§3.1) fixes each polynomial before any are revealed, raising the bar
+      against a rushing guardian who would otherwise choose its polynomial after seeing the
+      others' (see the caveat below on the limits of this guarantee).</li>
+  <li><strong>Correctness</strong> — once all checks pass, the shares lie on the single
+      degree-$(t-1)$ polynomial $F$, so any $t$ of them Lagrange-interpolate to the same key
+      $x$, exactly as required by the downstream threshold schemes.</li>
+</ul>
+
+<div class="box warn">
+<strong>Implementation note — cooperative ceremony with abort.</strong>
+<p>
+The implementation assumes all guardians are present and cooperative: there is no
+complaint-and-disqualification phase, and an invalid hash, commitment, or share causes the
+whole ceremony to abort rather than excluding the offending guardian. This is appropriate
+for a one-time setup among a known guardian set — a failed run is simply retried — but it
+means liveness requires every guardian to behave during setup, even though the resulting
+key tolerates up to $f$ faults thereafter.
+</p>
+<p>
+More subtly, formally guaranteeing a <em>uniformly</em> distributed key in a dealerless DKG
+is notoriously delicate: Gennaro, Jarecki, Krawczyk and Rabin showed that plain
+Joint-Feldman admits a small bias in the public key, exploited through the disqualification
+phase. The hash-commit-then-reveal round here fixes each guardian's polynomial before any
+are opened, and aborting on any fault removes the disqualification phase that the classic
+attack turns on; the design thus targets an honest-majority-with-abort model rather than a
+formally analysed uniform-key DKG. The residual bias is harmless for the threshold schemes
+built on top, which only require that fewer than $t$ shares hide the key.
+</p>
+</div>
+
+<h2>References</h2>
+<ul>
+  <li>A. Shamir. <em>How to Share a Secret.</em> Communications of the ACM, 1979.</li>
+  <li>P. Feldman. <em>A Practical Scheme for Non-Interactive Verifiable Secret Sharing.</em> FOCS 1987.</li>
+  <li>T. P. Pedersen. <em>Non-Interactive and Information-Theoretic Secure Verifiable Secret Sharing.</em> CRYPTO 1991.</li>
+  <li>R. Gennaro, S. Jarecki, H. Krawczyk, T. Rabin. <em>Secure Distributed Key Generation for Discrete-Log Based Cryptosystems.</em> EUROCRYPT 1999 / Journal of Cryptology, 2007.</li>
+</ul>
+
+<footer>
+Generated from <code>fedimint-server</code> — sources:
+<code>fedimint-server/src/config/dkg.rs</code>,
+<code>config/dkg_g1.rs</code>, <code>config/dkg_g2.rs</code>, and the helpers in
+<code>fedimint-server-core/src/config.rs</code>. Part of the
+<a href="./index.html">Fedimint cryptographic schemes</a>.
+</footer>
+
+</body>
+</html>

--- a/docs/crypto/index.html
+++ b/docs/crypto/index.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Cryptographic schemes — Fedimint</title>
+<style>
+  body {
+    font-family: -apple-system, "Segoe UI", Helvetica, Arial, sans-serif;
+    max-width: 880px;
+    margin: 0 auto;
+    padding: 2rem 1.5rem 6rem;
+    color: #1c1e21;
+    line-height: 1.6;
+  }
+  h1 { font-size: 1.9rem; border-bottom: 2px solid #e0e0e0; padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin: 0; }
+  h2 a { color: #4a6fa5; text-decoration: none; }
+  code { background: #f4f4f6; padding: .1em .35em; border-radius: 4px; font-size: .9em; }
+  .card {
+    background: #f8f9fb;
+    border: 1px solid #e3e6ea;
+    border-left: 4px solid #4a6fa5;
+    border-radius: 6px;
+    padding: 1rem 1.2rem;
+    margin: 1.2rem 0;
+  }
+  .card p { margin: .5rem 0 0; }
+  .nav { font-size: .9rem; margin-bottom: 1.5rem; }
+  .nav a { color: #4a6fa5; text-decoration: none; }
+  footer { margin-top: 3rem; color: #888; font-size: .85rem; }
+</style>
+</head>
+<body>
+
+<div class="nav"><a href="../index.html">← Fedimint technical reference</a></div>
+
+<h1>Fedimint cryptographic schemes</h1>
+<p>
+Self-contained write-ups of the pairing-based cryptography used inside Fedimint. Each page
+derives the scheme directly from its implementing crate, in the language of linear algebra
+over the BLS12-381 pairing groups.
+</p>
+
+<div class="card">
+  <h2><a href="./tbs.html">Threshold Blind Signatures</a></h2>
+  <p>
+    <code>fedimint-tbs</code> — the blind BLS signature behind Chaumian e-cash. The
+    federation blindly signs a note so no guardian learns which note it signed, and any
+    holder verifies it against one aggregate public key. Covers blinding, the pairing
+    verification, and the $t$-of-$n$ threshold construction.
+  </p>
+</div>
+
+<div class="card">
+  <h2><a href="./tpe.html">Threshold Point Encryption</a></h2>
+  <p>
+    <code>fedimint-tpe</code> — committed Diffie–Hellman encryption of a Lightning preimage
+    to the federation. Covers the ephemeral-key encryption, the embedded BLS signature that
+    binds the ciphertext to a contract commitment, and threshold decryption via
+    Lagrange-in-the-exponent.
+  </p>
+</div>
+
+<div class="card">
+  <h2><a href="./dkg.html">Distributed Key Generation</a></h2>
+  <p>
+    <code>fedimint-server</code> — the dealer-free Pedersen DKG ceremony that sets up a
+    federation's threshold keys at creation time, producing exactly the Shamir-shared key
+    the two schemes above assume. Covers the Feldman commitments, the hash-commit and
+    share-verification rounds, and what the ceremony outputs.
+  </p>
+</div>
+
+<footer>
+Part of the <a href="../index.html">Fedimint technical reference</a>, generated from the
+<code>fedimint/fedimint</code> source tree.
+</footer>
+
+</body>
+</html>

--- a/docs/crypto/tbs.html
+++ b/docs/crypto/tbs.html
@@ -1,0 +1,269 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Threshold Blind Signatures — fedimint-tbs</title>
+<script>
+MathJax = { tex: { inlineMath: [['$', '$'], ['\\(', '\\)']] } };
+</script>
+<script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" async></script>
+<style>
+  body {
+    font-family: -apple-system, "Segoe UI", Helvetica, Arial, sans-serif;
+    max-width: 880px;
+    margin: 0 auto;
+    padding: 2rem 1.5rem 6rem;
+    color: #1c1e21;
+    line-height: 1.6;
+  }
+  h1 { font-size: 1.9rem; border-bottom: 2px solid #e0e0e0; padding-bottom: .4rem; }
+  h2 { font-size: 1.4rem; margin-top: 2.4rem; border-bottom: 1px solid #ececec; padding-bottom: .3rem; }
+  h3 { font-size: 1.1rem; margin-top: 1.8rem; }
+  code { background: #f4f4f6; padding: .1em .35em; border-radius: 4px; font-size: .9em; }
+  .box {
+    background: #f8f9fb;
+    border: 1px solid #e3e6ea;
+    border-left: 4px solid #4a6fa5;
+    border-radius: 6px;
+    padding: .8rem 1.2rem;
+    margin: 1.2rem 0;
+  }
+  .warn { border-left-color: #c0883a; background: #fbf7f0; }
+  .role { color: #4a6fa5; font-weight: 600; }
+  .nav { font-size: .9rem; margin-bottom: 1.5rem; }
+  .nav a { color: #4a6fa5; text-decoration: none; }
+  table { border-collapse: collapse; margin: 1rem 0; }
+  td, th { border: 1px solid #ddd; padding: .4rem .8rem; text-align: left; }
+  th { background: #f4f4f6; }
+  footer { margin-top: 3rem; color: #888; font-size: .85rem; }
+</style>
+</head>
+<body>
+
+<div class="nav"><a href="./index.html">← Cryptographic schemes</a></div>
+
+<h1>Threshold Blind Signatures</h1>
+<p>
+This page describes the cryptographic scheme implemented in <code>fedimint-tbs</code>:
+an ad-hoc <strong>threshold blind signature</strong> built from
+<strong>BLS signatures</strong> over the pairing-friendly curve BLS12-381. It is the
+primitive behind Fedimint's <strong>Chaumian e-cash</strong>: the federation blindly
+signs a note so that no guardian learns which note it signed, yet any later holder can
+verify the note against a single aggregate public key.
+</p>
+<p>
+Sections 1–3 present the scheme with a <em>single</em> signer; Section 5 then replaces
+the signer by a $t$-of-$n$ federation of guardians — a standard transformation that
+exploits only the linearity of signing in the secret key.
+</p>
+<div class="box">
+<strong>Where this is used.</strong>
+This is the signature on Chaumian e-cash notes in Fedimint's mint module. A note is a pair
+$(\mathit{nonce}, \sigma)$, where the message $m = \mathsf{H}_{\mathbb{G}_1}(\mathit{nonce})$
+is signed blindly at issuance and $\sigma$ is checked at redemption, with the federation
+marking each nonce spent to prevent double-spending. Crucially, a note's <em>amount is not a
+signed attribute</em>: the mint holds a separate keypair per denomination tier — a distinct
+key generation per tier — so the value of a note is fixed by <em>which</em> aggregate key
+verifies it. This is the point of departure from an attribute-based credential scheme, in
+which the amount would instead be a hidden message inside a single signature.
+</div>
+
+<h2>1. Setting and notation</h2>
+<p>
+Throughout, $K := \mathbb{Z}/p\mathbb{Z}$ denotes the field of integers modulo the
+prime $p$, and $K^n$ the $K$-vector space of (column) vectors of length $n$.
+</p>
+<p>
+Let $\mathbb{G}_1, \mathbb{G}_2, \mathbb{G}_T$ be the BLS12-381 pairing groups, all of
+order $p$ and written additively, with fixed generators $g_1 \in \mathbb{G}_1$,
+$g_2 \in \mathbb{G}_2$, and let
+$e : \mathbb{G}_1 \times \mathbb{G}_2 \to \mathbb{G}_T$ be the pairing, a nondegenerate
+$K$-bilinear map. Messages and signatures live in $\mathbb{G}_1$; keys live in $\mathbb{G}_2$.
+</p>
+<div class="box">
+<strong>Groups as vector spaces.</strong>
+Since $|\mathbb{G}_i| = p$ is prime, scalar multiplication
+$K \times \mathbb{G}_i \to \mathbb{G}_i$, $(\lambda, v) \mapsto \lambda\, v$ is
+well defined and makes each $\mathbb{G}_i$ a one-dimensional $K$-vector space; every
+nonzero element is a basis. Consequently the group homomorphisms appearing below are
+exactly the <em>$K$-linear maps</em> between these spaces, and the whole scheme can be
+read in the language of linear algebra.
+</div>
+<p>
+A note is identified by a message point obtained by hashing arbitrary bytes into the
+curve, $\mathsf{H}_{\mathbb{G}_1} : \{0,1\}^* \to \mathbb{G}_1$, modeled as a random
+oracle:
+</p>
+<p>
+$$m \;=\; \mathsf{H}_{\mathbb{G}_1}(\mathit{data}) \;\in\; \mathbb{G}_1.$$
+</p>
+<p>
+Because $\mathsf{H}_{\mathbb{G}_1}$ is a random oracle, no party knows the discrete
+logarithm of $m$ with respect to $g_1$, so a signature on $m$ cannot be produced by the
+holder alone.
+</p>
+
+<h2>2. Keys and the underlying signature</h2>
+<p>
+The <span class="role">signer</span>'s secret key is a single scalar $x \in K$, and the
+public key publishes it in $\mathbb{G}_2$:
+</p>
+<p>
+$$\mathsf{sk} = x \in K, \qquad \mathsf{pk} = x\, g_2 \in \mathbb{G}_2.$$
+</p>
+<div class="box">
+<strong>Underlying primitive — BLS.</strong>
+A BLS signature on a message point $m \in \mathbb{G}_1$ is
+$$\sigma = x\, m \;\in\; \mathbb{G}_1,$$
+verified by the single pairing equation
+$$e(m,\; \mathsf{pk}) \;=\; e(\sigma,\; g_2),$$
+which holds because $e(m, x\,g_2) = e(m,g_2)^x = e(x\,m, g_2)$ by bilinearity. Signing is
+the $K$-linear map $x \mapsto x\,m$ in the key — the single fact that makes both
+<em>blinding</em> (§3) and <em>thresholdizing</em> (§5) work.
+</div>
+
+<h2>3. Blind signing</h2>
+<p>
+To have a note signed without revealing it, the <span class="role">user</span> samples a
+blinding key $r \stackrel{\$}{\leftarrow} K \setminus \{0\}$ and sends the blinded
+message
+</p>
+<p>
+$$\bar{m} \;=\; r\, m \;\in\; \mathbb{G}_1.$$
+</p>
+<p>The <span class="role">signer</span> applies its key and returns the blinded signature</p>
+<p>
+$$\bar{\sigma} \;=\; x\, \bar{m} \;=\; r\,(x\,m) \;\in\; \mathbb{G}_1.$$
+</p>
+<p>
+The user verifies the response against the public key,
+$e(\bar{m}, \mathsf{pk}) = e(\bar{\sigma}, g_2)$, and removes the blinding by dividing out
+$r$ in the exponent:
+</p>
+<p>
+$$\sigma \;=\; r^{-1}\, \bar{\sigma} \;=\; x\, m,$$
+</p>
+<p>
+a plain BLS signature on $m$ that verifies under $\mathsf{pk}$ via the equation of §2.
+</p>
+<div class="box">
+<strong>Why blinding hides the note.</strong>
+Multiplication by a uniformly random nonzero scalar is a bijection of
+$\mathbb{G}_1 \setminus \{0\}$, so $\bar{m} = r\,m$ is uniformly distributed and carries
+no information about $m$. The signer's entire view $(\bar{m}, \bar{\sigma})$ is therefore
+statistically independent of which note is being signed: blindness is
+<em>perfect</em>, not merely computational.
+</div>
+
+<h2>4. Security properties (informal)</h2>
+<ul>
+  <li><strong>Unforgeability</strong> — from the unforgeability of BLS signatures: in the
+      random-oracle model, producing $x\,m$ for a fresh hash point $m$ without the key is
+      the (chosen-target) co-CDH problem on BLS12-381. A user who interacts with the signer
+      $k$ times cannot derive signatures on more than $k$ distinct notes (one-more
+      unforgeability).</li>
+  <li><strong>Blindness</strong> — the signer sees only the re-randomized point $\bar{m}$,
+      which is uniform and independent of $m$ (§3); it cannot link a later-shown note to
+      any signing interaction.</li>
+  <li><strong>Public verifiability</strong> — anyone holding $\mathsf{pk}$ (or the
+      aggregate key of §5) checks a note with one pairing equation; there is no interaction
+      and no secret involved in verification.</li>
+</ul>
+
+<h2>5. The threshold construction</h2>
+<p>
+Nothing above requires a single signer. Because signing
+$$\bar{\sigma} \;=\; x\, \bar{m}$$
+is <em>$K$-linear in the secret key</em> $x$, the signer can be replaced by a
+$t$-of-$n$ federation via Shamir secret sharing plus Lagrange interpolation
+<em>in the exponent</em> — the textbook threshold-BLS construction.
+</p>
+
+<h3>5.1 Key sharing</h3>
+<p>
+The key $x$ is Shamir-shared: pick a random polynomial $f \in K[X]$ of degree at most
+$t-1$ with $f(0) = x$, and give <span class="role">guardian</span>
+$i \in \{1, \dots, n\}$ the key share and public key share
+$$\mathsf{sk}_i = f(i) \in K, \qquad \mathsf{pk}_i = f(i)\, g_2 \in \mathbb{G}_2.$$
+The aggregate public key is unchanged: $\mathsf{pk} = f(0)\, g_2 = x\, g_2$.
+(Evaluation points are the indices $i = \texttt{peer} + 1$, since the point $0$ is
+reserved for the secret itself.) In a real federation this sharing is set up without a
+trusted dealer by a <a href="./dkg.html">distributed key generation</a>.
+</p>
+
+<h3>5.2 Share signing and aggregation</h3>
+<p>
+Each guardian signs the blinded message with its own share,
+$$\bar{\sigma}_i \;=\; f(i)\, \bar{m},$$
+and the user verifies each share independently against $\mathsf{pk}_i$ by the pairing
+equation $e(\bar{m}, \mathsf{pk}_i) = e(\bar{\sigma}_i, g_2)$ — so a misbehaving guardian
+is identified immediately and its share discarded. Any set $S$ of $t$ valid shares then
+interpolates to the federation signature. Write $\lambda_i^S$ for the Lagrange coefficients
+that reconstruct a degree-$(t-1)$ polynomial at the point $0$:
+$$\lambda_i^S \;=\; \prod_{\substack{j \in S \\ j \neq i}} \frac{j}{\,j - i\,},
+\qquad\text{so that}\qquad
+\sum_{i \in S} \lambda_i^S\, f(i) \;=\; f(0) \;=\; x
+\quad\text{for every } f \text{ with } \deg f \le t-1.$$
+</p>
+<p>
+The aggregation is this same combination carried out <em>in the exponent</em>. It lands on
+the single-signer signature because scalar multiplication
+$K \times \mathbb{G}_1 \to \mathbb{G}_1$, $(\lambda, v) \mapsto \lambda\,v$, is
+<strong>bilinear</strong> — in particular linear in its scalar argument — so it commutes
+with the Lagrange sum, letting the interpolation run on the group element $\bar{m}$ rather
+than on the field values $f(i)$:
+$$\begin{aligned}
+\bar{\sigma}
+&\;=\; \sum_{i \in S} \lambda_i^S\, \bar{\sigma}_i
+  && \text{(combine the shares)} \\[2pt]
+&\;=\; \sum_{i \in S} \lambda_i^S\, \bigl(f(i)\, \bar{m}\bigr)
+  && \text{(each share is } \bar{\sigma}_i = f(i)\,\bar{m}) \\[2pt]
+&\;=\; \Bigl(\sum_{i \in S} \lambda_i^S\, f(i)\Bigr) \bar{m}
+  && \text{(linearity in the scalar argument)} \\[2pt]
+&\;=\; f(0)\, \bar{m}
+  && \text{(Lagrange interpolation at } 0) \\[2pt]
+&\;=\; x\, \bar{m}.
+  && (f(0) = x)
+\end{aligned}$$
+The middle equality is the crux: pulling the coefficients $\lambda_i^S$ out through the
+scalar multiplication is exactly the bilinear map commuting with the interpolation, and it
+turns $t$ independent group elements back into the evaluation of the joint key polynomial at
+the secret point $0$. (For a $1$-of-$1$ federation the single share is already the aggregate
+and no interpolation is needed.)
+</p>
+<p>
+The user then unblinds as in §3, $\sigma = r^{-1}\bar{\sigma} = x\,m$, and the result
+verifies against the aggregate public key $\mathsf{pk}$ — identical to the single-signer
+scheme. Fewer than $t$ guardians learn nothing about $x$ and cannot assemble a valid
+combination.
+</p>
+<div class="box">
+<strong>Aggregating public keys.</strong>
+The same Lagrange-at-$0$ formula recombines public key shares
+$\mathsf{pk}_i = f(i)\,g_2$ into the aggregate $\mathsf{pk} = f(0)\,g_2$. The library
+exposes this as <code>aggregate_public_key_shares</code>, though the aggregate is more
+directly obtained by evaluating the DKG polynomial at $0$ during setup.
+</div>
+
+<div class="box warn">
+<strong>Implementation caveat (prototype).</strong>
+Hash-to-group is implemented by seeding a ChaCha RNG with SHA-256 rather than a
+standard <code>hash_to_curve</code> ciphersuite — fine as a random oracle into the group,
+but non-interoperable with other BLS implementations.
+</div>
+
+<h2>References</h2>
+<ul>
+  <li>D. Boneh, B. Lynn, H. Shacham. <em>Short Signatures from the Weil Pairing.</em> ASIACRYPT 2001.</li>
+  <li>A. Boldyreva. <em>Threshold Signatures, Multisignatures and Blind Signatures Based on the Gap-Diffie-Hellman-Group Signature Scheme.</em> PKC 2003.</li>
+  <li>A. Shamir. <em>How to Share a Secret.</em> Communications of the ACM, 1979.</li>
+</ul>
+
+<footer>
+Generated from <code>fedimint-tbs</code> — sources: <code>crypto/tbs/src/lib.rs</code>,
+<code>crypto/tbs/src/tests.rs</code>. Part of the
+<a href="./index.html">Fedimint cryptographic schemes</a>.
+</footer>
+
+</body>
+</html>

--- a/docs/crypto/tpe.html
+++ b/docs/crypto/tpe.html
@@ -1,0 +1,276 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Threshold Point Encryption — fedimint-tpe</title>
+<script>
+MathJax = { tex: { inlineMath: [['$', '$'], ['\\(', '\\)']] } };
+</script>
+<script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" async></script>
+<style>
+  body {
+    font-family: -apple-system, "Segoe UI", Helvetica, Arial, sans-serif;
+    max-width: 880px;
+    margin: 0 auto;
+    padding: 2rem 1.5rem 6rem;
+    color: #1c1e21;
+    line-height: 1.6;
+  }
+  h1 { font-size: 1.9rem; border-bottom: 2px solid #e0e0e0; padding-bottom: .4rem; }
+  h2 { font-size: 1.4rem; margin-top: 2.4rem; border-bottom: 1px solid #ececec; padding-bottom: .3rem; }
+  h3 { font-size: 1.1rem; margin-top: 1.8rem; }
+  code { background: #f4f4f6; padding: .1em .35em; border-radius: 4px; font-size: .9em; }
+  .box {
+    background: #f8f9fb;
+    border: 1px solid #e3e6ea;
+    border-left: 4px solid #4a6fa5;
+    border-radius: 6px;
+    padding: .8rem 1.2rem;
+    margin: 1.2rem 0;
+  }
+  .warn { border-left-color: #c0883a; background: #fbf7f0; }
+  .role { color: #4a6fa5; font-weight: 600; }
+  .nav { font-size: .9rem; margin-bottom: 1.5rem; }
+  .nav a { color: #4a6fa5; text-decoration: none; }
+  table { border-collapse: collapse; margin: 1rem 0; }
+  td, th { border: 1px solid #ddd; padding: .4rem .8rem; text-align: left; }
+  th { background: #f4f4f6; }
+  footer { margin-top: 3rem; color: #888; font-size: .85rem; }
+</style>
+</head>
+<body>
+
+<div class="nav"><a href="./index.html">← Cryptographic schemes</a></div>
+
+<h1>Threshold Point Encryption</h1>
+<p>
+This page describes the cryptographic scheme implemented in <code>fedimint-tpe</code>:
+an encryption of a 32-byte secret to a keyholder, built from a pairing-based
+<strong>committed Diffie–Hellman</strong> construction over BLS12-381. It is used by the
+<strong>Lightning v2 module</strong> to encrypt a payment <em>preimage</em> to the
+federation, bound to a contract commitment, so that the secret can be recovered once the
+contract's conditions are met.
+</p>
+<p>
+Sections 1–5 present the complete scheme with a <em>single</em> keyholder; Section 6 then
+replaces the keyholder by a $t$-of-$n$ federation of guardians — a standard transformation
+that exploits only the linearity of the decryption operation in the secret key, and is the
+same threshold backbone as the <a href="./tbs.html">blind signature scheme</a>. Throughout,
+the encryptor and the keyholder play the two sides of a Diffie–Hellman exchange: the same
+shared secret is computed by the encryptor from its ephemeral key and the keyholder's public
+key, and by the keyholder from its secret key and the ephemeral public key.
+</p>
+<div class="box">
+<strong>Where this is used.</strong>
+This encrypts the Lightning preimage in Fedimint's lnv2 module. The binding commitment
+$\mathit{cm}$ is the payment hash of the contract, so a ciphertext is cryptographically tied
+to the specific contract it pays. The federation produces decryption shares — and thereby
+reveals the preimage — only once the contract's spend conditions are satisfied, which is what
+lets a Lightning payment settle atomically against the on-ledger contract.
+</div>
+
+<h2>1. Setting and notation</h2>
+<p>
+$K := \mathbb{Z}/p\mathbb{Z}$ is the field of integers modulo the prime $p$. Let
+$\mathbb{G}_1, \mathbb{G}_2, \mathbb{G}_T$ be the BLS12-381 pairing groups of order $p$,
+written additively, with generators $g_1 \in \mathbb{G}_1$, $g_2 \in \mathbb{G}_2$ and
+nondegenerate $K$-bilinear pairing $e : \mathbb{G}_1 \times \mathbb{G}_2 \to \mathbb{G}_T$.
+Keys and the ephemeral public key live in $\mathbb{G}_1$; hashed messages and signatures
+live in $\mathbb{G}_2$.
+</p>
+<div class="box">
+<strong>Groups as vector spaces.</strong>
+Because $|\mathbb{G}_i| = p$ is prime, each $\mathbb{G}_i$ is a one-dimensional
+$K$-vector space under scalar multiplication, and the maps below are $K$-linear. The
+single fact driving the construction is bilinearity of $e$: it lets anyone check ciphertext
+well-formedness with a pairing equation, and (in §6) lets a federation recombine a
+Diffie–Hellman secret across key shares.
+</div>
+<p>The plaintext and the binding value are:</p>
+<table>
+  <tr><th>Value</th><th>Meaning</th></tr>
+  <tr><td>$\mathit{preimage} \in \{0,1\}^{256}$</td><td>the 32-byte secret to be encrypted (a Lightning preimage)</td></tr>
+  <tr><td>$\mathit{cm}$</td><td>a SHA-256 <em>commitment</em> the ciphertext is bound to (the contract / payment hash)</td></tr>
+</table>
+<p>
+A hash $\mathsf{H}_{\mathbb{G}_2} : \{0,1\}^* \to \mathbb{G}_2$ maps bytes into the second
+group, modeled as a random oracle.
+</p>
+
+<h2>2. Keys and encryption</h2>
+<p>
+The <span class="role">keyholder</span>'s secret key is a scalar $x \in K$ with public key
+in $\mathbb{G}_1$:
+$$\mathsf{sk} = x \in K, \qquad \mathsf{pk} = x\, g_1 \in \mathbb{G}_1.$$
+</p>
+<p>
+To encrypt under $\mathsf{pk}$ and bind to commitment $\mathit{cm}$, the
+<span class="role">encryptor</span> derives an ephemeral scalar $\eta \in K$ from a
+32-byte encryption seed and forms:
+</p>
+<p>
+$$\begin{aligned}
+E &= \eta\, g_1 \in \mathbb{G}_1
+  && \text{(ephemeral public key)} \\[2pt]
+D &= \eta\, \mathsf{pk} = \eta x\, g_1 \in \mathbb{G}_1
+  && \text{(Diffie–Hellman shared secret)} \\[2pt]
+\mathit{ct} &= \mathit{preimage} \,\oplus\, \mathsf{SHA256}(D)
+  && \text{(one-time-pad encryption)} \\[2pt]
+M &= \mathsf{H}_{\mathbb{G}_2}(\mathit{ct} \,\|\, E \,\|\, \mathit{cm}) \in \mathbb{G}_2
+  && \text{(message point binding } \mathit{ct}, E, \mathit{cm}) \\[2pt]
+S &= \eta\, M \in \mathbb{G}_2
+  && \text{(ephemeral BLS signature)}
+\end{aligned}$$
+</p>
+<p>
+The ciphertext is the triple $(\mathit{ct}, E, S)$. The shared secret $D$ is the ECDH
+point of the ephemeral key $\eta$ and the keyholder's key $x$; its hash is used as a
+one-time pad over the preimage.
+</p>
+<div class="box">
+<strong>Why the embedded signature?</strong>
+$S = \eta\, M$ is a BLS signature under the ephemeral key $E$ on the message point
+$M = \mathsf{H}_{\mathbb{G}_2}(\mathit{ct} \,\|\, E \,\|\, \mathit{cm})$, which itself hashes
+the full ciphertext together with the commitment. It makes the ciphertext
+<em>non-malleable</em> and <em>publicly checkable</em>: nobody can alter $\mathit{ct}$, $E$,
+or the bound commitment without invalidating $S$, so the keyholder can safely decrypt only
+well-formed ciphertexts tied to the intended contract.
+</div>
+
+<h2>3. Ciphertext validity</h2>
+<p>
+Anyone can check that a ciphertext is well formed, against its commitment, with a single
+pairing equation:
+$$e(g_1,\; S) \;\stackrel{?}{=}\; e(E,\; M), \qquad M = \mathsf{H}_{\mathbb{G}_2}(\mathit{ct} \,\|\, E \,\|\, \mathit{cm}).$$
+This holds for an honest ciphertext because, by bilinearity,
+$$e(g_1,\; \eta M) = e(g_1, M)^{\eta} = e(\eta g_1,\; M) = e(E,\; M).$$
+A passing check certifies that $S$ is the ephemeral key's signature on the exact bytes of
+$(\mathit{ct}, E, \mathit{cm})$ — i.e. that $S = \eta M$ for the same $\eta$ as
+$E = \eta g_1$.
+</p>
+
+<h2>4. Decryption</h2>
+<p>
+The <span class="role">keyholder</span> recovers the shared secret from the <em>other</em>
+side of the Diffie–Hellman exchange. Where the encryptor formed $D = \eta\,\mathsf{pk}$ from
+the ephemeral scalar and the public key, the keyholder applies its secret key to the
+ephemeral public key:
+$$D \;=\; x\, E \;=\; x\,\eta\, g_1 \;=\; \eta\,(x\, g_1) \;=\; \eta\,\mathsf{pk},$$
+the very same group element. The preimage is then unmasked with the one-time pad:
+$$\mathit{preimage} \;=\; \mathit{ct} \,\oplus\, \mathsf{SHA256}(D).$$
+</p>
+<div class="box">
+<strong>The two sides of the exchange.</strong>
+Scalar multiplication commutes, $x\,(\eta g_1) = \eta\,(x g_1)$, so the encryptor (who knows
+$\eta$ and $\mathsf{pk}$) and the keyholder (who knows $x$ and $E$) arrive at the identical
+point $D = \eta x\, g_1$ without either learning the other's scalar. This is plain ElGamal /
+ECDH decryption; §6 performs exactly this step without ever assembling $x$.
+</div>
+
+<h2>5. Security properties (informal)</h2>
+<ul>
+  <li><strong>Confidentiality</strong> — recovering $D = \eta x\, g_1$ from the public
+      $E = \eta g_1$ and $\mathsf{pk} = x g_1$ is the computational Diffie–Hellman problem
+      in $\mathbb{G}_1$. Modeling $\mathsf{SHA256}$ as a random oracle, the one-time pad
+      $\mathit{ct} = \mathit{preimage} \oplus \mathsf{SHA256}(D)$ hides the preimage under
+      the hashed-DH assumption.</li>
+  <li><strong>Ciphertext integrity / non-malleability</strong> — the embedded BLS
+      signature $S = \eta M$, with $M$ hashing $(\mathit{ct}, E, \mathit{cm})$, is publicly
+      verifiable (§3); any tampering with the ciphertext or its bound commitment breaks the
+      pairing check, so a mauled or re-bound ciphertext is never decrypted.</li>
+</ul>
+
+<h2>6. The threshold construction</h2>
+<p>
+Nothing above requires a single keyholder. Because decryption
+$$D \;=\; x\, E$$
+is <em>$K$-linear in the secret key</em> $x$, the keyholder can be replaced by a
+$t$-of-$n$ federation via Shamir secret sharing plus Lagrange interpolation
+<em>in the exponent</em> — the same construction that thresholdizes
+<a href="./tbs.html">BLS signing</a>. Encryption (§2) and the validity check (§3) are
+unchanged; only the recovery of $D$ is distributed.
+</p>
+
+<h3>6.1 Key sharing</h3>
+<p>
+The key $x$ is Shamir-shared: pick a random polynomial $f \in K[X]$ of degree at most
+$t-1$ with $f(0) = x$, and give <span class="role">guardian</span>
+$i \in \{1, \dots, n\}$ the key share and public key share
+$$\mathsf{sk}_i = f(i) \in K, \qquad \mathsf{pk}_i = f(i)\, g_1 \in \mathbb{G}_1.$$
+The aggregate public key is unchanged: $\mathsf{pk} = f(0)\, g_1 = x\, g_1$. Evaluation
+points are the indices $i = \texttt{peer} + 1$, since the point $0$ is reserved for the
+secret. In a real federation this sharing is set up without a trusted dealer by a
+<a href="./dkg.html">distributed key generation</a>.
+</p>
+
+<h3>6.2 Decryption shares and aggregation</h3>
+<p>
+Each guardian applies its share to the ephemeral public key, producing a
+<em>decryption-key share</em>
+$$D_i \;=\; f(i)\, E \;\in\; \mathbb{G}_1,$$
+which the requester verifies independently (on a ciphertext already known to be valid, §3)
+by the pairing equation
+$$e(D_i,\; M) \;\stackrel{?}{=}\; e(\mathsf{pk}_i,\; S),$$
+both sides being $e(g_1, M)^{f(i)\,\eta}$: the left is $e(f(i)\eta g_1, M)$ and the right is
+$e(f(i) g_1,\, \eta M)$. So a misbehaving guardian is identified immediately and its share
+discarded.
+</p>
+<p>
+Any set $S$ of $t$ valid shares then interpolates to the shared secret. With the Lagrange
+coefficients $\lambda_i^S$ that reconstruct a degree-$(t-1)$ polynomial at the point $0$,
+$$\lambda_i^S \;=\; \prod_{\substack{j \in S \\ j \neq i}} \frac{j}{\,j - i\,},
+\qquad
+\sum_{i \in S} \lambda_i^S\, f(i) \;=\; f(0) \;=\; x,$$
+the recombination is a Lagrange combination <em>in the exponent</em>. As with signing, it
+lands on the single-keyholder secret because scalar multiplication
+$K \times \mathbb{G}_1 \to \mathbb{G}_1$ is bilinear, hence linear in its scalar argument, so
+it commutes with the Lagrange sum:
+$$\begin{aligned}
+D
+&\;=\; \sum_{i \in S} \lambda_i^S\, D_i
+  && \text{(combine the shares)} \\[2pt]
+&\;=\; \sum_{i \in S} \lambda_i^S\, \bigl(f(i)\, E\bigr)
+  && \text{(each share is } D_i = f(i)\,E) \\[2pt]
+&\;=\; \Bigl(\sum_{i \in S} \lambda_i^S\, f(i)\Bigr) E
+  && \text{(linearity in the scalar argument)} \\[2pt]
+&\;=\; f(0)\, E
+  && \text{(Lagrange interpolation at } 0) \\[2pt]
+&\;=\; x\, E \;=\; \eta\,\mathsf{pk},
+  && (f(0) = x)
+\end{aligned}$$
+which is exactly the shared secret of §4, so the preimage is unmasked as before,
+$\mathit{preimage} = \mathit{ct} \oplus \mathsf{SHA256}(D)$. Fewer than $t$ guardians learn
+nothing about $x$ and cannot assemble $D$.
+</p>
+<div class="box">
+<strong>Verifying the recombined key.</strong>
+The aggregate $D$ can itself be checked against the public key without decrypting, by
+$$e(D,\; M) \;\stackrel{?}{=}\; e(\mathsf{pk},\; S),$$
+again both sides being $e(g_1, M)^{x\eta}$. This certifies that $D$ is the correct ECDH
+point $\eta\,\mathsf{pk}$ before it is used to unmask the preimage.
+</div>
+
+<div class="box warn">
+<strong>Implementation caveat (prototype).</strong>
+Hash-to-group is implemented by seeding a ChaCha RNG with SHA-256 rather than a standard
+<code>hash_to_curve</code> ciphersuite — fine as a random oracle into the group, but
+non-interoperable. Note also that the share- and aggregate-verification routines
+<em>assert</em> ciphertext validity internally and will panic on a malformed ciphertext, so
+callers must run the ciphertext check of §3 first.
+</div>
+
+<h2>References</h2>
+<ul>
+  <li>T. ElGamal. <em>A Public-Key Cryptosystem and a Signature Scheme Based on Discrete Logarithms.</em> CRYPTO 1984.</li>
+  <li>D. Boneh, B. Lynn, H. Shacham. <em>Short Signatures from the Weil Pairing.</em> ASIACRYPT 2001.</li>
+  <li>A. Shamir. <em>How to Share a Secret.</em> Communications of the ACM, 1979.</li>
+</ul>
+
+<footer>
+Generated from <code>fedimint-tpe</code> — sources: <code>crypto/tpe/src/lib.rs</code>,
+<code>crypto/tpe/src/tests.rs</code>. Part of the
+<a href="./index.html">Fedimint cryptographic schemes</a>.
+</footer>
+
+</body>
+</html>

--- a/docs/rustdoc-index.md
+++ b/docs/rustdoc-index.md
@@ -61,6 +61,16 @@ You might consider viewing the following top-level crates:
 * [fedimint_dbtool](./fedimint_dbtool/index.html) implements a helpful database helper tool.
 * [recoverytool](./recoverytool/index.html) implements an on chain multisig recovery tool for defunct/test Federations.
 
+# Cryptographic schemes
+
+Self-contained write-ups of the pairing-based cryptography used inside Fedimint, derived
+directly from the implementing crates:
+
+* [Cryptographic schemes overview](./crypto/index.html)
+* [Threshold Blind Signatures](./crypto/tbs.html) — the blind BLS signature behind Chaumian e-cash ([`fedimint-tbs`](./tbs/index.html)).
+* [Threshold Point Encryption](./crypto/tpe.html) — committed Diffie–Hellman encryption of Lightning preimages to the federation ([`fedimint-tpe`](./tpe/index.html)).
+* [Distributed Key Generation](./crypto/dkg.html) — the dealer-free Pedersen DKG that sets up a federation's threshold keys.
+
 # API documentation
 
 See [AI-generated API documentation](./api.md).

--- a/scripts/dev/build-docs.sh
+++ b/scripts/dev/build-docs.sh
@@ -5,7 +5,12 @@ set -euo pipefail
 source "./scripts/_common.sh"
 
 fm_index_md=${FM_RUSTDOC_INDEX_MD:-./docs/rustdoc-index.md}
-index_html="${CARGO_BUILD_TARGET_DIR:-target}/doc/index.html"
+doc_dir="${CARGO_BUILD_TARGET_DIR:-target}/doc"
+index_html="${doc_dir}/index.html"
+
+# Hand-written cryptographic scheme write-ups, published alongside the rustdoc
+# output at https://docs.fedimint.org/crypto/ and linked from the index page.
+crypto_src="./docs/crypto"
 
 export RUSTDOCFLAGS='-D rustdoc::broken_intra_doc_links -D warnings -A unknown-lints'
 if cargo version | grep -q nightly ; then
@@ -16,6 +21,12 @@ fi
 echo RUSTDOCFLAGS: "$RUSTDOCFLAGS"
 
 cargo doc --exclude fedimint-fuzz --profile "$CARGO_PROFILE" --locked --workspace --no-deps --document-private-items
+
+# Publish the static crypto write-ups under <doc>/crypto/.
+if [ -d "${crypto_src}" ]; then
+  mkdir -p "${doc_dir}/crypto"
+  cp -a "${crypto_src}"/*.html "${doc_dir}/crypto/"
+fi
 
 if [ -e "${index_html}" ]; then
   if command -v pandoc >/dev/null 2>/dev/null ; then


### PR DESCRIPTION
## Summary

Adds self-contained, MathJax-rendered write-ups of the pairing-based cryptography used inside Fedimint — threshold blind signatures (`fedimint-tbs`), threshold point encryption (`fedimint-tpe`), and the distributed key generation (`fedimint-server`). They are published at https://docs.fedimint.org/crypto/ and linked from the docs landing page and the README.

## Details

- Each scheme is derived directly from its implementing crate and presented in the same linear-algebra-over-BLS12-381 style: the single-keyholder construction first, then the `t`-of-`n` threshold version via Shamir sharing + Lagrange interpolation in the exponent.
- **tbs** — the blind BLS signature behind Chaumian e-cash, including the full equation chain showing the bilinear scalar multiplication commuting with Lagrange interpolation. Notes that a note's amount is encoded by the per-denomination key, not as a signed attribute.
- **tpe** — committed Diffie–Hellman encryption of the lnv2 preimage, bound to the contract payment hash, then thresholdized.
- **dkg** — the dealer-free Pedersen / Joint-Feldman ceremony that produces the Shamir-shared keys the two schemes assume; honest about the honest-majority-with-abort model and the Gennaro et al. uniformity caveat.
- Hosting reuses the existing rustdoc pipeline with no new infra: `scripts/dev/build-docs.sh` copies `docs/crypto/*.html` into the published `target/doc/crypto/`, so the pages appear at `docs.fedimint.org/crypto/`. Linked from `docs/rustdoc-index.md` and `README.md`.

## Reviewing

- These are mathematical concept docs aimed at readers, not API docs. The math was derived from the source rather than an external spec, so a careful read for accuracy is the most useful review.
- The "implementation caveat" boxes flag the non-standard ChaCha-seeded hash-to-curve and (for tpe) the assert-on-invalid-ciphertext behavior — confirm those characterizations match intent.

## Testing

- Static HTML rendered with MathJax from CDN; open `docs/crypto/index.html` locally to view.
- Pages validated for well-formed/balanced markup; `build-docs.sh` copies them into the doc output during the docs build.
- `just final-lint` passes.