### PR TITLE
feat(lnv2): report invoice amount and fee in payment events

### DIFF
--- a/fedimint-recurringdv2/src/main.rs
+++ b/fedimint-recurringdv2/src/main.rs
@@ -14,11 +14,10 @@ use fedimint_core::base32::{FEDIMINT_PREFIX, decode_prefixed};
 use fedimint_core::config::FederationId;
 use fedimint_core::encoding::Encodable;
 use fedimint_core::secp256k1::Scalar;
-use fedimint_core::time::duration_since_epoch;
 use fedimint_core::util::SafeUrl;
 use fedimint_core::{Amount, BitcoinHash};
 use fedimint_lnurl::{InvoiceResponse, LnurlResponse, PayResponse, pay_request_tag};
-use fedimint_lnv2_common::contracts::{IncomingContract, PaymentImage};
+use fedimint_lnv2_common::contracts::{IncomingContract, PaymentImage, fee_encoded_expiration};
 use fedimint_lnv2_common::gateway_api::{
     GatewayConnection, PaymentFee, RealGatewayConnection, RoutingInfo,
 };
@@ -210,9 +209,12 @@ async fn create_contract_and_fetch_invoice(
         "Amount too small"
     );
 
-    let expiration = duration_since_epoch()
-        .as_secs()
-        .saturating_add(u64::from(expiry_secs));
+    // Encode the gateway fee in the contract expiration so the receiving client
+    // can recover it and report the invoice amount in its payment events. These
+    // contracts are discovered via the contract stream rather than awaited
+    // per-invoice, so a real expiration is not needed here; the bolt11 invoice
+    // still carries the real expiry of `expiry_secs`.
+    let expiration = fee_encoded_expiration(routing_info.receive_fee.fee(amount).msats);
 
     let contract = IncomingContract::new(
         aggregate_pk,

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -3083,7 +3083,7 @@ impl Gateway {
             )));
         }
 
-        if payload.contract.commitment.expiration <= duration_since_epoch().as_secs() {
+        if payload.contract.commitment.expiration_or_fee <= duration_since_epoch().as_secs() {
             return Err(PublicGatewayError::LNv2(LNv2Error::IncomingPayment(
                 "The contract has already expired".to_string(),
             )));

--- a/modules/fedimint-lnv2-client/src/events.rs
+++ b/modules/fedimint-lnv2-client/src/events.rs
@@ -45,6 +45,10 @@ impl Event for SendPaymentUpdateEvent {
 pub struct ReceivePaymentEvent {
     pub operation_id: OperationId,
     pub amount: Amount,
+    /// Absolute fee paid to the gateway. Defaults to zero for events recorded
+    /// before this field was added.
+    #[serde(default)]
+    pub fee: Amount,
 }
 
 impl Event for ReceivePaymentEvent {

--- a/modules/fedimint-lnv2-client/src/lib.rs
+++ b/modules/fedimint-lnv2-client/src/lib.rs
@@ -660,7 +660,7 @@ impl LightningClientModule {
                 &mut dbtx,
                 SendPaymentEvent {
                     operation_id,
-                    amount: send_fee.add_to(amount),
+                    amount: Amount::from_msats(amount),
                     fee: send_fee.fee(amount),
                 },
             )

--- a/modules/fedimint-lnv2-client/src/receive_sm.rs
+++ b/modules/fedimint-lnv2-client/src/receive_sm.rs
@@ -101,7 +101,10 @@ impl ReceiveStateMachine {
     ) -> Option<OutPoint> {
         global_context
             .module_api()
-            .await_incoming_contract(&contract.contract_id(), contract.commitment.expiration)
+            .await_incoming_contract(
+                &contract.contract_id(),
+                contract.commitment.expiration_or_fee,
+            )
             .await
     }
 
@@ -146,7 +149,7 @@ impl ReceiveStateMachine {
             // operation), so the fee is recovered from the fee-encoded expiration.
             Ok(LightningOperationMeta::Receive(meta)) => meta.gateway_fee(),
             _ => Amount::from_msats(fee_from_expiration(
-                old_state.common.contract.commitment.expiration,
+                old_state.common.contract.commitment.expiration_or_fee,
             )),
         };
 

--- a/modules/fedimint-lnv2-client/src/receive_sm.rs
+++ b/modules/fedimint-lnv2-client/src/receive_sm.rs
@@ -1,20 +1,20 @@
 use fedimint_client_module::DynGlobalClientContext;
 use fedimint_client_module::sm::{ClientSMDatabaseTransaction, State, StateTransition};
 use fedimint_client_module::transaction::{ClientInput, ClientInputBundle};
-use fedimint_core::OutPoint;
 use fedimint_core::core::OperationId;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::Amounts;
 use fedimint_core::secp256k1::Keypair;
-use fedimint_lnv2_common::contracts::IncomingContract;
+use fedimint_core::{Amount, OutPoint};
+use fedimint_lnv2_common::contracts::{IncomingContract, fee_from_expiration};
 use fedimint_lnv2_common::{LightningInput, LightningInputV0};
 use fedimint_logging::LOG_CLIENT_MODULE_LNV2;
 use tpe::AggregateDecryptionKey;
 use tracing::instrument;
 
-use crate::LightningClientContext;
 use crate::api::LightningFederationApi;
 use crate::events::ReceivePaymentEvent;
+use crate::{LightningClientContext, LightningOperationMeta};
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct ReceiveStateMachine {
@@ -130,6 +130,26 @@ impl ReceiveStateMachine {
             .await
             .expect("Cannot claim input, additional funding needed");
 
+        // The event reports the invoice amount and the gateway fee separately.
+        // Manual receives carry the invoice in their operation meta, so the fee
+        // is the difference between invoice and contract amount. Lnurl receives
+        // do not have an invoice on the client, so the fee is recovered from the
+        // fee-encoded contract expiration set by the recurring daemon instead.
+        let fee = match context
+            .client_ctx
+            .get_operation(old_state.common.operation_id)
+            .await
+            .map(|operation| operation.meta::<LightningOperationMeta>())
+        {
+            // A receive operation meta is only recorded for manually created
+            // invoices; lnurl receives have no invoice on the client (and no
+            // operation), so the fee is recovered from the fee-encoded expiration.
+            Ok(LightningOperationMeta::Receive(meta)) => meta.gateway_fee(),
+            _ => Amount::from_msats(fee_from_expiration(
+                old_state.common.contract.commitment.expiration,
+            )),
+        };
+
         // Log event when receive completes successfully
         context
             .client_ctx
@@ -137,7 +157,8 @@ impl ReceiveStateMachine {
                 &mut dbtx.module_tx(),
                 ReceivePaymentEvent {
                     operation_id: old_state.common.operation_id,
-                    amount: old_state.common.contract.commitment.amount,
+                    amount: old_state.common.contract.commitment.amount + fee,
+                    fee,
                 },
             )
             .await;

--- a/modules/fedimint-lnv2-common/src/contracts.rs
+++ b/modules/fedimint-lnv2-common/src/contracts.rs
@@ -29,7 +29,11 @@ pub struct IncomingContract {
 pub struct Commitment {
     pub payment_image: PaymentImage,
     pub amount: Amount,
-    pub expiration: u64,
+    /// A real unix-time expiration for ordinary incoming contracts, or a
+    /// fee-encoded value for lnurl receives (see [`fee_encoded_expiration`]).
+    /// The wire name stays `expiration` for backwards compatibility.
+    #[serde(rename = "expiration")]
+    pub expiration_or_fee: u64,
     pub claim_pk: PublicKey,
     pub refund_pk: PublicKey,
     pub ephemeral_pk: PublicKey,
@@ -71,7 +75,7 @@ impl IncomingContract {
         let commitment = Commitment {
             payment_image,
             amount,
-            expiration,
+            expiration_or_fee: expiration,
             claim_pk,
             refund_pk,
             ephemeral_pk,

--- a/modules/fedimint-lnv2-common/src/contracts.rs
+++ b/modules/fedimint-lnv2-common/src/contracts.rs
@@ -35,6 +35,26 @@ pub struct Commitment {
     pub ephemeral_pk: PublicKey,
 }
 
+/// Encode a gateway fee into an incoming-contract expiration.
+///
+/// Incoming contracts created for lnurl receives store the gateway fee here
+/// instead of a real timestamp: the receiving client never sees the invoice for
+/// these contracts, so this is the only way for it to recover the fee and
+/// report the invoice amount in its payment events. A real expiration is not
+/// needed as these contracts are discovered via the contract stream rather than
+/// awaited per-invoice, and the funding-time validation only requires the
+/// expiration to lie in the future, which the resulting near-`u64::MAX` value
+/// satisfies.
+pub fn fee_encoded_expiration(fee_msats: u64) -> u64 {
+    u64::MAX - fee_msats
+}
+
+/// Recover the gateway fee from an incoming-contract expiration created with
+/// [`fee_encoded_expiration`].
+pub fn fee_from_expiration(expiration: u64) -> u64 {
+    u64::MAX - expiration
+}
+
 impl IncomingContract {
     #[allow(clippy::too_many_arguments)]
     pub fn new(

--- a/modules/fedimint-lnv2-server/src/lib.rs
+++ b/modules/fedimint-lnv2-server/src/lib.rs
@@ -560,7 +560,7 @@ impl ServerModule for Lightning {
                     return Err(LightningOutputError::InvalidContract);
                 }
 
-                if contract.commitment.expiration <= self.consensus_unix_time(dbtx).await {
+                if contract.commitment.expiration_or_fee <= self.consensus_unix_time(dbtx).await {
                     return Err(LightningOutputError::ContractExpired);
                 }
 


### PR DESCRIPTION
## Summary

Aligns the lnv2 send/receive payment events with the walletv2 events: both now report the **invoice amount** as `amount` and the **gateway fee** as a separate `fee` field.

Previously:
- The **receive** event reported the incoming contract amount (invoice amount *minus* the gateway fee) and had no `fee` field.
- The **send** event reported the invoice amount *plus* the gateway fee.

Neither matched walletv2, which reports the transfer value and fee separately.

## The lnurl problem

For receives via lnurl the client never sees the invoice, so it cannot recover the gateway fee from the contract alone (the contract only holds the net amount). To make the fee available, the recurring daemon now encodes it in the otherwise-unused `expiration` field of the incoming contract as `u64::MAX - fee_msats`.

This is safe because:
- These contracts are discovered via the contract stream, not awaited per-invoice, so a real expiration is not needed.
- The only consensus check on an incoming contract's expiration is the funding-time gate (`expiration > consensus_unix_time`), which the encoded value trivially satisfies — claim/refund of incoming contracts does not consult `expiration` at all.
- The bolt11 invoice still carries the real expiry.

## Changes

- `fedimint-lnv2-common`: add `fee_encoded_expiration` / `fee_from_expiration` helpers that store/recover the gateway fee in the incoming-contract expiration field.
- `fedimint-recurringdv2`: set the incoming-contract expiration to the fee-encoded value.
- `fedimint-lnv2-client`: add `fee` to `ReceivePaymentEvent` (`#[serde(default)]` for old events); compute the fee in the receive transition (manual receives from the invoice in their operation meta, lnurl receives — identified by the absence of a `Receive` operation meta — from the fee-encoded expiration); report the invoice amount in the send event.

## Compatibility note

The `amount` semantics change on both events (send was invoice+fee, receive was net). Historical events keep their old values; the new `fee` field defaults to zero for events recorded before this change. Downstream consumers should be aware that `amount` now means the invoice amount on both events.
