### PR TITLE
fix(server): reap idle iroh API connections

### DIFF
--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -35,7 +35,7 @@ use fedimint_server_core::migration::apply_migrations_server_dbtx;
 use fedimint_server_core::{DynServerModule, ServerModuleInitRegistry};
 use futures::FutureExt;
 use iroh::Endpoint;
-use iroh::endpoint::{Incoming, RecvStream, SendStream};
+use iroh::endpoint::{Incoming, RecvStream, SendStream, VarInt};
 use jsonrpsee::RpcModule;
 use jsonrpsee::server::ServerHandle;
 use serde_json::Value;
@@ -59,6 +59,16 @@ use crate::{DashboardUiRouter, net, update_server_info_version_dbtx};
 
 /// How many txs can be stored in memory before blocking the API
 const TRANSACTION_BUFFER: usize = 1000;
+
+/// How long an iroh API connection may stay idle before the server closes it.
+const IROH_API_CONNECTION_IDLE_TIMEOUT: Duration = Duration::from_secs(5 * 60);
+
+/// Application-level QUIC error code for expected idle iroh API connection
+/// reaping.
+const IROH_API_CONNECTION_IDLE_TIMEOUT_ERROR_CODE: u32 = 0;
+
+/// Application-level QUIC close reason for idle iroh API connection reaping.
+const IROH_API_CONNECTION_IDLE_TIMEOUT_ERROR_REASON: &[u8] = b"idle timeout";
 
 #[allow(clippy::too_many_arguments)]
 pub async fn run(
@@ -529,7 +539,33 @@ async fn handle_incoming(
     }
 
     loop {
-        let (send_stream, recv_stream) = connection.accept_bi().await?;
+        let accept_result = fedimint_core::runtime::timeout(
+            IROH_API_CONNECTION_IDLE_TIMEOUT,
+            connection.accept_bi(),
+        )
+        .await;
+
+        let (send_stream, recv_stream) = match accept_result {
+            Ok(streams) => streams?,
+            Err(_)
+                if parallel_requests_limit.available_permits()
+                    < iroh_api_max_requests_per_connection =>
+            {
+                continue;
+            }
+            Err(_) => {
+                info!(
+                    target: LOG_NET_API,
+                    idle_timeout_secs = IROH_API_CONNECTION_IDLE_TIMEOUT.as_secs(),
+                    "Closing idle iroh API connection"
+                );
+                connection.close(
+                    VarInt::from_u32(IROH_API_CONNECTION_IDLE_TIMEOUT_ERROR_CODE),
+                    IROH_API_CONNECTION_IDLE_TIMEOUT_ERROR_REASON,
+                );
+                return Ok(());
+            }
+        };
 
         if parallel_requests_limit.available_permits() == 0 {
             warn!(

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -49,8 +49,8 @@ use crate::consensus::api::{ConsensusApi, server_endpoints};
 use crate::consensus::engine::ConsensusEngine;
 use crate::db::verify_server_db_integrity_dbtx;
 use crate::metrics::{
-    IROH_API_CONNECTION_DURATION_SECONDS, IROH_API_CONNECTIONS_ACTIVE,
-    IROH_API_REQUEST_DURATION_SECONDS, IROH_API_REQUEST_RESPONSE_CODE,
+    IROH_API_CONNECTION_DURATION_SECONDS, IROH_API_CONNECTION_IDLE_TIMEOUT_TOTAL,
+    IROH_API_CONNECTIONS_ACTIVE, IROH_API_REQUEST_DURATION_SECONDS, IROH_API_REQUEST_RESPONSE_CODE,
 };
 use crate::net::api::announcement::get_api_urls;
 use crate::net::api::{ApiSecrets, HasApiContext};
@@ -554,7 +554,8 @@ async fn handle_incoming(
                 continue;
             }
             Err(_) => {
-                info!(
+                IROH_API_CONNECTION_IDLE_TIMEOUT_TOTAL.inc();
+                tracing::debug!(
                     target: LOG_NET_API,
                     idle_timeout_secs = IROH_API_CONNECTION_IDLE_TIMEOUT.as_secs(),
                     "Closing idle iroh API connection"

--- a/fedimint-server/src/metrics.rs
+++ b/fedimint-server/src/metrics.rs
@@ -10,7 +10,8 @@ use fedimint_core::backup::ClientBackupKeyPrefix;
 use fedimint_core::db::{Database, IDatabaseTransactionOpsCoreTyped};
 use fedimint_core::task::{TaskGroup, sleep};
 use fedimint_metrics::prometheus::{
-    HistogramVec, IntCounterVec, IntGauge, IntGaugeVec, register_histogram_vec_with_registry,
+    HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec,
+    register_histogram_vec_with_registry, register_int_counter_with_registry,
     register_int_gauge_vec_with_registry, register_int_gauge_with_registry,
 };
 use fedimint_metrics::{
@@ -119,6 +120,18 @@ pub(crate) static IROH_API_CONNECTION_DURATION_SECONDS: LazyLock<Histogram> = La
     )
     .unwrap()
 });
+
+pub(crate) static IROH_API_CONNECTION_IDLE_TIMEOUT_TOTAL: LazyLock<IntCounter> =
+    LazyLock::new(|| {
+        register_int_counter_with_registry!(
+            opts!(
+                "iroh_api_connection_idle_timeout_total",
+                "Number of iroh API connections closed by the server after being idle",
+            ),
+            REGISTRY
+        )
+        .unwrap()
+    });
 
 pub(crate) static IROH_API_REQUEST_DURATION_SECONDS: LazyLock<HistogramVec> = LazyLock::new(|| {
     register_histogram_vec_with_registry!(


### PR DESCRIPTION
*PR published by Tau*

### Summary

Close idle server-side iroh API connections after five minutes without a newly accepted request stream, so fedimintd does not rely solely on iroh/quinn to eventually clean up abandoned connections.

### Details

The iroh API connection handler now wraps `accept_bi()` in a Fedimint runtime timeout. On timeout, it closes the QUIC connection and exits the handler when there are no in-flight request handlers for that connection. If requests are still active, the handler keeps waiting, so legitimate long-poll API calls are not cut off just because they run longer than the idle timeout.

### Reviewing

The main policy question is whether five minutes is the right idle timeout. The implementation intentionally treats active requests differently from idle connections to avoid disrupting long-poll endpoints.

### Testing

`just final-lint`
