### PR TITLE
fix(ci): start gateway before waiting for registration

### DIFF
--- a/devimint/src/devfed.rs
+++ b/devimint/src/devfed.rs
@@ -467,6 +467,7 @@ impl DevJitFed {
         );
 
         if !self.pre_dkg && !self.skip_setup {
+            let _ = self.gw_lnd_registered().await?;
             let _ = self.internal_client_gw_registered().await?;
         }
         let _ = self.channel_opened.get_try().await?;


### PR DESCRIPTION
*PR published by Tau*

## Summary

Fixes an upgrade-test flake where devimint could poll for gateway registration before explicitly waiting for the LND gateway registration task.

## Details

The failing scheduled CI run timed out in `await_gateways_registered` with `0` gateways and no gateway daemon log output. `DevJitFed::finalize` was using `internal_client_gw_registered()` as an implicit wait for gateway startup/registration, then only later awaited `gw_lnd_registered()` directly.

This makes the dependency explicit by awaiting `gw_lnd_registered()` before polling the federation. If gateway startup or registration fails, that path should now be surfaced directly instead of showing only a blind federation poll timeout.

## Testing

- `cargo check -p devimint`
- Previous version of this branch with the same logical fix passed:
  `TEST_KINDS=gateway FM_TEST_CI_ALL_JOBS=1 FM_TEST_CI_ALL_MAX_LOAD=100000 FM_TEST_UPGRADE_TIMEOUT=800 ./scripts/tests/upgrade-test.sh 'v0.9.1 current'`
