### PR TITLE
fix(client-module): prevent state machine stall on notifier broadcast lag

### DIFF
--- a/fedimint-client-module/src/sm/notifier.rs
+++ b/fedimint-client-module/src/sm/notifier.rs
@@ -2,11 +2,11 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 
 use fedimint_core::core::{ModuleInstanceId, OperationId};
-use fedimint_core::util::broadcaststream::BroadcastStream;
-use fedimint_core::util::{BoxStream, FmtCompact};
+use fedimint_core::util::broadcaststream::{BroadcastStream, BroadcastStreamRecvError};
+use fedimint_core::util::BoxStream;
 use fedimint_logging::LOG_CLIENT;
 use futures::StreamExt as _;
-use tracing::{debug, error, trace};
+use tracing::{debug, trace, warn};
 
 use super::{DynState, State};
 use crate::module::FinalClientIface;
@@ -143,26 +143,25 @@ where
         let module_instance_id = self.module_instance;
         Box::pin(
             BroadcastStream::new(self.broadcast.subscribe())
-                .take_while(|res| {
-                    let cont = if let Err(err) = res {
-                        error!(target: LOG_CLIENT, err = %err.fmt_compact(), "ModuleNotifier stream stopped on error");
-                        false
-                    } else {
-                        true
-                    };
-                    std::future::ready(cont)
-                })
                 .filter_map(move |res| async move {
-                    let s = res.expect("We filtered out errors above");
-                    if s.module_instance_id() == module_instance_id {
-                        Some(
-                            s.as_any()
-                                .downcast_ref::<S>()
-                                .expect("Tried to subscribe to wrong state type")
-                                .clone(),
-                        )
-                    } else {
-                        None
+                    match res {
+                        Ok(state) => {
+                            if state.module_instance_id() == module_instance_id {
+                                Some(
+                                    state
+                                        .as_any()
+                                        .downcast_ref::<S>()
+                                        .expect("Tried to subscribe to wrong state type")
+                                        .clone(),
+                                )
+                            } else {
+                                None
+                            }
+                        }
+                        Err(BroadcastStreamRecvError::Lagged(n)) => {
+                            warn!(target: LOG_CLIENT, skipped = n, "ModuleNotifier consumer lagged, catching up");
+                            None
+                        }
                     }
                 }),
         )

--- a/fedimint-client-module/src/sm/notifier.rs
+++ b/fedimint-client-module/src/sm/notifier.rs
@@ -1,12 +1,12 @@
 use std::marker::PhantomData;
-use std::sync::Arc;
 
 use fedimint_core::core::{ModuleInstanceId, OperationId};
-use fedimint_core::util::broadcaststream::{BroadcastStream, BroadcastStreamRecvError};
+use fedimint_core::util::broadcaststream::BroadcastStream;
 use fedimint_core::util::BoxStream;
 use fedimint_logging::LOG_CLIENT;
 use futures::StreamExt as _;
-use tracing::{debug, trace, warn};
+use tokio::sync::mpsc;
+use tracing::{debug, error, trace};
 
 use super::{DynState, State};
 use crate::module::FinalClientIface;
@@ -52,90 +52,110 @@ where
     /// loaded from the database are not returned in a specific order. There may
     /// also be duplications.
     pub async fn subscribe(&self, operation_id: OperationId) -> BoxStream<'static, S> {
-        let to_typed_state = |state: DynState| {
-            state
-                .as_any()
-                .downcast_ref::<S>()
-                .expect("Tried to subscribe to wrong state type")
-                .clone()
-        };
+        let (tx, rx) = mpsc::unbounded_channel();
+        let this = self.clone();
 
-        // It's important to start the subscription first and then query the database to
-        // not lose any transitions in the meantime.
-        let new_transitions = self.subscribe_all_operations();
+        tokio::spawn(async move {
+            loop {
+                // Subscribe first, then query DB to not miss any transitions that
+                // happen between the two operations.
+                let new_transitions = this.subscribe_all_operations();
 
-        let client_strong = self.client.get();
-        let db_states = {
-            let mut dbtx = client_strong.db().begin_transaction_nc().await;
-            let active_states = client_strong
-                .read_operation_active_states(operation_id, self.module_instance, &mut dbtx)
-                .await
-                .map(|(key, val): (ActiveStateKey, ActiveStateMeta)| {
-                    (to_typed_state(key.state), val.created_at)
-                })
-                .collect::<Vec<(S, _)>>()
-                .await;
+                let client_strong = this.client.get();
+                let db_states: Vec<S> = {
+                    let to_typed_state = |state: DynState| {
+                        state
+                            .as_any()
+                            .downcast_ref::<S>()
+                            .expect("Tried to subscribe to wrong state type")
+                            .clone()
+                    };
 
-            let inactive_states = self
-                .client
-                .get()
-                .read_operation_inactive_states(operation_id, self.module_instance, &mut dbtx)
-                .await
-                .map(|(key, val): (InactiveStateKey, InactiveStateMeta)| {
-                    (to_typed_state(key.state), val.created_at)
-                })
-                .collect::<Vec<(S, _)>>()
-                .await;
+                    let mut dbtx = client_strong.db().begin_transaction_nc().await;
+                    let active_states = client_strong
+                        .read_operation_active_states(
+                            operation_id,
+                            this.module_instance,
+                            &mut dbtx,
+                        )
+                        .await
+                        .map(|(key, val): (ActiveStateKey, ActiveStateMeta)| {
+                            (to_typed_state(key.state), val.created_at)
+                        })
+                        .collect::<Vec<(S, _)>>()
+                        .await;
 
-            // FIXME: don't rely on SystemTime for ordering and introduce a state transition
-            // index instead (dpc was right again xD)
-            let num_active = active_states.len();
-            let num_inactive = inactive_states.len();
-            let mut all_states_timed = active_states
-                .into_iter()
-                .chain(inactive_states)
-                .collect::<Vec<(S, _)>>();
-            all_states_timed.sort_by_key(|(_, t1)| *t1);
-            debug!(
-                operation_id = %operation_id.fmt_short(),
-                module_instance = %self.module_instance,
-                active = num_active,
-                inactive = num_inactive,
-                "Returning state transitions from DB for notifier subscription",
-            );
-            all_states_timed
-                .into_iter()
-                .map(|(s, _)| s)
-                .collect::<Vec<S>>()
-        };
+                    let inactive_states = this
+                        .client
+                        .get()
+                        .read_operation_inactive_states(
+                            operation_id,
+                            this.module_instance,
+                            &mut dbtx,
+                        )
+                        .await
+                        .map(|(key, val): (InactiveStateKey, InactiveStateMeta)| {
+                            (to_typed_state(key.state), val.created_at)
+                        })
+                        .collect::<Vec<(S, _)>>()
+                        .await;
 
-        let new_transitions = new_transitions.filter_map({
-            let db_states: Arc<_> = Arc::new(db_states.clone());
+                    // FIXME: don't rely on SystemTime for ordering and introduce a state
+                    // transition index instead (dpc was right again xD)
+                    let num_active = active_states.len();
+                    let num_inactive = inactive_states.len();
+                    let mut all_states_timed = active_states
+                        .into_iter()
+                        .chain(inactive_states)
+                        .collect::<Vec<(S, _)>>();
+                    all_states_timed.sort_by_key(|(_, t1)| *t1);
+                    debug!(
+                        operation_id = %operation_id.fmt_short(),
+                        module_instance = %this.module_instance,
+                        active = num_active,
+                        inactive = num_inactive,
+                        "Returning state transitions from DB for notifier subscription",
+                    );
+                    all_states_timed
+                        .into_iter()
+                        .map(|(s, _)| s)
+                        .collect::<Vec<S>>()
+                };
 
-            move |state: S| {
-                let db_states = db_states.clone();
-                async move {
+                let mut stream =
+                    futures::stream::iter(db_states.clone()).chain(new_transitions);
+
+                while let Some(state) = stream.next().await {
                     if state.operation_id() == operation_id {
-                        trace!(operation_id = %operation_id.fmt_short(), ?state, "Received state transition notification");
-                        // Deduplicate events that might have both come from the DB and streamed,
-                        // due to subscribing to notifier before querying the DB.
-                        //
-                        // Note: linear search should be good enough in practice for many reasons.
-                        // Eg. states tend to have all the states in the DB, or all streamed "live",
-                        // so the overlap here should be minimal.
-                        // And we'll rewrite the whole thing anyway and use only db as a reference.
+                        // Deduplicate events that might have both come from the DB and
+                        // streamed, due to subscribing before querying the DB.
                         if db_states.iter().any(|db_s| db_s == &state) {
-                            debug!(operation_id = %operation_id.fmt_short(), ?state, "Ignoring duplicated event");
-                            return None;
+                            debug!(
+                                operation_id = %operation_id.fmt_short(),
+                                ?state,
+                                "Ignoring duplicated event"
+                            );
+                            continue;
                         }
-                        Some(state)
-                    } else {
-                        None
+                        if tx.send(state).is_err() {
+                            return;
+                        }
                     }
                 }
+
+                // Live stream ended (e.g. Lagged or Closed). If the broadcast
+                // sender has been dropped the client is shutting down, so we stop.
+                if this.broadcast.is_closed() {
+                    return;
+                }
+                debug!(
+                    operation_id = %operation_id.fmt_short(),
+                    "Notifier stream ended, re-syncing from database"
+                );
             }
         });
-        Box::pin(futures::stream::iter(db_states).chain(new_transitions))
+
+        Box::pin(tokio_stream::wrappers::UnboundedReceiverStream::new(rx))
     }
 
     /// Subscribe to all state transitions belonging to the module instance.
@@ -143,25 +163,26 @@ where
         let module_instance_id = self.module_instance;
         Box::pin(
             BroadcastStream::new(self.broadcast.subscribe())
+                .take_while(|res| {
+                    let cont = if let Err(err) = res {
+                        error!(target: LOG_CLIENT, ?err, "ModuleNotifier stream stopped on error");
+                        false
+                    } else {
+                        true
+                    };
+                    std::future::ready(cont)
+                })
                 .filter_map(move |res| async move {
-                    match res {
-                        Ok(state) => {
-                            if state.module_instance_id() == module_instance_id {
-                                Some(
-                                    state
-                                        .as_any()
-                                        .downcast_ref::<S>()
-                                        .expect("Tried to subscribe to wrong state type")
-                                        .clone(),
-                                )
-                            } else {
-                                None
-                            }
-                        }
-                        Err(BroadcastStreamRecvError::Lagged(n)) => {
-                            warn!(target: LOG_CLIENT, skipped = n, "ModuleNotifier consumer lagged, catching up");
-                            None
-                        }
+                    let s = res.expect("We filtered out errors above");
+                    if s.module_instance_id() == module_instance_id {
+                        Some(
+                            s.as_any()
+                                .downcast_ref::<S>()
+                                .expect("Tried to subscribe to wrong state type")
+                                .clone(),
+                        )
+                    } else {
+                        None
                     }
                 }),
         )


### PR DESCRIPTION
## Description

When a receiver of the `ModuleNotifier` broadcast channel temporarily falls behind (more than 10,000 state transitions queued), `tokio::sync::broadcast` returns `RecvError::Lagged(n)`. This PR fixes the resulting state machine stall by **re-syncing from the database** when the live notification stream terminates.

### Problem

The previous approach (replaced by this PR's initial version) silently skipped lagged messages in `subscribe_all_operations()` using `.filter_map()`. This was incorrect: after `Lagged(n)`, the broadcast receiver advances past the missed messages, so any intermediate state among the skipped `n` is permanently lost to the subscriber. Operations waiting for that intermediate state would still hang forever.

### Solution

This PR takes the correct approach:

- **`subscribe_all_operations()`**: retains its original `take_while` that terminates the stream on any error (`Lagged` or `Closed`). This is the correct signal — "the live stream is broken, you need to re-sync."

- **`subscribe()`**: wraps the DB-query + live-stream pipeline in a reconnection loop. When the live stream ends (e.g. due to `Lagged`), it:
  1. Re-queries the database for all committed states of the operation
  2. Starts a fresh live subscription
  3. Chains them together with dedup, just like a first-time subscription

- **Shutdown safety**: if the broadcast sender has been dropped (client shutting down), `broadcast.is_closed()` terminates the loop instead of retrying.

### Why this is correct

The database is the complete, durable source of truth for committed state transitions. The broadcast channel is purely a real-time delivery optimization. By re-syncing from the DB on stream failure, no state transitions are ever permanently lost — the worst case is a brief delay while the DB is re-queried.

### State machine executor independence

This notifier serves `ModuleNotifier::subscribe(...)` callers (operation update subscribers), not the executor's own state-machine progress. The executor uses `sm_update_tx` directly and persists active/inactive states in the DB independently. On restart it seeds active states from the DB. This fix ensures the notifier matches the same robustness.

### Fixes

Addresses the long-standing FIXME at `fedimint-client/src/sm/notifier.rs:30`:
> `// FIXME: use more robust notification mechanism`

Closes the underlying issue described in #3557.
