### PR TITLE
ci(review): use dependency review skills for Dependabot

### DIFF
--- a/.github/agents/review.md
+++ b/.github/agents/review.md
@@ -46,6 +46,25 @@ before posting them; when acting as that validation subagent, keep every
 finding that is demonstrably a real problem and drop anything speculative or
 unsupported by the diff.
 
+## Dependabot Dependency Bumps
+
+If the PR metadata says `PR Author: dependabot[bot]`, use the relevant
+dependency-bump review skill instead of treating the PR as a generic low-risk
+dependency bump:
+
+- For Rust/Cargo updates (`Cargo.toml` or `Cargo.lock`), read and follow
+  `.agents/skills/github-cargo-dependabot-review/SKILL.md`.
+- For GitHub Actions updates (`.github/workflows/**`, `.github/actions/**`,
+  `action.yml`, or `action.yaml`), read and follow
+  `.agents/skills/github-actions-dependabot-review/SKILL.md`.
+
+Adapt those skills to this workflow's JSON output: do not post PR comments
+yourself, put line-specific findings in `inline_comments`, and use the
+top-level `reason` for review-wide dependency-risk notes. Only output
+`APPROVE` after the applicable upstream/tarball checks are complete and no
+risks were found. If the required dependency review cannot be completed,
+output `COMMENT` with a concise reason explaining what remains unreviewed.
+
 ## Consensus-Critical Code
 
 ### What is consensus-critical?

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -52,6 +52,7 @@ jobs:
           echo "base_ref=$(echo "$PR_JSON" | jq -r '.base.ref')" >> "$GITHUB_OUTPUT"
           echo "base_sha=$(echo "$PR_JSON" | jq -r '.base.sha')" >> "$GITHUB_OUTPUT"
           echo "head_sha=$(echo "$PR_JSON" | jq -r '.head.sha')" >> "$GITHUB_OUTPUT"
+          echo "author_login=$(echo "$PR_JSON" | jq -r '.user.login')" >> "$GITHUB_OUTPUT"
           echo "title=$(echo "$PR_JSON" | jq -r '.title')" >> "$GITHUB_OUTPUT"
 
       - name: Acknowledge review request
@@ -175,6 +176,7 @@ jobs:
       - name: Build review prompt
         env:
           PR_TITLE: ${{ steps.pr.outputs.title }}
+          PR_AUTHOR: ${{ steps.pr.outputs.author_login }}
         run: |
           IS_CONSENSUS="${{ steps.changed.outputs.consensus }}"
           TRUNCATED="${{ steps.diff.outputs.truncated }}"
@@ -211,6 +213,7 @@ jobs:
           PR metadata:
           PROMPT_META
           printf 'PR Title: %s\n' "$PR_TITLE" >> /tmp/review_prompt.txt
+          printf 'PR Author: %s\n' "$PR_AUTHOR" >> /tmp/review_prompt.txt
           printf 'Consensus-critical files changed: %s\n' "$IS_CONSENSUS" >> /tmp/review_prompt.txt
 
           # Conditional instructions


### PR DESCRIPTION
Summary

Make the automated Codex review workflow recognize Dependabot PRs and route them through the repository's dependency-bump review skill instructions instead of treating dependency bumps as generic low-risk changes.

Details

The workflow now includes the PR author in the review prompt metadata. The existing review instructions use that metadata to tell the bot that Dependabot-authored Cargo or GitHub Actions dependency bumps should read and follow the matching repository skill:

- `.agents/skills/github-cargo-dependabot-review/SKILL.md`
- `.agents/skills/github-actions-dependabot-review/SKILL.md`

The skill guidance is adapted to the review workflow's JSON output: do not post comments directly, use inline findings when possible, and only approve after the applicable dependency review checks are complete.

Reviewing

Please check whether keeping the logic in `.github/agents/review.md` is enough context for the bot while avoiding extra workflow branching.

Testing

- `just format`
- `git diff --check`
- `just final-lint` attempted, but failed before linting because `cargo clippy --offline` could not download `addr2line v0.25.1` in this environment.
