### PR TITLE
test(ci): use backend-neutral wallet test groups

### DIFF
--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -53,13 +53,9 @@ fn bsats(satoshi: u64) -> bitcoin::Amount {
 const PEG_IN_AMOUNT_SATS: u64 = 10000;
 const PEG_OUT_AMOUNT_SATS: u64 = 1000;
 const FM_WALLET_TEST_GROUP_ENV: &str = "FM_WALLET_TEST_GROUP";
-const FM_BITCOIND_WALLET_TEST_GROUP_ENV: &str = "FM_BITCOIND_WALLET_TEST_GROUP";
 
 fn should_skip_wallet_test_group(test_group: &str) -> bool {
-    let selected_group =
-        env::var(FM_WALLET_TEST_GROUP_ENV).or_else(|_| env::var(FM_BITCOIND_WALLET_TEST_GROUP_ENV));
-
-    match selected_group {
+    match env::var(FM_WALLET_TEST_GROUP_ENV) {
         Ok(selected_group) if selected_group != test_group => {
             info!(
                 selected_group,

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -52,10 +52,14 @@ fn bsats(satoshi: u64) -> bitcoin::Amount {
 
 const PEG_IN_AMOUNT_SATS: u64 = 10000;
 const PEG_OUT_AMOUNT_SATS: u64 = 1000;
+const FM_WALLET_TEST_GROUP_ENV: &str = "FM_WALLET_TEST_GROUP";
 const FM_BITCOIND_WALLET_TEST_GROUP_ENV: &str = "FM_BITCOIND_WALLET_TEST_GROUP";
 
 fn should_skip_wallet_test_group(test_group: &str) -> bool {
-    match env::var(FM_BITCOIND_WALLET_TEST_GROUP_ENV) {
+    let selected_group =
+        env::var(FM_WALLET_TEST_GROUP_ENV).or_else(|_| env::var(FM_BITCOIND_WALLET_TEST_GROUP_ENV));
+
+    match selected_group {
         Ok(selected_group) if selected_group != test_group => {
             info!(
                 selected_group,

--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -366,11 +366,11 @@ function bckn_esplora() {
   if [ -z "${FM_BACKWARDS_COMPATIBILITY_TEST:-}" ]; then
     fm-run-test "${FUNCNAME[0]}_group_1" env \
       FM_TEST_ONLY=esplora \
-      FM_BITCOIND_WALLET_TEST_GROUP=1 \
+      FM_WALLET_TEST_GROUP=1 \
       ./scripts/tests/backend-test.sh
     fm-run-test "${FUNCNAME[0]}_group_2" env \
       FM_TEST_ONLY=esplora \
-      FM_BITCOIND_WALLET_TEST_GROUP=2 \
+      FM_WALLET_TEST_GROUP=2 \
       ./scripts/tests/backend-test.sh
   fi
 }

--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -302,12 +302,12 @@ function bckn_bitcoind_wallet() {
     fm-run-test "${FUNCNAME[0]}_group_1" env \
       FM_TEST_ONLY=bitcoind \
       FM_BITCOIND_TEST_ONLY=wallet \
-      FM_BITCOIND_WALLET_TEST_GROUP=1 \
+      FM_WALLET_TEST_GROUP=1 \
       ./scripts/tests/backend-test.sh
     fm-run-test "${FUNCNAME[0]}_group_2" env \
       FM_TEST_ONLY=bitcoind \
       FM_BITCOIND_TEST_ONLY=wallet \
-      FM_BITCOIND_WALLET_TEST_GROUP=2 \
+      FM_WALLET_TEST_GROUP=2 \
       ./scripts/tests/backend-test.sh
   fi
 }


### PR DESCRIPTION
Summary
-------

Use a backend-neutral wallet test group environment variable for split wallet CI scenarios.

Details
-------

The wallet tests already gate individual cases by a group selector. That selector was named `FM_BITCOIND_WALLET_TEST_GROUP`, but the same grouping is also used by the Esplora backend split. This renames the selector to `FM_WALLET_TEST_GROUP` and updates both bitcoind and Esplora `test-ci-all` callers to use it.

The first commit introduces the neutral env var with a compatibility fallback while moving the bitcoind split over. The second commit moves the already-split Esplora path over and removes the old bitcoind-specific fallback.

Testing
-------

- `bash -n scripts/tests/test-ci-all.sh`
- `cargo fmt --check --package fedimint-wallet-tests`
- `git diff --check`
- `just format`
- `env NO_STASH=true ./misc/git-hooks/pre-commit`

Note: `just final-lint` could not run in this worktree because the shared git hook symlink points at a stale absolute worktree path. The direct hook command above is the same pre-commit hook CI invokes.
