### PR TITLE
feat(lnv2): cache gateways for synchronous selection

### DIFF
--- a/modules/fedimint-lnv2-client/src/cli.rs
+++ b/modules/fedimint-lnv2-client/src/cli.rs
@@ -52,10 +52,6 @@ enum LnurlOpts {
 
 #[derive(Clone, Subcommand, Serialize)]
 enum GatewaysOpts {
-    /// Update the mapping from lightning node public keys to gateway api
-    /// endpoints maintained in the module database to optimise gateway
-    /// selection for a given invoice; this command is intended for testing.
-    Map,
     /// Select an online vetted gateway; this command is intended for testing.
     Select {
         #[arg(long)]
@@ -110,9 +106,13 @@ pub(crate) async fn handle_cli_command(
             } => json(lightning.generate_lnurl(recurringd, gateway).await?),
         },
         Opts::Gateways(gateway_opts) => match gateway_opts {
-            #[allow(clippy::unit_arg)]
-            GatewaysOpts::Map => json(lightning.update_gateway_map().await),
-            GatewaysOpts::Select { invoice } => json(lightning.select_gateway(invoice).await?.0),
+            GatewaysOpts::Select { invoice } => {
+                // The client is short-lived, so the in-memory gateway cache
+                // starts empty; populate it before selecting.
+                lightning.update_gateway_map().await;
+
+                json(lightning.select_gateway(invoice)?.0)
+            }
             GatewaysOpts::List { peer } => json(lightning.list_gateways(peer).await?),
             GatewaysOpts::Add { gateway } => {
                 let auth = lightning

--- a/modules/fedimint-lnv2-client/src/lib.rs
+++ b/modules/fedimint-lnv2-client/src/lib.rs
@@ -15,12 +15,12 @@ mod receive_sm;
 mod send_sm;
 
 use std::collections::{BTreeMap, BTreeSet};
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 use async_stream::stream;
 use bitcoin::hashes::{Hash, sha256};
 use bitcoin::secp256k1;
-use db::{DbKeyPrefix, GatewayKey, IncomingContractStreamIndexKey};
+use db::{DbKeyPrefix, IncomingContractStreamIndexKey};
 use fedimint_api_client::api::DynModuleApi;
 use fedimint_client_module::module::init::{ClientModuleInit, ClientModuleInitArgs};
 use fedimint_client_module::module::recovery::NoModuleBackup;
@@ -42,7 +42,8 @@ use fedimint_core::module::{
 use fedimint_core::secp256k1::SECP256K1;
 use fedimint_core::task::TaskGroup;
 use fedimint_core::time::duration_since_epoch;
-use fedimint_core::util::SafeUrl;
+use fedimint_core::util::backoff_util::api_networking_backoff;
+use fedimint_core::util::{SafeUrl, retry};
 use fedimint_core::{Amount, PeerId, apply, async_trait_maybe_send};
 use fedimint_derive_secret::{ChildId, DerivableSecret};
 use fedimint_lnv2_common::config::LightningClientConfig;
@@ -57,13 +58,13 @@ use fedimint_lnv2_common::{
 };
 use futures::StreamExt;
 use lightning_invoice::{Bolt11Invoice, Currency};
+use rand::seq::IteratorRandom;
 use secp256k1::{Keypair, PublicKey, Scalar, SecretKey, ecdh};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use strum::IntoEnumIterator as _;
 use thiserror::Error;
 use tpe::{AggregateDecryptionKey, derive_agg_dk};
-use tracing::warn;
 
 use crate::api::LightningFederationApi;
 use crate::events::SendPaymentEvent;
@@ -309,6 +310,13 @@ impl Context for LightningClientContext {
     const KIND: Option<ModuleKind> = Some(KIND);
 }
 
+/// In-memory cache of the federation's registered gateways and their
+/// `RoutingInfo`, populated by the gateway update task. Cloning shares the
+/// underlying map, so background updates are visible to all holders. It backs
+/// the synchronous [`LightningClientModule::select_gateway`].
+#[derive(Debug, Clone, Default)]
+struct GatewayCache(Arc<RwLock<BTreeMap<SafeUrl, RoutingInfo>>>);
+
 #[derive(Debug, Clone)]
 pub struct LightningClientModule {
     federation_id: FederationId,
@@ -319,6 +327,7 @@ pub struct LightningClientModule {
     keypair: Keypair,
     lnurl_keypair: Keypair,
     gateway_conn: Arc<dyn GatewayConnection + Send + Sync>,
+    gateway_cache: GatewayCache,
     #[allow(unused)] // The field is only used by the cli feature
     admin_auth: Option<ApiAuth>,
 }
@@ -396,6 +405,7 @@ impl LightningClientModule {
                 .child_key(ChildId(1))
                 .to_secp_key(SECP256K1),
             gateway_conn,
+            gateway_cache: GatewayCache::default(),
             admin_auth,
         };
 
@@ -421,71 +431,102 @@ impl LightningClientModule {
     }
 
     async fn update_gateway_map(&self) {
-        // Update the mapping from lightning node public keys to gateway api
-        // endpoints maintained in the module database. When paying an invoice this
-        // enables the client to select the gateway that has created the invoice,
-        // if possible, such that the payment does not go over lightning, reducing
-        // fees and latency.
+        // Query the federation for its registered gateways — retrying transient
+        // failures with the api backoff, exactly like the per-gateway probes
+        // below — then probe each gateway's routing info to populate the
+        // in-memory cache used by synchronous gateway selection. Nothing is
+        // persisted; the cache is rebuilt from scratch on every client start.
+        let gateways = retry("gateway-list", api_networking_backoff(), || {
+            let api = self.module_api.clone();
 
-        if let Ok(gateways) = self.module_api.gateways().await {
-            let mut dbtx = self.client_ctx.module_db().begin_transaction().await;
-
-            for gateway in gateways {
-                if let Ok(Some(routing_info)) = self
-                    .gateway_conn
-                    .routing_info(gateway.clone(), &self.federation_id)
+            async move {
+                api.gateways()
                     .await
-                {
-                    dbtx.insert_entry(&GatewayKey(routing_info.lightning_public_key), &gateway)
-                        .await;
+                    .map_err(|_| anyhow::anyhow!("Failed to list gateways"))
+            }
+        })
+        .await
+        .expect("The backoff has no maximum number of retries");
+
+        // Probe the gateways concurrently. Transient connection failures are
+        // retried with backoff so a gateway that is briefly unreachable still
+        // makes it into the cache once it recovers; a gateway that does not serve
+        // our federation returns `None` and is simply left out. Gateways that
+        // stay unreachable keep retrying in the background until the task group
+        // cancels this task on shutdown.
+        futures::future::join_all(gateways.into_iter().map(|gateway| {
+            let module = self.clone();
+
+            async move {
+                let routing_info = retry("gateway-routing-info", api_networking_backoff(), || {
+                    let module = module.clone();
+                    let gateway = gateway.clone();
+
+                    async move {
+                        module
+                            .routing_info(&gateway)
+                            .await
+                            .map_err(|_| anyhow::anyhow!("Failed to request routing info"))
+                    }
+                })
+                .await
+                .expect("The backoff has no maximum number of retries");
+
+                if let Some(routing_info) = routing_info {
+                    module
+                        .gateway_cache
+                        .0
+                        .write()
+                        .expect("gateway cache lock is poisoned")
+                        .insert(gateway, routing_info);
                 }
             }
-
-            if let Err(e) = dbtx.commit_tx_result().await {
-                warn!("Failed to commit the updated gateway mapping to the database: {e}");
-            }
-        }
+        }))
+        .await;
     }
 
-    /// Selects an available gateway by querying the federation's registered
-    /// gateways, checking if one of them match the invoice's payee public
-    /// key, then queries the gateway for `RoutingInfo` to determine if it is
-    /// online.
-    pub async fn select_gateway(
+    /// Look up a gateway's routing info in the in-memory cache populated by
+    /// `update_gateway_map`, returning `None` if it has not been probed.
+    fn cached_routing_info(&self, gateway: &SafeUrl) -> Option<RoutingInfo> {
+        self.gateway_cache
+            .0
+            .read()
+            .expect("gateway cache lock is poisoned")
+            .get(gateway)
+            .cloned()
+    }
+
+    /// Selects an available gateway from the in-memory cache, preferring the
+    /// gateway that issued the invoice so the payment can be settled as a
+    /// direct swap between fedimints instead of going over lightning. Reads
+    /// only the cache, so it is synchronous and never hits the network; the
+    /// cache is populated by `update_gateway_map`.
+    pub fn select_gateway(
         &self,
         invoice: Option<Bolt11Invoice>,
     ) -> Result<(SafeUrl, RoutingInfo), SelectGatewayError> {
-        let gateways = self
-            .module_api
-            .gateways()
-            .await
-            .map_err(|e| SelectGatewayError::FailedToRequestGateways(e.to_string()))?;
+        let cache = self
+            .gateway_cache
+            .0
+            .read()
+            .expect("gateway cache lock is poisoned");
 
-        if gateways.is_empty() {
-            return Err(SelectGatewayError::NoGatewaysAvailable);
-        }
+        if let Some(invoice) = invoice {
+            let payee = invoice.recover_payee_pub_key();
 
-        if let Some(invoice) = invoice
-            && let Some(gateway) = self
-                .client_ctx
-                .module_db()
-                .begin_transaction_nc()
-                .await
-                .get_value(&GatewayKey(invoice.recover_payee_pub_key()))
-                .await
-                .filter(|gateway| gateways.contains(gateway))
-            && let Ok(Some(routing_info)) = self.routing_info(&gateway).await
-        {
-            return Ok((gateway, routing_info));
-        }
-
-        for gateway in gateways {
-            if let Ok(Some(routing_info)) = self.routing_info(&gateway).await {
-                return Ok((gateway, routing_info));
+            if let Some((gateway, routing_info)) = cache
+                .iter()
+                .find(|(_, routing_info)| routing_info.lightning_public_key == payee)
+            {
+                return Ok((gateway.clone(), routing_info.clone()));
             }
         }
 
-        Err(SelectGatewayError::GatewaysUnresponsive)
+        cache
+            .iter()
+            .choose(&mut rand::thread_rng())
+            .map(|(gateway, routing_info)| (gateway.clone(), routing_info.clone()))
+            .ok_or(SelectGatewayError::NoGatewaysAvailable)
     }
 
     /// Sends a request to each peer for their registered gateway list and
@@ -573,16 +614,22 @@ impl LightningClientModule {
             .keypair(secp256k1::SECP256K1);
 
         let (gateway_api, routing_info) = match gateway {
-            Some(gateway_api) => (
-                gateway_api.clone(),
-                self.routing_info(&gateway_api)
-                    .await
-                    .map_err(|e| SendPaymentError::FailedToConnectToGateway(e.to_string()))?
-                    .ok_or(SendPaymentError::FederationNotSupported)?,
-            ),
+            Some(gateway_api) => {
+                // Prefer the cached routing info for this gateway; only hit the
+                // network if it is not already in the map.
+                let routing_info = match self.cached_routing_info(&gateway_api) {
+                    Some(routing_info) => routing_info,
+                    None => self
+                        .routing_info(&gateway_api)
+                        .await
+                        .map_err(|e| SendPaymentError::FailedToConnectToGateway(e.to_string()))?
+                        .ok_or(SendPaymentError::FederationNotSupported)?,
+                };
+
+                (gateway_api, routing_info)
+            }
             None => self
                 .select_gateway(Some(invoice.clone()))
-                .await
                 .map_err(SendPaymentError::SelectGateway)?,
         };
 
@@ -962,11 +1009,14 @@ impl LightningClientModule {
         gateway: Option<SafeUrl>,
     ) -> anyhow::Result<Amount> {
         let routing_info = match gateway {
-            Some(gateway) => self
-                .routing_info(&gateway)
-                .await?
-                .ok_or_else(|| anyhow::anyhow!("Federation not supported by gateway"))?,
-            None => self.select_gateway(None).await?.1,
+            Some(gateway) => match self.cached_routing_info(&gateway) {
+                Some(routing_info) => routing_info,
+                None => self
+                    .routing_info(&gateway)
+                    .await?
+                    .ok_or_else(|| anyhow::anyhow!("Federation not supported by gateway"))?,
+            },
+            None => self.select_gateway(None)?.1,
         };
 
         // The default (Lightning-swap) send fee is the higher of the gateway's
@@ -1013,16 +1063,22 @@ impl LightningClientModule {
             .to_byte_array();
 
         let (gateway, routing_info) = match gateway {
-            Some(gateway) => (
-                gateway.clone(),
-                self.routing_info(&gateway)
-                    .await
-                    .map_err(|e| ReceiveError::FailedToConnectToGateway(e.to_string()))?
-                    .ok_or(ReceiveError::FederationNotSupported)?,
-            ),
+            Some(gateway) => {
+                // Prefer the cached routing info for this gateway; only hit the
+                // network if it is not already in the map.
+                let routing_info = match self.cached_routing_info(&gateway) {
+                    Some(routing_info) => routing_info,
+                    None => self
+                        .routing_info(&gateway)
+                        .await
+                        .map_err(|e| ReceiveError::FailedToConnectToGateway(e.to_string()))?
+                        .ok_or(ReceiveError::FederationNotSupported)?,
+                };
+
+                (gateway, routing_info)
+            }
             None => self
                 .select_gateway(None)
-                .await
                 .map_err(ReceiveError::SelectGateway)?,
         };
 
@@ -1236,11 +1292,17 @@ impl LightningClientModule {
         let gateways = if let Some(gateway) = gateway {
             vec![gateway]
         } else {
+            // Read the gateway list from the in-memory cache, which the gateway
+            // update task keeps populated from the federation, so lnurl
+            // generation is instant and needs no network round trip.
             let gateways = self
-                .module_api
-                .gateways()
-                .await
-                .map_err(|e| GenerateLnurlError::FailedToRequestGateways(e.to_string()))?;
+                .gateway_cache
+                .0
+                .read()
+                .expect("gateway cache lock is poisoned")
+                .keys()
+                .cloned()
+                .collect::<Vec<SafeUrl>>();
 
             if gateways.is_empty() {
                 return Err(GenerateLnurlError::NoGatewaysAvailable);

--- a/modules/fedimint-lnv2-tests/bin/tests.rs
+++ b/modules/fedimint-lnv2-tests/bin/tests.rs
@@ -197,10 +197,6 @@ async fn test_gateway_registration(dev_fed: &DevJitFed) -> anyhow::Result<()> {
         )
     );
 
-    cmd!(client, "module", "lnv2", "gateways", "map")
-        .out_json()
-        .await?;
-
     for _ in 0..10 {
         for gateway in &gateways {
             let invoice = common::receive(&client, gateway, 1_000_000).await?.0;


### PR DESCRIPTION
## Summary

Port picomint's gateway prefetching to the lnv2 client so gateway selection is a synchronous in-memory read and lnurl generation is instant, instead of both doing network round trips on every call.

## Details

A background task (the existing gateway update task) now, once at startup:

1. Queries the federation for its registered gateways via `gateways()`.
2. Persists the list to the database as one row per gateway (`CachedGatewayKey(SafeUrl) => ()`).
3. Probes each gateway's `routing_info` concurrently and stores it in a new in-memory `GatewayCache` (`Arc<RwLock<BTreeMap<SafeUrl, RoutingInfo>>>`).

Probes retry transient failures with `api_networking_backoff`, so a gateway that is briefly unreachable still lands in the cache once it recovers; a gateway that does not serve our federation returns `None` and is left out. Unreachable gateways keep retrying in the background until the task group cancels the task on shutdown.

With the cache in place:

- **`select_gateway` is now synchronous** — it reads only the cache (preferring the gateway that issued the invoice, for a direct swap, else a random one) and never touches the network. Callers in `send`/`receive` drop the `.await`.
- **`generate_lnurl` reads the persisted rows from the database** rather than querying the federation, so it is instant and works offline.
- The persisted rows also **seed the next cold start** before the consensus gateway query returns.

This replaces the old `GatewayKey` (lightning-pubkey → gateway-url) database map; its job — picking the gateway that issued an invoice — is now done by scanning the cached `RoutingInfo`, whose `lightning_public_key` is matched against the invoice payee.

## Design decisions

Following picomint, with two deliberate divergences:
- **Refresh:** probe once at startup (no periodic loop), but retry failed probes with backoff. picomint does not retry.
- **lnurl source:** read the gateway list from the DB. picomint still fetches it fresh from consensus.
- **Persistence:** only the URL list is persisted, one row per gateway; `RoutingInfo` stays in memory (like picomint persisting only PKs).

## Reviewing

- **Cold-start window:** `select_gateway` returns `NoGatewaysAvailable` until the first probe round populates the cache (sub-second after the client is up). This matches picomint's behavior; a caller that races startup should retry. Flagging in case any consumer expects `select_gateway` to block until a gateway is available.
- **Routing-info staleness:** with no periodic refresh, cached fees can age within a session. The receive invoice is still fetched fresh from the gateway (which re-quotes), and a stale send fee would surface as a normal gateway rejection/refund. If we'd rather bound staleness, a periodic re-probe is a small follow-up.
- The `Gateway = 0x41` db prefix is retained (marked historical) so the discriminant is not reused; old `GatewayKey` rows are left orphaned and harmless.