### PR TITLE
perf(lnv2): long-poll decryption key share endpoint

### DIFF
--- a/modules/fedimint-gwv2-client/src/receive_sm.rs
+++ b/modules/fedimint-gwv2-client/src/receive_sm.rs
@@ -142,34 +142,49 @@ impl ReceiveStateMachine {
         outpoint: OutPoint,
         contract: IncomingContract,
     ) -> Result<BTreeMap<PeerId, DecryptionKeyShare>, String> {
-        global_context.await_tx_accepted(outpoint.txid).await?;
+        let num_peers = global_context.api().all_peers().to_num_peers();
+        let module_api = global_context.module_api();
 
-        Ok(global_context
-            .module_api()
-            .request_with_strategy_retry(
-                FilterMapThreshold::new(
-                    move |peer_id, share: DecryptionKeyShare| {
-                        if !contract.verify_decryption_share(
-                            tpe_pks
-                                .get(&peer_id)
-                                .ok_or(ServerError::InternalClientError(anyhow!(
-                                    "Missing TPE PK for peer {peer_id}?!"
-                                )))?,
-                            &share,
-                        ) {
-                            return Err(fedimint_api_client::api::ServerError::InvalidResponse(
-                                anyhow!("Invalid decryption share"),
-                            ));
-                        }
+        // The decryption key share endpoint long-polls until the share exists, which
+        // happens atomically when the funding transaction is accepted. We can therefore
+        // fire the request up front and let it overlap with awaiting transaction
+        // acceptance instead of serializing the two, saving a round trip on the happy
+        // path. Acceptance is still awaited to detect a rejected funding transaction.
+        let decryption_shares = module_api.request_with_strategy_retry(
+            FilterMapThreshold::new(
+                move |peer_id, share: DecryptionKeyShare| {
+                    if !contract.verify_decryption_share(
+                        tpe_pks
+                            .get(&peer_id)
+                            .ok_or(ServerError::InternalClientError(anyhow!(
+                                "Missing TPE PK for peer {peer_id}?!"
+                            )))?,
+                        &share,
+                    ) {
+                        return Err(fedimint_api_client::api::ServerError::InvalidResponse(
+                            anyhow!("Invalid decryption share"),
+                        ));
+                    }
 
-                        Ok(share)
-                    },
-                    global_context.api().all_peers().to_num_peers(),
-                ),
-                DECRYPTION_KEY_SHARE_ENDPOINT.to_owned(),
-                ApiRequestErased::new(outpoint),
-            )
-            .await)
+                    Ok(share)
+                },
+                num_peers,
+            ),
+            DECRYPTION_KEY_SHARE_ENDPOINT.to_owned(),
+            ApiRequestErased::new(outpoint),
+        );
+
+        let decryption_shares = std::pin::pin!(decryption_shares);
+        let tx_accepted = std::pin::pin!(global_context.await_tx_accepted(outpoint.txid));
+
+        match futures::future::select(decryption_shares, tx_accepted).await {
+            futures::future::Either::Left((shares, _)) => Ok(shares),
+            futures::future::Either::Right((accepted, decryption_shares)) => {
+                accepted?;
+
+                Ok(decryption_shares.await)
+            }
+        }
     }
 
     async fn transition_decryption_shares(

--- a/modules/fedimint-lnv2-server/src/lib.rs
+++ b/modules/fedimint-lnv2-server/src/lib.rs
@@ -671,15 +671,15 @@ impl ServerModule for Lightning {
                 DECRYPTION_KEY_SHARE_ENDPOINT,
                 ApiVersion::new(0, 0),
                 async |_module: &Lightning, context, params: OutPoint| -> DecryptionKeyShare {
-                    let share = context
+                    // Long-poll until the decryption key share exists. The share is written
+                    // atomically when the funding transaction output is accepted, so blocking
+                    // here lets a client request the share before acceptance and receive it the
+                    // instant it becomes available, rather than polling and backing off. This
+                    // mirrors the AWAIT_INCOMING_CONTRACT and AWAIT_PREIMAGE endpoints.
+                    Ok(context
                         .db()
-                        .begin_transaction_nc()
-                        .await
-                        .get_value(&DecryptionKeyShareKey(params))
-                        .await
-                        .ok_or(ApiError::bad_request("No decryption key share found".to_string()))?;
-
-                    Ok(share)
+                        .wait_key_exists(&DecryptionKeyShareKey(params))
+                        .await)
                 }
             },
             api_endpoint! {


### PR DESCRIPTION
## Summary

Make the lnv2 `DECRYPTION_KEY_SHARE_ENDPOINT` long-poll server-side until the share exists, and parallelize the gateway's decryption-share fetch with awaiting transaction acceptance.
