### PR TITLE
feat(client): compile mintv2 and walletv2 clients under wasm

### DIFF
--- a/justfile.fedimint.just
+++ b/justfile.fedimint.just
@@ -108,6 +108,8 @@ check-wasm *EXTRA_ARGS:
         --package fedimint-client \
         --package fedimint-client-wasm \
         --package fedimint-wasm-tests \
+        --package fedimint-mintv2-client \
+        --package fedimint-walletv2-client \
         {{EXTRA_ARGS}}
 
 # regenerate server db migration snapshots

--- a/modules/fedimint-mintv2-client/src/api.rs
+++ b/modules/fedimint-mintv2-client/src/api.rs
@@ -5,7 +5,7 @@ use bitcoin_hashes::sha256;
 use fedimint_api_client::api::{DynModuleApi, FederationApiExt, ServerError};
 use fedimint_api_client::query::FilterMapThreshold;
 use fedimint_core::module::ApiRequestErased;
-use fedimint_core::{NumPeersExt, OutPointRange, PeerId};
+use fedimint_core::{NumPeersExt, OutPointRange, PeerId, apply, async_trait_maybe_send};
 use fedimint_mintv2_common::endpoint_constants::{
     RECOVERY_COUNT_ENDPOINT, RECOVERY_SLICE_ENDPOINT, RECOVERY_SLICE_HASH_ENDPOINT,
     SIGNATURE_SHARES_ENDPOINT, SIGNATURE_SHARES_RECOVERY_ENDPOINT,
@@ -16,7 +16,7 @@ use tbs::{BlindedMessage, BlindedSignatureShare, PublicKeyShare};
 use crate::NoteIssuanceRequest;
 use crate::output::verify_blind_shares;
 
-#[async_trait::async_trait]
+#[apply(async_trait_maybe_send!)]
 pub trait MintV2ModuleApi {
     async fn fetch_signature_shares(
         &self,
@@ -44,7 +44,7 @@ pub trait MintV2ModuleApi {
     ) -> anyhow::Result<Vec<RecoveryItem>>;
 }
 
-#[async_trait::async_trait]
+#[apply(async_trait_maybe_send!)]
 impl MintV2ModuleApi for DynModuleApi {
     async fn fetch_signature_shares(
         &self,

--- a/modules/fedimint-mintv2-client/src/lib.rs
+++ b/modules/fedimint-mintv2-client/src/lib.rs
@@ -297,7 +297,13 @@ impl ClientModuleInit for MintClientInit {
 
         let filter = issuance::tweak_filter(args.module_root_secret());
 
-        tokio::task::spawn_blocking(move || {
+        // Only ~1/65536 random tweaks pass the filter, so grinding is
+        // CPU-bound. Pre-grind in the background and feed tweaks through a
+        // channel to keep the cost off the spend path. `send` only suspends
+        // once the channel is full, so we yield explicitly on each found tweak
+        // to keep single-threaded (wasm) runtimes responsive while the channel
+        // still has space.
+        fedimint_core::task::spawn("mintv2-tweak-grinder", async move {
             loop {
                 let tweak: [u8; 16] = thread_rng().r#gen();
 
@@ -305,9 +311,11 @@ impl ClientModuleInit for MintClientInit {
                     continue;
                 }
 
-                if tweak_sender.send_blocking(tweak).is_err() {
+                if tweak_sender.send(tweak).await.is_err() {
                     return;
                 }
+
+                fedimint_core::task::sleep(Duration::ZERO).await;
             }
         });
 

--- a/modules/fedimint-walletv2-client/src/lib.rs
+++ b/modules/fedimint-walletv2-client/src/lib.rs
@@ -44,7 +44,7 @@ use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::{
     AmountUnit, Amounts, ApiVersion, CommonModuleInit, ModuleCommon, ModuleInit, MultiApiVersion,
 };
-use fedimint_core::task::{TaskGroup, TaskHandle, block_in_place, sleep};
+use fedimint_core::task::{TaskGroup, TaskHandle, sleep};
 use fedimint_core::{Amount, OutPoint, TransactionId, apply, async_trait_maybe_send};
 use fedimint_derive_secret::{ChildId, DerivableSecret};
 use fedimint_eventlog::{Event, EventLogId};
@@ -595,18 +595,32 @@ impl WalletClientModule {
     /// Find the next valid index starting from (and including) `start_index`.
     ///
     /// Only ~1/65536 indices are valid, so the search is CPU-bound and may scan
-    /// many indices before finding one. To avoid blocking client shutdown, the
-    /// search stops and returns `None` once the task group begins shutting
-    /// down.
-    #[allow(clippy::maybe_infinite_iter)]
-    fn next_valid_index(&self, start_index: u64, handle: &TaskHandle) -> Option<u64> {
+    /// many indices before finding one. The scan runs in bounded batches and
+    /// yields to the executor between them, so it does not stall the runtime —
+    /// important on wasm, which is single-threaded. It stops and returns `None`
+    /// once the task group begins shutting down.
+    async fn next_valid_index(&self, start_index: u64, handle: &TaskHandle) -> Option<u64> {
+        /// Indices to scan per batch before yielding to the executor.
+        const SCAN_BATCH: u64 = 256;
+
         let pks_hash = self.cfg.bitcoin_pks.consensus_hash();
 
-        block_in_place(|| {
-            (start_index..)
-                .take_while(|_| !handle.is_shutting_down())
-                .find(|i| is_potential_receive(&self.derive_address(*i).script_pubkey(), &pks_hash))
-        })
+        let mut index = start_index;
+
+        while !handle.is_shutting_down() {
+            for _ in 0..SCAN_BATCH {
+                if is_potential_receive(&self.derive_address(index).script_pubkey(), &pks_hash) {
+                    return Some(index);
+                }
+
+                index += 1;
+            }
+
+            // Hand control back to the executor between batches.
+            sleep(Duration::ZERO).await;
+        }
+
+        None
     }
 
     /// Issue ecash for an unspent output with a given fee.
@@ -705,7 +719,7 @@ impl WalletClientModule {
                 .await
                 .is_none()
             {
-                let Some(index) = module.next_valid_index(0, &handle) else {
+                let Some(index) = module.next_valid_index(0, &handle).await else {
                     return;
                 };
 
@@ -767,7 +781,8 @@ impl WalletClientModule {
 
                 // If we used the highest valid index, add the next valid one
                 if address_index == next_address_index {
-                    let Some(index) = self.next_valid_index(next_address_index + 1, handle) else {
+                    let Some(index) = self.next_valid_index(next_address_index + 1, handle).await
+                    else {
                         return Ok(false);
                     };
 

--- a/nix/flakebox.nix
+++ b/nix/flakebox.nix
@@ -1026,7 +1026,7 @@ in
       };
 
     cargoCheckWasmNoDefaultFeatures = cargoCheckCommand {
-      args = "--package fedimint-client --package fedimint-client-wasm --package fedimint-wasm-tests --no-default-features";
+      args = "--package fedimint-client --package fedimint-client-wasm --package fedimint-wasm-tests --package fedimint-mintv2-client --package fedimint-walletv2-client --no-default-features";
     };
 
     cargoWorkspacesCheckDefaultFeatures = cargoWorkspacesCommand {


### PR DESCRIPTION
## Summary

Make `fedimint-mintv2-client` and `fedimint-walletv2-client` compile for `wasm32-unknown-unknown`, and add them to the wasm CI check so they stay that way. `fedimint-lnv2-client` already compiled; these two were the remaining blockers.

## Details

Three independent wasm incompatibilities:

- **mintv2 `api.rs` — forced-`Send` futures.** The `MintV2ModuleApi` trait used plain `#[async_trait::async_trait]`, which forces returned futures to be `Send`. The underlying `DynModuleApi` futures are intentionally non-`Send` on wasm, so this failed to compile. Switched to `#[apply(async_trait_maybe_send!)]`, the same wasm-aware macro already used by `fedimint-mint-client` and `fedimint-lnv2-client` (it becomes `?Send` on wasm).

- **mintv2 `init` — blocking tweak grinder.** Only ~1/65536 random tweaks pass the filter, so tweaks are pre-ground in the background to keep that cost off the spend path. That producer used `tokio::task::spawn_blocking` + `send_blocking`, neither of which exists on wasm (no blocking threadpool). Replaced with a single cross-platform background task (`fedimint_core::task::spawn`) that grinds on the executor and feeds tweaks through an async `send`. Since `async_channel`'s `send` only suspends when the channel is full, it yields explicitly on each found tweak so single-threaded (wasm) runtimes stay responsive while the channel still has space.

- **walletv2 `next_valid_index` — `block_in_place`.** `fedimint_core::task::block_in_place` is `#[cfg(not(target_family = "wasm"))]`. The same `~1/65536` index scan is now a batched async loop that yields to the executor every `SCAN_BATCH` indices. This is a single implementation for both platforms (no `#[cfg]`): on native the yield is negligible, and on wasm it keeps the event loop responsive during the scan. The shutdown-on-task-group-shutdown behaviour is preserved.

- **CI.** Added both crates to `cargoCheckWasmNoDefaultFeatures` (the nix wasm-check derivation) and the mirrored `just check-wasm` recipe. Both crates have empty default features, so adding them to the existing `--no-default-features` list is equivalent to a plain `cargo check -p <crate> --target wasm32-unknown-unknown`, and neither is a transitive dep of the already-checked crates, so this is genuinely new coverage.

## Reviewing

Both grinds are "make it compile, stay responsive" fixes — they keep the single-threaded wasm runtime from freezing but do not make the grinding *fast* on wasm (still ~65k attempts per result). The tweak grinder yields once per found tweak, so on wasm a fill/refill burst still grinds in ~one-find chunks between yields; if that proves too coarse in practice it can be batched like the wallet scan (`SCAN_BATCH`, currently 256, is likewise an untuned starting value).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
