### PR TITLE
refactor(client): address operation fee API follow-ups

### DIFF
--- a/fedimint-client/src/client.rs
+++ b/fedimint-client/src/client.rs
@@ -992,7 +992,7 @@ impl Client {
     ///
     /// # Errors
     /// Returns an error if the operation does not exist.
-    pub async fn get_transaction_fees(
+    pub async fn get_operation_fees(
         &self,
         operation_id: OperationId,
     ) -> anyhow::Result<Option<Amounts>> {

--- a/fedimint-client/src/client.rs
+++ b/fedimint-client/src/client.rs
@@ -109,6 +109,13 @@ pub(crate) mod handle;
 const SUPPORTED_CORE_API_VERSIONS: &[fedimint_core::module::ApiVersion] =
     &[ApiVersion { major: 0, minor: 0 }];
 
+struct FinalizedTransaction {
+    transaction: Transaction,
+    states: Vec<DynState>,
+    change_range: Range<u64>,
+    fees: Amounts,
+}
+
 /// Primary module candidates at specific priority level
 #[derive(Default)]
 pub(crate) struct PrimaryModuleCandidates {
@@ -652,7 +659,7 @@ impl Client {
         dbtx: &mut DatabaseTransaction<'_>,
         operation_id: OperationId,
         mut partial_transaction: TransactionBuilder,
-    ) -> anyhow::Result<(Transaction, Vec<DynState>, Range<u64>, Amounts)> {
+    ) -> anyhow::Result<FinalizedTransaction> {
         let (in_amounts, out_amounts) = self.transaction_builder_get_balance(&partial_transaction);
 
         let mut added_inputs_bundles = vec![];
@@ -744,9 +751,14 @@ impl Client {
                 .expect("Inputs >= outputs for own transactions")
         };
 
-        let (tx, states) = partial_transaction.build(&self.secp_ctx, thread_rng());
+        let (transaction, states) = partial_transaction.build(&self.secp_ctx, thread_rng());
 
-        Ok((tx, states, change_range, fees))
+        Ok(FinalizedTransaction {
+            transaction,
+            states,
+            change_range,
+            fees,
+        })
     }
 
     /// Add funding and/or change to the transaction builder as needed, finalize
@@ -847,7 +859,12 @@ impl Client {
         operation_id: OperationId,
         tx_builder: TransactionBuilder,
     ) -> anyhow::Result<OutPointRange> {
-        let (transaction, mut states, change_range, fees) = self
+        let FinalizedTransaction {
+            transaction,
+            mut states,
+            change_range,
+            fees,
+        } = self
             .finalize_transaction(&mut dbtx.to_ref_nc(), operation_id, tx_builder)
             .await?;
 

--- a/modules/fedimint-lnv2-tests/tests/tests.rs
+++ b/modules/fedimint-lnv2-tests/tests/tests.rs
@@ -268,7 +268,7 @@ async fn unilateral_refund_of_outgoing_contracts() -> anyhow::Result<()> {
 
     // Verify that fees were paid, which is always the case for LNv2
     let operation_fees = client
-        .get_transaction_fees(operation_id)
+        .get_operation_fees(operation_id)
         .await
         .expect("Operation exists")
         .expect("Fee data is present for new operations");

--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -159,7 +159,7 @@ async fn sends_ecash_out_of_band() -> anyhow::Result<()> {
         )
         .expect("Balance higher than received amount");
     let fees_from_operation = client2
-        .get_transaction_fees(op)
+        .get_operation_fees(op)
         .await
         .expect("Operation exists")
         .expect("Fee data is present for new operations");


### PR DESCRIPTION
## Summary

Addresses the remaining operation-fee API follow-ups from #8294 by naming the finalized transaction return value and renaming the fee accessor to `get_operation_fees`.

Closes #8752.
Closes #8753.

## Details

This PR contains two follow-up commits on top of current `master`:

- `refactor(client): name finalized transaction result`
- `refactor(client): rename operation fee accessor`

The first commit replaces the expanded `finalize_transaction` tuple with a private `FinalizedTransaction` struct. The second commit renames `Client::get_transaction_fees` to `Client::get_operation_fees` and updates the tests.

## Reviewing

Reviewers may want to focus on the API naming and whether the private struct's field names capture the transaction finalization outputs clearly.

## Testing

- `cargo check -q -p fedimint-client`
- `cargo check -q -p fedimint-mint-tests -p fedimint-lnv2-tests`
- `just final-lint`
