### PR TITLE
feat(ln): add manual receive reclaim

### DIFF
--- a/fedimint-client-module/src/module/mod.rs
+++ b/fedimint-client-module/src/module/mod.rs
@@ -26,7 +26,7 @@ use fedimint_core::{
 };
 use fedimint_eventlog::{Event, EventKind, EventPersistence};
 use fedimint_logging::LOG_CLIENT;
-use futures::Stream;
+use futures::{Stream, StreamExt};
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 use tracing::warn;
@@ -488,6 +488,61 @@ where
                 )
             })
             .collect()
+    }
+
+    /// Returns this module's currently active state machines for the operation.
+    pub async fn get_own_operation_active_states(
+        &self,
+        operation_id: OperationId,
+    ) -> Vec<(M::States, ActiveStateMeta)> {
+        let db = self.global_db();
+        let mut dbtx = db.begin_transaction_nc().await;
+
+        self.client
+            .get()
+            .read_operation_active_states(operation_id, self.module_instance_id, &mut dbtx)
+            .await
+            .map(|(key, meta)| {
+                (
+                    Clone::clone(
+                        key.state
+                            .as_any()
+                            .downcast_ref::<M::States>()
+                            .expect("incorrect output type passed to module plugin"),
+                    ),
+                    meta,
+                )
+            })
+            .collect()
+            .await
+    }
+
+    /// Returns this module's previously active state machines for the
+    /// operation.
+    pub async fn get_own_operation_inactive_states(
+        &self,
+        operation_id: OperationId,
+    ) -> Vec<(M::States, InactiveStateMeta)> {
+        let db = self.global_db();
+        let mut dbtx = db.begin_transaction_nc().await;
+
+        self.client
+            .get()
+            .read_operation_inactive_states(operation_id, self.module_instance_id, &mut dbtx)
+            .await
+            .map(|(key, meta)| {
+                (
+                    Clone::clone(
+                        key.state
+                            .as_any()
+                            .downcast_ref::<M::States>()
+                            .expect("incorrect output type passed to module plugin"),
+                    ),
+                    meta,
+                )
+            })
+            .collect()
+            .await
     }
 
     pub async fn get_config(&self) -> ClientConfig {

--- a/modules/fedimint-ln-client/src/db.rs
+++ b/modules/fedimint-ln-client/src/db.rs
@@ -32,6 +32,7 @@ pub enum DbKeyPrefix {
     MetaOverridesDeprecated = 0x30,
     LightningGateway = 0x45,
     RecurringPaymentKey = 0x46,
+    ReceiveReclaim = 0x47,
     /// Prefixes between 0xb0..=0xcf shall all be considered allocated for
     /// historical and future external use
     ExternalReservedStart = 0xb0,
@@ -120,6 +121,36 @@ impl_db_record!(
 impl_db_lookup!(
     key = RecurringPaymentCodeKey,
     query_prefix = RecurringPaymentCodeKeyPrefix
+);
+
+/// Maps an original lightning receive operation to its manual reclaim
+/// operation.
+#[derive(Debug, Encodable, Decodable, Serialize)]
+pub struct ReceiveReclaimKey {
+    /// Original lightning receive operation being reclaimed.
+    pub original_operation_id: OperationId,
+}
+
+/// Prefix for manual lightning receive reclaim operation mappings.
+#[derive(Debug, Encodable, Decodable, Serialize)]
+pub struct ReceiveReclaimKeyPrefix;
+
+/// Stores the reclaim operation created for an original lightning receive.
+#[derive(Debug, Encodable, Decodable, Serialize)]
+pub struct ReceiveReclaimOperation {
+    /// Operation id of the reclaim operation.
+    pub operation_id: OperationId,
+}
+
+impl_db_record!(
+    key = ReceiveReclaimKey,
+    value = ReceiveReclaimOperation,
+    db_prefix = DbKeyPrefix::ReceiveReclaim,
+);
+
+impl_db_lookup!(
+    key = ReceiveReclaimKey,
+    query_prefix = ReceiveReclaimKeyPrefix
 );
 
 /// Migrates `SubmittedOfferV0` to `SubmittedOffer` and `ConfirmedInvoiceV0` to

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -32,6 +32,7 @@ use bitcoin::Network;
 use bitcoin::hashes::{Hash, HashEngine, Hmac, HmacEngine, sha256};
 use db::{
     DbKeyPrefix, LightningGatewayKey, LightningGatewayKeyPrefix, PaymentResult, PaymentResultKey,
+    ReceiveReclaimKey, ReceiveReclaimKeyPrefix, ReceiveReclaimOperation,
     RecurringPaymentCodeKeyPrefix,
 };
 use fedimint_api_client::api::{DynModuleApi, ServerError};
@@ -40,7 +41,9 @@ use fedimint_client_module::module::init::{ClientModuleInit, ClientModuleInitArg
 use fedimint_client_module::module::recovery::NoModuleBackup;
 use fedimint_client_module::module::{ClientContext, ClientModule, IClientModule, OutPointRange};
 use fedimint_client_module::oplog::UpdateStreamOrOutcome;
-use fedimint_client_module::sm::{DynState, ModuleNotifier, State, StateTransition};
+use fedimint_client_module::sm::{
+    DynState, InactiveStateMeta, ModuleNotifier, State, StateTransition,
+};
 use fedimint_client_module::transaction::{
     ClientInput, ClientInputBundle, ClientOutput, ClientOutputBundle, ClientOutputSM,
     TransactionBuilder,
@@ -108,8 +111,8 @@ use crate::pay::{
     LightningPayStateMachine,
 };
 use crate::receive::{
-    LightningReceiveError, LightningReceiveStateMachine, LightningReceiveStates,
-    LightningReceiveSubmittedOffer, get_incoming_contract,
+    LightningReceiveConfirmedInvoice, LightningReceiveError, LightningReceiveStateMachine,
+    LightningReceiveStates, LightningReceiveSubmittedOffer, get_incoming_contract,
 };
 use crate::recurring::RecurringPaymentCodeEntry;
 
@@ -277,7 +280,8 @@ pub use deprecated_variant_hack::LightningOperationMetaVariant;
 #[allow(deprecated)]
 mod deprecated_variant_hack {
     use super::{
-        Bolt11Invoice, Deserialize, LightningOperationMetaPay, OutPoint, Serialize, secp256k1,
+        Bolt11Invoice, Deserialize, LightningOperationMetaPay, OperationId, OutPoint, Serialize,
+        secp256k1,
     };
     use crate::recurring::ReurringPaymentReceiveMeta;
 
@@ -287,6 +291,11 @@ mod deprecated_variant_hack {
         Pay(LightningOperationMetaPay),
         Receive {
             out_point: OutPoint,
+            invoice: Bolt11Invoice,
+            gateway_id: Option<secp256k1::PublicKey>,
+        },
+        ReceiveReclaim {
+            original_operation_id: OperationId,
             invoice: Bolt11Invoice,
             gateway_id: Option<secp256k1::PublicKey>,
         },
@@ -354,6 +363,16 @@ impl ModuleInit for LightningClientInit {
                         RecurringPaymentCodeEntry,
                         ln_client_items,
                         "Recurring Payment Code"
+                    );
+                }
+                DbKeyPrefix::ReceiveReclaim => {
+                    push_db_pair_items!(
+                        dbtx,
+                        ReceiveReclaimKeyPrefix,
+                        ReceiveReclaimKey,
+                        ReceiveReclaimOperation,
+                        ln_client_items,
+                        "Receive Reclaim"
                     );
                 }
                 DbKeyPrefix::ExternalReservedStart
@@ -559,6 +578,13 @@ impl ClientModule for LightningClientModule {
                         yield serde_json::to_value(state)?;
                     }
                 }
+                "reclaim_ln_receive" => {
+                    let req: ReclaimLnReceiveRequest = serde_json::from_value(payload)?;
+                    let operation_id = self.reclaim_ln_receive(req.original_operation_id).await?;
+                    yield serde_json::json!({
+                        "operation_id": operation_id,
+                    });
+                }
                 "create_bolt11_invoice_for_user_tweaked" => {
                     let req: CreateBolt11InvoiceForUserTweakedRequest = serde_json::from_value(payload)?;
                     let (op, invoice, _) = self
@@ -652,6 +678,11 @@ struct SubscribeInternalPayRequest {
 #[derive(Deserialize)]
 struct SubscribeLnReceiveRequest {
     operation_id: OperationId,
+}
+
+#[derive(Deserialize)]
+struct ReclaimLnReceiveRequest {
+    original_operation_id: OperationId,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -1895,6 +1926,185 @@ impl LightningClientModule {
         Ok((operation_id, invoice, preimage))
     }
 
+    /// Starts a new state machine that retries claiming a previously paid
+    /// invoice.
+    ///
+    /// This is a local state-history recovery tool: it requires the client DB
+    /// to still contain a historical `SubmittedOffer` or `ConfirmedInvoice`
+    /// state for the original operation. It does not recover seed-only
+    /// restores where that local state-machine history is unavailable.
+    ///
+    /// Repeated calls for the same original receive return the existing reclaim
+    /// operation id while that reclaim is active or successful. If the previous
+    /// reclaim also ended in claim rejection, a new reclaim operation is
+    /// created so support can retry after the underlying issue is fixed.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the original operation is not a reclaimable
+    /// lightning receive, if it is still active, if it did not end in claim
+    /// rejection, or if the original receiving key cannot be recovered from
+    /// state history.
+    pub async fn reclaim_ln_receive(
+        &self,
+        original_operation_id: OperationId,
+    ) -> anyhow::Result<OperationId> {
+        let operation = self.client_ctx.get_operation(original_operation_id).await?;
+        let LightningOperationMeta {
+            variant,
+            extra_meta,
+        } = operation
+            .try_meta::<LightningOperationMeta>()
+            .context("Invalid lightning operation metadata")?;
+
+        let (invoice, gateway_id) = match variant {
+            LightningOperationMetaVariant::Receive {
+                invoice,
+                gateway_id,
+                ..
+            } => (invoice, gateway_id),
+            LightningOperationMetaVariant::RecurringPaymentReceive(meta) => (meta.invoice, None),
+            _ => bail!("Operation is not a reclaimable lightning receive"),
+        };
+
+        let active_states = self
+            .client_ctx
+            .get_own_operation_active_states(original_operation_id)
+            .await;
+        ensure!(
+            !active_states
+                .iter()
+                .any(|(state, _)| matches!(state, LightningClientStateMachines::Receive(_))),
+            "Cannot reclaim an active lightning receive"
+        );
+
+        let inactive_states = self
+            .client_ctx
+            .get_own_operation_inactive_states(original_operation_id)
+            .await;
+        ensure!(
+            Self::ln_receive_ended_claim_rejected(&inactive_states),
+            "Can only reclaim a lightning receive that ended with a rejected claim"
+        );
+
+        let receiving_key = inactive_states
+            .iter()
+            .find_map(|(state, _)| Self::ln_receive_key_from_state(state))
+            .ok_or_else(|| {
+                anyhow!("Cannot reclaim LN receive because the original receive key is unavailable")
+            })?;
+        let reclaim_key = ReceiveReclaimKey {
+            original_operation_id,
+        };
+        let db = self.client_ctx.module_db();
+        let mut dbtx = db.begin_transaction().await;
+        if let Some(existing_reclaim) = dbtx.get_value(&reclaim_key).await {
+            let needs_retry = self
+                .ln_receive_reclaim_needs_retry(existing_reclaim.operation_id)
+                .await;
+            if !needs_retry {
+                return Ok(existing_reclaim.operation_id);
+            }
+        }
+
+        let reclaim_operation_id = OperationId::new_random();
+        let operation_meta = LightningOperationMeta {
+            variant: LightningOperationMetaVariant::ReceiveReclaim {
+                original_operation_id,
+                invoice: invoice.clone(),
+                gateway_id,
+            },
+            extra_meta,
+        };
+        let state = LightningClientStateMachines::Receive(LightningReceiveStateMachine {
+            operation_id: reclaim_operation_id,
+            state: LightningReceiveStates::ConfirmedInvoice(LightningReceiveConfirmedInvoice {
+                invoice,
+                receiving_key,
+            }),
+        });
+
+        dbtx.insert_entry(
+            &reclaim_key,
+            &ReceiveReclaimOperation {
+                operation_id: reclaim_operation_id,
+            },
+        )
+        .await;
+        self.client_ctx
+            .manual_operation_start_dbtx(
+                &mut dbtx.to_ref_nc(),
+                reclaim_operation_id,
+                LightningCommonInit::KIND.as_str(),
+                operation_meta,
+                vec![self.client_ctx.make_dyn_state(state)],
+            )
+            .await?;
+
+        if dbtx.commit_tx_result().await.is_err() {
+            let mut dbtx = db.begin_transaction_nc().await;
+            if let Some(existing_reclaim) = dbtx.get_value(&reclaim_key).await {
+                return Ok(existing_reclaim.operation_id);
+            }
+
+            bail!(
+                "Concurrent LN receive reclaim conflicted before the reclaim operation was recorded"
+            );
+        }
+
+        Ok(reclaim_operation_id)
+    }
+
+    async fn ln_receive_reclaim_needs_retry(&self, operation_id: OperationId) -> bool {
+        let has_active_receive_state = self
+            .client_ctx
+            .get_own_operation_active_states(operation_id)
+            .await
+            .into_iter()
+            .any(|(state, _)| matches!(state, LightningClientStateMachines::Receive(_)));
+        if has_active_receive_state {
+            return false;
+        }
+
+        let inactive_states = self
+            .client_ctx
+            .get_own_operation_inactive_states(operation_id)
+            .await;
+        Self::ln_receive_ended_claim_rejected(&inactive_states)
+    }
+
+    fn ln_receive_ended_claim_rejected(
+        states: &[(LightningClientStateMachines, InactiveStateMeta)],
+    ) -> bool {
+        states.iter().any(|(state, _)| {
+            matches!(
+                state,
+                LightningClientStateMachines::Receive(LightningReceiveStateMachine {
+                    state: LightningReceiveStates::Canceled(LightningReceiveError::ClaimRejected),
+                    ..
+                })
+            )
+        })
+    }
+
+    fn ln_receive_key_from_state(state: &LightningClientStateMachines) -> Option<ReceivingKey> {
+        match state {
+            LightningClientStateMachines::Receive(receive) => match &receive.state {
+                LightningReceiveStates::SubmittedOffer(submitted_offer) => {
+                    Some(submitted_offer.receiving_key)
+                }
+                LightningReceiveStates::ConfirmedInvoice(confirmed_invoice) => {
+                    Some(confirmed_invoice.receiving_key)
+                }
+                LightningReceiveStates::Canceled(_)
+                | LightningReceiveStates::Funded(_)
+                | LightningReceiveStates::Success(_) => None,
+            },
+            LightningClientStateMachines::InternalPay(_)
+            | LightningClientStateMachines::LightningPay(_) => None,
+        }
+    }
+
     #[deprecated(since = "0.7.0", note = "Use recurring payment functionality instead")]
     #[allow(deprecated)]
     pub async fn subscribe_ln_claim(
@@ -1928,18 +2138,21 @@ impl LightningClientModule {
         operation_id: OperationId,
     ) -> anyhow::Result<UpdateStreamOrOutcome<LnReceiveState>> {
         let operation = self.client_ctx.get_operation(operation_id).await?;
-        let LightningOperationMetaVariant::Receive {
-            out_point, invoice, ..
-        } = operation.meta::<LightningOperationMeta>().variant
-        else {
-            bail!("Operation is not a lightning payment")
+        let (invoice, tx_accepted_future) = match operation.meta::<LightningOperationMeta>().variant
+        {
+            LightningOperationMetaVariant::Receive {
+                out_point, invoice, ..
+            } => {
+                let tx_accepted_future = self
+                    .client_ctx
+                    .transaction_updates(operation_id)
+                    .await
+                    .await_tx_accepted(out_point.txid);
+                (invoice, Some(tx_accepted_future))
+            }
+            LightningOperationMetaVariant::ReceiveReclaim { invoice, .. } => (invoice, None),
+            _ => bail!("Operation is not a lightning receive"),
         };
-
-        let tx_accepted_future = self
-            .client_ctx
-            .transaction_updates(operation_id)
-            .await
-            .await_tx_accepted(out_point.txid);
 
         let client_ctx = self.client_ctx.clone();
 
@@ -1950,7 +2163,11 @@ impl LightningClientModule {
 
                 yield LnReceiveState::Created;
 
-                if tx_accepted_future.await.is_err() {
+                let tx_rejected = match tx_accepted_future {
+                    Some(tx_accepted_future) => tx_accepted_future.await.is_err(),
+                    None => false,
+                };
+                if tx_rejected {
                     yield LnReceiveState::Canceled { reason: LightningReceiveError::Rejected };
                     return;
                 }
@@ -1961,16 +2178,24 @@ impl LightningClientModule {
 
                         yield LnReceiveState::Funded;
 
-                        if let Ok(out_points) = self_ref.await_claim_acceptance(operation_id).await {
-                            yield LnReceiveState::AwaitingFunds;
+                        match self_ref.await_claim_acceptance(operation_id).await {
+                            Ok(out_points) => {
+                                yield LnReceiveState::AwaitingFunds;
 
-                            if client_ctx.await_primary_module_outputs(operation_id, out_points).await.is_ok() {
-                                yield LnReceiveState::Claimed;
-                                return;
+                                if client_ctx.await_primary_module_outputs(operation_id, out_points).await.is_ok() {
+                                    yield LnReceiveState::Claimed;
+                                    return;
+                                }
+
+                                // The claim transaction was accepted, but its outputs were not
+                                // confirmed by the primary module. The incoming contract is already
+                                // spent, so this is not reclaimable as a rejected claim.
+                                yield LnReceiveState::Canceled { reason: LightningReceiveError::Rejected };
+                            }
+                            Err(e) => {
+                                yield LnReceiveState::Canceled { reason: e };
                             }
                         }
-
-                        yield LnReceiveState::Canceled { reason: LightningReceiveError::Rejected };
                     }
                     Err(e) => {
                         yield LnReceiveState::Canceled { reason: e };

--- a/modules/fedimint-ln-tests/tests/tests.rs
+++ b/modules/fedimint-ln-tests/tests/tests.rs
@@ -1563,6 +1563,17 @@ mod fedimint_migration_tests {
 
                             info!("Validated RecurringPaymentCodes");
                         }
+                        fedimint_ln_client::db::DbKeyPrefix::ReceiveReclaim => {
+                            let receive_reclaims = dbtx
+                                .find_by_prefix(&fedimint_ln_client::db::ReceiveReclaimKeyPrefix)
+                                .await
+                                .collect::<Vec<_>>()
+                                .await;
+                            ensure!(
+                                receive_reclaims.is_empty(),
+                                "validate_migrations found unexpected ReceiveReclaims"
+                            );
+                        }
                         fedimint_ln_client::db::DbKeyPrefix::CoreInternalReservedStart
                         | fedimint_ln_client::db::DbKeyPrefix::ExternalReservedStart
                         | fedimint_ln_client::db::DbKeyPrefix::CoreInternalReservedEnd => {}


### PR DESCRIPTION
*PR published by Tau*

## Summary

Adds a manual LN receive reclaim path for support cases where an invoice was funded but the original claim transaction failed before ecash was issued.

## Details

- Adds client-module helpers to inspect active/inactive operation state-machine history.
- Adds a `ReceiveReclaim` LN operation metadata variant and `reclaim_ln_receive` module RPC.
- Starts reclaim operations from `ConfirmedInvoice` using the original invoice and receiving key recovered from local inactive history.
- Restricts reclaim to non-active receives that ended with `ClaimRejected`.
- Supports both one-shot and recurring receive metadata as reclaim originals.
- Fixes receive subscription reporting for claim rejection.

## Reviewing

This is intentionally local-state-history recovery, not seed-only recovery: it requires the client DB to retain historical `SubmittedOffer` or `ConfirmedInvoice` state for the original operation.

## Testing

- `cargo check -p fedimint-ln-client -p fedimint-client-module`
- `cargo clippy -p fedimint-ln-client -p fedimint-client-module --all-targets -- -D warnings`
- `just final-lint`