### PR TITLE
feat(iroh): bump client iroh-next to 1.0.0 and always run dual-stack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2023,12 +2023,12 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "5.0.0-pre.6"
+version = "5.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335f1947f241137a14106b6f5acc5918a5ede29c9d71d3f2cb1678d5075d9fc3"
+checksum = "4f359e08ca85e7bd759e1fd933ff2bccd81864c60a8fba0e259c7f822b0924bf"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures 0.3.0",
  "curve25519-dalek-derive",
  "digest 0.11.3",
  "fiat-crypto 0.3.0",
@@ -2504,7 +2504,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
- "const-oid 0.10.2",
  "crypto-common 0.2.1",
 ]
 
@@ -2695,11 +2694,11 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "3.0.0-pre.7"
+version = "3.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20449acd54b660981ae5caa2bcb56d1fe7f25f2e37a38ec507400fab034d4bb6"
+checksum = "b011170fe4f04665565b4110afef66774fe9ffff278f3eb5b81cc73d26e27d60"
 dependencies = [
- "curve25519-dalek 5.0.0-pre.6",
+ "curve25519-dalek 5.0.0-rc.0",
  "ed25519 3.0.0",
  "rand_core 0.10.1",
  "serde",
@@ -3252,7 +3251,7 @@ dependencies = [
  "fedimint-metrics",
  "futures",
  "iroh 0.35.0",
- "iroh 1.0.0-rc.1",
+ "iroh 1.0.0",
  "iroh-base 0.35.0",
  "iroh-mainline-address-lookup",
  "jsonrpsee-core",
@@ -6679,9 +6678,9 @@ dependencies = [
 
 [[package]]
 name = "iroh"
-version = "1.0.0-rc.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef865dc2d11a19fe670ff217b68ffc3b511bddf473dc3a3e120090b9f691803"
+checksum = "6435544bb3a5c4e6ff7affaa0c0aa0d1bca45bd700226329d5059d3eb54f9dff"
 dependencies = [
  "backon",
  "blake3",
@@ -6690,33 +6689,32 @@ dependencies = [
  "ctutils",
  "data-encoding",
  "derive_more 2.1.1",
- "ed25519-dalek 3.0.0-pre.7",
+ "ed25519-dalek 3.0.0-rc.0",
  "futures-util",
  "getrandom 0.4.2",
  "hickory-resolver 0.26.1",
  "http 1.3.1",
  "ipnet",
- "iroh-base 1.0.0-rc.1",
+ "iroh-base 1.0.0",
  "iroh-dns",
- "iroh-metrics 1.0.0-rc.0",
- "iroh-relay 1.0.0-rc.1",
+ "iroh-metrics 1.0.1",
+ "iroh-relay 1.0.0",
  "n0-error",
  "n0-future 0.3.2",
  "n0-watcher",
- "netwatch 0.18.0",
+ "netwatch 0.19.0",
  "noq",
  "noq-proto",
  "noq-udp",
  "papaya",
  "pin-project",
  "portable-atomic",
- "portmapper 0.18.0",
+ "portmapper 0.19.0",
  "rand 0.10.1",
  "reqwest 0.13.1",
  "rustc-hash",
  "rustls 0.23.38",
  "rustls-pki-types",
- "rustls-webpki 0.103.13",
  "serde",
  "smallvec",
  "strum 0.28.0",
@@ -6727,7 +6725,6 @@ dependencies = [
  "tracing",
  "url",
  "wasm-bindgen-futures",
- "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -6749,42 +6746,39 @@ dependencies = [
 
 [[package]]
 name = "iroh-base"
-version = "1.0.0-rc.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af93d67701c00c504982154569192ad384738c0450ba1196930314b955100552"
+checksum = "c9c95e4459d9bb828a77084277abd308aa2b58a096652b079bddfd6ef2361f53"
 dependencies = [
- "curve25519-dalek 5.0.0-pre.6",
+ "curve25519-dalek 5.0.0-rc.0",
  "data-encoding",
  "data-encoding-macro",
  "derive_more 2.1.1",
- "digest 0.11.3",
- "ed25519-dalek 3.0.0-pre.7",
+ "ed25519-dalek 3.0.0-rc.0",
  "getrandom 0.4.2",
  "n0-error",
  "rand 0.10.1",
  "serde",
- "sha2 0.11.0",
  "url",
  "zeroize",
- "zeroize_derive",
 ]
 
 [[package]]
 name = "iroh-dns"
-version = "1.0.0-rc.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de4112c91eb64094d77df9d3112606dcf7ff216421afccd2dc762fda5a7b2879"
+checksum = "754f7e0c1f67938e1d671007264ffef158f14a9f795a7cc219ea68ea09a9d4c9"
 dependencies = [
  "arc-swap",
  "cfg_aliases",
  "derive_more 2.1.1",
  "hickory-resolver 0.26.1",
- "iroh-base 1.0.0-rc.1",
+ "iroh-base 1.0.0",
  "n0-error",
  "n0-future 0.3.2",
  "ndk-context",
+ "portable-atomic",
  "rand 0.10.1",
- "reqwest 0.13.1",
  "rustls 0.23.38",
  "simple-dns 0.11.3",
  "strum 0.28.0",
@@ -6795,13 +6789,13 @@ dependencies = [
 
 [[package]]
 name = "iroh-mainline-address-lookup"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c406ca9915461110734901f28e0e093ae713490ca3fe1681df5a60f435d708c"
+checksum = "b1fd07cb8b4af54ccf367fe79516484c544ea3e4b1984cdd2b9aaf3bacaa80f2"
 dependencies = [
  "derive_more 2.1.1",
- "iroh 1.0.0-rc.1",
- "iroh-base 1.0.0-rc.1",
+ "iroh 1.0.0",
+ "iroh-base 1.0.0",
  "iroh-dns",
  "n0-error",
  "n0-future 0.3.2",
@@ -6826,11 +6820,11 @@ dependencies = [
 
 [[package]]
 name = "iroh-metrics"
-version = "1.0.0-rc.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d102597d0ee523f17fdb672c532395e634dbe945429284c811430d63bacc0d8a"
+checksum = "291065721ad7c477b972e581bbc528df031dc8eb5e39fe1ff3300ae5dfb157ef"
 dependencies = [
- "iroh-metrics-derive 1.0.0-rc.0",
+ "iroh-metrics-derive 1.0.1",
  "itoa",
  "n0-error",
  "portable-atomic",
@@ -6853,9 +6847,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-metrics-derive"
-version = "1.0.0-rc.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c8e0c97f1dc787107f388433c349397c565572fe6406d600ff7bb7b7fe3b30"
+checksum = "1ae5f0c4405d1fbc9fb16ff422ca40620e93dc36c30ecaba0c2aee3992b7bd48"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -6966,9 +6960,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-relay"
-version = "1.0.0-rc.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a70030b9e71c1183bd4f88fbdbebfa1af2a5be549dd6f20a1e8ac3cd0202ee9d"
+checksum = "1c12e48fef252fd04f8e6b6a8802b377baf72548d62ae4838816624cd0e06b79"
 dependencies = [
  "blake3",
  "bytes",
@@ -6981,9 +6975,9 @@ dependencies = [
  "http-body-util",
  "hyper 1.9.0",
  "hyper-util",
- "iroh-base 1.0.0-rc.1",
+ "iroh-base 1.0.0",
  "iroh-dns",
- "iroh-metrics 1.0.0-rc.0",
+ "iroh-metrics 1.0.1",
  "lru 0.18.0",
  "n0-error",
  "n0-future 0.3.2",
@@ -7932,9 +7926,9 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "n0-error"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "223e946a84aa91644507a6b7865cfebbb9a231ace499041c747ab0fd30408212"
+checksum = "c37e81176a83a77d2514528b91bdafc70ef88aab428f0e1b91aebb8d99888895"
 dependencies = [
  "n0-error-macros",
  "spez",
@@ -7942,9 +7936,9 @@ dependencies = [
 
 [[package]]
 name = "n0-error-macros"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "565305a21e6b3bf26640ad98f05a0fda12d3ab4315394566b52a7bddb8b34828"
+checksum = "e2acd8b070213b0299282f884b4beba4e7b52d624fdcd504a3ad3665390c11e1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7995,15 +7989,15 @@ dependencies = [
 
 [[package]]
 name = "n0-mainline"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4015a994f4fc3e3bff900dcea1cb9cbbfc644d0b865fa6704cd2dd7f7ffd47"
+checksum = "d976b09e7ed101cc2571d9423584e3c3eea38afad32fc305c1beae0a4eeadcde"
 dependencies = [
  "crc",
  "dyn-clone",
- "ed25519-dalek 3.0.0-pre.7",
+ "ed25519-dalek 3.0.0-rc.0",
  "futures-core",
- "lru 0.16.3",
+ "lru 0.18.0",
  "n0-error",
  "noq-udp",
  "rand 0.10.1",
@@ -8017,9 +8011,9 @@ dependencies = [
 
 [[package]]
 name = "n0-watcher"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928d8039a66cce5efcfd35e88b32d3defc8eba630b3ac451522997f563956a52"
+checksum = "bbc618745ad0b7414b149d0517ad8b5573b2fb4d4e2717add3d2446ce1fdd826"
 dependencies = [
  "derive_more 2.1.1",
  "n0-error",
@@ -8063,19 +8057,22 @@ dependencies = [
 
 [[package]]
 name = "netdev"
-version = "0.43.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57bacaf873ee4eab5646f99b381b271ec75e716902a67cf962c0f328c5eb5bfb"
+checksum = "9d31e7286c21ceaf0ddb1d881964011214555ea0b317cc2eb1a1d68d861386fc"
 dependencies = [
  "block2",
  "dispatch2",
  "dlopen2 0.8.2",
  "ipnet",
+ "jni 0.21.1",
  "libc",
  "mac-addr",
+ "ndk-context",
  "netlink-packet-core 0.8.1",
  "netlink-packet-route 0.29.0",
  "netlink-sys",
+ "objc2",
  "objc2-core-foundation",
  "objc2-core-wlan",
  "objc2-foundation",
@@ -8148,9 +8145,9 @@ dependencies = [
 
 [[package]]
 name = "netlink-packet-route"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8919612f6028ab4eacbbfe1234a9a43e3722c6e0915e7ff519066991905092"
+checksum = "e2288fcb784eb3defd5fb16f4c4160d5f477de192eac730f43e1d11c24d9a007"
 dependencies = [
  "bitflags 2.11.1",
  "libc",
@@ -8246,22 +8243,23 @@ dependencies = [
 
 [[package]]
 name = "netwatch"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2071e0c2b5b229622c459096b84f1ad51afa150cdeeefdad491ef3704e581d91"
+checksum = "8487d26d691cd98d5c17b2adb4b1fd4b31cccc820da1eac827d483295d7bb94a"
 dependencies = [
  "atomic-waker",
  "bytes",
  "cfg_aliases",
  "derive_more 2.1.1",
+ "ipnet",
  "js-sys",
  "libc",
  "n0-error",
  "n0-future 0.3.2",
  "n0-watcher",
- "netdev 0.43.0",
+ "netdev 0.44.0",
  "netlink-packet-core 0.8.1",
- "netlink-packet-route 0.30.0",
+ "netlink-packet-route 0.31.0",
  "netlink-proto 0.12.0",
  "netlink-sys",
  "noq-udp",
@@ -8316,9 +8314,9 @@ checksum = "f6b8866ec53810a9a4b3d434a29801e78c707430a9ae11c2db4b8b62bb9675a0"
 
 [[package]]
 name = "noq"
-version = "1.0.0-rc.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "198b99fc085a5db1f7d259edb5ede8311e59f28cdd2687920b4313613d21a73f"
+checksum = "11f0c73794bfde94db01379c46990b9a773993fca2b61a66184ce148b7c7a187"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -8338,9 +8336,9 @@ dependencies = [
 
 [[package]]
 name = "noq-proto"
-version = "1.0.0-rc.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ab0ac774795ce1e42a7e61266e71f3be8110210630441169ac8dda403dd23f1"
+checksum = "775be06b8d66c2c64db60140bf54dee8410f67b73c81cc1e1e32f11dfdaae501"
 dependencies = [
  "aes-gcm",
  "bytes",
@@ -8365,9 +8363,9 @@ dependencies = [
 
 [[package]]
 name = "noq-udp"
-version = "1.0.0-rc.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3c1520eacd33fd6b009e2e70116b05508ade51db5e0d315ff8bf6b702148c2b"
+checksum = "cd5a37756f168cf350d68a97c4f0158bdf3c76f10175123941569b09ab51f011"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -9323,20 +9321,20 @@ dependencies = [
 
 [[package]]
 name = "portmapper"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64959cbabf952c8ffcbaea13745308508f1f825922f4068353f3de08d42cf214"
+checksum = "ccc716c56a0a50f7e4e25f41446419599d47c6197cc5c9858174220e97c272e6"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "derive_more 2.1.1",
  "hyper-util",
  "igd-next 0.17.0",
- "iroh-metrics 1.0.0-rc.0",
+ "iroh-metrics 1.0.1",
  "libc",
  "n0-error",
  "n0-future 0.3.2",
- "netwatch 0.18.0",
+ "netwatch 0.19.0",
  "num_enum",
  "rand 0.10.1",
  "serde",
@@ -11667,9 +11665,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.9.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -14563,18 +14561,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -259,11 +259,11 @@ imbl = "5.0.0"
 impl-tools = "0.10.3"
 iroh = { version = "=0.35.0", default-features = false }
 iroh-base = { version = "=0.35.0", default-features = false }
-iroh-mainline-address-lookup = "0.3.0"
-iroh-next = { version = "=1.0.0-rc.1", default-features = false, features = [
+iroh-mainline-address-lookup = "0.4.0"
+iroh-next = { version = "=1.0.0", default-features = false, features = [
     "tls-ring",
 ], package = "iroh" }
-iroh-next-base = { version = "=1.0.0-rc.1", default-features = false, package = "iroh-base" }
+iroh-next-base = { version = "=1.0.0", default-features = false, package = "iroh-base" }
 iroh-relay = { version = "=0.35.0", default-features = false }
 itertools = "0.14.0"
 jaq-core = "2.1.1"

--- a/fedimint-cli/src/cli.rs
+++ b/fedimint-cli/src/cli.rs
@@ -15,7 +15,7 @@ use crate::client::{ClientCmd, ModuleSelector};
 use crate::envs::FM_USE_TOR_ENV;
 use crate::envs::{
     FM_API_SECRET_ENV, FM_CLIENT_DIR_ENV, FM_DB_BACKEND_ENV, FM_FEDERATION_SECRET_HEX_ENV,
-    FM_IROH_ENABLE_DHT_ENV, FM_IROH_ENABLE_NEXT_ENV, FM_OUR_ID_ENV, FM_PASSWORD_ENV,
+    FM_IROH_ENABLE_DHT_ENV, FM_OUR_ID_ENV, FM_PASSWORD_ENV,
 };
 use crate::utils::parse_peer_id;
 
@@ -56,10 +56,6 @@ pub(crate) struct Opts {
     // Enable using DHT name resolution in Iroh
     #[arg(long, env = FM_IROH_ENABLE_DHT_ENV)]
     pub iroh_enable_dht: Option<bool>,
-
-    // Enable using (in parallel) unstable/next Iroh stack
-    #[arg(long, env = FM_IROH_ENABLE_NEXT_ENV)]
-    pub iroh_enable_next: Option<bool>,
 
     /// Database backend to use.
     #[arg(long, env = FM_DB_BACKEND_ENV, value_enum, default_value = "rocksdb")]

--- a/fedimint-cli/src/envs.rs
+++ b/fedimint-cli/src/envs.rs
@@ -16,8 +16,6 @@ pub const FM_USE_TOR_ENV: &str = "FM_USE_TOR";
 
 pub const FM_IROH_ENABLE_DHT_ENV: &str = "FM_IROH_ENABLE_DHT";
 
-pub const FM_IROH_ENABLE_NEXT_ENV: &str = "FM_IROH_ENABLE_NEXT";
-
 // Api authentication secret
 pub const FM_API_SECRET_ENV: &str = "FM_API_SECRET";
 

--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -239,10 +239,6 @@ impl Opts {
         self.iroh_enable_dht.unwrap_or(true)
     }
 
-    fn iroh_enable_next(&self) -> bool {
-        self.iroh_enable_next.unwrap_or(true)
-    }
-
     fn use_tor(&self) -> bool {
         #[cfg(feature = "tor")]
         return self.use_tor;
@@ -299,7 +295,6 @@ impl Opts {
 
     async fn make_endpoints(&self) -> Result<ConnectorRegistry, anyhow::Error> {
         ConnectorRegistry::build_from_client_defaults()
-            .iroh_next(self.iroh_enable_next())
             .iroh_pkarr_dht(self.iroh_enable_dht())
             .ws_force_tor(self.use_tor())
             .bind()
@@ -440,8 +435,7 @@ impl FedimintCli {
         let mut client_builder = Client::builder()
             .await
             .map_err_cli()?
-            .with_iroh_enable_dht(cli.iroh_enable_dht())
-            .with_iroh_enable_next(cli.iroh_enable_next());
+            .with_iroh_enable_dht(cli.iroh_enable_dht());
         client_builder.with_module_inits(self.module_inits.clone());
 
         let db = cli.load_database().await?;

--- a/fedimint-client/src/client.rs
+++ b/fedimint-client/src/client.rs
@@ -169,7 +169,6 @@ pub struct Client {
     log_event_added_transient_tx: broadcast::Sender<EventLogEntry>,
     request_hook: ApiRequestHook,
     iroh_enable_dht: bool,
-    iroh_enable_next: bool,
     /// User-provided Bitcoin RPC client for modules to use
     ///
     /// Stored here for potential future access; currently passed to modules

--- a/fedimint-client/src/client/builder.rs
+++ b/fedimint-client/src/client/builder.rs
@@ -125,7 +125,6 @@ pub struct ClientBuilder {
     log_event_added_transient_tx: broadcast::Sender<EventLogEntry>,
     request_hook: ApiRequestHook,
     iroh_enable_dht: bool,
-    iroh_enable_next: bool,
     bitcoind_rpc_factory: Option<BitcoindRpcFactory>,
     bitcoind_rpc_no_chain_id_factory: Option<BitcoindRpcNoChainIdFactory>,
 }
@@ -149,7 +148,6 @@ impl ClientBuilder {
             log_event_added_transient_tx,
             request_hook: Arc::new(|api| api),
             iroh_enable_dht: true,
-            iroh_enable_next: true,
             bitcoind_rpc_factory: None,
             bitcoind_rpc_no_chain_id_factory: None,
         }
@@ -165,7 +163,6 @@ impl ClientBuilder {
             log_event_added_transient_tx: client.log_event_added_transient_tx.clone(),
             request_hook: client.request_hook.clone(),
             iroh_enable_dht: client.iroh_enable_dht,
-            iroh_enable_next: client.iroh_enable_next,
             // Note: bitcoind_rpc_factory is not cloned from existing client
             // since it's a one-time factory that's consumed during build
             bitcoind_rpc_factory: None,
@@ -208,13 +205,6 @@ impl ClientBuilder {
     /// the federation
     pub fn with_iroh_enable_dht(mut self, iroh_enable_dht: bool) -> Self {
         self.iroh_enable_dht = iroh_enable_dht;
-        self
-    }
-
-    /// Override if the parallel unstable/next Iroh stack should be enabled when
-    /// using Iroh to connect to the federation
-    pub fn with_iroh_enable_next(mut self, iroh_enable_next: bool) -> Self {
-        self.iroh_enable_next = iroh_enable_next;
         self
     }
 
@@ -1050,7 +1040,6 @@ impl ClientBuilder {
             client_recovery_progress_receiver,
             meta_service: self.meta_service,
             iroh_enable_dht: self.iroh_enable_dht,
-            iroh_enable_next: self.iroh_enable_next,
             user_bitcoind_rpc,
             user_bitcoind_rpc_no_chain_id: self.bitcoind_rpc_no_chain_id_factory,
         });

--- a/fedimint-connectors/src/iroh.rs
+++ b/fedimint-connectors/src/iroh.rs
@@ -93,7 +93,7 @@ use crate::{Connectivity, DynGatewayConnection, IConnection, IGatewayConnection}
 #[derive(Clone)]
 pub(crate) struct IrohConnector {
     stable: iroh::endpoint::Endpoint,
-    next: Option<iroh_next::endpoint::Endpoint>,
+    next: iroh_next::endpoint::Endpoint,
 
     /// List of overrides to use when attempting to connect to given
     /// `NodeId`
@@ -113,7 +113,7 @@ impl fmt::Debug for IrohConnector {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("IrohEndpoint")
             .field("stable-id", &self.stable.node_id())
-            .field("next-id", &self.next.as_ref().map(iroh_next::Endpoint::id))
+            .field("next-id", &self.next.id())
             .finish_non_exhaustive()
     }
 }
@@ -122,14 +122,11 @@ impl IrohConnector {
     pub async fn new(
         iroh_dns: Option<SafeUrl>,
         iroh_enable_dht: bool,
-        iroh_enable_next: bool,
         path_change: Arc<watch::Sender<u64>>,
     ) -> anyhow::Result<Self> {
         const FM_IROH_CONNECT_OVERRIDES_ENV: &str = "FM_IROH_CONNECT_OVERRIDES";
         const FM_GW_IROH_CONNECT_OVERRIDES_ENV: &str = "FM_GW_IROH_CONNECT_OVERRIDES";
-        let mut s =
-            Self::new_no_overrides(iroh_dns, iroh_enable_dht, iroh_enable_next, path_change)
-                .await?;
+        let mut s = Self::new_no_overrides(iroh_dns, iroh_enable_dht, path_change).await?;
 
         for (k, v) in parse_kv_list_from_env::<_, NodeTicket>(FM_IROH_CONNECT_OVERRIDES_ENV)? {
             s = s.with_connection_override(k, v.into());
@@ -146,7 +143,6 @@ impl IrohConnector {
     pub async fn new_no_overrides(
         iroh_dns: Option<SafeUrl>,
         iroh_enable_dht: bool,
-        iroh_enable_next: bool,
         path_change: Arc<watch::Sender<u64>>,
     ) -> anyhow::Result<Self> {
         let endpoint_stable = Box::pin({
@@ -250,12 +246,7 @@ impl IrohConnector {
             Ok(endpoint)
         });
 
-        let (endpoint_stable, endpoint_next) = if iroh_enable_next {
-            let (s, n) = tokio::try_join!(endpoint_stable, endpoint_next)?;
-            (s, Some(n))
-        } else {
-            (endpoint_stable.await?, None)
-        };
+        let (endpoint_stable, endpoint_next) = tokio::try_join!(endpoint_stable, endpoint_next)?;
 
         Ok(Self {
             stable: endpoint_stable,
@@ -328,19 +319,17 @@ impl crate::Connector for IrohConnector {
             }
         }));
 
-        if let Some(endpoint_next) = &self.next {
-            let self_clone = self.clone();
-            let endpoint_next = endpoint_next.clone();
-            futures.push(Box::pin(async move {
-                (
-                    self_clone
-                        .make_new_connection_next(&endpoint_next, node_id, connection_override)
-                        .await
-                        .map(super::IGuardianConnection::into_dyn),
-                    "next",
-                )
-            }));
-        }
+        let self_clone = self.clone();
+        let endpoint_next = self.next.clone();
+        futures.push(Box::pin(async move {
+            (
+                self_clone
+                    .make_new_connection_next(&endpoint_next, node_id, connection_override)
+                    .await
+                    .map(super::IGuardianConnection::into_dyn),
+                "next",
+            )
+        }));
 
         // Remember last error, so we have something to return if
         // neither connection works.

--- a/fedimint-connectors/src/lib.rs
+++ b/fedimint-connectors/src/lib.rs
@@ -54,8 +54,6 @@ pub struct ConnectorRegistryBuilder {
     iroh_enable: bool,
     /// Override the Iroh DNS server to use
     iroh_dns: Option<SafeUrl>,
-    /// Should start the "next/unstable" Iroh stack
-    iroh_next: bool,
     /// Enable Pkarr DHT discovery
     iroh_pkarr_dht: bool,
 
@@ -140,13 +138,8 @@ impl ConnectorRegistryBuilder {
             bail!("Iroh connector not enabled");
         }
         Ok(Arc::new(
-            iroh::IrohConnector::new(
-                self.iroh_dns.clone(),
-                self.iroh_pkarr_dht,
-                self.iroh_next,
-                path_change,
-            )
-            .await?,
+            iroh::IrohConnector::new(self.iroh_dns.clone(), self.iroh_pkarr_dht, path_change)
+                .await?,
         ) as DynConnector)
     }
 
@@ -180,13 +173,6 @@ impl ConnectorRegistryBuilder {
     pub fn iroh_pkarr_dht(self, enable: bool) -> Self {
         Self {
             iroh_pkarr_dht: enable,
-            ..self
-        }
-    }
-
-    pub fn iroh_next(self, enable: bool) -> Self {
-        Self {
-            iroh_next: enable,
             ..self
         }
     }
@@ -285,7 +271,6 @@ impl ConnectorRegistry {
             iroh_enable: true,
             iroh_dns: None,
             iroh_pkarr_dht: false,
-            iroh_next: true,
             ws_enable: true,
             ws_force_tor: false,
             http_enable: true,
@@ -301,7 +286,6 @@ impl ConnectorRegistry {
             iroh_enable: true,
             iroh_dns: None,
             iroh_pkarr_dht: true,
-            iroh_next: true,
             ws_enable: true,
             ws_force_tor: false,
             http_enable: false,
@@ -317,7 +301,6 @@ impl ConnectorRegistry {
             iroh_enable: true,
             iroh_dns: None,
             iroh_pkarr_dht: false,
-            iroh_next: false,
             ws_enable: true,
             ws_force_tor: false,
             http_enable: true,

--- a/gateway/fedimint-gateway-server/src/client.rs
+++ b/gateway/fedimint-gateway-server/src/client.rs
@@ -82,8 +82,7 @@ impl GatewayClientBuilder {
         let mut client_builder = Client::builder()
             .await
             .map_err(AdminGatewayError::ClientCreationError)?
-            .with_iroh_enable_dht(true)
-            .with_iroh_enable_next(true);
+            .with_iroh_enable_dht(true);
         client_builder.with_module_inits(registry);
         Ok(client_builder)
     }


### PR DESCRIPTION
## Summary

Bumps the client's parallel "next" iroh stack from `1.0.0-rc.1` to `1.0.0` and removes the client connector's toggle for running a single iroh stack, so the client is always dual-stack (0.35 + 1.0). The iroh/iroh-next alias scheme is left unchanged, and guardian-side code keeps running iroh 0.35.

## Details

The client connector already spoke both iroh 0.35 (`iroh`) and the 1.0 release candidate (`iroh-next`) behind an `iroh_enable_next` toggle. This is a first, minimal step of the iroh 1.0 migration:

- Bump `iroh-next` / `iroh-next-base` from `1.0.0-rc.1` to `1.0.0`. This also requires bumping `iroh-mainline-address-lookup` from `0.3.0` to `0.4.0`, since `0.3.0` transitively pins iroh to `1.0.0-rc.1`. The 1.0 construction API is unchanged from rc.1.
- Drop the connector's single-stack toggle (`FM_IROH_ENABLE_NEXT` / `--iroh-enable-next` / `with_iroh_enable_next` / the `iroh_next` builder field) so both endpoints are always built. The `next` endpoint is now a plain `Endpoint` instead of `Option`.

The workspace dependency alias names (`iroh` = 0.35, `iroh-next` = 1.0) and the `FM_IROH_CONNECT_OVERRIDES` `NodeTicket` format are left as-is.

## Reviewing

The change is confined to the client connector toggle removal and the version bump. There is no `iroh` → `iroh-legacy` rename and no connect-override format change. Guardian behavior is unchanged (still iroh 0.35).

## Testing

- `cargo check --workspace` passes.
- No guardian behavior change (still iroh 0.35); the client retains its 0.35 connection path.