### PR TITLE
perf(lnv2): long-poll outgoing contract expiration and send optimistically

### DIFF
--- a/modules/fedimint-lnv2-client/src/lib.rs
+++ b/modules/fedimint-lnv2-client/src/lib.rs
@@ -138,21 +138,27 @@ pub struct LnurlReceiveOperationMeta {
 /// classDef virtual fill:#fff,stroke-dasharray: 5 5
 ///
 ///     Funding -- funding transaction is rejected --> Rejected
-///     Funding -- funding transaction is accepted --> Funded
-///     Funded -- payment is confirmed  --> Success
-///     Funded -- payment attempt expires --> Refunding
-///     Funded -- gateway cancels payment attempt --> Refunding
+///     Funding -- payment is confirmed  --> Success
+///     Funding -- payment attempt expires --> Refunding
+///     Funding -- gateway cancels payment attempt --> Refunding
 ///     Refunding -- payment is confirmed --> Success
 ///     Refunding -- ecash is minted --> Refunded
 ///     Refunding -- minting ecash fails --> Failure
 /// ```
+/// The gateway is asked to pay optimistically, while the funding transaction is
+/// still being confirmed, so a successful send goes straight from `Funding` to
+/// `Success` without a distinct `Funded` step. `Funded` is only ever yielded
+/// for operations that were persisted before this behavior was introduced.
+///
 /// The transition from Refunding to Success is only possible if the gateway
 /// misbehaves.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub enum SendOperationState {
     /// We are funding the contract to incentivize the gateway.
     Funding,
-    /// We are waiting for the gateway to complete the payment.
+    /// We are waiting for the gateway to complete the payment. Only yielded for
+    /// operations persisted before optimistic send was introduced; new sends go
+    /// straight from `Funding` to a final state.
     Funded,
     /// The payment was successful.
     Success([u8; 32]),

--- a/modules/fedimint-lnv2-client/src/send_sm.rs
+++ b/modules/fedimint-lnv2-client/src/send_sm.rs
@@ -3,7 +3,6 @@ use bitcoin::hashes::sha256;
 use fedimint_client_module::DynGlobalClientContext;
 use fedimint_client_module::sm::{ClientSMDatabaseTransaction, State, StateTransition};
 use fedimint_client_module::transaction::{ClientInput, ClientInputBundle};
-use fedimint_core::config::FederationId;
 use fedimint_core::core::OperationId;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::Amounts;
@@ -83,12 +82,22 @@ async fn send_update_event(
 /// classDef virtual fill:#fff,stroke-dasharray: 5 5
 ///
 ///     Funding -- funding tx is rejected --> Rejected
-///     Funding -- funding tx is accepted --> Funded
-///     Funded -- post invoice returns preimage  --> Success
-///     Funded -- post invoice returns forfeit tx --> Refunding
-///     Funded -- await_preimage returns preimage --> Success
-///     Funded -- await_preimage expires --> Refunding
+///     Funding -- post invoice returns preimage  --> Success
+///     Funding -- post invoice returns forfeit tx --> Refunding
+///     Funding -- await_preimage returns preimage --> Success
+///     Funding -- await_preimage expires --> Refunding
 /// ```
+///
+/// We ask the gateway to pay the invoice optimistically, before the funding
+/// transaction is even confirmed. The gateway's outgoing-contract-expiration
+/// endpoint long-polls until the contract is accepted, so the request parks
+/// server-side and the gateway proceeds the instant the funding lands, saving a
+/// serialized round trip. `await_funding_rejection` runs alongside it purely to
+/// tear the request down should the funding transaction be rejected.
+///
+/// The `Funded` state is retained for state machines persisted before
+/// optimistic send was introduced; such operations are already confirmed and so
+/// do not need to watch for a rejected funding transaction.
 impl State for SendStateMachine {
     type ModuleContext = LightningClientContext;
 
@@ -99,29 +108,23 @@ impl State for SendStateMachine {
     ) -> Vec<StateTransition<Self>> {
         let c_pay = context.clone();
         let gc_pay = global_context.clone();
+        let gc_gateway = global_context.clone();
         let c_preimage = context.clone();
         let gc_preimage = global_context.clone();
+        let gc_rejection = global_context.clone();
 
         match &self.state {
-            SendSMState::Funding => {
-                vec![StateTransition::new(
-                    Self::await_funding(global_context.clone(), self.common.outpoint.txid),
-                    move |_, error, old_state| {
-                        Box::pin(async move { Self::transition_funding(error, &old_state) })
-                    },
-                )]
-            }
-            SendSMState::Funded => {
-                vec![
+            SendSMState::Funding | SendSMState::Funded => {
+                let mut transitions = vec![
                     StateTransition::new(
                         Self::gateway_send_payment(
                             self.common.gateway_api.clone().unwrap(),
-                            context.federation_id,
                             self.common.outpoint,
                             self.common.contract.clone(),
                             self.common.invoice.clone().unwrap(),
                             self.common.refund_keypair,
                             context.clone(),
+                            gc_gateway.clone(),
                         ),
                         move |dbtx, response, old_state| {
                             Box::pin(Self::transition_gateway_send_payment(
@@ -149,7 +152,24 @@ impl State for SendStateMachine {
                             ))
                         },
                     ),
-                ]
+                ];
+
+                // An unconfirmed (optimistically funded) operation watches for a
+                // rejected funding transaction so it can transition to Rejected and
+                // tear down the optimistic gateway request. A persisted `Funded`
+                // operation is already confirmed, so this never applies to it.
+                if matches!(self.state, SendSMState::Funding) {
+                    transitions.push(StateTransition::new(
+                        Self::await_funding_rejection(gc_rejection, self.common.outpoint.txid),
+                        move |_, rejected: String, old_state: SendStateMachine| {
+                            Box::pin(
+                                async move { old_state.update(SendSMState::Rejected(rejected)) },
+                            )
+                        },
+                    ));
+                }
+
+                transitions
             }
             SendSMState::Refunding(..) | SendSMState::Success(..) | SendSMState::Rejected(..) => {
                 vec![]
@@ -163,57 +183,73 @@ impl State for SendStateMachine {
 }
 
 impl SendStateMachine {
-    async fn await_funding(
+    /// Resolves only if the funding transaction is rejected, yielding the
+    /// error. On acceptance it stays pending forever so that it never
+    /// fires: an accepted funding transaction is driven to completion by
+    /// the gateway-send-payment and await-preimage transitions, and this
+    /// one is dropped when one of them wins.
+    async fn await_funding_rejection(
         global_context: DynGlobalClientContext,
         txid: TransactionId,
-    ) -> Result<(), String> {
-        global_context.await_tx_accepted(txid).await
-    }
-
-    fn transition_funding(
-        result: Result<(), String>,
-        old_state: &SendStateMachine,
-    ) -> SendStateMachine {
-        match result {
-            Ok(()) => old_state.update(SendSMState::Funded),
-            Err(error) => old_state.update(SendSMState::Rejected(error)),
+    ) -> String {
+        match global_context.await_tx_accepted(txid).await {
+            Ok(()) => pending().await,
+            Err(rejected) => rejected,
         }
     }
 
-    #[instrument(target = LOG_CLIENT_MODULE_LNV2, skip(refund_keypair, context))]
+    #[instrument(target = LOG_CLIENT_MODULE_LNV2, skip(refund_keypair, context, global_context))]
     async fn gateway_send_payment(
         gateway_api: SafeUrl,
-        federation_id: FederationId,
         outpoint: OutPoint,
         contract: OutgoingContract,
         invoice: LightningInvoice,
         refund_keypair: Keypair,
         context: LightningClientContext,
+        global_context: DynGlobalClientContext,
     ) -> Result<[u8; 32], Signature> {
-        util::retry("gateway-send-payment", api_networking_backoff(), || async {
-            let payment_result = context
-                .gateway_conn
-                .send_payment(
-                    gateway_api.clone(),
-                    federation_id,
-                    outpoint,
-                    contract.clone(),
-                    invoice.clone(),
-                    refund_keypair.sign_schnorr(secp256k1::Message::from_digest(
-                        *invoice.consensus_hash::<sha256::Hash>().as_ref(),
-                    )),
-                )
-                .await?;
+        let payment_result =
+            util::retry("gateway-send-payment", api_networking_backoff(), || async {
+                let payment_result = context
+                    .gateway_conn
+                    .send_payment(
+                        gateway_api.clone(),
+                        context.federation_id,
+                        outpoint,
+                        contract.clone(),
+                        invoice.clone(),
+                        refund_keypair.sign_schnorr(secp256k1::Message::from_digest(
+                            *invoice.consensus_hash::<sha256::Hash>().as_ref(),
+                        )),
+                    )
+                    .await?;
 
-            ensure!(
-                contract.verify_gateway_response(&payment_result),
-                "Invalid gateway response: {payment_result:?}"
-            );
+                ensure!(
+                    contract.verify_gateway_response(&payment_result),
+                    "Invalid gateway response: {payment_result:?}"
+                );
 
-            Ok(payment_result)
-        })
-        .await
-        .expect("Number of retries has no limit")
+                Ok(payment_result)
+            })
+            .await
+            .expect("Number of retries has no limit");
+
+        // The gateway is asked to pay optimistically, before the funding transaction
+        // is confirmed (its outgoing-contract-expiration endpoint long-polls until the
+        // contract is accepted). Do not act on the response until the funding
+        // transaction is accepted: success must not be reported before the sender's
+        // ecash is committed to the contract, and the refund path spends the
+        // now-existing contract. If the funding is instead rejected,
+        // `await_funding_rejection` drives the operation to `Rejected`, so park here.
+        if global_context
+            .await_tx_accepted(outpoint.txid)
+            .await
+            .is_err()
+        {
+            return pending().await;
+        }
+
+        payment_result
     }
 
     async fn transition_gateway_send_payment(

--- a/modules/fedimint-lnv2-server/src/lib.rs
+++ b/modules/fedimint-lnv2-server/src/lib.rs
@@ -857,9 +857,17 @@ impl Lightning {
         db: Database,
         outpoint: OutPoint,
     ) -> Option<(ContractId, u64)> {
-        let mut dbtx = db.begin_transaction_nc().await;
+        // Long-poll until the outgoing contract has been accepted. The contract is
+        // written atomically when its funding output is accepted, so a client can
+        // fire this request the instant it submits the funding transaction and be
+        // woken the moment the contract is confirmed, rather than polling and
+        // backing off. This mirrors the AWAIT_INCOMING_CONTRACT and AWAIT_PREIMAGE
+        // endpoints. There is no expiration to bound the wait on before the contract
+        // exists; a client whose funding transaction is ultimately rejected tears the
+        // request down instead by racing it against funding-transaction acceptance.
+        let contract = db.wait_key_exists(&OutgoingContractKey(outpoint)).await;
 
-        let contract = dbtx.get_value(&OutgoingContractKey(outpoint)).await?;
+        let mut dbtx = db.begin_transaction_nc().await;
 
         let consensus_block_count = self.consensus_block_count(&mut dbtx).await;
 

--- a/modules/fedimint-lnv2-tests/tests/tests.rs
+++ b/modules/fedimint-lnv2-tests/tests/tests.rs
@@ -140,7 +140,6 @@ async fn can_pay_external_invoice_exactly_once() -> anyhow::Result<()> {
         .into_stream();
 
     assert_eq!(sub.ok().await?, SendOperationState::Funding);
-    assert_eq!(sub.ok().await?, SendOperationState::Funded);
     assert_eq!(
         sub.ok().await?,
         SendOperationState::Success(MOCK_INVOICE_PREIMAGE)
@@ -201,7 +200,6 @@ async fn refund_failed_payment() -> anyhow::Result<()> {
         .into_stream();
 
     assert_eq!(sub.ok().await?, SendOperationState::Funding);
-    assert_eq!(sub.ok().await?, SendOperationState::Funded);
     assert_eq!(sub.ok().await?, SendOperationState::Refunding);
     assert_eq!(sub.ok().await?, SendOperationState::Refunded);
 
@@ -253,7 +251,6 @@ async fn unilateral_refund_of_outgoing_contracts() -> anyhow::Result<()> {
         .into_stream();
 
     assert_eq!(sub.ok().await?, SendOperationState::Funding);
-    assert_eq!(sub.ok().await?, SendOperationState::Funded);
 
     fixtures.bitcoin().mine_blocks(1440 + 12).await;
 
@@ -300,7 +297,6 @@ async fn claiming_outgoing_contract_triggers_success() -> anyhow::Result<()> {
         .into_stream();
 
     assert_eq!(sub.ok().await?, SendOperationState::Funding);
-    assert_eq!(sub.ok().await?, SendOperationState::Funded);
 
     let operation = client
         .operation_log()
@@ -315,6 +311,16 @@ async fn claiming_outgoing_contract_triggers_success() -> anyhow::Result<()> {
             panic!("Operation Meta is a LnurlReceive variant")
         }
     };
+
+    // Wait for the funding transaction to be accepted so the outgoing contract
+    // exists before we claim it. The send now goes straight from Funding to a
+    // final state, so there is no intermediate Funded update to synchronize on.
+    client
+        .transaction_updates(operation_id)
+        .await
+        .await_tx_accepted(txid)
+        .await
+        .expect("Funding transaction was not accepted");
 
     let client_input = ClientInput::<LightningInput> {
         input: LightningInput::V0(LightningInputV0::Outgoing(


### PR DESCRIPTION
## Summary

Cut a serialized round trip out of the lnv2 internal-payment send path by letting the gateway start waiting for the outgoing contract *before* it is confirmed, instead of confirming it after the fact.

## Details

When a client sends over lnv2, the sender funds an outgoing contract and then asks the gateway to pay. The gateway, before it will fund anything on the receiving side, independently re-confirms the outgoing contract against consensus via `outgoing_contract_expiration` — a `request_current_consensus` query. Today this is **serialized after** funding acceptance: the sender waits for its funding transaction to be accepted (one consensus round), *then* asks the gateway, which *then* spends another round-trip re-confirming a contract that is already accepted.

This PR overlaps those two waits:

- **Server**: `OUTGOING_CONTRACT_EXPIRATION_ENDPOINT` now long-polls on `wait_key_exists(&OutgoingContractKey(outpoint))` instead of a one-shot read. The contract key is written atomically when its funding output is accepted (in `process_output`), so the endpoint returns the instant the contract lands — mirroring the existing `AWAIT_INCOMING_CONTRACT` and `AWAIT_PREIMAGE` endpoints.

- **Client**: the send state machine asks the gateway to pay **optimistically**, right after submitting the funding transaction, rather than gating the request on funding acceptance. The gateway's confirmation query then parks server-side and is woken the moment the funding lands, collapsing the gateway's separate re-confirmation round-trip into the funding round. An `await_funding_rejection` transition runs alongside to drive the operation to `Rejected` (and tear the optimistic request down) if the funding transaction is rejected.

The solvency guard is preserved: the gateway still does not fund the incoming contract until the confirmation returns a real, accepted contract — only the *waiting* moves from a poll-after-acceptance to a parked long-poll. The two halves also degrade gracefully against an old federation: the long-poll is absent, the query returns "not confirmed", and the existing client-side `api_networking_backoff` retry covers it, exactly as today.

## Behavior change: no distinct `Funded` state

Because the gateway request is fired optimistically and must survive funding acceptance, there is no longer a `Funding -> Funded` transition: a send now goes straight from `Funding` to a final state (`Success` / `Refunding` / `Rejected`). `SendOperationState::Funded` is retained only so operations persisted before this change still resume.

To keep the original guarantees, the gateway's response is **not acted upon until the funding transaction is confirmed** (`gateway_send_payment` awaits `await_tx_accepted` after receiving the response):

- `Success` is never reported before the sender's ecash is actually committed to the contract (so a completed send has no lingering active states), and
- the refund path always spends a contract that exists.

So the only externally visible change is the disappearance of the intermediate `Funded` update; the timing of `Success`/refund relative to funding acceptance is unchanged.

## Reviewing

- The endpoint wait is **unbounded** — there is no expiration to bound on before the contract exists. As with `DECRYPTION_KEY_SHARE_ENDPOINT`, the wait is torn down by the client dropping the request (when `await_funding_rejection` fires on a rejected funding transaction). Worth a sanity check that we are comfortable with the unbounded long-poll vs. adding a bound.
- Removing the observable `Funded` update is the main semantic change worth a look. The four `fedimint-lnv2-tests` send tests are updated accordingly; one of them (`claiming_outgoing_contract_triggers_success`) gained an explicit `await_tx_accepted` barrier in place of the `Funded` update it used to synchronize on.