### PR TITLE
ci: support additional fedimint-bot invocations

### DIFF
--- a/.github/scripts/run-codex-agent.sh
+++ b/.github/scripts/run-codex-agent.sh
@@ -147,8 +147,10 @@ jq '{
 
 cat > "${context_dir}/prompt.md" <<'EOF'
 You are fedimint-bot, an automation agent for the Fedimint GitHub repository.
-An organization member mentioned @fedimint-bot in a GitHub issue, pull request,
-or pull request review thread. Decide what action is useful from the context.
+An organization member invoked you by mentioning @fedimint-bot in a GitHub
+issue, pull request, or pull request review thread; by opening an issue that
+mentions @fedimint-bot; or by assigning an issue to fedimint-bot. Decide what
+action is useful from the context.
 
 You may:
 - answer the question directly in the relevant GitHub thread;
@@ -161,6 +163,10 @@ Use judgment. Prefer a concise answer when the user is asking a question. Only
 change code for simple, well-scoped fixes. Do not make broad refactors. Do not
 push to contributor PR branches. If you implement a fix, create a new branch
 named like `fedimint-bot/<short-topic>-<run-id>` and open a draft PR.
+
+Write GitHub comments and PR descriptions in concise, scannable Markdown:
+use short headings, bullets, code spans, and checklists when they make the
+result easier to read. Avoid wall-of-text replies, but do not add filler.
 
 Available tools:
 - `gh`, authenticated as fedimint-bot via `GH_TOKEN`;
@@ -181,10 +187,13 @@ Operational rules:
 - The GitHub event payload is at `$RUNNER_TEMP/codex-agent/context/event.json`.
 - The checked out repository is at `$GITHUB_WORKSPACE`.
 - First inspect the normalized `event_name` field in the event payload to
-  understand whether this is an issue comment, PR comment, or inline PR review
-  comment. Inline PR review comments may arrive through a privileged follow-up
-  workflow, but the payload is normalized to `pull_request_review_comment`.
+  understand whether this is an issue event, issue comment, PR comment, or
+  inline PR review comment. Inline PR review comments may arrive through a
+  privileged follow-up workflow, but the payload is normalized to
+  `pull_request_review_comment`.
 - Use `gh` to fetch additional context as needed.
+- For issue assignment events, treat the assignment as a request to open a
+  small draft PR when the issue is well scoped and implementation is low risk.
 - For inline PR review comments, get the pull request number from the event
   payload and use `gh api
   repos/:owner/:repo/pulls/:pull_number/comments/:comment_id/replies

--- a/.github/workflows/codex-agent.yml
+++ b/.github/workflows/codex-agent.yml
@@ -1,6 +1,8 @@
 name: "Codex Agent"
 
 on:
+  issues:
+    types: [opened, assigned]
   issue_comment:
     types: [created]
   workflow_run:
@@ -22,7 +24,13 @@ jobs:
     timeout-minutes: 120
     if: >-
       github.repository == 'fedimint/fedimint' &&
-      ((github.event_name == 'issue_comment' &&
+      ((github.event_name == 'issues' &&
+        github.actor != 'fedimint-bot' &&
+        github.actor != 'github-actions[bot]' &&
+        (github.event.action == 'opened' ||
+         (github.event.action == 'assigned' &&
+          github.event.assignee.login == 'fedimint-bot'))) ||
+       (github.event_name == 'issue_comment' &&
         github.actor != 'fedimint-bot' &&
         github.actor != 'github-actions[bot]') ||
        (github.event_name == 'workflow_run' &&
@@ -53,6 +61,7 @@ jobs:
           comment_endpoint=""
           comment_user=""
           comment_id=""
+          issue_number=""
           body=""
           artifact_dir=""
 
@@ -100,7 +109,7 @@ jobs:
             fi
 
             comment_endpoint="repos/${GITHUB_REPOSITORY}/pulls/comments/${comment_id}"
-          else
+          elif [ "${event_name}" = "issue_comment" ]; then
             body=$(jq -r '.comment.body // ""' "${event_payload}")
             comment_id=$(jq -r '.comment.id // ""' "${event_payload}")
             comment_user=$(jq -r '.comment.user.login // ""' "${event_payload}")
@@ -118,6 +127,42 @@ jobs:
             fi
 
             comment_endpoint="repos/${GITHUB_REPOSITORY}/issues/comments/${comment_id}"
+          else
+            issue_number=$(jq -r '.issue.number // ""' "${event_payload}")
+            comment_id="${issue_number}"
+            action=$(jq -r '.action // ""' "${event_payload}")
+            assignee=$(jq -r '.assignee.login // ""' "${event_payload}")
+            title=$(jq -r '.issue.title // ""' "${event_payload}")
+            body=$(jq -r '.issue.body // ""' "${event_payload}")
+            issue_text=$(printf '%s\n%s' "${title}" "${body}")
+            comment_user=$(jq -r '.sender.login // env.GITHUB_ACTOR' "${event_payload}")
+            author_association=$(jq -r '.issue.author_association // ""' "${event_payload}")
+
+            echo "event=${event_name}"
+            echo "action=${action}"
+            echo "issue_number=${issue_number}"
+            echo "request_user=${comment_user}"
+            echo "author_association=${author_association:-<missing>}"
+
+            if ! [[ "${issue_number}" =~ ^[0-9]+$ ]]; then
+              echo "run=false" >> "${GITHUB_OUTPUT}"
+              echo "Skipping: issues event has invalid issue number"
+              exit 0
+            fi
+
+            if [ "${action}" = "opened" ] && [[ "${issue_text}" != *"@fedimint-bot"* ]]; then
+              echo "run=false" >> "${GITHUB_OUTPUT}"
+              echo "Skipping: opened issue does not mention @fedimint-bot"
+              exit 0
+            fi
+
+            if [ "${action}" = "assigned" ] && [ "${assignee}" != "fedimint-bot" ]; then
+              echo "run=false" >> "${GITHUB_OUTPUT}"
+              echo "Skipping: issue was not assigned to fedimint-bot"
+              exit 0
+            fi
+
+            comment_endpoint="repos/${GITHUB_REPOSITORY}/issues/${issue_number}"
           fi
 
           live_comment=$(curl --fail-with-body --silent --show-error \
@@ -127,15 +172,40 @@ jobs:
             "${api_url}/${comment_endpoint}")
 
           body=$(jq -r '.body // ""' <<<"${live_comment}")
-          comment_user=$(jq -r '.user.login // ""' <<<"${live_comment}")
           live_author_association=$(jq -r '.author_association // ""' <<<"${live_comment}")
+          if [ "${event_name}" != "issues" ]; then
+            comment_user=$(jq -r '.user.login // ""' <<<"${live_comment}")
+          fi
 
           echo "event=${event_name}"
           echo "comment_id=${comment_id}"
           echo "comment_user=${comment_user}"
           echo "live_author_association=${live_author_association:-<missing>}"
 
-          if [[ "${body}" != *"@fedimint-bot"* ]]; then
+          if [ "${event_name}" = "issues" ]; then
+            action=$(jq -r '.action // ""' "${event_payload}")
+            assignee=$(jq -r '.assignee.login // ""' "${event_payload}")
+            title=$(jq -r '.title // ""' <<<"${live_comment}")
+            issue_text=$(printf '%s\n%s' "${title}" "${body}")
+
+            if [ "${action}" = "opened" ] && [[ "${issue_text}" != *"@fedimint-bot"* ]]; then
+              echo "run=false" >> "${GITHUB_OUTPUT}"
+              echo "Skipping: live issue does not mention @fedimint-bot"
+              exit 0
+            fi
+
+            if [ "${action}" = "assigned" ] && [ "${assignee}" != "fedimint-bot" ]; then
+              echo "run=false" >> "${GITHUB_OUTPUT}"
+              echo "Skipping: issue assignment event is not for fedimint-bot"
+              exit 0
+            fi
+
+            if [ "${action}" = "assigned" ] && ! jq -e '.assignees[]? | select(.login == "fedimint-bot")' <<<"${live_comment}" >/dev/null; then
+              echo "run=false" >> "${GITHUB_OUTPUT}"
+              echo "Skipping: live issue is no longer assigned to fedimint-bot"
+              exit 0
+            fi
+          elif [[ "${body}" != *"@fedimint-bot"* ]]; then
             echo "run=false" >> "${GITHUB_OUTPUT}"
             echo "Skipping: live comment does not mention @fedimint-bot"
             exit 0
@@ -162,7 +232,7 @@ jobs:
 
           if [ "${membership_state}" != "active" ]; then
             echo "run=false" >> "${GITHUB_OUTPUT}"
-            echo "Skipping: comment author is not an active fedimint/reviewers team member"
+            echo "Skipping: requester is not an active fedimint/reviewers team member"
             exit 0
           fi
 
@@ -195,7 +265,7 @@ jobs:
           else
             cp "${event_payload}" "${agent_event_path}"
             echo "agent_event_name=${event_name}" >> "${GITHUB_OUTPUT}"
-            echo "agent_actor=${GITHUB_ACTOR}" >> "${GITHUB_OUTPUT}"
+            echo "agent_actor=${comment_user}" >> "${GITHUB_OUTPUT}"
           fi
 
           echo "agent_event_path=${agent_event_path}" >> "${GITHUB_OUTPUT}"
@@ -224,6 +294,8 @@ jobs:
 
           if [ "${COMMENT_KIND}" = "workflow_run" ]; then
             endpoint="repos/${REPOSITORY}/pulls/comments/${COMMENT_ID}/reactions"
+          elif [ "${COMMENT_KIND}" = "issues" ]; then
+            endpoint="repos/${REPOSITORY}/issues/${COMMENT_ID}/reactions"
           else
             endpoint="repos/${REPOSITORY}/issues/comments/${COMMENT_ID}/reactions"
           fi

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -5,7 +5,7 @@ on:
   # Safety: we checkout the base branch (trusted) and only fetch the PR
   # diff as text — no untrusted code is checked out or executed.
   pull_request_target:
-    types: [opened, ready_for_review]
+    types: [opened, ready_for_review, review_requested]
   # Re-review only when explicitly requested via "/review" comment on a PR
   issue_comment:
     types: [created]
@@ -19,10 +19,13 @@ permissions: {}
 
 jobs:
   review:
-    # Run on PR open/ready-for-review, or when someone comments "/review" on a PR
+    # Run on PR open/ready-for-review, when fedimint-bot is requested for
+    # review, or when someone comments "/review" on a PR
     if: >-
       github.repository == 'fedimint/fedimint' && (
-        (github.event_name == 'pull_request_target' && !github.event.pull_request.draft) ||
+        (github.event_name == 'pull_request_target' && !github.event.pull_request.draft &&
+         (github.event.action != 'review_requested' ||
+          github.event.requested_reviewer.login == 'fedimint-bot')) ||
         (github.event_name == 'issue_comment' && github.event.issue.pull_request &&
          contains(github.event.comment.body, '/review'))
       )


### PR DESCRIPTION
## Summary

Adds the requested extra `fedimint-bot` invocation paths for issues and review requests, and updates the agent prompt to prefer concise, scannable Markdown.

## Details

The Codex agent workflow now handles:

- newly opened issues that mention `@fedimint-bot` in the title or body;
- issues assigned to `fedimint-bot`, treating assignment as a request to open a small draft PR when practical;
- the existing issue-comment and inline review-comment paths.

The PR review workflow now also runs when `fedimint-bot` is explicitly requested as reviewer on a non-draft PR, which covers review and re-review requests.

For issue events, the workflow still validates that the requester is an active `fedimint/reviewers` team member before running the privileged self-hosted agent. Assignment events also re-check that the live issue is still assigned to `fedimint-bot`.

## Reviewing

Please pay close attention to the `issues` event validation in `.github/workflows/codex-agent.yml`, especially the distinction between issue author, assigning actor, and live issue assignees.

## Testing

Ran:

- `just format`
- `bash -n .github/scripts/run-codex-agent.sh`
- `git diff --check`
- `actionlint` via Nix on the touched workflows, ignoring the existing `SC2129`/`SC2016` shellcheck warning codes
- `just final-lint`

Closes #8737.
