### PR TITLE
feat(walletv2): expose receive_fee on the cli

### DIFF
--- a/modules/fedimint-walletv2-client/src/cli.rs
+++ b/modules/fedimint-walletv2-client/src/cli.rs
@@ -16,6 +16,8 @@ enum Opts {
     Info(InfoOpts),
     /// Fetch the current fee required to send an onchain payment.
     SendFee,
+    /// Fetch the current fee required to claim an onchain deposit (peg-in).
+    ReceiveFee,
     /// Send an onchain payment.
     Send {
         address: Address<NetworkUnchecked>,
@@ -68,6 +70,7 @@ pub(crate) async fn handle_cli_command(
             InfoOpts::TxChain => json(wallet.tx_chain().await?),
         },
         Opts::SendFee => json(wallet.send_fee().await?),
+        Opts::ReceiveFee => json(wallet.receive_fee().await?),
         Opts::Send {
             address,
             value,

--- a/modules/fedimint-walletv2-client/src/lib.rs
+++ b/modules/fedimint-walletv2-client/src/lib.rs
@@ -268,11 +268,12 @@ impl WalletClientModule {
     }
 
     /// Fetch the current fee required to claim an onchain deposit (peg-in).
-    pub async fn receive_fee(&self) -> anyhow::Result<bitcoin::Amount> {
+    pub async fn receive_fee(&self) -> Result<bitcoin::Amount, ReceiveError> {
         self.module_api
             .receive_fee()
-            .await?
-            .ok_or_else(|| anyhow!("No consensus feerate is available"))
+            .await
+            .map_err(|e| ReceiveError::FederationError(e.to_string()))?
+            .ok_or(ReceiveError::NoConsensusFeerateAvailable)
     }
 
     /// Send an onchain payment with the given fee.
@@ -906,6 +907,14 @@ pub enum SendError {
     InsufficientFunds,
     #[error("Unsupported address type")]
     UnsupportedAddress,
+}
+
+#[derive(Error, Debug, Clone, Eq, PartialEq)]
+pub enum ReceiveError {
+    #[error("Federation returned an error: {0}")]
+    FederationError(String),
+    #[error("No consensus feerate is available at this time")]
+    NoConsensusFeerateAvailable,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]


### PR DESCRIPTION
Mirrors `send_fee` for the receive path.

- `WalletClientModule::receive_fee` now returns a typed `Result<bitcoin::Amount, ReceiveError>` instead of `anyhow::Result`, matching the shape of `send_fee` (which returns `Result<_, SendError>`). A new `ReceiveError` enum carries the `FederationError` / `NoConsensusFeerateAvailable` variants the fee lookup can produce.
- Adds a `ReceiveFee` subcommand to the walletv2 client CLI, alongside the existing `SendFee`, so the receive fee is queryable from the CLI for parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)