### PR TITLE
feat: Mint Send Quote

### DIFF
--- a/fedimint-client-module/src/transaction/builder.rs
+++ b/fedimint-client-module/src/transaction/builder.rs
@@ -461,6 +461,15 @@ pub struct FeeQuote {
 }
 
 impl FeeQuote {
+    /// A zero fee, for operations that incur no cost at all — e.g. an ecash
+    /// send served entirely from existing exact-change notes, which submits
+    /// no transaction.
+    pub const ZERO: Self = Self {
+        input: Amounts::ZERO,
+        output: Amounts::ZERO,
+        dust: Amounts::ZERO,
+    };
+
     /// Total fee per unit: everything the gross input value does not become a
     /// net wallet gain. Equal to `input + output + dust`.
     pub fn total(&self) -> Amounts {

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -1328,6 +1328,8 @@ impl MintClientModule {
             return ClientOutputBundle::new(vec![], vec![]);
         }
 
+        // Change layout: carve notes out of `exact_amount`, paying each note's
+        // own fee from that same value (the leftover below a note's fee is dust).
         let denominations = represent_amount(
             exact_amount,
             &self.get_note_counts_by_denomination(dbtx).await,
@@ -1336,6 +1338,60 @@ impl MintClientModule {
             &self.cfg.fee_consensus,
         );
 
+        self.create_output_for_denominations(dbtx, operation_id, denominations)
+            .await
+    }
+
+    /// Issues note outputs worth *exactly* `amount`, with no fee carved out of
+    /// that value — the federation fee is funded separately by the primary
+    /// module's balancing (extra inputs pulled in by
+    /// `create_final_inputs_and_outputs`). This is how a *target* amount should
+    /// be minted (e.g. an ecash send reissuing itself the denominations to hand
+    /// out), as opposed to laying out change; it mirrors mintv2's `send`.
+    ///
+    /// Because the smallest denomination is 1 msat (denominations are
+    /// contiguous powers of two), every amount is exactly representable, so
+    /// a single reissue always yields notes that can be spent for the exact
+    /// amount.
+    async fn create_exact_output(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        operation_id: OperationId,
+        amount: Amount,
+    ) -> ClientOutputBundle<MintOutput, MintClientStateMachines> {
+        if amount == Amount::ZERO {
+            return ClientOutputBundle::new(vec![], vec![]);
+        }
+
+        self.create_output_for_denominations(
+            dbtx,
+            operation_id,
+            self.represent_exact_amount(amount),
+        )
+        .await
+    }
+
+    /// Decomposes `amount` into the minimal set of note denominations summing
+    /// to *exactly* `amount` — a plain greedy power-of-two breakdown with
+    /// no fee subtracted (unlike [`represent_amount`], which lays out
+    /// change). Used when minting a target amount; see
+    /// [`Self::create_exact_output`].
+    fn represent_exact_amount(&self, amount: Amount) -> TieredCounts {
+        represent_amount(
+            amount,
+            &TieredCounts::default(),
+            &self.cfg.tbs_pks,
+            0,
+            &FeeConsensus::zero(),
+        )
+    }
+
+    async fn create_output_for_denominations(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        operation_id: OperationId,
+        denominations: TieredCounts,
+    ) -> ClientOutputBundle<MintOutput, MintClientStateMachines> {
         let mut outputs = Vec::new();
         let mut issuance_requests = Vec::new();
 
@@ -1783,6 +1839,67 @@ impl MintClientModule {
             .await
     }
 
+    /// Computes the fee a `send_oob_notes(amount)` would incur given the
+    /// wallet's current note inventory, without sending anything.
+    ///
+    /// A send is free when the wallet's existing notes can cover the (rounded)
+    /// amount exactly — it just hands those notes out. Otherwise the send first
+    /// reissues itself the right denominations, and that self-reissue
+    /// transaction is the only thing a send ever pays a fee for. This quote
+    /// mirrors that: it returns [`FeeQuote::ZERO`] when exact change is
+    /// available, and otherwise quotes the reissue the same way the real send
+    /// submits it (explicit outputs representing `amount`, no explicit inputs)
+    /// via the shared, module-agnostic fee quote over the real inventory. The
+    /// quote is point-in-time: it depends on the current inventory and can move
+    /// as notes change.
+    pub async fn send_fee_quote(&self, amount: Amount) -> anyhow::Result<FeeQuote> {
+        let amount = self.cfg.fee_consensus.round_up(amount);
+
+        let mut dbtx = self.client_ctx.module_db().begin_transaction_nc().await;
+
+        // Exact-change path: handing out existing notes never costs a fee. This
+        // is the same selection `send_oob_notes` tries first (see
+        // `try_spend_exact_notes_dbtx`).
+        if Self::select_notes(
+            &mut dbtx,
+            &SelectNotesWithExactAmount,
+            amount,
+            FeeConsensus::zero(),
+        )
+        .await
+        .is_ok()
+        {
+            return Ok(FeeQuote::ZERO);
+        }
+
+        drop(dbtx);
+
+        // Reissue path: the send mints itself notes worth exactly `amount` as
+        // explicit outputs (no explicit inputs) and the primary module funds and
+        // balances it. Quote that exact transaction — the same exact
+        // decomposition the real send's `create_exact_output` uses, so a single
+        // reissue covers it.
+        let denominations = self.represent_exact_amount(amount);
+
+        let output_amount = denominations.total_amount();
+        let output_fee: Amount = denominations
+            .iter()
+            .map(|(denomination, count)| self.cfg.fee_consensus.fee(denomination) * count as u64)
+            .sum();
+
+        self.client_ctx
+            .fee_quote(
+                OperationId::new_random(),
+                FeeQuoteRequest {
+                    input_amount: Amounts::ZERO,
+                    output_amount: Amounts::new_bitcoin(output_amount),
+                    input_fee: Amounts::ZERO,
+                    output_fee: Amounts::new_bitcoin(output_fee),
+                },
+            )
+            .await
+    }
+
     /// Try to reissue e-cash notes received from a third party to receive them
     /// in our wallet. The progress and outcome can be observed using
     /// [`MintClientModule::subscribe_reissue_external_notes`].
@@ -2149,8 +2266,11 @@ impl MintClientModule {
 
         let operation_id = OperationId::new_random();
 
-        // Create outputs for reissuance, committing the note index counter
-        // updates so that create_final_inputs_and_outputs won't reuse the same
+        // Reissue ourselves notes worth *exactly* `amount` (fee funded by the
+        // balancing layer), so the retry below can hand out the exact amount in a
+        // single reissue — rather than minting `amount` minus fees and having to
+        // reissue repeatedly to make up the difference. Commit the note index
+        // counter updates so create_final_inputs_and_outputs won't reuse the same
         // indices for change outputs.
         let output_bundle = self
             .client_ctx
@@ -2159,7 +2279,7 @@ impl MintClientModule {
                 |dbtx, _| {
                     Box::pin(async {
                         Ok::<_, anyhow::Error>(
-                            self.create_output(dbtx, operation_id, 1, amount).await,
+                            self.create_exact_output(dbtx, operation_id, amount).await,
                         )
                     })
                 },

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -84,7 +84,7 @@ use fedimint_core::secp256k1::rand::thread_rng;
 use fedimint_core::secp256k1::{All, Keypair, Secp256k1};
 use fedimint_core::util::{BoxFuture, BoxStream, NextOrPending, SafeUrl};
 use fedimint_core::{
-    Amount, OutPoint, PeerId, Tiered, TieredCounts, TieredMulti, TransactionId, apply,
+    Amount, IdxRange, OutPoint, PeerId, Tiered, TieredCounts, TieredMulti, TransactionId, apply,
     async_trait_maybe_send, base32, push_db_pair_items,
 };
 use fedimint_derive_secret::{ChildId, DerivableSecret};
@@ -2288,6 +2288,13 @@ impl MintClientModule {
             .await
             .expect("Failed to commit output creation after 100 retries");
 
+        // The explicit outputs we just minted (worth exactly `amount`) occupy the
+        // first `explicit_output_count` out points of the transaction; the
+        // primary module's change is appended after them. The recursion below
+        // hands out these exact notes, so we must wait for *them* to finalize —
+        // not just the change.
+        let explicit_output_count = output_bundle.outputs().len() as u64;
+
         // Combine the output bundle state machines with the send state machine
         let combined_bundle = ClientOutputBundle::new(
             output_bundle.outputs().to_vec(),
@@ -2321,9 +2328,17 @@ impl MintClientModule {
             .await
             .context("Failed to submit reissuance transaction")?;
 
-        // Wait for outputs to be finalized
+        // Wait for *all* of the transaction's outputs to be finalized — both the
+        // change (returned in `out_point_range`) and the explicit exact-amount
+        // notes at out points `[0, explicit_output_count)`. The recursion below
+        // can only hand out the exact notes once they are spendable; awaiting
+        // only the change (as before) raced the recursion against issuance,
+        // causing it to re-reissue and drain the wallet.
+        let txid = out_point_range.txid();
+        let total_output_count = explicit_output_count + out_point_range.count() as u64;
+        let all_outputs = OutPointRange::new(txid, IdxRange::from(0..total_output_count));
         self.client_ctx
-            .await_primary_module_outputs(operation_id, out_point_range.into_iter().collect())
+            .await_primary_module_outputs(operation_id, all_outputs.into_iter().collect())
             .await
             .context("Failed to await output finalization")?;
 

--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -276,6 +276,34 @@ async fn send_fee_quote_matches_actual_fee() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Regression test: a send that requires a self-reissue must succeed without
+/// settling state machines between sends (as a wallet UI does).
+///
+/// Three 5,000,000 msat sends from a 20,000,000 msat balance. The first two are
+/// served from exact change; the third can't make exact change and triggers a
+/// self-reissue. Previously the reissue recursion ran before its freshly-minted
+/// notes were spendable (it awaited only the *change* outputs), failed to make
+/// exact change, re-reissued, and drained the wallet — surfacing as
+/// "Failed to submit reissuance transaction: Insufficient balance" even though
+/// the `send_fee_quote` had just succeeded.
+#[tokio::test(flavor = "multi_thread")]
+async fn send_oob_notes_reissue_without_settling() -> anyhow::Result<()> {
+    let fed = fixtures().new_fed_degraded().await;
+    let client = fed.new_client().await;
+    issue_ecash(&client, Amount::from_msats(20_000_000)).await?;
+
+    for i in 0..3 {
+        let mint = client.get_first_module::<MintClientModule>()?;
+        // The quote must succeed (it always did); the send must succeed too.
+        mint.send_fee_quote(Amount::from_msats(5_000_000)).await?;
+        mint.send_oob_notes(Amount::from_msats(5_000_000), ())
+            .await
+            .map_err(|e| anyhow::anyhow!("iteration {i}: send_oob_notes failed: {e:#}"))?;
+    }
+
+    Ok(())
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn blind_nonce_index() -> anyhow::Result<()> {
     // Give client initial balance

--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -237,6 +237,46 @@ async fn reissue_fee_quote_matches_actual_fee() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn send_fee_quote_matches_actual_fee() -> anyhow::Result<()> {
+    let fed = fixtures().new_fed_degraded().await;
+    let client = fed.new_client().await;
+    issue_ecash(&client, sats(11_000)).await?;
+
+    // Send several times so the wallet's note inventory — and therefore whether a
+    // self-reissue (and its fee) is needed to reach the requested denomination —
+    // differs between iterations.
+    for i in 0..5 {
+        let mint = client.get_first_module::<MintClientModule>()?;
+
+        // Settle any pending change from the previous iteration so the quote and
+        // the send observe the same inventory.
+        client.wait_for_all_active_state_machines().await?;
+
+        let quote = mint.send_fee_quote(sats(1_000)).await?;
+        let before = client.get_balance_for_btc().await?;
+
+        let notes = mint.send_oob_notes(sats(1_000), ()).await?;
+        let sent_value = notes.total_amount();
+
+        // A send may trigger an internal reissue whose change notes are credited
+        // by output state machines; wait for them before reading the balance.
+        client.wait_for_all_active_state_machines().await?;
+        let after = client.get_balance_for_btc().await?;
+
+        // Value conservation: the wallet loses exactly the sent value plus the fee.
+        let actual_fee = before - after - sent_value;
+
+        assert_eq!(
+            quote.total(),
+            Amounts::new_bitcoin(actual_fee),
+            "iteration {i}: quoted fee {quote:?} != actual fee {actual_fee:?}"
+        );
+    }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn blind_nonce_index() -> anyhow::Result<()> {
     // Give client initial balance
     let fed = fixtures().new_fed_degraded().await;

--- a/modules/fedimint-mintv2-client/src/lib.rs
+++ b/modules/fedimint-mintv2-client/src/lib.rs
@@ -839,31 +839,14 @@ impl MintClientModule {
     async fn send_ecash_dbtx(
         &self,
         dbtx: &mut DatabaseTransaction<'_>,
-        mut remaining_amount: Amount,
+        remaining_amount: Amount,
         custom_meta: Value,
         include_invite: bool,
     ) -> Result<Option<(OperationId, ECash)>, Infallible> {
-        let mut stream = dbtx
-            .find_by_prefix_sorted_descending(&SpendableNotePrefix)
-            .await
-            .map(|entry| entry.0.0);
-
-        let mut notes = vec![];
-
-        while let Some(spendable_note) = stream.next().await {
-            remaining_amount = match remaining_amount.checked_sub(spendable_note.amount()) {
-                Some(amount) => amount,
-                None => continue,
-            };
-
-            notes.push(spendable_note);
-        }
-
-        drop(stream);
-
-        if remaining_amount != Amount::ZERO {
+        let Some(notes) = Self::select_exact_change(&mut dbtx.to_ref_nc(), remaining_amount).await
+        else {
             return Ok(None);
-        }
+        };
 
         for spendable_note in &notes {
             self.remove_spendable_note(dbtx, spendable_note).await;
@@ -1047,14 +1030,31 @@ impl MintClientModule {
 
     /// Returns whether the client's current notes can be handed out to cover
     /// `amount` exactly — the free path in [`Self::send`] — without modifying
-    /// the inventory. Mirrors the greedy selection in
-    /// [`Self::send_ecash_dbtx`].
-    async fn can_make_exact_change(&self, mut remaining_amount: Amount) -> bool {
+    /// the inventory. Shares its greedy selection with
+    /// [`Self::send_ecash_dbtx`] via [`Self::select_exact_change`].
+    async fn can_make_exact_change(&self, remaining_amount: Amount) -> bool {
         let mut dbtx = self.client_ctx.module_db().begin_transaction_nc().await;
+
+        Self::select_exact_change(&mut dbtx, remaining_amount)
+            .await
+            .is_some()
+    }
+
+    /// Greedily selects spendable notes (largest-first) summing to *exactly*
+    /// `remaining_amount`, or `None` if the inventory can't make exact change.
+    /// Reads the DB but does not modify it. Single source of truth for the free
+    /// (hand-out-existing-notes) selection shared by [`Self::send_ecash_dbtx`]
+    /// and [`Self::can_make_exact_change`].
+    async fn select_exact_change(
+        dbtx: &mut DatabaseTransaction<'_>,
+        mut remaining_amount: Amount,
+    ) -> Option<Vec<SpendableNote>> {
         let mut stream = dbtx
             .find_by_prefix_sorted_descending(&SpendableNotePrefix)
             .await
             .map(|entry| entry.0.0);
+
+        let mut notes = vec![];
 
         while let Some(spendable_note) = stream.next().await {
             remaining_amount = match remaining_amount.checked_sub(spendable_note.amount()) {
@@ -1062,12 +1062,14 @@ impl MintClientModule {
                 None => continue,
             };
 
+            notes.push(spendable_note);
+
             if remaining_amount == Amount::ZERO {
-                return true;
+                break;
             }
         }
 
-        remaining_amount == Amount::ZERO
+        (remaining_amount == Amount::ZERO).then_some(notes)
     }
 
     /// Await the final state of the receive operation.

--- a/modules/fedimint-mintv2-client/src/lib.rs
+++ b/modules/fedimint-mintv2-client/src/lib.rs
@@ -1001,6 +1001,75 @@ impl MintClientModule {
             .await
     }
 
+    /// Computes the fee a `send(amount)` would incur given the client's current
+    /// note inventory, without sending anything.
+    ///
+    /// A send is free when the client's existing notes can cover the (rounded)
+    /// amount exactly — it just hands those notes out. Otherwise the send first
+    /// reissues itself the right denominations, and that self-reissue
+    /// transaction is the only thing a send ever pays a fee for. This quote
+    /// mirrors that: it returns [`FeeQuote::ZERO`] when exact change is
+    /// available, and otherwise quotes the reissue the same way the real send
+    /// submits it (explicit outputs `represent_amount(amount)`, no explicit
+    /// inputs) via the shared, module-agnostic fee quote over the real
+    /// inventory. The quote is point-in-time: it depends on the current
+    /// inventory and can move as notes change.
+    pub async fn send_fee_quote(&self, amount: Amount) -> anyhow::Result<FeeQuote> {
+        let amount = round_to_multiple(amount, client_denominations().next().unwrap().amount());
+
+        // Exact-change path: handing out existing notes never costs a fee.
+        if self.can_make_exact_change(amount).await {
+            return Ok(FeeQuote::ZERO);
+        }
+
+        // Reissue path: the send mints itself `represent_amount(amount)` as
+        // explicit outputs (no explicit inputs) and the primary module funds and
+        // balances it. Quote that exact transaction.
+        let denominations = represent_amount(amount);
+        let output_amount: Amount = denominations.iter().map(|d| d.amount()).sum();
+        let output_fee: Amount = denominations
+            .iter()
+            .map(|d| self.cfg.fee_consensus.fee(d.amount()))
+            .sum();
+
+        self.client_ctx
+            .fee_quote(
+                OperationId::new_random(),
+                FeeQuoteRequest {
+                    input_amount: Amounts::ZERO,
+                    output_amount: Amounts::new_custom(self.cfg.amount_unit, output_amount),
+                    input_fee: Amounts::ZERO,
+                    output_fee: Amounts::new_custom(self.cfg.amount_unit, output_fee),
+                },
+            )
+            .await
+    }
+
+    /// Returns whether the client's current notes can be handed out to cover
+    /// `amount` exactly — the free path in [`Self::send`] — without modifying
+    /// the inventory. Mirrors the greedy selection in
+    /// [`Self::send_ecash_dbtx`].
+    async fn can_make_exact_change(&self, mut remaining_amount: Amount) -> bool {
+        let mut dbtx = self.client_ctx.module_db().begin_transaction_nc().await;
+        let mut stream = dbtx
+            .find_by_prefix_sorted_descending(&SpendableNotePrefix)
+            .await
+            .map(|entry| entry.0.0);
+
+        while let Some(spendable_note) = stream.next().await {
+            remaining_amount = match remaining_amount.checked_sub(spendable_note.amount()) {
+                Some(amount) => amount,
+                None => continue,
+            };
+
+            if remaining_amount == Amount::ZERO {
+                return true;
+            }
+        }
+
+        remaining_amount == Amount::ZERO
+    }
+
     /// Await the final state of the receive operation.
     pub async fn await_final_receive_operation_state(
         &self,

--- a/modules/fedimint-mintv2-tests/tests/tests.rs
+++ b/modules/fedimint-mintv2-tests/tests/tests.rs
@@ -261,6 +261,52 @@ async fn receive_fee_quote_matches_actual_fee() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn send_fee_quote_matches_actual_fee() -> anyhow::Result<()> {
+    let fixtures = fixtures();
+    let fed = fixtures.new_fed_not_degraded().await;
+
+    let client = fed
+        .join_client_with_db(MemDatabase::new().into(), root_secret(&SEND_SK))
+        .await;
+
+    issue_ecash(&client, Amount::from_sats(11_000)).await?;
+
+    // Send several times so the wallet's note inventory — and therefore whether a
+    // self-reissue (and its fee) is needed to reach the requested denomination —
+    // differs between iterations.
+    for i in 0..5 {
+        let mint = client.get_first_module::<MintClientModule>()?;
+
+        // Settle any pending change from the previous iteration so the quote and
+        // the send observe the same inventory.
+        client.wait_for_all_active_state_machines().await?;
+
+        let quote = mint.send_fee_quote(Amount::from_sats(1_000)).await?;
+        let before = client.get_balance_for_btc().await?;
+
+        let (_operation_id, ecash) = mint
+            .send(Amount::from_sats(1_000), Value::Null, false)
+            .await?;
+        let sent_value = ecash.amount();
+
+        // A send may trigger an internal reissue whose change notes are credited
+        // by output state machines; wait for them before reading the balance.
+        client.wait_for_all_active_state_machines().await?;
+        let after = client.get_balance_for_btc().await?;
+
+        // Value conservation: the wallet loses exactly the sent value plus the fee.
+        let actual_fee = before - after - sent_value;
+
+        ensure!(
+            quote.total() == Amounts::new_bitcoin(actual_fee),
+            "iteration {i}: quoted fee {quote:?} != actual fee {actual_fee:?}"
+        );
+    }
+
+    Ok(())
+}
+
 async fn test_client_recovery(
     fed: &FederationTest,
     client: &ClientHandleArc,


### PR DESCRIPTION
Builds on: https://github.com/fedimint/fedimint/pull/8689

Adds `send_fee_quote` to both MintV1 and MintV2. Also adds tests for each module.

This is opened as a separate PR because it primarily fixes a bug with `send_oob_notes` in MintV1. There are two bugs:

1) `send_oob_notes` targets minting `amount - fees`, which does not guarantee that the next recursion of `send_oob_notes` will be able to represent the amount. In which case it needs to recurse, which is wasteful since it costs fees. This PR adds `create_exact_amount` so that it mints exactly `amount`, which means that the next recursion of `send_oob_notes` will be able to represent `amount`.
2) `send_oob_notes` does not wait for the primary module outputs to be reissued. It currently only waits for the change. This means that there's a race, if the next recursion of `send_oob_notes` executes before the primary module outputs of the previous execution has finished, it won't be able to represent the amount and it will fail.