### PR TITLE
fix(ci): trigger Codex agent from review bodies

### DIFF
--- a/.github/scripts/run-codex-agent.sh
+++ b/.github/scripts/run-codex-agent.sh
@@ -150,9 +150,9 @@ jq '{
 cat > "${context_dir}/prompt.md" <<'EOF'
 You are fedimint-bot, an automation agent for the Fedimint GitHub repository.
 An organization member invoked you by mentioning @fedimint-bot in a GitHub
-issue, pull request, or pull request review thread; by opening an issue that
-mentions @fedimint-bot; or by assigning an issue to fedimint-bot. Decide what
-action is useful from the context.
+issue, pull request, pull request review body, or pull request review thread;
+by opening an issue that mentions @fedimint-bot; or by assigning an issue to
+fedimint-bot. Decide what action is useful from the context.
 
 You may:
 - answer the question directly in the relevant GitHub thread;
@@ -189,9 +189,10 @@ Operational rules:
 - The GitHub event payload is at `$RUNNER_TEMP/codex-agent/context/event.json`.
 - The checked out repository is at `$GITHUB_WORKSPACE`.
 - First inspect the normalized `event_name` field in the event payload to
-  understand whether this is an issue event, issue comment, PR comment, or
-  inline PR review comment. Inline PR review comments may arrive through a
-  privileged follow-up workflow, but the payload is normalized to
+  understand whether this is an issue event, issue comment, PR comment,
+  submitted PR review, or inline PR review comment. Submitted PR reviews and
+  inline PR review comments may arrive through a privileged follow-up workflow,
+  but their payloads are normalized to `pull_request_review` or
   `pull_request_review_comment`.
 - Use `gh` to fetch additional context as needed.
 - For issue assignment events, treat the assignment as a request to open a
@@ -207,6 +208,8 @@ Operational rules:
   and body text, then retry the reply using the matched comment id if found.
 - If responding to a pull request review comment, prefer replying to that
   review comment thread when possible. Otherwise comment on the issue or PR.
+- If responding to a submitted pull request review body, prefer a top-level PR
+  comment because GitHub does not expose a review-body reply thread.
 - Before finishing, post a GitHub comment/reply, open a GitHub issue, or open a
   draft PR, unless the safest action is explicitly to do nothing.
 - If you cannot complete the requested action, post a short comment explaining

--- a/.github/workflows/codex-agent-review-comment-receiver.yml
+++ b/.github/workflows/codex-agent-review-comment-receiver.yml
@@ -1,11 +1,13 @@
 name: "Codex Agent Review Comment Receiver"
 
 on:
+  pull_request_review:
+    types: [submitted]
   pull_request_review_comment:
     types: [created]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.comment.id }}
+  group: ${{ github.workflow }}-${{ github.event.comment.id || github.event.review.id }}
   cancel-in-progress: false
 
 permissions:
@@ -13,7 +15,7 @@ permissions:
 
 jobs:
   receive:
-    name: Receive review-comment mention
+    name: Receive review mention
     runs-on: ubuntu-latest
     timeout-minutes: 5
     if: >-
@@ -26,52 +28,92 @@ jobs:
         id: capture
         run: |
           set -euo pipefail
-          body=$(jq -r '.comment.body // ""' "${GITHUB_EVENT_PATH}")
+          if [ "${GITHUB_EVENT_NAME}" = "pull_request_review" ]; then
+            body=$(jq -r '.review.body // ""' "${GITHUB_EVENT_PATH}")
+            mention_source="review body"
+          else
+            body=$(jq -r '.comment.body // ""' "${GITHUB_EVENT_PATH}")
+            mention_source="review comment"
+          fi
 
           if [[ "${body}" != *"@fedimint-bot"* ]]; then
             echo "upload=false" >> "${GITHUB_OUTPUT}"
-            echo "Skipping: comment does not mention @fedimint-bot"
+            echo "Skipping: ${mention_source} does not mention @fedimint-bot"
             exit 0
           fi
 
-          mkdir -p "${RUNNER_TEMP}/codex-agent-review-comment"
+          mkdir -p "${RUNNER_TEMP}/codex-agent-review"
           # This workflow intentionally has no secrets on fork PRs. It only
           # carries enough context for the default-branch workflow_run handler
-          # to re-fetch and re-validate the live comment before using secrets.
-          jq '{
-            action,
-            comment: {
-              id: .comment.id,
-              node_id: .comment.node_id,
-              body: .comment.body,
-              html_url: .comment.html_url,
-              pull_request_url: .comment.pull_request_url,
-              user: { login: .comment.user.login },
-              author_association: .comment.author_association
-            },
-            pull_request: {
-              number: .pull_request.number,
-              html_url: .pull_request.html_url,
-              url: .pull_request.url,
-              base: {
-                ref: .pull_request.base.ref,
-                sha: .pull_request.base.sha,
-                repo: { full_name: .pull_request.base.repo.full_name }
+          # to re-fetch and re-validate the live review object before using secrets.
+          if [ "${GITHUB_EVENT_NAME}" = "pull_request_review" ]; then
+            jq --arg event_name "${GITHUB_EVENT_NAME}" '{
+              event_name: $event_name,
+              action,
+              review: {
+                id: .review.id,
+                node_id: .review.node_id,
+                body: .review.body,
+                html_url: .review.html_url,
+                pull_request_url: .review.pull_request_url,
+                state: .review.state,
+                user: { login: .review.user.login },
+                author_association: .review.author_association
               },
-              head: {
-                ref: .pull_request.head.ref,
-                sha: .pull_request.head.sha,
-                repo: { full_name: .pull_request.head.repo.full_name }
-              }
-            },
-            sender: { login: .sender.login }
-          }' "${GITHUB_EVENT_PATH}" > "${RUNNER_TEMP}/codex-agent-review-comment/event.json"
+              pull_request: {
+                number: .pull_request.number,
+                html_url: .pull_request.html_url,
+                url: .pull_request.url,
+                base: {
+                  ref: .pull_request.base.ref,
+                  sha: .pull_request.base.sha,
+                  repo: { full_name: .pull_request.base.repo.full_name }
+                },
+                head: {
+                  ref: .pull_request.head.ref,
+                  sha: .pull_request.head.sha,
+                  repo: { full_name: .pull_request.head.repo.full_name }
+                }
+              },
+              sender: { login: .sender.login }
+            }' "${GITHUB_EVENT_PATH}" > "${RUNNER_TEMP}/codex-agent-review/event.json"
+          else
+            jq --arg event_name "${GITHUB_EVENT_NAME}" '{
+              event_name: $event_name,
+              action,
+              comment: {
+                id: .comment.id,
+                node_id: .comment.node_id,
+                body: .comment.body,
+                html_url: .comment.html_url,
+                pull_request_url: .comment.pull_request_url,
+                user: { login: .comment.user.login },
+                author_association: .comment.author_association
+              },
+              pull_request: {
+                number: .pull_request.number,
+                html_url: .pull_request.html_url,
+                url: .pull_request.url,
+                base: {
+                  ref: .pull_request.base.ref,
+                  sha: .pull_request.base.sha,
+                  repo: { full_name: .pull_request.base.repo.full_name }
+                },
+                head: {
+                  ref: .pull_request.head.ref,
+                  sha: .pull_request.head.sha,
+                  repo: { full_name: .pull_request.head.repo.full_name }
+                }
+              },
+              sender: { login: .sender.login }
+            }' "${GITHUB_EVENT_PATH}" > "${RUNNER_TEMP}/codex-agent-review/event.json"
+          fi
           echo "upload=true" >> "${GITHUB_OUTPUT}"
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: steps.capture.outputs.upload == 'true'
         with:
-          name: codex-agent-review-comment-event
-          path: ${{ runner.temp }}/codex-agent-review-comment/event.json
+          name: codex-agent-review-event
+          path: ${{ runner.temp }}/codex-agent-review/event.json
           retention-days: 1
           if-no-files-found: error

--- a/.github/workflows/codex-agent.yml
+++ b/.github/workflows/codex-agent.yml
@@ -34,7 +34,8 @@ jobs:
         github.actor != 'fedimint-bot' &&
         github.actor != 'github-actions[bot]') ||
        (github.event_name == 'workflow_run' &&
-        github.event.workflow_run.event == 'pull_request_review_comment' &&
+        (github.event.workflow_run.event == 'pull_request_review' ||
+         github.event.workflow_run.event == 'pull_request_review_comment') &&
         github.event.workflow_run.conclusion == 'success'))
 
     steps:
@@ -62,13 +63,14 @@ jobs:
           comment_user=""
           comment_id=""
           issue_number=""
+          request_kind="${event_name}"
           body=""
           artifact_dir=""
 
           if [ "${event_name}" = "workflow_run" ]; then
             # The receiver may have run without secrets on a fork PR. Treat its
             # artifact as untrusted and use it only to find the live review
-            # comment, then re-check the mention and reviewer membership here.
+            # object, then re-check the mention and reviewer membership here.
             artifacts_url=$(jq -r '.workflow_run.artifacts_url // ""' "${GITHUB_EVENT_PATH}")
             if [ -z "${artifacts_url}" ]; then
               echo "run=false" >> "${GITHUB_OUTPUT}"
@@ -77,16 +79,16 @@ jobs:
             fi
 
             artifact_id=$(gh api "${artifacts_url}" \
-              --jq '.artifacts[] | select(.name == "codex-agent-review-comment-event") | .id' \
+              --jq '.artifacts[] | select(.name == "codex-agent-review-event" or .name == "codex-agent-review-comment-event") | .id' \
               | head -n1)
 
             if [ -z "${artifact_id}" ]; then
               echo "run=false" >> "${GITHUB_OUTPUT}"
-              echo "Skipping: receiver uploaded no review-comment event artifact"
+              echo "Skipping: receiver uploaded no review event artifact"
               exit 0
             fi
 
-            artifact_dir="${RUNNER_TEMP}/codex-agent-review-comment-artifact"
+            artifact_dir="${RUNNER_TEMP}/codex-agent-review-artifact"
             rm -rf "${artifact_dir}"
             mkdir -p "${artifact_dir}"
             gh api \
@@ -97,18 +99,48 @@ jobs:
             event_payload="${artifact_dir}/event.json"
             if [ ! -s "${event_payload}" ]; then
               echo "run=false" >> "${GITHUB_OUTPUT}"
-              echo "Skipping: review-comment event artifact is missing event.json"
+              echo "Skipping: review event artifact is missing event.json"
               exit 0
             fi
 
-            comment_id=$(jq -r '.comment.id // ""' "${event_payload}")
-            if ! [[ "${comment_id}" =~ ^[0-9]+$ ]]; then
+            request_kind=$(jq -r '.event_name // ""' "${event_payload}")
+            if [ -z "${request_kind}" ]; then
+              if jq -e '.comment.id?' "${event_payload}" >/dev/null; then
+                request_kind="pull_request_review_comment"
+              elif jq -e '.review.id?' "${event_payload}" >/dev/null; then
+                request_kind="pull_request_review"
+              fi
+            fi
+
+            if [ "${request_kind}" = "pull_request_review_comment" ]; then
+              comment_id=$(jq -r '.comment.id // ""' "${event_payload}")
+              if ! [[ "${comment_id}" =~ ^[0-9]+$ ]]; then
+                echo "run=false" >> "${GITHUB_OUTPUT}"
+                echo "Skipping: review-comment artifact has invalid comment id"
+                exit 0
+              fi
+
+              comment_endpoint="repos/${GITHUB_REPOSITORY}/pulls/comments/${comment_id}"
+            elif [ "${request_kind}" = "pull_request_review" ]; then
+              comment_id=$(jq -r '.review.id // ""' "${event_payload}")
+              pull_number=$(jq -r '.pull_request.number // ""' "${event_payload}")
+              if ! [[ "${comment_id}" =~ ^[0-9]+$ ]]; then
+                echo "run=false" >> "${GITHUB_OUTPUT}"
+                echo "Skipping: review artifact has invalid review id"
+                exit 0
+              fi
+              if ! [[ "${pull_number}" =~ ^[0-9]+$ ]]; then
+                echo "run=false" >> "${GITHUB_OUTPUT}"
+                echo "Skipping: review artifact has invalid pull request number"
+                exit 0
+              fi
+
+              comment_endpoint="repos/${GITHUB_REPOSITORY}/pulls/${pull_number}/reviews/${comment_id}"
+            else
               echo "run=false" >> "${GITHUB_OUTPUT}"
-              echo "Skipping: review-comment artifact has invalid comment id"
+              echo "Skipping: review artifact has unsupported event_name=${request_kind:-<missing>}"
               exit 0
             fi
-
-            comment_endpoint="repos/${GITHUB_REPOSITORY}/pulls/comments/${comment_id}"
           elif [ "${event_name}" = "issue_comment" ]; then
             body=$(jq -r '.comment.body // ""' "${event_payload}")
             comment_id=$(jq -r '.comment.id // ""' "${event_payload}")
@@ -240,9 +272,9 @@ jobs:
 
           if [ "${event_name}" = "workflow_run" ]; then
             pull_request_url=$(jq -r '.pull_request_url // ""' <<<"${live_comment}")
-            if [ -z "${pull_request_url}" ]; then
+            if [ -z "${pull_request_url}" ] || [ "${pull_request_url}" = "null" ]; then
               echo "run=false" >> "${GITHUB_OUTPUT}"
-              echo "Skipping: live review comment has no pull_request_url"
+              echo "Skipping: live review object has no pull_request_url"
               exit 0
             fi
 
@@ -252,15 +284,27 @@ jobs:
               -H "X-GitHub-Api-Version: 2022-11-28" \
               "${pull_request_url}")
 
-            jq -n \
-              --argjson comment "${live_comment}" \
-              --argjson pull_request "${pull_request}" \
-              '{
-                action: "created",
-                comment: $comment,
-                pull_request: $pull_request
-              }' > "${agent_event_path}"
-            echo "agent_event_name=pull_request_review_comment" >> "${GITHUB_OUTPUT}"
+            if [ "${request_kind}" = "pull_request_review_comment" ]; then
+              jq -n \
+                --argjson comment "${live_comment}" \
+                --argjson pull_request "${pull_request}" \
+                '{
+                  action: "created",
+                  comment: $comment,
+                  pull_request: $pull_request
+                }' > "${agent_event_path}"
+              echo "agent_event_name=pull_request_review_comment" >> "${GITHUB_OUTPUT}"
+            else
+              jq -n \
+                --argjson review "${live_comment}" \
+                --argjson pull_request "${pull_request}" \
+                '{
+                  action: "submitted",
+                  review: $review,
+                  pull_request: $pull_request
+                }' > "${agent_event_path}"
+              echo "agent_event_name=pull_request_review" >> "${GITHUB_OUTPUT}"
+            fi
             echo "agent_actor=${comment_user}" >> "${GITHUB_OUTPUT}"
           else
             cp "${event_payload}" "${agent_event_path}"
@@ -270,7 +314,7 @@ jobs:
 
           echo "agent_event_path=${agent_event_path}" >> "${GITHUB_OUTPUT}"
           echo "comment_id=${comment_id}" >> "${GITHUB_OUTPUT}"
-          echo "comment_kind=${event_name}" >> "${GITHUB_OUTPUT}"
+          echo "comment_kind=${request_kind}" >> "${GITHUB_OUTPUT}"
           echo "run=true" >> "${GITHUB_OUTPUT}"
           echo "Trigger accepted"
           BASH
@@ -292,8 +336,11 @@ jobs:
           set -euo pipefail
           api_url="${GITHUB_API_URL:-https://api.github.com}"
 
-          if [ "${COMMENT_KIND}" = "workflow_run" ]; then
+          if [ "${COMMENT_KIND}" = "pull_request_review_comment" ]; then
             endpoint="repos/${REPOSITORY}/pulls/comments/${COMMENT_ID}/reactions"
+          elif [ "${COMMENT_KIND}" = "pull_request_review" ]; then
+            echo "Skipping reaction: pull request reviews do not have a supported reactions endpoint"
+            exit 0
           elif [ "${COMMENT_KIND}" = "issues" ]; then
             endpoint="repos/${REPOSITORY}/issues/${COMMENT_ID}/reactions"
           else


### PR DESCRIPTION
### Summary

Teach the Codex agent trigger path to accept `@fedimint-bot` mentions in submitted pull request review bodies, not just top-level comments and inline review comments.

### Details

The review-comment receiver now also listens for `pull_request_review` submissions, captures a sanitized review payload when the review body mentions the bot, and uploads a generic review event artifact. The privileged Codex Agent workflow re-fetches and validates either live review comments or live review bodies before using secrets, normalizes submitted reviews to `pull_request_review`, and skips the reaction step for review bodies because GitHub does not expose a review-body reaction endpoint.

The agent prompt now explicitly tells the bot how to handle submitted PR review events and to use a top-level PR comment when responding to a review body.

### Testing

- `nix --extra-experimental-features 'nix-command flakes' --accept-flake-config shell nixpkgs#actionlint -c actionlint .github/workflows/codex-agent.yml .github/workflows/codex-agent-review-comment-receiver.yml`
- `just format`
- `bash -n .github/scripts/run-codex-agent.sh`
- `just final-lint`
