### PR TITLE
docs: update Conduit Wallet link to joschisan.github.io/conduit

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ You can pick one of Fedimint-supporting applications:
 
 * [Fedi](https://www.fedi.xyz/) - for MacOS, Android and Web browsers
 * [Ecash App](https://ecash.love) - Android and desktop wallet
-* [Conduit Wallet](https://conduit.cash/) - iOS and Android wallet
+* [Conduit Wallet](https://joschisan.github.io/conduit) - iOS and Android wallet
 * [Harbor Wallet](https://harbor.cash/) - desktop wallet
 * [Vipr Wallet](https://github.com/ngutech21/vipr-wallet) - Web (PWA) wallet
 * `fedimint-cli` - built-in CLI wallet


### PR DESCRIPTION
## Summary

Points the Conduit Wallet entry in the README at `https://joschisan.github.io/conduit` instead of `https://conduit.cash/`.

## Details

The `conduit.cash` domain currently serves an untrusted TLS certificate, which fails the `markdown-link-check` CI job (`SSL certificate not trusted`). Switching the link to the GitHub Pages site resolves the failure.