### PR TITLE
fix(ci): switch Codex automation back to PPQ

### DIFF
--- a/.github/scripts/run-codex-agent.sh
+++ b/.github/scripts/run-codex-agent.sh
@@ -15,10 +15,10 @@ require_env GITHUB_EVENT_NAME
 require_env GITHUB_EVENT_PATH
 require_env GITHUB_REPOSITORY
 require_env GITHUB_WORKSPACE
-require_env OPENAI_API_KEY
+require_env PPQ_KEY
 require_env RUNNER_TEMP
 
-OPENAI_MODEL="${OPENAI_MODEL:-gpt-5.5}"
+PPQ_MODEL="${PPQ_MODEL:-openai/gpt-5.5}"
 agent_event_name="${CODEX_AGENT_EVENT_NAME:-${GITHUB_EVENT_NAME}}"
 agent_event_path="${CODEX_AGENT_EVENT_PATH:-${GITHUB_EVENT_PATH}}"
 agent_actor="${CODEX_AGENT_ACTOR:-${GITHUB_ACTOR}}"
@@ -45,17 +45,16 @@ path_toml=$(jq -Rn --arg value "${PATH}" '$value')
 # isolation for process containment, and on Codex's shell environment policy
 # to keep provider credentials out of agent-spawned commands.
 cat > "${codex_home}/config.toml" <<EOF
-model = "${OPENAI_MODEL}"
-model_provider = "openai-api-key"
+model = "${PPQ_MODEL}"
+model_provider = "ppq"
 sandbox_mode = "danger-full-access"
 approval_policy = "never"
 
 
-[model_providers.openai-api-key]
-name = "OpenAI"
-base_url = "https://api.openai.com/v1"
-env_key = "OPENAI_API_KEY"
-supports_websockets = true
+[model_providers.ppq]
+name = "PPQ"
+base_url = "https://api.ppq.ai/v1"
+env_key = "PPQ_KEY"
 wire_api = "responses"
 
 

--- a/.github/scripts/run-codex-ci-debug.sh
+++ b/.github/scripts/run-codex-ci-debug.sh
@@ -17,8 +17,8 @@ require_env GITHUB_EVENT_NAME
 require_env GITHUB_EVENT_PATH
 require_env GITHUB_REPOSITORY
 require_env GITHUB_WORKSPACE
-require_env OPENAI_API_KEY
-require_env OPENAI_MODEL
+require_env PPQ_KEY
+require_env PPQ_MODEL
 require_env RUNNER_TEMP
 
 # Workflow-dispatch runs intentionally leave some CI_DEBUG_* values empty.
@@ -38,17 +38,16 @@ mkdir -p \
 path_toml=$(jq -Rn --arg value "${PATH}" '$value')
 
 cat > "${codex_home}/config.toml" <<EOF
-model = "${OPENAI_MODEL}"
-model_provider = "openai-api-key"
+model = "${PPQ_MODEL}"
+model_provider = "ppq"
 sandbox_mode = "danger-full-access"
 approval_policy = "never"
 
 
-[model_providers.openai-api-key]
-name = "OpenAI"
-base_url = "https://api.openai.com/v1"
-env_key = "OPENAI_API_KEY"
-supports_websockets = true
+[model_providers.ppq]
+name = "PPQ"
+base_url = "https://api.ppq.ai/v1"
+env_key = "PPQ_KEY"
 wire_api = "responses"
 
 

--- a/.github/workflows/codex-agent.yml
+++ b/.github/workflows/codex-agent.yml
@@ -324,8 +324,8 @@ jobs:
           CODEX_AGENT_ACTOR: ${{ steps.validate.outputs.agent_actor }}
           CODEX_AGENT_EVENT_NAME: ${{ steps.validate.outputs.agent_event_name }}
           CODEX_AGENT_EVENT_PATH: ${{ steps.validate.outputs.agent_event_path }}
-          OPENAI_API_KEY: ${{ secrets.OPEN_AI_KEY }}
-          OPENAI_MODEL: ${{ vars.OPENAI_MODEL || 'gpt-5.5' }}
+          PPQ_KEY: ${{ secrets.PPQ_KEY }}
+          PPQ_MODEL: ${{ vars.PPQ_MODEL || 'openai/gpt-5.5' }}
         run: |
           set -euo pipefail
           nix --extra-experimental-features 'nix-command flakes' \

--- a/.github/workflows/codex-ci-debug.yml
+++ b/.github/workflows/codex-ci-debug.yml
@@ -109,8 +109,8 @@ jobs:
           CI_DEBUG_WORKFLOW_EVENT: ${{ steps.target.outputs.run_event }}
           CI_DEBUG_HEAD_BRANCH: ${{ steps.target.outputs.head_branch }}
           CI_DEBUG_HEAD_SHA: ${{ steps.target.outputs.head_sha }}
-          OPENAI_API_KEY: ${{ secrets.OPEN_AI_KEY }}
-          OPENAI_MODEL: ${{ vars.OPENAI_MODEL || 'gpt-5.5' }}
+          PPQ_KEY: ${{ secrets.PPQ_KEY }}
+          PPQ_MODEL: ${{ vars.PPQ_MODEL || 'openai/gpt-5.5' }}
         run: |
           set -euo pipefail
           nix --extra-experimental-features 'nix-command flakes' \

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -246,8 +246,8 @@ jobs:
       - name: Run Codex review
         id: codex-review
         env:
-          OPENAI_API_KEY: ${{ secrets.OPEN_AI_KEY }}
-          OPENAI_MODEL: ${{ vars.OPENAI_MODEL || 'gpt-5.5' }}
+          PPQ_KEY: ${{ secrets.PPQ_KEY }}
+          PPQ_MODEL: ${{ vars.PPQ_MODEL || 'openai/gpt-5.5' }}
         run: |
           set -euo pipefail
 
@@ -255,19 +255,18 @@ jobs:
           mkdir -p "$CODEX_HOME"
           path_toml=$(jq -Rn --arg value "$PATH" '$value')
           {
-            printf 'model = "%s"\n' "$OPENAI_MODEL"
+            printf 'model = "%s"\n' "$PPQ_MODEL"
             printf '%s\n' \
-              'model_provider = "openai-api-key"' \
+              'model_provider = "ppq"' \
               'model_reasoning_effort = "xhigh"' \
               'sandbox_mode = "read-only"' \
               'approval_policy = "never"' \
               'hide_agent_reasoning = true' \
               '' \
-              '[model_providers.openai-api-key]' \
-              'name = "OpenAI"' \
-              'base_url = "https://api.openai.com/v1"' \
-              'env_key = "OPENAI_API_KEY"' \
-              'supports_websockets = true' \
+              '[model_providers.ppq]' \
+              'name = "PPQ"' \
+              'base_url = "https://api.ppq.ai/v1"' \
+              'env_key = "PPQ_KEY"' \
               'wire_api = "responses"' \
               '' \
               '[history]' \


### PR DESCRIPTION
## Summary

Switch the Codex-based GitHub Actions automation back to PPQ for now.

## Details

PR #8750 moved the agent, CI-debug agent, and review bot to direct OpenAI API usage, but the OpenAI secret path is not working reliably. This PR is based on current `master` and restores the previous PPQ provider wiring while keeping the newer bot invocation behavior.

The workflows pass `PPQ_KEY` and `PPQ_MODEL`, and the generated Codex configs use `model_provider = "ppq"` with `https://api.ppq.ai/v1` and `env_key = "PPQ_KEY"`.

## Reviewing

Check that all Codex automation entry points consistently use PPQ again and no affected file still references the OpenAI API-key provider.

## Testing

- `bash -n .github/scripts/run-codex-agent.sh .github/scripts/run-codex-ci-debug.sh`
- Verified the PPQ Codex provider config parses with `codex debug prompt-input`
- Verified no affected Codex workflow/script still references `OPENAI`, `OPEN_AI`, `openai-api-key`, or `https://api.openai.com`
- `just format`
- `just final-lint`
