### PR TITLE
chore(deps): address cargo audit quick-xml advisory

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -43,6 +43,11 @@ ignore = [
   "RUSTSEC-2026-0118",
   # hickory-proto O(n²) name compression on message encoding; only affects encoding large DNS messages, which we do not do (we are a resolver consumer). Fix is in 0.26.1; transitive via iroh, can't update yet.
   "RUSTSEC-2026-0119",
+  # quick-xml duplicate-attribute and namespace DoS; transitive through
+  # netdev -> plist. Updated plist to the newest compatible release, but plist
+  # still pins quick-xml to ^0.39 and the advisory requires >=0.41.0.
+  "RUSTSEC-2026-0194",
+  "RUSTSEC-2026-0195",
 ]
 
 [output]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9193,9 +9193,9 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plist"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
+checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.9.0",
@@ -9772,9 +9772,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
 ]


### PR DESCRIPTION
## Summary

Address the cargo-audit failure caused by newly published `quick-xml` advisories.

## Details

The failing audit job reports many noisy yanked-check lookup errors from the Nix cargo-audit derivation, but the actionable non-ignored advisories are `RUSTSEC-2026-0194` and `RUSTSEC-2026-0195` for `quick-xml 0.38.4`.

`quick-xml` is pulled in transitively through `iroh -> netwatch -> netdev -> plist`. This updates `plist` to the newest compatible release, which moves `quick-xml` from `0.38.4` to `0.39.4`. The advisory fix requires `quick-xml >=0.41.0`, but current `plist` still constrains `quick-xml` below that, so the two advisories are added to `.cargo/audit.toml` with an explanation.

## Testing

- `cargo audit -n --ignore yanked`
- Emulated CI audit with updated advisory DB: `nix flake update advisory-db && ./.github/scripts/pin-nix-flake-inputs.sh . && nix build -L .#ci.cargoAudit` (then restored `flake.lock`)
- Fresh-target `cargo check -p fedimint-connectors`
- `selfci check --candidate 99760ee75ab58174562cd7f5ab2c9d0dc86bb896`
