### PR TITLE
fix(bitcoind): configure esplora request timeouts

### DIFF
--- a/fedimint-bitcoind/src/lib.rs
+++ b/fedimint-bitcoind/src/lib.rs
@@ -26,6 +26,8 @@ use tracing::trace;
 
 use crate::metrics::{BITCOIND_RPC_DURATION_SECONDS, BITCOIND_RPC_REQUESTS_TOTAL};
 
+const ESPLORA_CLIENT_TIMEOUT_SECONDS: u64 = 60;
+
 #[cfg(feature = "bitcoincore")]
 pub mod bitcoincore;
 
@@ -190,10 +192,11 @@ pub struct EsploraClient {
 
 impl EsploraClient {
     pub fn new(url: &SafeUrl) -> anyhow::Result<Self> {
-        Ok(Self {
-            // URL needs to have any trailing path including '/' removed
-            client: Builder::new(url.as_str().trim_end_matches('/')).build_async()?,
-        })
+        let client = Builder::new(url.as_str().trim_end_matches('/'))
+            .timeout(ESPLORA_CLIENT_TIMEOUT_SECONDS)
+            .build_async()?;
+
+        Ok(Self { client })
     }
 }
 

--- a/fedimint-server-bitcoin-rpc/src/esplora.rs
+++ b/fedimint-server-bitcoin-rpc/src/esplora.rs
@@ -10,6 +10,7 @@ use fedimint_logging::LOG_SERVER;
 use fedimint_server_core::bitcoin_rpc::IServerBitcoinRpc;
 use tracing::info;
 
+const ESPLORA_CLIENT_TIMEOUT_SECONDS: u64 = 60;
 #[derive(Debug)]
 pub struct EsploraClient {
     client: esplora_client::AsyncClient,
@@ -27,7 +28,8 @@ impl EsploraClient {
         // URL needs to have any trailing path including '/' removed
         let without_trailing = url.as_str().trim_end_matches('/');
 
-        let builder = esplora_client::Builder::new(without_trailing);
+        let builder =
+            esplora_client::Builder::new(without_trailing).timeout(ESPLORA_CLIENT_TIMEOUT_SECONDS);
         let client = builder.build_async()?;
         Ok(Self {
             client,


### PR DESCRIPTION
*PR published by Tau*

### Summary

Configure Fedimint's Esplora-backed bitcoin RPC clients with a per-request timeout so stalled HTTP requests fail and existing retry/backoff logic can recover.

### Details

`esplora-client` supports an async timeout through `Builder::timeout`, but defaults to no timeout and therefore passes no overall request timeout to `reqwest`. This affected wallet recovery because an Esplora endpoint could accept a connection and then never respond, preventing the surrounding retry loop from running again.

This sets a 60 second timeout for both the client-side Esplora bitcoind wrapper and the server Esplora backend. I also checked the Bitcoin Core based backends: they use `bitcoincore-rpc`/`jsonrpc`'s simple HTTP transport, which already has a 15 second default socket timeout.

Fixes #8678.

### Testing

- `cargo check -q -p fedimint-bitcoind -p fedimint-server-bitcoin-rpc`
- `cargo clippy -q -p fedimint-bitcoind -p fedimint-server-bitcoin-rpc --all-targets -- -D warnings`
- `just final-lint`
