### PR TITLE
feat(modules): enable lnv2/mintv2/walletv2 by default

### DIFF
--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -1166,6 +1166,15 @@ impl Federation {
     }
 
     pub async fn await_gateways_registered(&self) -> Result<()> {
+        // `list-gateways` is an LNv1 concept: gateways register with the LNv1
+        // module and the client lists them. LNv2 instead addresses gateways
+        // directly and vets them via an explicit consensus item, so there is
+        // nothing to poll here when the LNv1 module isn't present. The gateway
+        // connection itself is awaited separately (via `connect_fed`).
+        if !crate::util::supports_lnv1() {
+            return Ok(());
+        }
+
         let start_time = Instant::now();
         debug!(target: LOG_DEVIMINT, "Awaiting LN gateways registration");
 

--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -11,7 +11,11 @@ use bitcoin::Txid;
 use clap::Subcommand;
 use fedimint_core::core::OperationId;
 use fedimint_core::encoding::{Decodable, Encodable};
-use fedimint_core::envs::{FM_DISABLE_BASE_FEES_ENV, FM_ENABLE_MODULE_LNV2_ENV, is_env_var_set};
+use fedimint_core::envs::{
+    FM_DISABLE_BASE_FEES_ENV, FM_ENABLE_MODULE_LNV1_ENV, FM_ENABLE_MODULE_LNV2_ENV,
+    FM_ENABLE_MODULE_MINT_ENV, FM_ENABLE_MODULE_MINTV2_ENV, FM_ENABLE_MODULE_WALLET_ENV,
+    FM_ENABLE_MODULE_WALLETV2_ENV, is_env_var_set,
+};
 use fedimint_core::module::registry::ModuleRegistry;
 use fedimint_core::net::api_announcement::SignedApiAnnouncement;
 use fedimint_core::task::block_in_place;
@@ -2954,7 +2958,17 @@ pub async fn handle_command(cmd: TestCmd, common_args: CommonArgs) -> Result<()>
         }
         TestCmd::UpgradeTests { binary, lnv2 } => {
             // TODO: Audit that the environment access only happens in single-threaded code.
-            unsafe { std::env::set_var(FM_ENABLE_MODULE_LNV2_ENV, lnv2) };
+            unsafe {
+                std::env::set_var(FM_ENABLE_MODULE_LNV2_ENV, lnv2);
+                // fedimintd now defaults to the v2 module set; pin the upgrade
+                // federation to the v1 modules (matching the previous default)
+                // so upgrade paths starting from older versions stay consistent.
+                std::env::set_var(FM_ENABLE_MODULE_LNV1_ENV, "1");
+                std::env::set_var(FM_ENABLE_MODULE_MINT_ENV, "1");
+                std::env::set_var(FM_ENABLE_MODULE_MINTV2_ENV, "0");
+                std::env::set_var(FM_ENABLE_MODULE_WALLET_ENV, "1");
+                std::env::set_var(FM_ENABLE_MODULE_WALLETV2_ENV, "0");
+            }
             let (process_mgr, _) = setup(common_args).await?;
             Box::pin(upgrade_tests(&process_mgr, binary)).await?;
         }

--- a/devimint/src/util.rs
+++ b/devimint/src/util.rs
@@ -985,11 +985,13 @@ pub fn supports_lnv2() -> bool {
 }
 
 pub fn supports_wallet_v2() -> bool {
-    is_env_var_set(FM_ENABLE_MODULE_WALLETV2_ENV)
+    std::env::var_os(FM_ENABLE_MODULE_WALLETV2_ENV).is_none()
+        || is_env_var_set(FM_ENABLE_MODULE_WALLETV2_ENV)
 }
 
 pub fn supports_mint_v2() -> bool {
-    is_env_var_set(FM_ENABLE_MODULE_MINTV2_ENV)
+    std::env::var_os(FM_ENABLE_MODULE_MINTV2_ENV).is_none()
+        || is_env_var_set(FM_ENABLE_MODULE_MINTV2_ENV)
 }
 
 /// Returns true if running backwards-compatibility tests

--- a/devimint/src/util.rs
+++ b/devimint/src/util.rs
@@ -12,8 +12,8 @@ use anyhow::{Context, Result, anyhow, bail, format_err};
 use fedimint_core::PeerId;
 use fedimint_core::admin_client::SetupStatus;
 use fedimint_core::envs::{
-    FM_ENABLE_MODULE_LNV2_ENV, FM_ENABLE_MODULE_MINTV2_ENV, FM_ENABLE_MODULE_WALLETV2_ENV,
-    is_env_var_set,
+    FM_ENABLE_MODULE_LNV1_ENV, FM_ENABLE_MODULE_LNV2_ENV, FM_ENABLE_MODULE_MINTV2_ENV,
+    FM_ENABLE_MODULE_WALLETV2_ENV, is_env_var_set,
 };
 use fedimint_core::module::ApiAuth;
 use fedimint_core::task::{self};
@@ -977,6 +977,11 @@ fn to_command(cli: Vec<String>) -> Command {
         cmd,
         args_debug: cli,
     }
+}
+
+pub fn supports_lnv1() -> bool {
+    // Mirrors the server default: LNv1 is disabled unless explicitly enabled.
+    is_env_var_set(FM_ENABLE_MODULE_LNV1_ENV)
 }
 
 pub fn supports_lnv2() -> bool {

--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -217,13 +217,13 @@ impl ServerModuleInit for LightningInit {
     }
 
     fn is_enabled_by_default(&self) -> bool {
-        is_env_var_set_opt(FM_ENABLE_MODULE_LNV1_ENV).unwrap_or(true)
+        is_env_var_set_opt(FM_ENABLE_MODULE_LNV1_ENV).unwrap_or(false)
     }
 
     fn get_documented_env_vars(&self) -> Vec<EnvVarDoc> {
         vec![EnvVarDoc {
             name: FM_ENABLE_MODULE_LNV1_ENV,
-            description: "Set to 0/false to disable the LNv1 Lightning module. Enabled by default.",
+            description: "Set to 1/true to enable the LNv1 Lightning module. Disabled by default.",
         }]
     }
 

--- a/modules/fedimint-mint-server/src/lib.rs
+++ b/modules/fedimint-mint-server/src/lib.rs
@@ -190,13 +190,13 @@ impl ServerModuleInit for MintInit {
     }
 
     fn is_enabled_by_default(&self) -> bool {
-        is_env_var_set_opt(FM_ENABLE_MODULE_MINT_ENV).unwrap_or(true)
+        is_env_var_set_opt(FM_ENABLE_MODULE_MINT_ENV).unwrap_or(false)
     }
 
     fn get_documented_env_vars(&self) -> Vec<EnvVarDoc> {
         vec![EnvVarDoc {
             name: FM_ENABLE_MODULE_MINT_ENV,
-            description: "Set to 0/false to disable the mint (e-cash) module. Enabled by default.",
+            description: "Set to 1/true to enable the mint (e-cash) module. Disabled by default.",
         }]
     }
 

--- a/modules/fedimint-mintv2-server/src/lib.rs
+++ b/modules/fedimint-mintv2-server/src/lib.rs
@@ -152,13 +152,13 @@ impl ServerModuleInit for MintInit {
     }
 
     fn is_enabled_by_default(&self) -> bool {
-        is_env_var_set_opt(FM_ENABLE_MODULE_MINTV2_ENV).unwrap_or(false)
+        is_env_var_set_opt(FM_ENABLE_MODULE_MINTV2_ENV).unwrap_or(true)
     }
 
     fn get_documented_env_vars(&self) -> Vec<EnvVarDoc> {
         vec![EnvVarDoc {
             name: FM_ENABLE_MODULE_MINTV2_ENV,
-            description: "Set to 1/true to enable the MintV2 module (experimental). Disabled by default.",
+            description: "Set to 0/false to disable the MintV2 module. Enabled by default.",
         }]
     }
 

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -332,14 +332,14 @@ impl ServerModuleInit for WalletInit {
     }
 
     fn is_enabled_by_default(&self) -> bool {
-        is_env_var_set_opt(FM_ENABLE_MODULE_WALLET_ENV).unwrap_or(true)
+        is_env_var_set_opt(FM_ENABLE_MODULE_WALLET_ENV).unwrap_or(false)
     }
 
     fn get_documented_env_vars(&self) -> Vec<EnvVarDoc> {
         vec![
             EnvVarDoc {
                 name: FM_ENABLE_MODULE_WALLET_ENV,
-                description: "Set to 0/false to disable the wallet (on-chain Bitcoin) module. Enabled by default.",
+                description: "Set to 1/true to enable the wallet (on-chain Bitcoin) module. Disabled by default.",
             },
             EnvVarDoc {
                 name: FM_WALLET_DISABLE_AUTOMATIC_CONSENSUS_VERSION_VOTING_ENV,

--- a/modules/fedimint-walletv2-server/src/lib.rs
+++ b/modules/fedimint-walletv2-server/src/lib.rs
@@ -285,13 +285,13 @@ impl ServerModuleInit for WalletInit {
     }
 
     fn is_enabled_by_default(&self) -> bool {
-        is_env_var_set_opt(FM_ENABLE_MODULE_WALLETV2_ENV).unwrap_or(false)
+        is_env_var_set_opt(FM_ENABLE_MODULE_WALLETV2_ENV).unwrap_or(true)
     }
 
     fn get_documented_env_vars(&self) -> Vec<EnvVarDoc> {
         vec![EnvVarDoc {
             name: FM_ENABLE_MODULE_WALLETV2_ENV,
-            description: "Set to 1/true to enable the WalletV2 module (experimental). Disabled by default.",
+            description: "Set to 0/false to disable the WalletV2 module. Enabled by default.",
         }]
     }
 

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -82,6 +82,18 @@ function run_test_for_versions() {
   gateway_version=$7
   export FM_ENABLE_MODULE_LNV2=$9
 
+  # fedimintd now enables the v2 module set (lnv2/mintv2/walletv2) by default.
+  # Pin the test baseline to the v1 module set so existing tests keep
+  # generating v1 federations; individual tests that exercise v2 modules
+  # opt in by overriding these (e.g. `env FM_ENABLE_MODULE_MINTV2=true
+  # FM_ENABLE_MODULE_MINT=false ...`). LNv1 stays on regardless of the
+  # `LNv2: 0/1` matrix flag, matching the previous always-on default.
+  export FM_ENABLE_MODULE_LNV1=1
+  export FM_ENABLE_MODULE_MINT=1
+  export FM_ENABLE_MODULE_MINTV2=0
+  export FM_ENABLE_MODULE_WALLET=1
+  export FM_ENABLE_MODULE_WALLETV2=0
+
   use_fed_binaries_for_version "$fed_version"
   use_client_binaries_for_version "$client_version"
   use_gateway_binaries_for_version "$gateway_version"

--- a/scripts/tests/wasm-test.sh
+++ b/scripts/tests/wasm-test.sh
@@ -9,6 +9,17 @@ build_workspace
 add_target_dir_to_path
 make_fm_test_marker
 
+# fedimintd now enables the v2 module set by default, but this test drives
+# the v1 client modules (e.g. `ln` list-gateways). Unlike the main suite,
+# the wasm test runs as its own derivation and does not flow through
+# `run_test_for_versions`, so pin the v1 module set explicitly here. LNv2
+# stays enabled by default, matching the previous wasm-test federation.
+export FM_ENABLE_MODULE_LNV1=1
+export FM_ENABLE_MODULE_MINT=1
+export FM_ENABLE_MODULE_MINTV2=0
+export FM_ENABLE_MODULE_WALLET=1
+export FM_ENABLE_MODULE_WALLETV2=0
+
 
 function run_tests() {
   set -euo pipefail


### PR DESCRIPTION
## Summary

Flip the default federation module set so that, with no `FM_ENABLE_MODULE_*` env vars set, a fresh federation runs the **v2** modules (lnv2, mintv2, walletv2) instead of the previous lnv1/lnv2/mintv1/walletv1.

The switch lives in each module init's `is_enabled_by_default()`, which is consulted only during DKG / config generation (`fedimint-server/src/config/setup.rs`). Existing federations load their module set from the stored config, so this is safe across upgrades.

| Module | Env var | Old default | New default |
|--------|---------|-------------|-------------|
| lnv1 | `FM_ENABLE_MODULE_LNV1` | enabled | disabled |
| lnv2 | `FM_ENABLE_MODULE_LNV2` | enabled | enabled |
| mintv1 | `FM_ENABLE_MODULE_MINT` | enabled | disabled |
| mintv2 | `FM_ENABLE_MODULE_MINTV2` | disabled | enabled |
| walletv1 | `FM_ENABLE_MODULE_WALLET` | enabled | disabled |
| walletv2 | `FM_ENABLE_MODULE_WALLETV2` | disabled | enabled |

## Keeping tests passing (v1 stays covered)

devimint's `supports_mint_v2`/`supports_wallet_v2` helpers are flipped to the same "unset means on" form as `supports_lnv2`, so devimint selects v2 commands by default to match the server.

To keep CI behavior unchanged and v1 fully under test, the v1 module set is pinned as the **test baseline** in the one function every CI test flows through (`run_test_for_versions` in `scripts/_common.sh`): lnv1/mintv1/walletv1 on, mintv2/walletv2 off, with lnv1 kept on regardless of the `LNv2: 0/1` matrix flag (matching the previous always-on default). Tests that exercise v2 modules already override these via per-test `env ...`, so each test ends up with exactly the same module set as before. The devimint `UpgradeTests` handler is pinned the same way so upgrade paths from older versions stay consistent.

Net effect: production/dev federations default to v2; CI exercises both v1 (baseline) and v2 (explicit) module sets exactly as it did before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)