### PR TITLE
chore(deps): pin actions/checkout to v7.0.0 in daily fuzz job

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -26,7 +26,7 @@ jobs:
   fuzz:
     runs-on: [self-hosted, linux, x64]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/pin-nix-flake-inputs
       - name: Quick fuzzing
         run: |


### PR DESCRIPTION
Follow-up to #8735 (Dependabot's `actions/checkout` v6 → v7 bump).

Dependabot updated all the SHA-pinned `actions/checkout` references to `9c091bb` (v7.0.0), but it left the one floating `@v6` tag in the `fuzz` job of `daily.yml` untouched — Dependabot only rewrites the SHA-pinned occurrences. This pins that last reference to the same v7.0.0 commit so the whole repo stays consistently SHA-pinned with a version comment.

```diff
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)