### PR TITLE
perf(gwv2): return preimage to sender without awaiting outgoing claim

### DIFF
--- a/modules/fedimint-gwv2-client/src/lib.rs
+++ b/modules/fedimint-gwv2-client/src/lib.rs
@@ -369,17 +369,11 @@ impl GatewayClientModuleV2 {
                 match state.state {
                     SendSMState::Sending => {}
                     SendSMState::Claiming(claiming) => {
-                        // This increases latency by one ordering and may eventually be removed;
-                        // however, at the current stage of lnv2 we prioritize the verification of
-                        // correctness above minimum latency.
-                        assert!(
-                            self.client_ctx
-                                .await_primary_module_outputs(operation_id, claiming.outpoints)
-                                .await
-                                .is_ok(),
-                            "Gateway Module V2 failed to claim outgoing contract with preimage"
-                        );
-
+                        // The preimage is proof the payment succeeded, so return it to
+                        // the sender as soon as it is available rather than waiting for
+                        // an additional ordering. The gateway's claim of the outgoing
+                        // contract has already been submitted by the send state machine
+                        // and finalizes in the background.
                         return Ok(claiming.preimage);
                     }
                     SendSMState::Cancelled(cancelled) => {

--- a/modules/fedimint-lnv2-tests/bin/tests.rs
+++ b/modules/fedimint-lnv2-tests/bin/tests.rs
@@ -408,14 +408,19 @@ async fn test_fees(
 
     common::await_receive_claimed(client, receive_op).await?;
 
-    let gw_lnd_ecash_after = gw_lnd.client().ecash_balance(fed_id.clone()).await?;
-
-    almost_equal(
+    // The sending gateway claims its outgoing contract in the background after
+    // returning the preimage to the sender, so its ecash balance is credited
+    // asynchronously. Wait for the claim to settle before asserting the fee.
+    while almost_equal(
         gw_lnd_ecash_prev + expected_addition,
-        gw_lnd_ecash_after,
+        gw_lnd.client().ecash_balance(fed_id.clone()).await?,
         5000,
     )
-    .unwrap();
+    .is_err()
+    {
+        info!("Waiting for the sending gateway's outgoing claim to settle...");
+        cmd!(client, "dev", "wait", "1").out_json().await?;
+    }
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

When relaying an outgoing LNv2 payment, the gateway held the send response until its *own* claim of the outgoing contract had been ordered and the resulting ecash outputs were issued. That added a full consensus ordering to every send — internal direct-swap payments included — even though the sender already has everything it needs (the preimage) one ordering earlier.

This returns the preimage to the sender as soon as the send state machine reaches the `Claiming` state.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
