### PR TITLE
feat(ln): add manual receive reclaim

### DIFF
--- a/fedimint-client-module/src/module/mod.rs
+++ b/fedimint-client-module/src/module/mod.rs
@@ -26,7 +26,7 @@ use fedimint_core::{
 };
 use fedimint_eventlog::{Event, EventKind, EventPersistence};
 use fedimint_logging::LOG_CLIENT;
-use futures::Stream;
+use futures::{Stream, StreamExt};
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 use tracing::warn;
@@ -488,6 +488,61 @@ where
                 )
             })
             .collect()
+    }
+
+    /// Returns this module's currently active state machines for the operation.
+    pub async fn get_own_operation_active_states(
+        &self,
+        operation_id: OperationId,
+    ) -> Vec<(M::States, ActiveStateMeta)> {
+        let db = self.global_db();
+        let mut dbtx = db.begin_transaction_nc().await;
+
+        self.client
+            .get()
+            .read_operation_active_states(operation_id, self.module_instance_id, &mut dbtx)
+            .await
+            .map(|(key, meta)| {
+                (
+                    Clone::clone(
+                        key.state
+                            .as_any()
+                            .downcast_ref::<M::States>()
+                            .expect("incorrect output type passed to module plugin"),
+                    ),
+                    meta,
+                )
+            })
+            .collect()
+            .await
+    }
+
+    /// Returns this module's previously active state machines for the
+    /// operation.
+    pub async fn get_own_operation_inactive_states(
+        &self,
+        operation_id: OperationId,
+    ) -> Vec<(M::States, InactiveStateMeta)> {
+        let db = self.global_db();
+        let mut dbtx = db.begin_transaction_nc().await;
+
+        self.client
+            .get()
+            .read_operation_inactive_states(operation_id, self.module_instance_id, &mut dbtx)
+            .await
+            .map(|(key, meta)| {
+                (
+                    Clone::clone(
+                        key.state
+                            .as_any()
+                            .downcast_ref::<M::States>()
+                            .expect("incorrect output type passed to module plugin"),
+                    ),
+                    meta,
+                )
+            })
+            .collect()
+            .await
     }
 
     pub async fn get_config(&self) -> ClientConfig {

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -108,8 +108,8 @@ use crate::pay::{
     LightningPayStateMachine,
 };
 use crate::receive::{
-    LightningReceiveError, LightningReceiveStateMachine, LightningReceiveStates,
-    LightningReceiveSubmittedOffer, get_incoming_contract,
+    LightningReceiveConfirmedInvoice, LightningReceiveError, LightningReceiveStateMachine,
+    LightningReceiveStates, LightningReceiveSubmittedOffer, get_incoming_contract,
 };
 use crate::recurring::RecurringPaymentCodeEntry;
 
@@ -277,7 +277,8 @@ pub use deprecated_variant_hack::LightningOperationMetaVariant;
 #[allow(deprecated)]
 mod deprecated_variant_hack {
     use super::{
-        Bolt11Invoice, Deserialize, LightningOperationMetaPay, OutPoint, Serialize, secp256k1,
+        Bolt11Invoice, Deserialize, LightningOperationMetaPay, OperationId, OutPoint, Serialize,
+        secp256k1,
     };
     use crate::recurring::ReurringPaymentReceiveMeta;
 
@@ -287,6 +288,11 @@ mod deprecated_variant_hack {
         Pay(LightningOperationMetaPay),
         Receive {
             out_point: OutPoint,
+            invoice: Bolt11Invoice,
+            gateway_id: Option<secp256k1::PublicKey>,
+        },
+        ReceiveReclaim {
+            original_operation_id: OperationId,
             invoice: Bolt11Invoice,
             gateway_id: Option<secp256k1::PublicKey>,
         },
@@ -559,6 +565,13 @@ impl ClientModule for LightningClientModule {
                         yield serde_json::to_value(state)?;
                     }
                 }
+                "reclaim_ln_receive" => {
+                    let req: ReclaimLnReceiveRequest = serde_json::from_value(payload)?;
+                    let operation_id = self.reclaim_ln_receive(req.original_operation_id).await?;
+                    yield serde_json::json!({
+                        "operation_id": operation_id,
+                    });
+                }
                 "create_bolt11_invoice_for_user_tweaked" => {
                     let req: CreateBolt11InvoiceForUserTweakedRequest = serde_json::from_value(payload)?;
                     let (op, invoice, _) = self
@@ -652,6 +665,11 @@ struct SubscribeInternalPayRequest {
 #[derive(Deserialize)]
 struct SubscribeLnReceiveRequest {
     operation_id: OperationId,
+}
+
+#[derive(Deserialize)]
+struct ReclaimLnReceiveRequest {
+    original_operation_id: OperationId,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -1895,6 +1913,119 @@ impl LightningClientModule {
         Ok((operation_id, invoice, preimage))
     }
 
+    /// Starts a new state machine that retries claiming a previously paid
+    /// invoice.
+    ///
+    /// This is a local state-history recovery tool: it requires the client DB
+    /// to still contain a historical `SubmittedOffer` or `ConfirmedInvoice`
+    /// state for the original operation. It does not recover seed-only
+    /// restores where that local state-machine history is unavailable.
+    ///
+    /// Repeated calls start independent reclaim attempts. This is intentional:
+    /// this is a manual break-glass recovery path, and concurrent attempts race
+    /// through the normal federation transaction validation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the original operation is not a reclaimable
+    /// lightning receive, if it is still active, or if the original receiving
+    /// key cannot be recovered from state history.
+    pub async fn reclaim_ln_receive(
+        &self,
+        original_operation_id: OperationId,
+    ) -> anyhow::Result<OperationId> {
+        let operation = self.client_ctx.get_operation(original_operation_id).await?;
+        let LightningOperationMeta {
+            variant,
+            extra_meta,
+        } = operation
+            .try_meta::<LightningOperationMeta>()
+            .context("Invalid lightning operation metadata")?;
+
+        let (invoice, gateway_id) = match variant {
+            LightningOperationMetaVariant::Receive {
+                invoice,
+                gateway_id,
+                ..
+            } => (invoice, gateway_id),
+            LightningOperationMetaVariant::RecurringPaymentReceive(meta) => (meta.invoice, None),
+            _ => bail!("Operation is not a reclaimable lightning receive"),
+        };
+
+        let active_states = self
+            .client_ctx
+            .get_own_operation_active_states(original_operation_id)
+            .await;
+        ensure!(
+            !active_states
+                .iter()
+                .any(|(state, _)| matches!(state, LightningClientStateMachines::Receive(_))),
+            "Cannot reclaim an active lightning receive"
+        );
+
+        let inactive_states = self
+            .client_ctx
+            .get_own_operation_inactive_states(original_operation_id)
+            .await;
+
+        let receiving_key = inactive_states
+            .iter()
+            .find_map(|(state, _)| Self::ln_receive_key_from_state(state))
+            .ok_or_else(|| {
+                anyhow!("Cannot reclaim LN receive because the original receive key is unavailable")
+            })?;
+        let db = self.client_ctx.module_db();
+        let mut dbtx = db.begin_transaction().await;
+        let reclaim_operation_id = OperationId::new_random();
+        let operation_meta = LightningOperationMeta {
+            variant: LightningOperationMetaVariant::ReceiveReclaim {
+                original_operation_id,
+                invoice: invoice.clone(),
+                gateway_id,
+            },
+            extra_meta,
+        };
+        let state = LightningClientStateMachines::Receive(LightningReceiveStateMachine {
+            operation_id: reclaim_operation_id,
+            state: LightningReceiveStates::ConfirmedInvoice(LightningReceiveConfirmedInvoice {
+                invoice,
+                receiving_key,
+            }),
+        });
+
+        self.client_ctx
+            .manual_operation_start_dbtx(
+                &mut dbtx.to_ref_nc(),
+                reclaim_operation_id,
+                LightningCommonInit::KIND.as_str(),
+                operation_meta,
+                vec![self.client_ctx.make_dyn_state(state)],
+            )
+            .await?;
+
+        dbtx.commit_tx().await;
+
+        Ok(reclaim_operation_id)
+    }
+
+    fn ln_receive_key_from_state(state: &LightningClientStateMachines) -> Option<ReceivingKey> {
+        match state {
+            LightningClientStateMachines::Receive(receive) => match &receive.state {
+                LightningReceiveStates::SubmittedOffer(submitted_offer) => {
+                    Some(submitted_offer.receiving_key)
+                }
+                LightningReceiveStates::ConfirmedInvoice(confirmed_invoice) => {
+                    Some(confirmed_invoice.receiving_key)
+                }
+                LightningReceiveStates::Canceled(_)
+                | LightningReceiveStates::Funded(_)
+                | LightningReceiveStates::Success(_) => None,
+            },
+            LightningClientStateMachines::InternalPay(_)
+            | LightningClientStateMachines::LightningPay(_) => None,
+        }
+    }
+
     #[deprecated(since = "0.7.0", note = "Use recurring payment functionality instead")]
     #[allow(deprecated)]
     pub async fn subscribe_ln_claim(
@@ -1928,18 +2059,21 @@ impl LightningClientModule {
         operation_id: OperationId,
     ) -> anyhow::Result<UpdateStreamOrOutcome<LnReceiveState>> {
         let operation = self.client_ctx.get_operation(operation_id).await?;
-        let LightningOperationMetaVariant::Receive {
-            out_point, invoice, ..
-        } = operation.meta::<LightningOperationMeta>().variant
-        else {
-            bail!("Operation is not a lightning payment")
+        let (invoice, tx_accepted_future) = match operation.meta::<LightningOperationMeta>().variant
+        {
+            LightningOperationMetaVariant::Receive {
+                out_point, invoice, ..
+            } => {
+                let tx_accepted_future = self
+                    .client_ctx
+                    .transaction_updates(operation_id)
+                    .await
+                    .await_tx_accepted(out_point.txid);
+                (invoice, Some(tx_accepted_future))
+            }
+            LightningOperationMetaVariant::ReceiveReclaim { invoice, .. } => (invoice, None),
+            _ => bail!("Operation is not a lightning receive"),
         };
-
-        let tx_accepted_future = self
-            .client_ctx
-            .transaction_updates(operation_id)
-            .await
-            .await_tx_accepted(out_point.txid);
 
         let client_ctx = self.client_ctx.clone();
 
@@ -1950,7 +2084,11 @@ impl LightningClientModule {
 
                 yield LnReceiveState::Created;
 
-                if tx_accepted_future.await.is_err() {
+                let tx_rejected = match tx_accepted_future {
+                    Some(tx_accepted_future) => tx_accepted_future.await.is_err(),
+                    None => false,
+                };
+                if tx_rejected {
                     yield LnReceiveState::Canceled { reason: LightningReceiveError::Rejected };
                     return;
                 }
@@ -1961,16 +2099,24 @@ impl LightningClientModule {
 
                         yield LnReceiveState::Funded;
 
-                        if let Ok(out_points) = self_ref.await_claim_acceptance(operation_id).await {
-                            yield LnReceiveState::AwaitingFunds;
+                        match self_ref.await_claim_acceptance(operation_id).await {
+                            Ok(out_points) => {
+                                yield LnReceiveState::AwaitingFunds;
 
-                            if client_ctx.await_primary_module_outputs(operation_id, out_points).await.is_ok() {
-                                yield LnReceiveState::Claimed;
-                                return;
+                                if client_ctx.await_primary_module_outputs(operation_id, out_points).await.is_ok() {
+                                    yield LnReceiveState::Claimed;
+                                    return;
+                                }
+
+                                // The claim transaction was accepted, but its outputs were not
+                                // confirmed by the primary module. The incoming contract is already
+                                // spent, so this is not reclaimable as a rejected claim.
+                                yield LnReceiveState::Canceled { reason: LightningReceiveError::Rejected };
+                            }
+                            Err(e) => {
+                                yield LnReceiveState::Canceled { reason: e };
                             }
                         }
-
-                        yield LnReceiveState::Canceled { reason: LightningReceiveError::Rejected };
                     }
                     Err(e) => {
                         yield LnReceiveState::Canceled { reason: e };

--- a/modules/fedimint-ln-tests/tests/tests.rs
+++ b/modules/fedimint-ln-tests/tests/tests.rs
@@ -1,10 +1,12 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::bail;
 use assert_matches::assert_matches;
 use bitcoin_hashes::{Hash, sha256};
 use fedimint_client::transaction::{
-    ClientOutput, ClientOutputBundle, TransactionBuilder, TxSubmissionStates, TxSubmissionStatesSM,
+    ClientOutput, ClientOutputBundle, ClientOutputSM, TransactionBuilder, TxSubmissionStates,
+    TxSubmissionStatesSM,
 };
 use fedimint_client::{Client, ClientHandleArc};
 use fedimint_client_module::oplog::OperationLogEntry;
@@ -14,9 +16,15 @@ use fedimint_core::util::{BoxStream, NextOrPending};
 use fedimint_core::{Amount, sats, secp256k1};
 use fedimint_dummy_client::{DummyClientInit, DummyClientModule};
 use fedimint_dummy_server::DummyInit;
+use fedimint_ln_client::receive::{
+    LightningReceiveError, LightningReceiveStateMachine, LightningReceiveStates,
+    LightningReceiveSubmittedOffer,
+};
 use fedimint_ln_client::{
-    InternalPayState, LightningClientInit, LightningClientModule, LightningOperationMeta,
-    LnPayState, LnReceiveState, MockGatewayConnection, OutgoingLightningPayment, PayType,
+    InternalPayState, LightningClientInit, LightningClientModule, LightningClientStateMachines,
+    LightningOperationMeta, LightningOperationMetaVariant, LnPayState, LnReceiveState,
+    MockGatewayConnection, OutgoingLightningPayment, PayType, ReceivingKey,
+    create_incoming_contract_output,
 };
 use fedimint_ln_common::contracts::incoming::IncomingContractOffer;
 use fedimint_ln_common::contracts::{EncryptedPreimage, PreimageKey};
@@ -80,6 +88,22 @@ async fn pay_invoice(
         None
     };
     ln_module.pay_bolt11_invoice(gateway, invoice, ()).await
+}
+
+async fn await_client_tx_accepted(
+    tx_updates: BoxStream<'static, TxSubmissionStatesSM>,
+) -> Result<(), String> {
+    tx_updates
+        .filter_map(|tx_update| {
+            std::future::ready(match tx_update.state {
+                TxSubmissionStates::Accepted(_) => Some(Ok(())),
+                TxSubmissionStates::Rejected(_, submit_error) => Some(Err(submit_error)),
+                _ => None,
+            })
+        })
+        .next()
+        .await
+        .expect("tx either accepted or rejected")
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -737,6 +761,159 @@ async fn rejects_expired_invoice() -> anyhow::Result<()> {
         error.to_string().contains("Invoice has expired"),
         "Expected 'Invoice has expired' error, got: {error}"
     );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn can_reclaim_receive_funded_after_invoice_expiry() -> anyhow::Result<()> {
+    let fixtures = fixtures();
+    let fed = fixtures.new_fed_degraded().await;
+    let (client1, client2) = fed.two_clients().await;
+    let client2_dummy_module = client2.get_first_module::<DummyClientModule>()?;
+
+    client2_dummy_module
+        .mock_receive(sats(1000), AmountUnit::BITCOIN)
+        .await?;
+
+    let ln_module = client1.get_first_module::<LightningClientModule>()?;
+    let amount = sats(250);
+
+    let receiving_keypair = Keypair::new_global(&mut OsRng);
+    let receiving_key = ReceivingKey::Personal(receiving_keypair);
+    let preimage_key: [u8; 33] = receiving_key.public_key().serialize();
+    let preimage = sha256::Hash::hash(&preimage_key);
+    let payment_hash = sha256::Hash::hash(&preimage.to_byte_array());
+    let operation_id = OperationId(payment_hash.to_byte_array());
+
+    let secp = secp256k1::Secp256k1::new();
+    let node_keypair = Keypair::new(&secp, &mut OsRng);
+    let stale_timestamp = fedimint_core::time::duration_since_epoch()
+        .checked_sub(Duration::from_secs(120))
+        .expect("current time is after unix epoch");
+    let invoice = InvoiceBuilder::new(Currency::Regtest)
+        .amount_milli_satoshis(amount.msats)
+        .description("stale receive".to_string())
+        .payment_hash(payment_hash)
+        .payment_secret(PaymentSecret([1; 32]))
+        .duration_since_epoch(stale_timestamp)
+        .min_final_cltv_expiry_delta(18)
+        .payee_pub_key(node_keypair.public_key())
+        .expiry_time(Duration::from_secs(1))
+        .build_signed(|m| {
+            secp.sign_ecdsa_recoverable(m, &secp256k1::SecretKey::from_keypair(&node_keypair))
+        })?;
+
+    let offer_output = LightningOutput::new_v0_offer(IncomingContractOffer {
+        amount,
+        hash: payment_hash,
+        encrypted_preimage: EncryptedPreimage::new(
+            &PreimageKey(preimage_key),
+            &ln_module.cfg.threshold_pub_key,
+        ),
+        expiry_time: Some(1),
+    });
+    let sm_invoice = invoice.clone();
+    let transaction_builder = TransactionBuilder::new().with_outputs(
+        ClientOutputBundle::new(
+            vec![ClientOutput {
+                output: offer_output,
+                amounts: Amounts::ZERO,
+            }],
+            vec![ClientOutputSM {
+                state_machines: Arc::new(move |out_point_range| {
+                    vec![LightningClientStateMachines::Receive(
+                        LightningReceiveStateMachine {
+                            operation_id,
+                            state: LightningReceiveStates::SubmittedOffer(
+                                LightningReceiveSubmittedOffer {
+                                    offer_txid: out_point_range.txid(),
+                                    invoice: sm_invoice.clone(),
+                                    receiving_key,
+                                },
+                            ),
+                        },
+                    )]
+                }),
+            }],
+        )
+        .into_dyn(ln_module.id),
+    );
+    let meta_invoice = invoice.clone();
+    client1
+        .finalize_and_submit_transaction(
+            operation_id,
+            LightningCommonInit::KIND.as_str(),
+            move |out_point_range| LightningOperationMeta {
+                variant: LightningOperationMetaVariant::Receive {
+                    out_point: fedimint_core::OutPoint {
+                        txid: out_point_range.txid(),
+                        out_idx: 0,
+                    },
+                    invoice: meta_invoice.clone(),
+                    gateway_id: None,
+                },
+                extra_meta: serde_json::Value::Null,
+            },
+            transaction_builder,
+        )
+        .await?;
+
+    let mut sub = ln_module
+        .subscribe_ln_receive(operation_id)
+        .await?
+        .into_stream();
+    loop {
+        match tokio::time::timeout(Duration::from_secs(10), sub.ok()).await?? {
+            LnReceiveState::Canceled {
+                reason: LightningReceiveError::Timeout,
+            } => break,
+            _ => continue,
+        }
+    }
+
+    let gateway_redeem_key = Keypair::new_global(&mut OsRng);
+    let (incoming_output, funded_amount, _contract_id) =
+        create_incoming_contract_output(&ln_module.api, payment_hash, amount, &gateway_redeem_key)
+            .await?;
+    let funding_operation_id = OperationId::new_random();
+    let funding_tx = TransactionBuilder::new().with_outputs(
+        ClientOutputBundle::new_no_sm(vec![ClientOutput {
+            output: LightningOutput::V0(incoming_output),
+            amounts: Amounts::new_bitcoin(funded_amount),
+        }])
+        .into_dyn(ln_module.id),
+    );
+    client2
+        .finalize_and_submit_transaction(
+            funding_operation_id,
+            LightningCommonInit::KIND.as_str(),
+            |_| (),
+            funding_tx,
+        )
+        .await?;
+    await_client_tx_accepted(
+        client2
+            .transaction_updates(funding_operation_id)
+            .await
+            .update_stream,
+    )
+    .await
+    .expect("late funding transaction should be accepted");
+
+    let reclaim_operation_id = ln_module.reclaim_ln_receive(operation_id).await?;
+    let mut reclaim_sub = ln_module
+        .subscribe_ln_receive(reclaim_operation_id)
+        .await?
+        .into_stream();
+    loop {
+        match tokio::time::timeout(Duration::from_secs(10), reclaim_sub.ok()).await?? {
+            LnReceiveState::Claimed => break,
+            _ => continue,
+        }
+    }
+
+    assert_eq!(client1.get_balance_for_btc().await?, amount);
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Replacement for #8711. Adds a manual LN receive reclaim path for support cases where incoming LN funds are stuck after the original receive operation has reached a terminal state.

## Details

This keeps the reclaim function intentionally broad as a break-glass recovery tool: it only checks that the original receive is no longer active and that the local client DB still has enough historical receive state to recover the receive key. It does not require a specific terminal failure reason.

This version also adds a regression test for the case where an invoice expires first, the incoming contract is funded afterward, and the manual reclaim path recovers the funds.

## Reviewing

This PR is intended to replace #8711. The main behavior difference is that reclaim eligibility is based on the original receive state machine being terminal, rather than matching a specific failure variant such as `ClaimRejected`.

## Testing

- `cargo test -p fedimint-ln-tests can_reclaim_receive_funded_after_invoice_expiry -- --nocapture`
- `cargo check -q -p fedimint-ln-client`
- `just final-lint`
