### PR TITLE
chore(ci): use partial clone for codex agent checkout

### DIFF
--- a/.github/scripts/run-codex-agent.sh
+++ b/.github/scripts/run-codex-agent.sh
@@ -188,8 +188,10 @@ Repository conventions:
 Operational rules:
 - The GitHub event payload is at `$RUNNER_TEMP/codex-agent/context/event.json`.
 - The checked out repository is at `$GITHUB_WORKSPACE`.
-- The checkout is intentionally shallow to keep CI startup fast. If you need
-  extra history, tags, or PR refs, fetch only the specific refs you need.
+- The checkout includes recent history using partial clone filtering
+  (`fetch-depth: 50` with `filter: blob:none`) to keep startup fast while
+  preserving local context for common history lookups. If you need older
+  history, tags, or PR refs, fetch only the specific refs you need.
 - First inspect the normalized `event_name` field in the event payload to
   understand whether this is an issue event, issue comment, PR comment,
   submitted PR review, or inline PR review comment. Submitted PR reviews and

--- a/.github/workflows/codex-agent.yml
+++ b/.github/workflows/codex-agent.yml
@@ -361,6 +361,8 @@ jobs:
         if: steps.validate.outputs.run == 'true'
         with:
           ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 50
+          filter: blob:none
           persist-credentials: false
 
       - name: Run Codex in Fedimint dev shell


### PR DESCRIPTION
*PR published by Tau*

### Summary

Use a partial-clone Codex Agent checkout with recent history so the agent has useful local context without downloading all historical blobs.

### Details

This implements #8763 by adding `fetch-depth: 50` and `filter: blob:none` to the Codex Agent `actions/checkout` step while keeping the default-branch ref and disabled persisted credentials. The agent prompt now describes the recent-history partial clone checkout instead of calling it simply shallow, and still tells the agent to fetch older history, tags, or PR refs only when needed.

### Reviewing

Please confirm the checkout settings are the desired middle ground between the previous full-history checkout and a minimal shallow checkout.

### Testing

- `just format`
- `bash -n .github/scripts/run-codex-agent.sh`
- `git diff --check`

`just final-lint` was attempted but did not complete because the local offline Cargo cache is missing `bcrypt v0.19.2`.
