### PR TITLE
Use direct OpenAI API for Codex jobs

### DIFF
--- a/.github/scripts/run-codex-agent.sh
+++ b/.github/scripts/run-codex-agent.sh
@@ -15,10 +15,10 @@ require_env GITHUB_EVENT_NAME
 require_env GITHUB_EVENT_PATH
 require_env GITHUB_REPOSITORY
 require_env GITHUB_WORKSPACE
-require_env PPQ_KEY
+require_env OPENAI_API_KEY
 require_env RUNNER_TEMP
 
-PPQ_MODEL="${PPQ_MODEL:-openai/gpt-5.5}"
+OPENAI_MODEL="${OPENAI_MODEL:-gpt-5.5}"
 agent_event_name="${CODEX_AGENT_EVENT_NAME:-${GITHUB_EVENT_NAME}}"
 agent_event_path="${CODEX_AGENT_EVENT_PATH:-${GITHUB_EVENT_PATH}}"
 agent_actor="${CODEX_AGENT_ACTOR:-${GITHUB_ACTOR}}"
@@ -45,16 +45,11 @@ path_toml=$(jq -Rn --arg value "${PATH}" '$value')
 # isolation for process containment, and on Codex's shell environment policy
 # to keep provider credentials out of agent-spawned commands.
 cat > "${codex_home}/config.toml" <<EOF
-model = "${PPQ_MODEL}"
-model_provider = "ppq"
+model = "${OPENAI_MODEL}"
+model_provider = "openai"
 sandbox_mode = "danger-full-access"
 approval_policy = "never"
 
-[model_providers.ppq]
-name = "PPQ"
-base_url = "https://api.ppq.ai/v1"
-env_key = "PPQ_KEY"
-wire_api = "responses"
 
 [shell_environment_policy]
 inherit = "all"

--- a/.github/scripts/run-codex-ci-debug.sh
+++ b/.github/scripts/run-codex-ci-debug.sh
@@ -17,8 +17,8 @@ require_env GITHUB_EVENT_NAME
 require_env GITHUB_EVENT_PATH
 require_env GITHUB_REPOSITORY
 require_env GITHUB_WORKSPACE
-require_env PPQ_KEY
-require_env PPQ_MODEL
+require_env OPENAI_API_KEY
+require_env OPENAI_MODEL
 require_env RUNNER_TEMP
 
 # Workflow-dispatch runs intentionally leave some CI_DEBUG_* values empty.
@@ -38,16 +38,11 @@ mkdir -p \
 path_toml=$(jq -Rn --arg value "${PATH}" '$value')
 
 cat > "${codex_home}/config.toml" <<EOF
-model = "${PPQ_MODEL}"
-model_provider = "ppq"
+model = "${OPENAI_MODEL}"
+model_provider = "openai"
 sandbox_mode = "danger-full-access"
 approval_policy = "never"
 
-[model_providers.ppq]
-name = "PPQ"
-base_url = "https://api.ppq.ai/v1"
-env_key = "PPQ_KEY"
-wire_api = "responses"
 
 [shell_environment_policy]
 inherit = "all"

--- a/.github/workflows/codex-agent.yml
+++ b/.github/workflows/codex-agent.yml
@@ -252,8 +252,8 @@ jobs:
           CODEX_AGENT_ACTOR: ${{ steps.validate.outputs.agent_actor }}
           CODEX_AGENT_EVENT_NAME: ${{ steps.validate.outputs.agent_event_name }}
           CODEX_AGENT_EVENT_PATH: ${{ steps.validate.outputs.agent_event_path }}
-          PPQ_KEY: ${{ secrets.PPQ_KEY }}
-          PPQ_MODEL: ${{ vars.PPQ_MODEL || 'openai/gpt-5.5' }}
+          OPENAI_API_KEY: ${{ secrets.OPEN_AI_KEY }}
+          OPENAI_MODEL: ${{ vars.OPENAI_MODEL || 'gpt-5.5' }}
         run: |
           set -euo pipefail
           nix --extra-experimental-features 'nix-command flakes' \

--- a/.github/workflows/codex-ci-debug.yml
+++ b/.github/workflows/codex-ci-debug.yml
@@ -109,8 +109,8 @@ jobs:
           CI_DEBUG_WORKFLOW_EVENT: ${{ steps.target.outputs.run_event }}
           CI_DEBUG_HEAD_BRANCH: ${{ steps.target.outputs.head_branch }}
           CI_DEBUG_HEAD_SHA: ${{ steps.target.outputs.head_sha }}
-          PPQ_KEY: ${{ secrets.PPQ_KEY }}
-          PPQ_MODEL: ${{ vars.PPQ_MODEL || 'openai/gpt-5.5' }}
+          OPENAI_API_KEY: ${{ secrets.OPEN_AI_KEY }}
+          OPENAI_MODEL: ${{ vars.OPENAI_MODEL || 'gpt-5.5' }}
         run: |
           set -euo pipefail
           nix --extra-experimental-features 'nix-command flakes' \

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -240,8 +240,8 @@ jobs:
       - name: Run Codex review
         id: codex-review
         env:
-          PPQ_KEY: ${{ secrets.PPQ_KEY }}
-          PPQ_MODEL: ${{ vars.PPQ_MODEL || 'openai/gpt-5.5' }}
+          OPENAI_API_KEY: ${{ secrets.OPEN_AI_KEY }}
+          OPENAI_MODEL: ${{ vars.OPENAI_MODEL || 'gpt-5.5' }}
         run: |
           set -euo pipefail
 
@@ -249,9 +249,9 @@ jobs:
           mkdir -p "$CODEX_HOME"
           path_toml=$(jq -Rn --arg value "$PATH" '$value')
           {
-            printf 'model = "%s"\n' "$PPQ_MODEL"
+            printf 'model = "%s"\n' "$OPENAI_MODEL"
             printf '%s\n' \
-              'model_provider = "ppq"' \
+              'model_provider = "openai"' \
               'model_reasoning_effort = "xhigh"' \
               'sandbox_mode = "read-only"' \
               'approval_policy = "never"' \
@@ -307,13 +307,7 @@ jobs:
               '  "CARGO_*",' \
               '  "NIX_*",' \
               '  "IN_NIX_SHELL",' \
-              ']' \
-              '' \
-              '[model_providers.ppq]' \
-              'name = "PPQ"' \
-              'base_url = "https://api.ppq.ai/v1"' \
-              'env_key = "PPQ_KEY"' \
-              'wire_api = "responses"'
+              ']'
           } > "$CODEX_HOME/config.toml"
 
           run_codex() {


### PR DESCRIPTION
## Summary

Switch the Codex automation workflows from the PPQ OpenAI-compatible proxy to the direct OpenAI API credential configured as `OPEN_AI_KEY`.

## Details

The Codex agent, CI debugger, and review workflows now expose `secrets.OPEN_AI_KEY` as `OPENAI_API_KEY`, use `OPENAI_MODEL` with a `gpt-5.5` default, and configure Codex with the built-in `openai` provider. The old PPQ provider configuration and `PPQ_KEY`/`PPQ_MODEL` references were removed from the GitHub workflow and helper script paths.

Closes #8736.

## Testing

- `just format`
- `bash -n .github/scripts/run-codex-agent.sh .github/scripts/run-codex-ci-debug.sh`
- `git diff --check`
- `rg -n "PPQ_KEY|PPQ_MODEL|model_provider = \\"ppq\\"|model_providers\\.ppq|api\\.ppq\\.ai|secrets\\.PPQ_KEY|vars\\.PPQ_MODEL" .github` (no matches)
- `just final-lint`