### PR TITLE
ci: pin flake inputs during Nix builds

### DIFF
--- a/.github/actions/pin-nix-flake-inputs/action.yml
+++ b/.github/actions/pin-nix-flake-inputs/action.yml
@@ -1,0 +1,13 @@
+name: 'Pin Nix flake inputs'
+description: 'Create temporary indirect GC roots for Nix flake input source paths'
+inputs:
+  flake:
+    description: 'Flake reference to archive and pin'
+    required: false
+    default: '.'
+runs:
+  using: 'composite'
+  steps:
+    - name: Pin Nix flake inputs
+      shell: bash
+      run: ./.github/scripts/pin-nix-flake-inputs.sh '${{ inputs.flake }}'

--- a/.github/scripts/pin-nix-flake-inputs.sh
+++ b/.github/scripts/pin-nix-flake-inputs.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+flake_ref="${1:-.}"
+root_dir="${NIX_FLAKE_INPUT_GCROOT_DIR:-${RUNNER_TEMP:-$PWD}/nix-flake-input-gcroots}"
+
+mkdir -p "$root_dir"
+
+archive_json="$(mktemp)"
+paths_expr="$(mktemp "${TMPDIR:-/tmp}/nix-flake-input-paths.XXXXXX.nix")"
+trap 'rm -f "$archive_json" "$paths_expr"' EXIT
+
+nix flake archive --json "$flake_ref" > "$archive_json"
+
+cat > "$paths_expr" <<EOF_NIX
+let
+  archive = builtins.fromJSON (builtins.readFile $archive_json);
+
+  collectPaths = value:
+    if builtins.isAttrs value then
+      (if value ? path && builtins.isString value.path && builtins.match "/nix/store/.*" value.path != null then
+        [ value.path ]
+      else
+        [ ])
+      ++ builtins.concatLists (map collectPaths (builtins.attrValues value))
+    else if builtins.isList value then
+      builtins.concatLists (map collectPaths value)
+    else
+      [ ];
+in
+  builtins.concatStringsSep "\\n" (collectPaths archive)
+EOF_NIX
+
+nix eval --raw --file "$paths_expr" \
+  | sort -u \
+  | while IFS= read -r path; do
+      [ -n "$path" ] || continue
+      root_name="$(basename "$path")"
+      nix-store --add-root "$root_dir/$root_name" --indirect --realise "$path" >/dev/null
+    done
+
+root_count=0
+for root in "$root_dir"/*; do
+  if [ -L "$root" ]; then
+    root_count=$((root_count + 1))
+  fi
+done
+echo "Pinned $root_count Nix flake input store paths under $root_dir"

--- a/.github/workflows/ci-backwards-compatibility.yml
+++ b/.github/workflows/ci-backwards-compatibility.yml
@@ -46,6 +46,7 @@ jobs:
           name: fedimint
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
         continue-on-error: true
+      - uses: ./.github/actions/pin-nix-flake-inputs
 
       - name: Backwards-compatibility tests
         run: |

--- a/.github/workflows/ci-crate-ownership.yml
+++ b/.github/workflows/ci-crate-ownership.yml
@@ -14,6 +14,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/pin-nix-flake-inputs
       - name: Check crates.io ownership
         run: |
           nix develop -c ./scripts/ci/check-crate-ownership.sh

--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -56,6 +56,7 @@ jobs:
           name: fedimint
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
         continue-on-error: true
+      - uses: ./.github/actions/pin-nix-flake-inputs
 
       # run the same check that git `pre-commit` hook would, just in case
       - name: Commit check
@@ -106,6 +107,8 @@ jobs:
           name: fedimint
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
         continue-on-error: true
+      - uses: ./.github/actions/pin-nix-flake-inputs
+        if: github.event_name != 'pull_request' || matrix.build-in-pr
 
       - name: Build dev shell
         if: github.event_name != 'pull_request' || matrix.build-in-pr
@@ -151,6 +154,8 @@ jobs:
           name: fedimint
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
         continue-on-error: true
+      - uses: ./.github/actions/pin-nix-flake-inputs
+        if: github.event_name != 'pull_request' || matrix.build-in-pr
 
       - name: Build workspace
         if: github.event_name != 'pull_request' || matrix.build-in-pr
@@ -234,6 +239,7 @@ jobs:
           name: fedimint
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
         continue-on-error: true
+      - uses: ./.github/actions/pin-nix-flake-inputs
       - name: Check package features
         run: |
           nix build -L .#wasm32-unknown.ci.cargoCheckWasmNoDefaultFeatures
@@ -261,10 +267,12 @@ jobs:
       - name: Run cargo audit
         run: |
           nix flake update advisory-db || nix flake lock --update-input advisory-db
+          ./.github/scripts/pin-nix-flake-inputs.sh .
           nix build -L .#ci.cargoAudit
 
       - name: Run cargo deny
         run: |
+          ./.github/scripts/pin-nix-flake-inputs.sh .
           nix build -L .#ci.cargoDeny
 
   cross:
@@ -310,6 +318,8 @@ jobs:
           name: fedimint
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
         continue-on-error: true
+      - uses: ./.github/actions/pin-nix-flake-inputs
+        if: github.event_name != 'pull_request' || matrix.build-in-pr
 
       - name: Build client packages for ${{ matrix.toolchain }}
         if: github.event_name != 'pull_request' || matrix.build-in-pr
@@ -369,6 +379,8 @@ jobs:
           name: fedimint
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
         continue-on-error: true
+      - uses: ./.github/actions/pin-nix-flake-inputs
+        if: github.event_name != 'pull_request' || matrix.platform.run_in_pr
 
       - name: Build ${{ matrix.container.name }} container for ${{ matrix.platform.arch }}
         if: github.event_name != 'pull_request' || matrix.platform.run_in_pr
@@ -523,6 +535,7 @@ jobs:
           name: fedimint
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
         continue-on-error: true
+      - uses: ./.github/actions/pin-nix-flake-inputs
 
       - name: Set BUILD_ID to tag or commit hash
         run: |

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -20,12 +20,14 @@ jobs:
       - name: Run cargo audit
         run: |
           nix flake update advisory-db || nix flake lock --update-input advisory-db
+          ./.github/scripts/pin-nix-flake-inputs.sh .
           nix build -L .#ci.cargoAudit
 
   fuzz:
     runs-on: [self-hosted, linux, x64]
     steps:
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/pin-nix-flake-inputs
       - name: Quick fuzzing
         run: |
           env \

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,6 +23,7 @@ jobs:
           name: fedimint
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
         continue-on-error: true
+      - uses: ./.github/actions/pin-nix-flake-inputs
 
       - name: Build docs
         run: nix build -L .#nightly.ci.workspaceDocExport

--- a/.github/workflows/hourly-run.yml
+++ b/.github/workflows/hourly-run.yml
@@ -49,6 +49,7 @@ jobs:
           name: fedimint
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
         continue-on-error: true
+      - uses: ./.github/actions/pin-nix-flake-inputs
 
       - name: Tests (5 times more)
         run: |

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -19,6 +19,7 @@ jobs:
           path: .lycheecache
           key: cache-lychee-${{ github.sha }}
           restore-keys: cache-lychee-
+      - uses: ./.github/actions/pin-nix-flake-inputs
 
       # Accept 429 status codes so we don't fail when GitHub rate-limits us. The --github-token option didn't work and
       # this way we'll successfully check *some* links each run, cache them and check others the next run.

--- a/.github/workflows/upgrade-tests.yml
+++ b/.github/workflows/upgrade-tests.yml
@@ -53,6 +53,7 @@ jobs:
           name: fedimint
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
         continue-on-error: true
+      - uses: ./.github/actions/pin-nix-flake-inputs
 
       - name: Upgrade tests
         run: |


### PR DESCRIPTION
*PR published by Tau*

## Summary

Pin Nix flake input source paths during self-hosted CI jobs so runner Nix GC cannot delete them while a job is still evaluating or building flake outputs.

## Details

Original failing CI run: https://github.com/fedimint/fedimint/actions/runs/27727547015/job/82027109061

A rare CI flake appears to come from host-level Nix GC overlapping with Nix evaluation, leaving inputs such as `nixpkgs-unstable` as invalid store paths during commands like `nix build -L .#wasm32-unknown.ci.ciTestAll`.

This adds a reusable script and composite action that runs `nix flake archive --json`, extracts all flake input source store paths using Nix itself, and creates indirect GC roots for them. The roots default to `$RUNNER_TEMP/nix-flake-input-gcroots`, so normal runner cleanup removes the root links after the job and later GC can reclaim the inputs.

The action is wired into the workflows that run Nix builds/develop shells on self-hosted runners, including nested-build upgrade/backwards-compatibility jobs.

## Testing

- Smoke-tested `.github/scripts/pin-nix-flake-inputs.sh .` locally.
- `git diff --check`
- `actionlint` on changed workflows, ignoring only pre-existing unrelated warnings.
- `just final-lint`

