### PR TITLE
chore(server): track iroh API response codes

### DIFF
--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -50,7 +50,7 @@ use crate::consensus::engine::ConsensusEngine;
 use crate::db::verify_server_db_integrity_dbtx;
 use crate::metrics::{
     IROH_API_CONNECTION_DURATION_SECONDS, IROH_API_CONNECTIONS_ACTIVE,
-    IROH_API_REQUEST_DURATION_SECONDS,
+    IROH_API_REQUEST_DURATION_SECONDS, IROH_API_REQUEST_RESPONSE_CODE,
 };
 use crate::net::api::announcement::get_api_urls;
 use crate::net::api::{ApiSecrets, HasApiContext};
@@ -582,6 +582,13 @@ async fn handle_request(
     let response = await_response(consensus_api, core_api, module_api, request).await;
 
     timer.observe_duration();
+
+    let response_code = response
+        .as_ref()
+        .map_or_else(|err| err.code.to_string(), |_| "0".to_string());
+    IROH_API_REQUEST_RESPONSE_CODE
+        .with_label_values(&[method.as_str(), response_code.as_str(), "default"])
+        .inc();
 
     let response = serde_json::to_vec(&response)?;
 

--- a/fedimint-server/src/metrics.rs
+++ b/fedimint-server/src/metrics.rs
@@ -132,6 +132,18 @@ pub(crate) static IROH_API_REQUEST_DURATION_SECONDS: LazyLock<HistogramVec> = La
     .unwrap()
 });
 
+pub(crate) static IROH_API_REQUEST_RESPONSE_CODE: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec_with_registry!(
+        opts!(
+            "iroh_api_request_response_code_total",
+            "Count of iroh API response codes and types",
+        ),
+        &["method", "code", "type"],
+        REGISTRY
+    )
+    .unwrap()
+});
+
 pub(crate) static JSONRPC_API_REQUEST_DURATION_SECONDS: LazyLock<HistogramVec> =
     LazyLock::new(|| {
         register_histogram_vec_with_registry!(


### PR DESCRIPTION
*PR published by Tau*

### Summary

Add a Prometheus counter for guardian iroh API response codes, mirroring the existing JSON-RPC response-code metric.

### Details

The guardian iroh API already exposed request durations and connection metrics, but not per-method response code totals. This PR adds `fm_iroh_api_request_response_code_total` with `method`, `code`, and `type` labels. Successful API responses are recorded as `code="0"`; API errors use their existing `ApiError::code`; `type` is always `default` because iroh API requests do not have JSON-RPC batch or subscription variants.

### Testing

- `cargo check -p fedimint-server`
- `just final-lint`
