### PR TITLE
feat(mintv2): return operation ID from send

### DIFF
--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -2560,7 +2560,7 @@ impl IAdminGateway for Gateway {
                 notes: notes.to_string(),
             })
         } else if let Ok(mint_module) = client.get_first_module::<MintV2ClientModule>() {
-            let ecash = mint_module
+            let (_, ecash) = mint_module
                 .send(payload.amount, serde_json::Value::Null, true)
                 .await
                 .map_err(|e| AdminGatewayError::Unexpected(e.into()))?;

--- a/modules/fedimint-mintv2-client/src/cli.rs
+++ b/modules/fedimint-mintv2-client/src/cli.rs
@@ -36,10 +36,8 @@ pub(crate) async fn handle_cli_command(
             amount,
             include_invite,
         } => {
-            let ecash = mint
-                .send(amount, Value::Null, include_invite)
-                .await
-                .map(|ecash| base32::encode_prefixed(FEDIMINT_PREFIX, &ecash))?;
+            let (_, ecash) = mint.send(amount, Value::Null, include_invite).await?;
+            let ecash = base32::encode_prefixed(FEDIMINT_PREFIX, &ecash);
 
             Ok(json(ecash))
         }

--- a/modules/fedimint-mintv2-client/src/lib.rs
+++ b/modules/fedimint-mintv2-client/src/lib.rs
@@ -757,7 +757,7 @@ impl MintClientModule {
             .await
     }
 
-    /// Send `ECash` for the given amount. The
+    /// Send `ECash` for the given amount and return the send operation ID. The
     /// amount will be rounded up to a multiple of 512 msats which is the
     /// smallest denomination used throughout the client. If the rounded
     /// amount cannot be covered with the ecash notes in the client's
@@ -775,10 +775,10 @@ impl MintClientModule {
         amount: Amount,
         custom_meta: Value,
         include_invite: bool,
-    ) -> Result<ECash, SendECashError> {
+    ) -> Result<(OperationId, ECash), SendECashError> {
         let amount = round_to_multiple(amount, client_denominations().next().unwrap().amount());
 
-        if let Some(ecash) = self
+        if let Some((operation_id, ecash)) = self
             .client_ctx
             .module_db()
             .autocommit(
@@ -795,7 +795,7 @@ impl MintClientModule {
             .await
             .expect("Failed to commit dbtx after 100 retries")
         {
-            return Ok(ecash);
+            return Ok((operation_id, ecash));
         }
 
         self.client_ctx
@@ -842,7 +842,7 @@ impl MintClientModule {
         mut remaining_amount: Amount,
         custom_meta: Value,
         include_invite: bool,
-    ) -> Result<Option<ECash>, Infallible> {
+    ) -> Result<Option<(OperationId, ECash)>, Infallible> {
         let mut stream = dbtx
             .find_by_prefix_sorted_descending(&SpendableNotePrefix)
             .await
@@ -904,7 +904,7 @@ impl MintClientModule {
         let sender = self.balance_update_sender.clone();
         dbtx.on_commit(move || sender.send_replace(()));
 
-        Ok(Some(ecash))
+        Ok(Some((operation_id, ecash)))
     }
 
     /// Receive the `ECash` by reissuing the notes and return the total amount

--- a/modules/fedimint-mintv2-tests/tests/tests.rs
+++ b/modules/fedimint-mintv2-tests/tests/tests.rs
@@ -130,14 +130,15 @@ async fn send_and_receive() -> anyhow::Result<()> {
         // Exercise both with and without the optional invite code.
         let include_invite = i % 2 == 0;
 
-        let ecash = client_send
+        let (operation_id, ecash) = client_send
             .get_first_module::<MintClientModule>()?
             .send(Amount::from_sats(1_000), Value::Null, include_invite)
             .await?;
 
-        let Some(MintEvent::Send(_)) = send_events.next().await else {
+        let Some(MintEvent::Send(send)) = send_events.next().await else {
             panic!("Expected Send event");
         };
+        assert_eq!(send.operation_id, operation_id);
 
         let ecash = base32::encode_prefixed(FEDIMINT_PREFIX, &ecash);
 
@@ -235,14 +236,15 @@ async fn double_spend_is_rejected() -> anyhow::Result<()> {
     let mut send_events = pin!(mint_event_stream(&client_send));
     let mut receive_events = pin!(mint_event_stream(&client_receive));
 
-    let ecash = client_send
+    let (send_operation_id, ecash) = client_send
         .get_first_module::<MintClientModule>()?
         .send(Amount::from_sats(1_000), Value::Null, false)
         .await?;
 
-    let Some(MintEvent::Send(_)) = send_events.next().await else {
+    let Some(MintEvent::Send(send)) = send_events.next().await else {
         panic!("Expected Send event");
     };
+    assert_eq!(send.operation_id, send_operation_id);
 
     let operation_id = client_send
         .get_first_module::<MintClientModule>()?
@@ -304,14 +306,15 @@ async fn transaction_with_invalid_signature_is_rejected() -> anyhow::Result<()> 
 
     let mut events = pin!(mint_event_stream(&client));
 
-    let ecash = client
+    let (operation_id, ecash) = client
         .get_first_module::<MintClientModule>()?
         .send(Amount::from_sats(1_000), Value::Null, false)
         .await?;
 
-    let Some(MintEvent::Send(_)) = events.next().await else {
+    let Some(MintEvent::Send(send)) = events.next().await else {
         panic!("Expected Send event");
     };
+    assert_eq!(send.operation_id, operation_id);
 
     let mut invalid_notes = ecash.notes();
 


### PR DESCRIPTION
Just exposing the OP ID for mintv2 send for integrator convenience. It is helpful to be able to attach things keyed by operation ID that can later be coalesced when building a TX history based on operation log—as an example.
