### PR TITLE
feat(wallet): track receives as per-UTXO operations

### DIFF
--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -615,8 +615,10 @@ pub struct UpgradeClients {
     fm_pay_client: Client,
 }
 
-/// Wallet clients/data prepared with an old `fedimint-cli` to exercise the
-/// on-chain receive operation backfill after upgrading the client binary.
+/// Wallet clients/data that an old `fedimint-cli` creates before upgrade.
+///
+/// The upgrade test reopens these clients with the new binary to exercise
+/// on-chain receive operation backfill.
 struct WalletReceiveUpgradeClients {
     allocated_client: Client,
     allocated_operation_id: OperationId,

--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -7,7 +7,7 @@ use std::time::{Duration, Instant};
 use std::{env, ffi};
 
 use anyhow::{Context, Result, anyhow, bail};
-use bitcoin::Txid;
+use bitcoin::{Address, Txid};
 use clap::Subcommand;
 use fedimint_core::core::OperationId;
 use fedimint_core::encoding::{Decodable, Encodable};
@@ -619,12 +619,12 @@ pub struct UpgradeClients {
 /// on-chain receive operation backfill after upgrading the client binary.
 struct WalletReceiveUpgradeClients {
     allocated_client: Client,
-    allocated_operation_id: String,
-    allocated_address: String,
+    allocated_operation_id: OperationId,
+    allocated_address: Address,
     claimed_client: Client,
-    claimed_operation_id: String,
+    claimed_operation_id: OperationId,
     pending_client: Client,
-    pending_operation_id: String,
+    pending_operation_id: OperationId,
 }
 
 async fn prepare_wallet_receive_upgrade_clients(
@@ -635,12 +635,18 @@ async fn prepare_wallet_receive_upgrade_clients(
         .new_joined_client("wallet-upgrade-allocated-client")
         .await?;
     let (allocated_address, allocated_operation_id) = allocated_client.get_deposit_addr().await?;
+    let allocated_address =
+        Address::from_str(&allocated_address)?.require_network(bitcoin::Network::Regtest)?;
+    let allocated_operation_id = OperationId::from_str(&allocated_operation_id)?;
 
     let claimed_client = dev_fed
         .fed
         .new_joined_client("wallet-upgrade-claimed-client")
         .await?;
     let (claimed_address, claimed_operation_id) = claimed_client.get_deposit_addr().await?;
+    let claimed_address =
+        Address::from_str(&claimed_address)?.require_network(bitcoin::Network::Regtest)?;
+    let claimed_operation_id = OperationId::from_str(&claimed_operation_id)?;
     fund_deposit_address_no_wait(dev_fed, &claimed_address).await?;
     fund_deposit_address_no_wait(dev_fed, &claimed_address).await?;
     cmd!(
@@ -649,7 +655,7 @@ async fn prepare_wallet_receive_upgrade_clients(
         "wallet",
         "await-deposit",
         "--operation-id",
-        &claimed_operation_id,
+        operation_id_arg(claimed_operation_id),
         "--num",
         "2"
     )
@@ -664,6 +670,7 @@ async fn prepare_wallet_receive_upgrade_clients(
         .fed
         .pegin_client_no_wait(10_000, &pending_client)
         .await?;
+    let pending_operation_id = OperationId::from_str(&pending_operation_id)?;
 
     Ok(WalletReceiveUpgradeClients {
         allocated_client,
@@ -682,7 +689,7 @@ async fn wallet_receive_upgrade_test(
 ) -> anyhow::Result<()> {
     assert_wallet_receive_operations(
         &clients.claimed_client,
-        &clients.claimed_operation_id,
+        clients.claimed_operation_id,
         false,
         2,
     )
@@ -695,7 +702,7 @@ async fn wallet_receive_upgrade_test(
         "wallet",
         "legacy-deposit-outcome",
         "--operation-id",
-        &clients.claimed_operation_id,
+        operation_id_arg(clients.claimed_operation_id),
     )
     .out_json()
     .await?;
@@ -706,7 +713,7 @@ async fn wallet_receive_upgrade_test(
 
     assert_wallet_receive_operations(
         &clients.allocated_client,
-        &clients.allocated_operation_id,
+        clients.allocated_operation_id,
         true,
         0,
     )
@@ -716,28 +723,30 @@ async fn wallet_receive_upgrade_test(
     fund_deposit_address_no_wait(dev_fed, &clients.allocated_address)
         .await
         .context("funding legacy allocated address after upgrade")?;
+    let allocated_operation_id = operation_id_arg(clients.allocated_operation_id);
     clients
         .allocated_client
-        .await_deposit(&clients.allocated_operation_id)
+        .await_deposit(&allocated_operation_id)
         .await
         .context("claiming legacy allocated address after upgrade")?;
     assert_wallet_receive_operations(
         &clients.allocated_client,
-        &clients.allocated_operation_id,
+        clients.allocated_operation_id,
         true,
         1,
     )
     .await
     .context("post-upgrade funding should create a live receive operation")?;
 
+    let pending_operation_id = operation_id_arg(clients.pending_operation_id);
     clients
         .pending_client
-        .await_deposit(&clients.pending_operation_id)
+        .await_deposit(&pending_operation_id)
         .await
         .context("claiming pre-upgrade funded deposit after upgrade")?;
     assert_wallet_receive_operations(
         &clients.pending_client,
-        &clients.pending_operation_id,
+        clients.pending_operation_id,
         true,
         1,
     )
@@ -747,7 +756,11 @@ async fn wallet_receive_upgrade_test(
     Ok(())
 }
 
-async fn fund_deposit_address_no_wait(dev_fed: &DevFed, address: &str) -> anyhow::Result<()> {
+fn operation_id_arg(operation_id: OperationId) -> String {
+    operation_id.fmt_full().to_string()
+}
+
+async fn fund_deposit_address_no_wait(dev_fed: &DevFed, address: &Address) -> anyhow::Result<()> {
     let deposit_fees_msat = dev_fed.fed.deposit_fees()?.msats;
     assert_eq!(
         deposit_fees_msat % 1000,
@@ -757,7 +770,7 @@ async fn fund_deposit_address_no_wait(dev_fed: &DevFed, address: &str) -> anyhow
 
     dev_fed
         .bitcoind
-        .send_to(address.to_owned(), 10_000 + deposit_fees_msat / 1000)
+        .send_to(address.to_string(), 10_000 + deposit_fees_msat / 1000)
         .await?;
     dev_fed.bitcoind.mine_blocks(21).await?;
     Ok(())
@@ -765,23 +778,20 @@ async fn fund_deposit_address_no_wait(dev_fed: &DevFed, address: &str) -> anyhow
 
 async fn assert_wallet_receive_operations(
     client: &Client,
-    address_operation_id: &str,
+    address_operation_id: OperationId,
     claim_owned_by_receive_operation: bool,
     expected_count: usize,
 ) -> anyhow::Result<()> {
     let receives = wallet_receive_operations_for_address(client, address_operation_id).await?;
     anyhow::ensure!(
         receives.len() == expected_count,
-        "expected {expected_count} receive operation(s) for address operation {address_operation_id}, found {receives:?}"
+        "expected {expected_count} receive operation(s) for address operation {}, found {receives:?}",
+        address_operation_id.fmt_full()
     );
 
-    for (receive_operation_id, receive) in receives {
-        let claim_operation_id = receive["claim_operation_id"]
-            .as_str()
-            .context("receive operation must have claim_operation_id")?;
-
+    for (receive_operation_id, _receive, claim_operation_id) in receives {
         let expected_claim_operation_id = if claim_owned_by_receive_operation {
-            receive_operation_id.as_str()
+            receive_operation_id
         } else {
             address_operation_id
         };
@@ -796,8 +806,8 @@ async fn assert_wallet_receive_operations(
 
 async fn wallet_receive_operations_for_address(
     client: &Client,
-    address_operation_id: &str,
-) -> anyhow::Result<Vec<(String, serde_json::Value)>> {
+    address_operation_id: OperationId,
+) -> anyhow::Result<Vec<(OperationId, serde_json::Value, OperationId)>> {
     let operations = cmd!(client, "list-operations", "--limit", "100")
         .out_json()
         .await?;
@@ -808,14 +818,16 @@ async fn wallet_receive_operations_for_address(
         .iter()
         .filter_map(|operation| {
             let receive = operation["operation_meta"]["variant"]["receive"].as_object()?;
-            if receive
-                .get("address_operation_id")
-                .and_then(|id| id.as_str())
-                == Some(address_operation_id)
-            {
+            let receive_address_operation_id =
+                OperationId::from_str(receive.get("address_operation_id")?.as_str()?).ok()?;
+            if receive_address_operation_id == address_operation_id {
+                let receive_operation_id = OperationId::from_str(operation["id"].as_str()?).ok()?;
+                let claim_operation_id =
+                    OperationId::from_str(receive.get("claim_operation_id")?.as_str()?).ok()?;
                 Some((
-                    operation["id"].as_str()?.to_owned(),
+                    receive_operation_id,
                     serde_json::Value::Object(receive.clone()),
+                    claim_operation_id,
                 ))
             } else {
                 None

--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -615,6 +615,215 @@ pub struct UpgradeClients {
     fm_pay_client: Client,
 }
 
+/// Wallet clients/data prepared with an old `fedimint-cli` to exercise the
+/// on-chain receive operation backfill after upgrading the client binary.
+struct WalletReceiveUpgradeClients {
+    allocated_client: Client,
+    allocated_operation_id: String,
+    allocated_address: String,
+    claimed_client: Client,
+    claimed_operation_id: String,
+    pending_client: Client,
+    pending_operation_id: String,
+}
+
+async fn prepare_wallet_receive_upgrade_clients(
+    dev_fed: &DevFed,
+) -> anyhow::Result<WalletReceiveUpgradeClients> {
+    let allocated_client = dev_fed
+        .fed
+        .new_joined_client("wallet-upgrade-allocated-client")
+        .await?;
+    let (allocated_address, allocated_operation_id) = allocated_client.get_deposit_addr().await?;
+
+    let claimed_client = dev_fed
+        .fed
+        .new_joined_client("wallet-upgrade-claimed-client")
+        .await?;
+    let (claimed_address, claimed_operation_id) = claimed_client.get_deposit_addr().await?;
+    fund_deposit_address_no_wait(dev_fed, &claimed_address).await?;
+    fund_deposit_address_no_wait(dev_fed, &claimed_address).await?;
+    cmd!(
+        claimed_client,
+        "module",
+        "wallet",
+        "await-deposit",
+        "--operation-id",
+        &claimed_operation_id,
+        "--num",
+        "2"
+    )
+    .run()
+    .await?;
+
+    let pending_client = dev_fed
+        .fed
+        .new_joined_client("wallet-upgrade-pending-client")
+        .await?;
+    let pending_operation_id = dev_fed
+        .fed
+        .pegin_client_no_wait(10_000, &pending_client)
+        .await?;
+
+    Ok(WalletReceiveUpgradeClients {
+        allocated_client,
+        allocated_operation_id,
+        allocated_address,
+        claimed_client,
+        claimed_operation_id,
+        pending_client,
+        pending_operation_id,
+    })
+}
+
+async fn wallet_receive_upgrade_test(
+    dev_fed: &DevFed,
+    clients: &WalletReceiveUpgradeClients,
+) -> anyhow::Result<()> {
+    assert_wallet_receive_operations(
+        &clients.claimed_client,
+        &clients.claimed_operation_id,
+        false,
+        2,
+    )
+    .await
+    .context("multiple claimed legacy deposits to the same address should be backfilled as receive operations")?;
+
+    let outcome = cmd!(
+        clients.claimed_client,
+        "module",
+        "wallet",
+        "legacy-deposit-outcome",
+        "--operation-id",
+        &clients.claimed_operation_id,
+    )
+    .out_json()
+    .await?;
+    anyhow::ensure!(
+        outcome.is_null(),
+        "v0.11 legacy address operation should still have no cached legacy outcome after receive backfill, got {outcome}"
+    );
+
+    assert_wallet_receive_operations(
+        &clients.allocated_client,
+        &clients.allocated_operation_id,
+        true,
+        0,
+    )
+    .await
+    .context("allocated-but-unfunded legacy address should not be backfilled")?;
+
+    fund_deposit_address_no_wait(dev_fed, &clients.allocated_address)
+        .await
+        .context("funding legacy allocated address after upgrade")?;
+    clients
+        .allocated_client
+        .await_deposit(&clients.allocated_operation_id)
+        .await
+        .context("claiming legacy allocated address after upgrade")?;
+    assert_wallet_receive_operations(
+        &clients.allocated_client,
+        &clients.allocated_operation_id,
+        true,
+        1,
+    )
+    .await
+    .context("post-upgrade funding should create a live receive operation")?;
+
+    clients
+        .pending_client
+        .await_deposit(&clients.pending_operation_id)
+        .await
+        .context("claiming pre-upgrade funded deposit after upgrade")?;
+    assert_wallet_receive_operations(
+        &clients.pending_client,
+        &clients.pending_operation_id,
+        true,
+        1,
+    )
+    .await
+    .context("pre-upgrade funded deposit claimed after upgrade should use receive operation")?;
+
+    Ok(())
+}
+
+async fn fund_deposit_address_no_wait(dev_fed: &DevFed, address: &str) -> anyhow::Result<()> {
+    let deposit_fees_msat = dev_fed.fed.deposit_fees()?.msats;
+    assert_eq!(
+        deposit_fees_msat % 1000,
+        0,
+        "Deposit fees expected to be whole sats in test suite"
+    );
+
+    dev_fed
+        .bitcoind
+        .send_to(address.to_owned(), 10_000 + deposit_fees_msat / 1000)
+        .await?;
+    dev_fed.bitcoind.mine_blocks(21).await?;
+    Ok(())
+}
+
+async fn assert_wallet_receive_operations(
+    client: &Client,
+    address_operation_id: &str,
+    claim_owned_by_receive_operation: bool,
+    expected_count: usize,
+) -> anyhow::Result<()> {
+    let receives = wallet_receive_operations_for_address(client, address_operation_id).await?;
+    anyhow::ensure!(
+        receives.len() == expected_count,
+        "expected {expected_count} receive operation(s) for address operation {address_operation_id}, found {receives:?}"
+    );
+
+    for (receive_operation_id, receive) in receives {
+        let claim_operation_id = receive["claim_operation_id"]
+            .as_str()
+            .context("receive operation must have claim_operation_id")?;
+
+        let expected_claim_operation_id = if claim_owned_by_receive_operation {
+            receive_operation_id.as_str()
+        } else {
+            address_operation_id
+        };
+        anyhow::ensure!(
+            claim_operation_id == expected_claim_operation_id,
+            "unexpected receive claim operation id"
+        );
+    }
+
+    Ok(())
+}
+
+async fn wallet_receive_operations_for_address(
+    client: &Client,
+    address_operation_id: &str,
+) -> anyhow::Result<Vec<(String, serde_json::Value)>> {
+    let operations = cmd!(client, "list-operations", "--limit", "100")
+        .out_json()
+        .await?;
+
+    Ok(operations["operations"]
+        .as_array()
+        .context("operations must be an array")?
+        .iter()
+        .filter_map(|operation| {
+            let receive = operation["operation_meta"]["variant"]["receive"].as_object()?;
+            if receive
+                .get("address_operation_id")
+                .and_then(|id| id.as_str())
+                == Some(address_operation_id)
+            {
+                Some((
+                    operation["id"].as_str()?.to_owned(),
+                    serde_json::Value::Object(receive.clone()),
+                ))
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>())
+}
+
 async fn stress_test_fed(dev_fed: &DevFed, clients: Option<&UpgradeClients>) -> anyhow::Result<()> {
     use futures::FutureExt;
 
@@ -752,6 +961,21 @@ pub async fn upgrade_tests(process_mgr: &ProcessManager, binary: UpgradeTest) ->
                 ln_receive_client: dev_fed.fed.new_joined_client("ln-receive-client").await?,
                 fm_pay_client: dev_fed.fed.new_joined_client("fm-pay-client").await?,
             };
+            let mut wallet_receive_upgrade_clients = if fedimint_cli_version < *VERSION_0_12_0_ALPHA
+                && paths.len() > 1
+            {
+                Some(
+                    prepare_wallet_receive_upgrade_clients(&dev_fed)
+                        .await
+                        .context("preparing wallet receive upgrade clients")?,
+                )
+            } else {
+                info!(
+                    %fedimint_cli_version,
+                    "Skipping wallet receive upgrade test because the initial fedimint-cli version is not legacy"
+                );
+                None
+            };
 
             try_join!(
                 stress_test_fed(&dev_fed, Some(&reusable_upgrade_clients)),
@@ -762,6 +986,14 @@ pub async fn upgrade_tests(process_mgr: &ProcessManager, binary: UpgradeTest) ->
                 set_fedimint_cli_path(path);
                 let fedimint_cli_version = crate::util::FedimintCli::version_or_default().await;
                 info!("upgraded fedimint-cli to version: {}", fedimint_cli_version);
+                if fedimint_cli_version >= *VERSION_0_12_0_ALPHA
+                    && let Some(wallet_receive_upgrade_clients) =
+                        wallet_receive_upgrade_clients.take()
+                {
+                    wallet_receive_upgrade_test(&dev_fed, &wallet_receive_upgrade_clients)
+                        .await
+                        .context("wallet receive operation upgrade test")?;
+                }
                 try_join!(
                     stress_test_fed(&dev_fed, Some(&reusable_upgrade_clients)),
                     wait_session_client.wait_session()

--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -621,6 +621,215 @@ pub struct UpgradeClients {
     fm_pay_client: Client,
 }
 
+/// Wallet clients/data prepared with an old `fedimint-cli` to exercise the
+/// on-chain receive operation backfill after upgrading the client binary.
+struct WalletReceiveUpgradeClients {
+    allocated_client: Client,
+    allocated_operation_id: String,
+    allocated_address: String,
+    claimed_client: Client,
+    claimed_operation_id: String,
+    pending_client: Client,
+    pending_operation_id: String,
+}
+
+async fn prepare_wallet_receive_upgrade_clients(
+    dev_fed: &DevFed,
+) -> anyhow::Result<WalletReceiveUpgradeClients> {
+    let allocated_client = dev_fed
+        .fed
+        .new_joined_client("wallet-upgrade-allocated-client")
+        .await?;
+    let (allocated_address, allocated_operation_id) = allocated_client.get_deposit_addr().await?;
+
+    let claimed_client = dev_fed
+        .fed
+        .new_joined_client("wallet-upgrade-claimed-client")
+        .await?;
+    let (claimed_address, claimed_operation_id) = claimed_client.get_deposit_addr().await?;
+    fund_deposit_address_no_wait(dev_fed, &claimed_address).await?;
+    fund_deposit_address_no_wait(dev_fed, &claimed_address).await?;
+    cmd!(
+        claimed_client,
+        "module",
+        "wallet",
+        "await-deposit",
+        "--operation-id",
+        &claimed_operation_id,
+        "--num",
+        "2"
+    )
+    .run()
+    .await?;
+
+    let pending_client = dev_fed
+        .fed
+        .new_joined_client("wallet-upgrade-pending-client")
+        .await?;
+    let pending_operation_id = dev_fed
+        .fed
+        .pegin_client_no_wait(10_000, &pending_client)
+        .await?;
+
+    Ok(WalletReceiveUpgradeClients {
+        allocated_client,
+        allocated_operation_id,
+        allocated_address,
+        claimed_client,
+        claimed_operation_id,
+        pending_client,
+        pending_operation_id,
+    })
+}
+
+async fn wallet_receive_upgrade_test(
+    dev_fed: &DevFed,
+    clients: &WalletReceiveUpgradeClients,
+) -> anyhow::Result<()> {
+    assert_wallet_receive_operations(
+        &clients.claimed_client,
+        &clients.claimed_operation_id,
+        false,
+        2,
+    )
+    .await
+    .context("multiple claimed legacy deposits to the same address should be backfilled as receive operations")?;
+
+    let outcome = cmd!(
+        clients.claimed_client,
+        "module",
+        "wallet",
+        "legacy-deposit-outcome",
+        "--operation-id",
+        &clients.claimed_operation_id,
+    )
+    .out_json()
+    .await?;
+    anyhow::ensure!(
+        outcome.is_null(),
+        "v0.11 legacy address operation should still have no cached legacy outcome after receive backfill, got {outcome}"
+    );
+
+    assert_wallet_receive_operations(
+        &clients.allocated_client,
+        &clients.allocated_operation_id,
+        true,
+        0,
+    )
+    .await
+    .context("allocated-but-unfunded legacy address should not be backfilled")?;
+
+    fund_deposit_address_no_wait(dev_fed, &clients.allocated_address)
+        .await
+        .context("funding legacy allocated address after upgrade")?;
+    clients
+        .allocated_client
+        .await_deposit(&clients.allocated_operation_id)
+        .await
+        .context("claiming legacy allocated address after upgrade")?;
+    assert_wallet_receive_operations(
+        &clients.allocated_client,
+        &clients.allocated_operation_id,
+        true,
+        1,
+    )
+    .await
+    .context("post-upgrade funding should create a live receive operation")?;
+
+    clients
+        .pending_client
+        .await_deposit(&clients.pending_operation_id)
+        .await
+        .context("claiming pre-upgrade funded deposit after upgrade")?;
+    assert_wallet_receive_operations(
+        &clients.pending_client,
+        &clients.pending_operation_id,
+        true,
+        1,
+    )
+    .await
+    .context("pre-upgrade funded deposit claimed after upgrade should use receive operation")?;
+
+    Ok(())
+}
+
+async fn fund_deposit_address_no_wait(dev_fed: &DevFed, address: &str) -> anyhow::Result<()> {
+    let deposit_fees_msat = dev_fed.fed.deposit_fees()?.msats;
+    assert_eq!(
+        deposit_fees_msat % 1000,
+        0,
+        "Deposit fees expected to be whole sats in test suite"
+    );
+
+    dev_fed
+        .bitcoind
+        .send_to(address.to_owned(), 10_000 + deposit_fees_msat / 1000)
+        .await?;
+    dev_fed.bitcoind.mine_blocks(21).await?;
+    Ok(())
+}
+
+async fn assert_wallet_receive_operations(
+    client: &Client,
+    address_operation_id: &str,
+    claim_owned_by_receive_operation: bool,
+    expected_count: usize,
+) -> anyhow::Result<()> {
+    let receives = wallet_receive_operations_for_address(client, address_operation_id).await?;
+    anyhow::ensure!(
+        receives.len() == expected_count,
+        "expected {expected_count} receive operation(s) for address operation {address_operation_id}, found {receives:?}"
+    );
+
+    for (receive_operation_id, receive) in receives {
+        let claim_operation_id = receive["claim_operation_id"]
+            .as_str()
+            .context("receive operation must have claim_operation_id")?;
+
+        let expected_claim_operation_id = if claim_owned_by_receive_operation {
+            receive_operation_id.as_str()
+        } else {
+            address_operation_id
+        };
+        anyhow::ensure!(
+            claim_operation_id == expected_claim_operation_id,
+            "unexpected receive claim operation id"
+        );
+    }
+
+    Ok(())
+}
+
+async fn wallet_receive_operations_for_address(
+    client: &Client,
+    address_operation_id: &str,
+) -> anyhow::Result<Vec<(String, serde_json::Value)>> {
+    let operations = cmd!(client, "list-operations", "--limit", "100")
+        .out_json()
+        .await?;
+
+    Ok(operations["operations"]
+        .as_array()
+        .context("operations must be an array")?
+        .iter()
+        .filter_map(|operation| {
+            let receive = operation["operation_meta"]["variant"]["receive"].as_object()?;
+            if receive
+                .get("address_operation_id")
+                .and_then(|id| id.as_str())
+                == Some(address_operation_id)
+            {
+                Some((
+                    operation["id"].as_str()?.to_owned(),
+                    serde_json::Value::Object(receive.clone()),
+                ))
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>())
+}
+
 async fn stress_test_fed(dev_fed: &DevFed, clients: Option<&UpgradeClients>) -> anyhow::Result<()> {
     use futures::FutureExt;
 
@@ -758,6 +967,21 @@ pub async fn upgrade_tests(process_mgr: &ProcessManager, binary: UpgradeTest) ->
                 ln_receive_client: dev_fed.fed.new_joined_client("ln-receive-client").await?,
                 fm_pay_client: dev_fed.fed.new_joined_client("fm-pay-client").await?,
             };
+            let mut wallet_receive_upgrade_clients = if fedimint_cli_version < *VERSION_0_12_0_ALPHA
+                && paths.len() > 1
+            {
+                Some(
+                    prepare_wallet_receive_upgrade_clients(&dev_fed)
+                        .await
+                        .context("preparing wallet receive upgrade clients")?,
+                )
+            } else {
+                info!(
+                    %fedimint_cli_version,
+                    "Skipping wallet receive upgrade test because the initial fedimint-cli version is not legacy"
+                );
+                None
+            };
 
             try_join!(
                 stress_test_fed(&dev_fed, Some(&reusable_upgrade_clients)),
@@ -768,6 +992,14 @@ pub async fn upgrade_tests(process_mgr: &ProcessManager, binary: UpgradeTest) ->
                 set_fedimint_cli_path(path);
                 let fedimint_cli_version = crate::util::FedimintCli::version_or_default().await;
                 info!("upgraded fedimint-cli to version: {}", fedimint_cli_version);
+                if fedimint_cli_version >= *VERSION_0_12_0_ALPHA
+                    && let Some(wallet_receive_upgrade_clients) =
+                        wallet_receive_upgrade_clients.take()
+                {
+                    wallet_receive_upgrade_test(&dev_fed, &wallet_receive_upgrade_clients)
+                        .await
+                        .context("wallet receive operation upgrade test")?;
+                }
                 try_join!(
                     stress_test_fed(&dev_fed, Some(&reusable_upgrade_clients)),
                     wait_session_client.wait_session()

--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -621,8 +621,10 @@ pub struct UpgradeClients {
     fm_pay_client: Client,
 }
 
-/// Wallet clients/data prepared with an old `fedimint-cli` to exercise the
-/// on-chain receive operation backfill after upgrading the client binary.
+/// Wallet clients/data that an old `fedimint-cli` creates before upgrade.
+///
+/// The upgrade test reopens these clients with the new binary to exercise
+/// on-chain receive operation backfill.
 struct WalletReceiveUpgradeClients {
     allocated_client: Client,
     allocated_operation_id: OperationId,

--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -7,7 +7,7 @@ use std::time::{Duration, Instant};
 use std::{env, ffi};
 
 use anyhow::{Context, Result, anyhow, bail};
-use bitcoin::Txid;
+use bitcoin::{Address, Txid};
 use clap::Subcommand;
 use fedimint_core::core::OperationId;
 use fedimint_core::encoding::{Decodable, Encodable};
@@ -625,12 +625,12 @@ pub struct UpgradeClients {
 /// on-chain receive operation backfill after upgrading the client binary.
 struct WalletReceiveUpgradeClients {
     allocated_client: Client,
-    allocated_operation_id: String,
-    allocated_address: String,
+    allocated_operation_id: OperationId,
+    allocated_address: Address,
     claimed_client: Client,
-    claimed_operation_id: String,
+    claimed_operation_id: OperationId,
     pending_client: Client,
-    pending_operation_id: String,
+    pending_operation_id: OperationId,
 }
 
 async fn prepare_wallet_receive_upgrade_clients(
@@ -641,12 +641,18 @@ async fn prepare_wallet_receive_upgrade_clients(
         .new_joined_client("wallet-upgrade-allocated-client")
         .await?;
     let (allocated_address, allocated_operation_id) = allocated_client.get_deposit_addr().await?;
+    let allocated_address =
+        Address::from_str(&allocated_address)?.require_network(bitcoin::Network::Regtest)?;
+    let allocated_operation_id = OperationId::from_str(&allocated_operation_id)?;
 
     let claimed_client = dev_fed
         .fed
         .new_joined_client("wallet-upgrade-claimed-client")
         .await?;
     let (claimed_address, claimed_operation_id) = claimed_client.get_deposit_addr().await?;
+    let claimed_address =
+        Address::from_str(&claimed_address)?.require_network(bitcoin::Network::Regtest)?;
+    let claimed_operation_id = OperationId::from_str(&claimed_operation_id)?;
     fund_deposit_address_no_wait(dev_fed, &claimed_address).await?;
     fund_deposit_address_no_wait(dev_fed, &claimed_address).await?;
     cmd!(
@@ -655,7 +661,7 @@ async fn prepare_wallet_receive_upgrade_clients(
         "wallet",
         "await-deposit",
         "--operation-id",
-        &claimed_operation_id,
+        operation_id_arg(claimed_operation_id),
         "--num",
         "2"
     )
@@ -670,6 +676,7 @@ async fn prepare_wallet_receive_upgrade_clients(
         .fed
         .pegin_client_no_wait(10_000, &pending_client)
         .await?;
+    let pending_operation_id = OperationId::from_str(&pending_operation_id)?;
 
     Ok(WalletReceiveUpgradeClients {
         allocated_client,
@@ -688,7 +695,7 @@ async fn wallet_receive_upgrade_test(
 ) -> anyhow::Result<()> {
     assert_wallet_receive_operations(
         &clients.claimed_client,
-        &clients.claimed_operation_id,
+        clients.claimed_operation_id,
         false,
         2,
     )
@@ -701,7 +708,7 @@ async fn wallet_receive_upgrade_test(
         "wallet",
         "legacy-deposit-outcome",
         "--operation-id",
-        &clients.claimed_operation_id,
+        operation_id_arg(clients.claimed_operation_id),
     )
     .out_json()
     .await?;
@@ -712,7 +719,7 @@ async fn wallet_receive_upgrade_test(
 
     assert_wallet_receive_operations(
         &clients.allocated_client,
-        &clients.allocated_operation_id,
+        clients.allocated_operation_id,
         true,
         0,
     )
@@ -722,28 +729,30 @@ async fn wallet_receive_upgrade_test(
     fund_deposit_address_no_wait(dev_fed, &clients.allocated_address)
         .await
         .context("funding legacy allocated address after upgrade")?;
+    let allocated_operation_id = operation_id_arg(clients.allocated_operation_id);
     clients
         .allocated_client
-        .await_deposit(&clients.allocated_operation_id)
+        .await_deposit(&allocated_operation_id)
         .await
         .context("claiming legacy allocated address after upgrade")?;
     assert_wallet_receive_operations(
         &clients.allocated_client,
-        &clients.allocated_operation_id,
+        clients.allocated_operation_id,
         true,
         1,
     )
     .await
     .context("post-upgrade funding should create a live receive operation")?;
 
+    let pending_operation_id = operation_id_arg(clients.pending_operation_id);
     clients
         .pending_client
-        .await_deposit(&clients.pending_operation_id)
+        .await_deposit(&pending_operation_id)
         .await
         .context("claiming pre-upgrade funded deposit after upgrade")?;
     assert_wallet_receive_operations(
         &clients.pending_client,
-        &clients.pending_operation_id,
+        clients.pending_operation_id,
         true,
         1,
     )
@@ -753,7 +762,11 @@ async fn wallet_receive_upgrade_test(
     Ok(())
 }
 
-async fn fund_deposit_address_no_wait(dev_fed: &DevFed, address: &str) -> anyhow::Result<()> {
+fn operation_id_arg(operation_id: OperationId) -> String {
+    operation_id.fmt_full().to_string()
+}
+
+async fn fund_deposit_address_no_wait(dev_fed: &DevFed, address: &Address) -> anyhow::Result<()> {
     let deposit_fees_msat = dev_fed.fed.deposit_fees()?.msats;
     assert_eq!(
         deposit_fees_msat % 1000,
@@ -763,7 +776,7 @@ async fn fund_deposit_address_no_wait(dev_fed: &DevFed, address: &str) -> anyhow
 
     dev_fed
         .bitcoind
-        .send_to(address.to_owned(), 10_000 + deposit_fees_msat / 1000)
+        .send_to(address.to_string(), 10_000 + deposit_fees_msat / 1000)
         .await?;
     dev_fed.bitcoind.mine_blocks(21).await?;
     Ok(())
@@ -771,23 +784,20 @@ async fn fund_deposit_address_no_wait(dev_fed: &DevFed, address: &str) -> anyhow
 
 async fn assert_wallet_receive_operations(
     client: &Client,
-    address_operation_id: &str,
+    address_operation_id: OperationId,
     claim_owned_by_receive_operation: bool,
     expected_count: usize,
 ) -> anyhow::Result<()> {
     let receives = wallet_receive_operations_for_address(client, address_operation_id).await?;
     anyhow::ensure!(
         receives.len() == expected_count,
-        "expected {expected_count} receive operation(s) for address operation {address_operation_id}, found {receives:?}"
+        "expected {expected_count} receive operation(s) for address operation {}, found {receives:?}",
+        address_operation_id.fmt_full()
     );
 
-    for (receive_operation_id, receive) in receives {
-        let claim_operation_id = receive["claim_operation_id"]
-            .as_str()
-            .context("receive operation must have claim_operation_id")?;
-
+    for (receive_operation_id, _receive, claim_operation_id) in receives {
         let expected_claim_operation_id = if claim_owned_by_receive_operation {
-            receive_operation_id.as_str()
+            receive_operation_id
         } else {
             address_operation_id
         };
@@ -802,8 +812,8 @@ async fn assert_wallet_receive_operations(
 
 async fn wallet_receive_operations_for_address(
     client: &Client,
-    address_operation_id: &str,
-) -> anyhow::Result<Vec<(String, serde_json::Value)>> {
+    address_operation_id: OperationId,
+) -> anyhow::Result<Vec<(OperationId, serde_json::Value, OperationId)>> {
     let operations = cmd!(client, "list-operations", "--limit", "100")
         .out_json()
         .await?;
@@ -814,14 +824,16 @@ async fn wallet_receive_operations_for_address(
         .iter()
         .filter_map(|operation| {
             let receive = operation["operation_meta"]["variant"]["receive"].as_object()?;
-            if receive
-                .get("address_operation_id")
-                .and_then(|id| id.as_str())
-                == Some(address_operation_id)
-            {
+            let receive_address_operation_id =
+                OperationId::from_str(receive.get("address_operation_id")?.as_str()?).ok()?;
+            if receive_address_operation_id == address_operation_id {
+                let receive_operation_id = OperationId::from_str(operation["id"].as_str()?).ok()?;
+                let claim_operation_id =
+                    OperationId::from_str(receive.get("claim_operation_id")?.as_str()?).ok()?;
                 Some((
-                    operation["id"].as_str()?.to_owned(),
+                    receive_operation_id,
                     serde_json::Value::Object(receive.clone()),
+                    claim_operation_id,
                 ))
             } else {
                 None

--- a/fedimint-client-module/src/module/init.rs
+++ b/fedimint-client-module/src/module/init.rs
@@ -136,9 +136,11 @@ where
     /// Get the [`ClientContext`] for later use
     ///
     /// Notably `ClientContext` can not be used during `ClientModuleInit::init`,
-    /// as the outer context is not yet complete. But it can be stored to be
-    /// used in the methods of [`ClientModule`], at which point it will be
-    /// ready.
+    /// as the outer context is not yet complete. It can be stored for later use
+    /// by [`ClientModule`] methods. During
+    /// [`ClientModule::pre_start_migration`](super::ClientModule::pre_start_migration),
+    /// final-client paths are still unavailable; use the explicit pre-start
+    /// migration context passed to that hook instead.
     pub fn context(&self) -> ClientContext<<C as ClientModuleInit>::Module> {
         self.context.clone()
     }

--- a/fedimint-client-module/src/module/init.rs
+++ b/fedimint-client-module/src/module/init.rs
@@ -137,9 +137,11 @@ where
     /// Get the [`ClientContext`] for later use
     ///
     /// Notably `ClientContext` can not be used during `ClientModuleInit::init`,
-    /// as the outer context is not yet complete. But it can be stored to be
-    /// used in the methods of [`ClientModule`], at which point it will be
-    /// ready.
+    /// as the outer context is not yet complete. It can be stored for later use
+    /// by [`ClientModule`] methods after startup completes. During
+    /// [`ClientModule::pre_start_migration`] and [`ClientModule::start`],
+    /// final-client paths are still unavailable; use the explicit pre-start
+    /// migration context in the migration hook instead.
     pub fn context(&self) -> ClientContext<<C as ClientModuleInit>::Module> {
         self.context.clone()
     }

--- a/fedimint-client-module/src/module/mod.rs
+++ b/fedimint-client-module/src/module/mod.rs
@@ -192,6 +192,24 @@ pub struct ClientContext<M> {
     _marker: marker::PhantomData<M>,
 }
 
+/// Explicit capabilities available to client modules during pre-start
+/// migrations.
+///
+/// This context intentionally exposes only migration-safe global services, so
+/// modules can backfill global client state before the final client interface
+/// is available and before module background work starts.
+pub struct ClientModulePreStartMigrationContext<'a> {
+    /// Operation log used for migration-time global operation log access.
+    operation_log: &'a maybe_add_send_sync!(dyn IOperationLog),
+}
+
+impl<'a> ClientModulePreStartMigrationContext<'a> {
+    /// Create a pre-start migration context around the client's operation log.
+    pub fn new(operation_log: &'a maybe_add_send_sync!(dyn IOperationLog)) -> Self {
+        Self { operation_log }
+    }
+}
+
 impl<M> Clone for ClientContext<M> {
     fn clone(&self) -> Self {
         Self {
@@ -548,6 +566,22 @@ where
             .await
     }
 
+    /// Check operation-log entry existence during pre-start migration.
+    pub async fn pre_start_operation_log_entry_exists_dbtx(
+        &self,
+        pre_start_ctx: &ClientModulePreStartMigrationContext<'_>,
+        dbtx: &mut DatabaseTransaction<'_>,
+        op_id: OperationId,
+    ) -> bool {
+        pre_start_ctx
+            .operation_log
+            .operation_log_entry_exists_dbtx(
+                &mut dbtx.global_dbtx(self.global_dbtx_access_token),
+                op_id,
+            )
+            .await
+    }
+
     pub async fn get_own_active_states(&self) -> Vec<(M::States, ActiveStateMeta)> {
         self.client
             .get()
@@ -843,6 +877,11 @@ where
             .await;
     }
 
+    /// Add an operation-log entry with a historical creation time.
+    ///
+    /// This should only be used by startup migrations/backfills that run before
+    /// operation-log pagination can cache the oldest entry. Runtime operation
+    /// creation should use [`Self::add_operation_log_entry_dbtx`].
     pub async fn add_operation_log_entry_dbtx_with_creation_time(
         &self,
         dbtx: &mut DatabaseTransaction<'_>,
@@ -854,6 +893,29 @@ where
         self.client
             .get()
             .operation_log()
+            .add_operation_log_entry_dbtx_with_creation_time(
+                &mut dbtx.global_dbtx(self.global_dbtx_access_token),
+                operation_id,
+                operation_type,
+                serde_json::to_value(operation_meta).expect("Can't fail"),
+                creation_time,
+            )
+            .await;
+    }
+
+    /// Add an operation-log entry with a historical creation time during
+    /// pre-start migration.
+    pub async fn pre_start_add_operation_log_entry_dbtx_with_creation_time(
+        &self,
+        pre_start_ctx: &ClientModulePreStartMigrationContext<'_>,
+        dbtx: &mut DatabaseTransaction<'_>,
+        operation_id: OperationId,
+        operation_type: &str,
+        operation_meta: impl serde::Serialize,
+        creation_time: SystemTime,
+    ) {
+        pre_start_ctx
+            .operation_log
             .add_operation_log_entry_dbtx_with_creation_time(
                 &mut dbtx.global_dbtx(self.global_dbtx_access_token),
                 operation_id,
@@ -961,12 +1023,27 @@ pub trait ClientModule: Debug + MaybeSend + MaybeSync + 'static {
 
     fn context(&self) -> Self::ModuleStateMachineContext;
 
-    /// Initialize client.
+    /// Start module-local background work.
     ///
-    /// Called by the core client code on start, after [`ClientContext`] is
-    /// fully initialized, so unlike during [`ClientModuleInit::init`],
-    /// access to global client is allowed.
+    /// Called by the core client after pre-start migrations complete and after
+    /// [`ClientContext`] is fully initialized, so access to the final global
+    /// client is allowed.
     async fn start(&self) {}
+
+    /// Run module-specific migrations/backfills before module background work.
+    ///
+    /// Called before the final client interface is installed in
+    /// [`ClientContext`]. Implementations can use `pre_start_ctx` for
+    /// explicitly provided migration-safe global services, but must not
+    /// access the final global client or start background runtime work. Errors
+    /// abort client startup, and implementations must be retry-safe/idempotent
+    /// because the hook runs again on the next startup.
+    async fn pre_start_migration(
+        &self,
+        _pre_start_ctx: &ClientModulePreStartMigrationContext<'_>,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
 
     async fn handle_cli_command(
         &self,
@@ -1167,6 +1244,11 @@ pub trait IClientModule: Debug {
 
     async fn start(&self);
 
+    async fn pre_start_migration(
+        &self,
+        pre_start_ctx: &ClientModulePreStartMigrationContext<'_>,
+    ) -> anyhow::Result<()>;
+
     async fn handle_cli_command(&self, args: &[ffi::OsString])
     -> anyhow::Result<serde_json::Value>;
 
@@ -1232,6 +1314,13 @@ where
 
     async fn start(&self) {
         <T as ClientModule>::start(self).await;
+    }
+
+    async fn pre_start_migration(
+        &self,
+        pre_start_ctx: &ClientModulePreStartMigrationContext<'_>,
+    ) -> anyhow::Result<()> {
+        <T as ClientModule>::pre_start_migration(self, pre_start_ctx).await
     }
 
     async fn handle_cli_command(

--- a/fedimint-client-module/src/module/mod.rs
+++ b/fedimint-client-module/src/module/mod.rs
@@ -4,6 +4,7 @@ use std::collections::BTreeSet;
 use std::fmt::Debug;
 use std::pin::Pin;
 use std::sync::{Arc, Weak};
+use std::time::SystemTime;
 use std::{ffi, marker, ops};
 
 use anyhow::{anyhow, bail};
@@ -25,7 +26,8 @@ use fedimint_core::{
     maybe_add_send_sync,
 };
 use fedimint_eventlog::{
-    DBTransactionEventLogExt, Event, EventKind, EventLogId, EventPersistence, PersistedLogEntry,
+    DBTransactionEventLogExt as _, Event, EventKind, EventLogId, EventPersistence,
+    PersistedLogEntry,
 };
 use fedimint_logging::LOG_CLIENT;
 use futures::{Stream, StreamExt};
@@ -504,12 +506,46 @@ where
             .await
     }
 
+    pub async fn get_event_log_dbtx(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        pos: Option<EventLogId>,
+        limit: u64,
+    ) -> Vec<PersistedLogEntry> {
+        dbtx.global_dbtx(self.global_dbtx_access_token)
+            .get_event_log(pos, limit)
+            .await
+    }
+
     pub async fn has_active_states(&self, op_id: OperationId) -> bool {
         self.client.get().has_active_states(op_id).await
     }
 
     pub async fn operation_exists(&self, op_id: OperationId) -> bool {
         self.client.get().operation_exists(op_id).await
+    }
+
+    pub async fn operation_log_entry_exists(&self, op_id: OperationId) -> bool {
+        self.client
+            .get()
+            .operation_log()
+            .operation_log_entry_exists(op_id)
+            .await
+    }
+
+    pub async fn operation_log_entry_exists_dbtx(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        op_id: OperationId,
+    ) -> bool {
+        self.client
+            .get()
+            .operation_log()
+            .operation_log_entry_exists_dbtx(
+                &mut dbtx.global_dbtx(self.global_dbtx_access_token),
+                op_id,
+            )
+            .await
     }
 
     pub async fn get_own_active_states(&self) -> Vec<(M::States, ActiveStateMeta)> {
@@ -803,6 +839,27 @@ where
                 operation_id,
                 operation_type,
                 serde_json::to_value(operation_meta).expect("Can't fail"),
+            )
+            .await;
+    }
+
+    pub async fn add_operation_log_entry_dbtx_with_creation_time(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        operation_id: OperationId,
+        operation_type: &str,
+        operation_meta: impl serde::Serialize,
+        creation_time: SystemTime,
+    ) {
+        self.client
+            .get()
+            .operation_log()
+            .add_operation_log_entry_dbtx_with_creation_time(
+                &mut dbtx.global_dbtx(self.global_dbtx_access_token),
+                operation_id,
+                operation_type,
+                serde_json::to_value(operation_meta).expect("Can't fail"),
+                creation_time,
             )
             .await;
     }

--- a/fedimint-client-module/src/module/mod.rs
+++ b/fedimint-client-module/src/module/mod.rs
@@ -4,6 +4,7 @@ use std::collections::BTreeSet;
 use std::fmt::Debug;
 use std::pin::Pin;
 use std::sync::{Arc, Weak};
+use std::time::SystemTime;
 use std::{ffi, marker, ops};
 
 use anyhow::{anyhow, bail};
@@ -25,7 +26,8 @@ use fedimint_core::{
     maybe_add_send_sync,
 };
 use fedimint_eventlog::{
-    DBTransactionEventLogExt, Event, EventKind, EventLogId, EventPersistence, PersistedLogEntry,
+    DBTransactionEventLogExt as _, Event, EventKind, EventLogId, EventPersistence,
+    PersistedLogEntry,
 };
 use fedimint_logging::LOG_CLIENT;
 use futures::{Stream, StreamExt};
@@ -517,12 +519,46 @@ where
             .await
     }
 
+    pub async fn get_event_log_dbtx(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        pos: Option<EventLogId>,
+        limit: u64,
+    ) -> Vec<PersistedLogEntry> {
+        dbtx.global_dbtx(self.global_dbtx_access_token)
+            .get_event_log(pos, limit)
+            .await
+    }
+
     pub async fn has_active_states(&self, op_id: OperationId) -> bool {
         self.client.get().has_active_states(op_id).await
     }
 
     pub async fn operation_exists(&self, op_id: OperationId) -> bool {
         self.client.get().operation_exists(op_id).await
+    }
+
+    pub async fn operation_log_entry_exists(&self, op_id: OperationId) -> bool {
+        self.client
+            .get()
+            .operation_log()
+            .operation_log_entry_exists(op_id)
+            .await
+    }
+
+    pub async fn operation_log_entry_exists_dbtx(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        op_id: OperationId,
+    ) -> bool {
+        self.client
+            .get()
+            .operation_log()
+            .operation_log_entry_exists_dbtx(
+                &mut dbtx.global_dbtx(self.global_dbtx_access_token),
+                op_id,
+            )
+            .await
     }
 
     pub async fn get_own_active_states(&self) -> Vec<(M::States, ActiveStateMeta)> {
@@ -877,6 +913,27 @@ where
                 operation_id,
                 operation_type,
                 serde_json::to_value(operation_meta).expect("Can't fail"),
+            )
+            .await;
+    }
+
+    pub async fn add_operation_log_entry_dbtx_with_creation_time(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        operation_id: OperationId,
+        operation_type: &str,
+        operation_meta: impl serde::Serialize,
+        creation_time: SystemTime,
+    ) {
+        self.client
+            .get()
+            .operation_log()
+            .add_operation_log_entry_dbtx_with_creation_time(
+                &mut dbtx.global_dbtx(self.global_dbtx_access_token),
+                operation_id,
+                operation_type,
+                serde_json::to_value(operation_meta).expect("Can't fail"),
+                creation_time,
             )
             .await;
     }

--- a/fedimint-client-module/src/module/mod.rs
+++ b/fedimint-client-module/src/module/mod.rs
@@ -196,6 +196,24 @@ pub struct ClientContext<M> {
     _marker: marker::PhantomData<M>,
 }
 
+/// Explicit capabilities available to client modules during pre-start
+/// migrations.
+///
+/// This context intentionally exposes only migration-safe global services, so
+/// modules can backfill global client state before the final client interface
+/// is available and before module background work starts.
+pub struct ClientModulePreStartMigrationContext<'a> {
+    /// Operation log used for migration-time global operation log access.
+    operation_log: &'a maybe_add_send_sync!(dyn IOperationLog),
+}
+
+impl<'a> ClientModulePreStartMigrationContext<'a> {
+    /// Create a pre-start migration context around the client's operation log.
+    pub fn new(operation_log: &'a maybe_add_send_sync!(dyn IOperationLog)) -> Self {
+        Self { operation_log }
+    }
+}
+
 impl<M> Clone for ClientContext<M> {
     fn clone(&self) -> Self {
         Self {
@@ -561,6 +579,22 @@ where
             .await
     }
 
+    /// Check operation-log entry existence during pre-start migration.
+    pub async fn pre_start_operation_log_entry_exists_dbtx(
+        &self,
+        pre_start_ctx: &ClientModulePreStartMigrationContext<'_>,
+        dbtx: &mut DatabaseTransaction<'_>,
+        op_id: OperationId,
+    ) -> bool {
+        pre_start_ctx
+            .operation_log
+            .operation_log_entry_exists_dbtx(
+                &mut dbtx.global_dbtx(self.global_dbtx_access_token),
+                op_id,
+            )
+            .await
+    }
+
     pub async fn get_own_active_states(&self) -> Vec<(M::States, ActiveStateMeta)> {
         self.client
             .get()
@@ -917,6 +951,12 @@ where
             .await;
     }
 
+    /// Add an operation-log entry with a historical creation time.
+    ///
+    /// Startup migrations and backfills use this to preserve original operation
+    /// chronology. Inserting an older entry also refreshes an initialized
+    /// oldest-entry cache. Runtime operation creation should use
+    /// [`Self::add_operation_log_entry_dbtx`].
     pub async fn add_operation_log_entry_dbtx_with_creation_time(
         &self,
         dbtx: &mut DatabaseTransaction<'_>,
@@ -928,6 +968,29 @@ where
         self.client
             .get()
             .operation_log()
+            .add_operation_log_entry_dbtx_with_creation_time(
+                &mut dbtx.global_dbtx(self.global_dbtx_access_token),
+                operation_id,
+                operation_type,
+                serde_json::to_value(operation_meta).expect("Can't fail"),
+                creation_time,
+            )
+            .await;
+    }
+
+    /// Add an operation-log entry with a historical creation time during
+    /// pre-start migration.
+    pub async fn pre_start_add_operation_log_entry_dbtx_with_creation_time(
+        &self,
+        pre_start_ctx: &ClientModulePreStartMigrationContext<'_>,
+        dbtx: &mut DatabaseTransaction<'_>,
+        operation_id: OperationId,
+        operation_type: &str,
+        operation_meta: impl serde::Serialize,
+        creation_time: SystemTime,
+    ) {
+        pre_start_ctx
+            .operation_log
             .add_operation_log_entry_dbtx_with_creation_time(
                 &mut dbtx.global_dbtx(self.global_dbtx_access_token),
                 operation_id,
@@ -1035,12 +1098,29 @@ pub trait ClientModule: Debug + MaybeSend + MaybeSync + 'static {
 
     fn context(&self) -> Self::ModuleStateMachineContext;
 
-    /// Initialize client.
+    /// Start module-local background work.
     ///
-    /// Called by the core client code on start, after [`ClientContext`] is
-    /// fully initialized, so unlike during [`ClientModuleInit::init`],
-    /// access to global client is allowed.
+    /// Called after pre-start migrations but before the final global client is
+    /// published. Implementations must not wait for final-client access: the
+    /// core publishes it only after every module's `start` call completes,
+    /// ensuring that any module that observes it can rely on all modules
+    /// being started.
     async fn start(&self) {}
+
+    /// Run module-specific migrations/backfills before module background work.
+    ///
+    /// Called before module startup and before the final client interface is
+    /// installed in [`ClientContext`]. Implementations can use `pre_start_ctx`
+    /// for explicitly provided migration-safe global services, but must not
+    /// access the final global client or start background runtime work. Errors
+    /// abort client startup, and implementations must be retry-safe/idempotent
+    /// because the hook runs again on the next startup.
+    async fn pre_start_migration(
+        &self,
+        _pre_start_ctx: &ClientModulePreStartMigrationContext<'_>,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
 
     async fn handle_cli_command(
         &self,
@@ -1243,6 +1323,11 @@ pub trait IClientModule: Debug {
 
     async fn start(&self);
 
+    async fn pre_start_migration(
+        &self,
+        pre_start_ctx: &ClientModulePreStartMigrationContext<'_>,
+    ) -> anyhow::Result<()>;
+
     async fn handle_cli_command(&self, args: &[ffi::OsString])
     -> anyhow::Result<serde_json::Value>;
 
@@ -1312,6 +1397,13 @@ where
 
     async fn start(&self) {
         <T as ClientModule>::start(self).await;
+    }
+
+    async fn pre_start_migration(
+        &self,
+        pre_start_ctx: &ClientModulePreStartMigrationContext<'_>,
+    ) -> anyhow::Result<()> {
+        <T as ClientModule>::pre_start_migration(self, pre_start_ctx).await
     }
 
     async fn handle_cli_command(

--- a/fedimint-client-module/src/oplog.rs
+++ b/fedimint-client-module/src/oplog.rs
@@ -46,12 +46,37 @@ pub trait IOperationLog {
         operation_id: OperationId,
     ) -> Option<OperationLogEntry>;
 
+    /// Returns `true` if an operation log entry for `operation_id` exists.
+    ///
+    /// Unlike `Client::operation_exists`, this checks for the operation *log
+    /// entry* itself, not for any state machines belonging to the operation.
+    /// Operations whose log entry is written before (or without) any state
+    /// machines must use this to test for existence.
+    async fn operation_log_entry_exists(&self, operation_id: OperationId) -> bool;
+
+    /// Same as [`IOperationLog::operation_log_entry_exists`], but reads through
+    /// an existing transaction so uncommitted entries are visible.
+    async fn operation_log_entry_exists_dbtx(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        operation_id: OperationId,
+    ) -> bool;
+
     async fn add_operation_log_entry_dbtx(
         &self,
         dbtx: &mut DatabaseTransaction<'_>,
         operation_id: OperationId,
         operation_type: &str,
         operation_meta: serde_json::Value,
+    );
+
+    async fn add_operation_log_entry_dbtx_with_creation_time(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        operation_id: OperationId,
+        operation_type: &str,
+        operation_meta: serde_json::Value,
+        creation_time: SystemTime,
     );
 
     fn outcome_or_updates(

--- a/fedimint-client-module/src/oplog.rs
+++ b/fedimint-client-module/src/oplog.rs
@@ -70,6 +70,11 @@ pub trait IOperationLog {
         operation_meta: serde_json::Value,
     );
 
+    /// Add an operation-log entry with a historical creation time.
+    ///
+    /// This should only be used by startup migrations/backfills that run before
+    /// operation-log pagination can cache the oldest entry. Runtime operation
+    /// creation should use [`IOperationLog::add_operation_log_entry_dbtx`].
     async fn add_operation_log_entry_dbtx_with_creation_time(
         &self,
         dbtx: &mut DatabaseTransaction<'_>,

--- a/fedimint-client-module/src/oplog.rs
+++ b/fedimint-client-module/src/oplog.rs
@@ -76,6 +76,12 @@ pub trait IOperationLog {
         operation_meta: serde_json::Value,
     );
 
+    /// Add an operation-log entry with a historical creation time.
+    ///
+    /// Startup migrations and backfills use this to preserve original operation
+    /// chronology. Inserting an older entry also refreshes an initialized
+    /// oldest-entry cache. Runtime operation creation should use
+    /// [`IOperationLog::add_operation_log_entry_dbtx`].
     async fn add_operation_log_entry_dbtx_with_creation_time(
         &self,
         dbtx: &mut DatabaseTransaction<'_>,

--- a/fedimint-client-module/src/oplog.rs
+++ b/fedimint-client-module/src/oplog.rs
@@ -58,12 +58,31 @@ pub trait IOperationLog {
         operation_id: OperationId,
     ) -> Option<OperationLogEntry>;
 
+    /// Returns whether the operation log contains `operation_id`.
+    async fn operation_log_entry_exists(&self, operation_id: OperationId) -> bool;
+
+    /// Returns whether an existing transaction can see `operation_id`.
+    async fn operation_log_entry_exists_dbtx(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        operation_id: OperationId,
+    ) -> bool;
+
     async fn add_operation_log_entry_dbtx(
         &self,
         dbtx: &mut DatabaseTransaction<'_>,
         operation_id: OperationId,
         operation_type: &str,
         operation_meta: serde_json::Value,
+    );
+
+    async fn add_operation_log_entry_dbtx_with_creation_time(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        operation_id: OperationId,
+        operation_type: &str,
+        operation_meta: serde_json::Value,
+        creation_time: SystemTime,
     );
 
     /// Wrap a module's operation update stream so that its last update is

--- a/fedimint-client/src/client/builder.rs
+++ b/fedimint-client/src/client/builder.rs
@@ -1127,11 +1127,13 @@ impl ClientBuilder {
 
         let client_arc = ClientHandle::new(client_inner);
 
+        // Must be set before starting modules: `module.start()` (e.g. the
+        // wallet's receive-operation backfill) may access the final client.
+        final_client.set(client_iface.clone());
+
         for (_, _, module) in client_arc.modules.iter_modules() {
             module.start().await;
         }
-
-        final_client.set(client_iface.clone());
 
         if !module_recoveries.is_empty() {
             client_arc.spawn_module_recoveries_task(

--- a/fedimint-client/src/client/builder.rs
+++ b/fedimint-client/src/client/builder.rs
@@ -20,7 +20,8 @@ use fedimint_client_module::module::init::{
 };
 use fedimint_client_module::module::recovery::RecoveryProgress;
 use fedimint_client_module::module::{
-    ClientModuleRegistry, FinalClientIface, PrimaryModulePriority, PrimaryModuleSupport,
+    ClientModulePreStartMigrationContext, ClientModuleRegistry, FinalClientIface,
+    PrimaryModulePriority, PrimaryModuleSupport,
 };
 use fedimint_client_module::secret::{DeriveableSecretClientExt as _, get_default_client_secret};
 use fedimint_client_module::transaction::{
@@ -1043,6 +1044,13 @@ impl ClientBuilder {
             user_bitcoind_rpc,
             user_bitcoind_rpc_no_chain_id: self.bitcoind_rpc_no_chain_id_factory,
         });
+
+        let pre_start_migration_ctx =
+            ClientModulePreStartMigrationContext::new(client_inner.operation_log());
+
+        for (_, _, module) in client_inner.modules.iter_modules() {
+            module.pre_start_migration(&pre_start_migration_ctx).await?;
+        }
         client_inner.spawn_cancellable("MetaService::update_continuously", {
             let client_inner = client_inner.clone();
             async move {
@@ -1127,8 +1135,6 @@ impl ClientBuilder {
 
         let client_arc = ClientHandle::new(client_inner);
 
-        // Must be set before starting modules: `module.start()` (e.g. the
-        // wallet's receive-operation backfill) may access the final client.
         final_client.set(client_iface.clone());
 
         for (_, _, module) in client_arc.modules.iter_modules() {

--- a/fedimint-client/src/client/builder.rs
+++ b/fedimint-client/src/client/builder.rs
@@ -1172,11 +1172,13 @@ impl ClientBuilder {
 
         let client_arc = ClientHandle::new(client_inner);
 
+        // Must be set before starting modules: `module.start()` (e.g. the
+        // wallet's receive-operation backfill) may access the final client.
+        final_client.set(client_iface.clone());
+
         for (_, _, module) in client_arc.modules.iter_modules() {
             module.start().await;
         }
-
-        final_client.set(client_iface.clone());
 
         if !module_recoveries.is_empty() {
             // Sourced from the config so recovering modules (which aren't yet in

--- a/fedimint-client/src/client/builder.rs
+++ b/fedimint-client/src/client/builder.rs
@@ -19,7 +19,8 @@ use fedimint_client_module::module::init::{
 };
 use fedimint_client_module::module::recovery::RecoveryProgress;
 use fedimint_client_module::module::{
-    ClientModuleRegistry, FinalClientIface, PrimaryModulePriority, PrimaryModuleSupport,
+    ClientModulePreStartMigrationContext, ClientModuleRegistry, FinalClientIface,
+    PrimaryModulePriority, PrimaryModuleSupport,
 };
 use fedimint_client_module::secret::{DeriveableSecretClientExt as _, get_default_client_secret};
 use fedimint_client_module::transaction::{
@@ -1088,6 +1089,13 @@ impl ClientBuilder {
             user_bitcoind_rpc,
             user_bitcoind_rpc_no_chain_id: self.bitcoind_rpc_no_chain_id_factory,
         });
+
+        let pre_start_migration_ctx =
+            ClientModulePreStartMigrationContext::new(client_inner.operation_log());
+
+        for (_, _, module) in client_inner.modules.iter_modules() {
+            module.pre_start_migration(&pre_start_migration_ctx).await?;
+        }
         client_inner.spawn_cancellable("MetaService::update_continuously", {
             let client_inner = client_inner.clone();
             async move {
@@ -1172,13 +1180,13 @@ impl ClientBuilder {
 
         let client_arc = ClientHandle::new(client_inner);
 
-        // Must be set before starting modules: `module.start()` (e.g. the
-        // wallet's receive-operation backfill) may access the final client.
-        final_client.set(client_iface.clone());
-
         for (_, _, module) in client_arc.modules.iter_modules() {
             module.start().await;
         }
+
+        // Publish the final client only after every module has finished starting,
+        // so any module that observes it can rely on all peers being started.
+        final_client.set(client_iface.clone());
 
         if !module_recoveries.is_empty() {
             // Sourced from the config so recovering modules (which aren't yet in

--- a/fedimint-client/src/oplog.rs
+++ b/fedimint-client/src/oplog.rs
@@ -1,7 +1,6 @@
 use std::collections::HashSet;
 use std::fmt::Debug;
 use std::ops::Range;
-use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime};
 
 use fedimint_client_module::oplog::{
@@ -17,6 +16,7 @@ use fedimint_logging::LOG_CLIENT;
 use futures::StreamExt as _;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
+use tokio::sync::OnceCell;
 use tracing::{error, instrument, warn};
 
 use crate::db::{ChronologicalOperationLogKey, OperationLogKey};
@@ -27,41 +27,34 @@ mod tests;
 #[derive(Debug, Clone)]
 pub struct OperationLog {
     db: Database,
-    oldest_entry: Arc<Mutex<Option<ChronologicalOperationLogKey>>>,
+    oldest_entry: OnceCell<ChronologicalOperationLogKey>,
 }
 
 impl OperationLog {
     pub fn new(db: Database) -> Self {
         Self {
             db,
-            oldest_entry: Arc::new(Mutex::new(None)),
+            oldest_entry: OnceCell::new(),
         }
     }
 
     /// Will return the oldest operation log key in the database and cache the
     /// result. If no entry exists yet the DB will be queried on each call till
-    /// an entry is present. Historical inserts can move the cached value
-    /// backwards.
+    /// an entry is present.
     async fn get_oldest_operation_log_key(&self) -> Option<ChronologicalOperationLogKey> {
-        if let Some(oldest_entry) = *self.oldest_entry.lock().expect("mutex poisoned") {
-            return Some(oldest_entry);
-        }
-
-        let oldest_entry = self
-            .db
-            .begin_transaction_nc()
+        let mut dbtx = self.db.begin_transaction_nc().await;
+        self.oldest_entry
+            .get_or_try_init(move || async move {
+                dbtx.find_by_prefix(&crate::db::ChronologicalOperationLogKeyPrefix)
+                    .await
+                    .map(|(key, ())| key)
+                    .next()
+                    .await
+                    .ok_or(())
+            })
             .await
-            .find_by_prefix(&crate::db::ChronologicalOperationLogKeyPrefix)
-            .await
-            .map(|(key, ())| key)
-            .next()
-            .await;
-
-        if let Some(oldest_entry) = oldest_entry {
-            *self.oldest_entry.lock().expect("mutex poisoned") = Some(oldest_entry);
-        }
-
-        oldest_entry
+            .ok()
+            .copied()
     }
 
     pub async fn add_operation_log_entry_dbtx(
@@ -71,7 +64,7 @@ impl OperationLog {
         operation_type: &str,
         operation_meta: impl serde::Serialize,
     ) {
-        self.add_operation_log_entry_dbtx_with_creation_time(
+        self.add_operation_log_entry_dbtx_inner(
             dbtx,
             operation_id,
             operation_type,
@@ -81,7 +74,34 @@ impl OperationLog {
         .await;
     }
 
+    /// Add an operation-log entry with a historical creation time.
+    ///
+    /// This is intended for startup migrations/backfills that run before normal
+    /// operation-log pagination can initialize the oldest-entry cache. Runtime
+    /// operation creation should use [`Self::add_operation_log_entry_dbtx`].
     pub async fn add_operation_log_entry_dbtx_with_creation_time(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        operation_id: OperationId,
+        operation_type: &str,
+        operation_meta: impl serde::Serialize,
+        creation_time: SystemTime,
+    ) {
+        debug_assert!(
+            self.oldest_entry.get().is_none(),
+            "historical operation-log entries must be inserted before pagination caches the oldest entry"
+        );
+        self.add_operation_log_entry_dbtx_inner(
+            dbtx,
+            operation_id,
+            operation_type,
+            operation_meta,
+            creation_time,
+        )
+        .await;
+    }
+
+    async fn add_operation_log_entry_dbtx_inner(
         &self,
         dbtx: &mut DatabaseTransaction<'_>,
         operation_id: OperationId,
@@ -106,19 +126,6 @@ impl OperationLog {
             operation_id,
         };
         dbtx.insert_new_entry(&chronological_key, &()).await;
-
-        let oldest_entry = Arc::clone(&self.oldest_entry);
-        dbtx.on_commit(move || {
-            let mut cached_oldest_entry = oldest_entry.lock().expect("mutex poisoned");
-            if cached_oldest_entry.is_none_or(|cached_key| {
-                (
-                    chronological_key.creation_time,
-                    chronological_key.operation_id.0,
-                ) < (cached_key.creation_time, cached_key.operation_id.0)
-            }) {
-                *cached_oldest_entry = Some(chronological_key);
-            }
-        });
     }
 
     #[deprecated(since = "0.6.0", note = "Use `paginate_operations_rev` instead")]

--- a/fedimint-client/src/oplog.rs
+++ b/fedimint-client/src/oplog.rs
@@ -1,7 +1,8 @@
 use std::collections::HashSet;
 use std::fmt::Debug;
 use std::ops::Range;
-use std::time::Duration;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, SystemTime};
 
 use fedimint_client_module::oplog::{
     IOperationLog, JsonStringed, OperationLogEntry, OperationOutcome, UpdateStreamOrOutcome,
@@ -16,7 +17,6 @@ use fedimint_logging::LOG_CLIENT;
 use futures::StreamExt as _;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
-use tokio::sync::OnceCell;
 use tracing::{error, instrument, warn};
 
 use crate::db::{ChronologicalOperationLogKey, OperationLogKey};
@@ -27,34 +27,41 @@ mod tests;
 #[derive(Debug, Clone)]
 pub struct OperationLog {
     db: Database,
-    oldest_entry: tokio::sync::OnceCell<ChronologicalOperationLogKey>,
+    oldest_entry: Arc<Mutex<Option<ChronologicalOperationLogKey>>>,
 }
 
 impl OperationLog {
     pub fn new(db: Database) -> Self {
         Self {
             db,
-            oldest_entry: OnceCell::new(),
+            oldest_entry: Arc::new(Mutex::new(None)),
         }
     }
 
     /// Will return the oldest operation log key in the database and cache the
     /// result. If no entry exists yet the DB will be queried on each call till
-    /// an entry is present.
+    /// an entry is present. Historical inserts can move the cached value
+    /// backwards.
     async fn get_oldest_operation_log_key(&self) -> Option<ChronologicalOperationLogKey> {
-        let mut dbtx = self.db.begin_transaction_nc().await;
-        self.oldest_entry
-            .get_or_try_init(move || async move {
-                dbtx.find_by_prefix(&crate::db::ChronologicalOperationLogKeyPrefix)
-                    .await
-                    .map(|(key, ())| key)
-                    .next()
-                    .await
-                    .ok_or(())
-            })
+        if let Some(oldest_entry) = *self.oldest_entry.lock().expect("mutex poisoned") {
+            return Some(oldest_entry);
+        }
+
+        let oldest_entry = self
+            .db
+            .begin_transaction_nc()
             .await
-            .ok()
-            .copied()
+            .find_by_prefix(&crate::db::ChronologicalOperationLogKeyPrefix)
+            .await
+            .map(|(key, ())| key)
+            .next()
+            .await;
+
+        if let Some(oldest_entry) = oldest_entry {
+            *self.oldest_entry.lock().expect("mutex poisoned") = Some(oldest_entry);
+        }
+
+        oldest_entry
     }
 
     pub async fn add_operation_log_entry_dbtx(
@@ -63,6 +70,24 @@ impl OperationLog {
         operation_id: OperationId,
         operation_type: &str,
         operation_meta: impl serde::Serialize,
+    ) {
+        self.add_operation_log_entry_dbtx_with_creation_time(
+            dbtx,
+            operation_id,
+            operation_type,
+            operation_meta,
+            now(),
+        )
+        .await;
+    }
+
+    pub async fn add_operation_log_entry_dbtx_with_creation_time(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        operation_id: OperationId,
+        operation_type: &str,
+        operation_meta: impl serde::Serialize,
+        creation_time: SystemTime,
     ) {
         dbtx.insert_new_entry(
             &OperationLogKey { operation_id },
@@ -76,14 +101,24 @@ impl OperationLog {
             ),
         )
         .await;
-        dbtx.insert_new_entry(
-            &ChronologicalOperationLogKey {
-                creation_time: now(),
-                operation_id,
-            },
-            &(),
-        )
-        .await;
+        let chronological_key = ChronologicalOperationLogKey {
+            creation_time,
+            operation_id,
+        };
+        dbtx.insert_new_entry(&chronological_key, &()).await;
+
+        let oldest_entry = Arc::clone(&self.oldest_entry);
+        dbtx.on_commit(move || {
+            let mut cached_oldest_entry = oldest_entry.lock().expect("mutex poisoned");
+            if cached_oldest_entry.is_none_or(|cached_key| {
+                (
+                    chronological_key.creation_time,
+                    chronological_key.operation_id.0,
+                ) < (cached_key.creation_time, cached_key.operation_id.0)
+            }) {
+                *cached_oldest_entry = Some(chronological_key);
+            }
+        });
     }
 
     #[deprecated(since = "0.6.0", note = "Use `paginate_operations_rev` instead")]
@@ -175,6 +210,23 @@ impl OperationLog {
         dbtx.get_value(&OperationLogKey { operation_id }).await
     }
 
+    pub async fn operation_log_entry_exists(&self, operation_id: OperationId) -> bool {
+        Self::operation_log_entry_exists_dbtx(
+            &mut self.db.begin_transaction_nc().await.into_nc(),
+            operation_id,
+        )
+        .await
+    }
+
+    pub async fn operation_log_entry_exists_dbtx(
+        dbtx: &mut DatabaseTransaction<'_>,
+        operation_id: OperationId,
+    ) -> bool {
+        dbtx.get_value(&OperationLogKey { operation_id })
+            .await
+            .is_some()
+    }
+
     /// Sets the outcome of an operation
     #[instrument(target = LOG_CLIENT, skip(db), level = "debug")]
     pub async fn set_operation_outcome(
@@ -256,6 +308,18 @@ impl IOperationLog for OperationLog {
         OperationLog::get_operation_dbtx(dbtx, operation_id).await
     }
 
+    async fn operation_log_entry_exists(&self, operation_id: OperationId) -> bool {
+        OperationLog::operation_log_entry_exists(self, operation_id).await
+    }
+
+    async fn operation_log_entry_exists_dbtx(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        operation_id: OperationId,
+    ) -> bool {
+        OperationLog::operation_log_entry_exists_dbtx(dbtx, operation_id).await
+    }
+
     async fn add_operation_log_entry_dbtx(
         &self,
         dbtx: &mut DatabaseTransaction<'_>,
@@ -269,6 +333,25 @@ impl IOperationLog for OperationLog {
             operation_id,
             operation_type,
             operation_meta,
+        )
+        .await
+    }
+
+    async fn add_operation_log_entry_dbtx_with_creation_time(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        operation_id: OperationId,
+        operation_type: &str,
+        operation_meta: serde_json::Value,
+        creation_time: SystemTime,
+    ) {
+        OperationLog::add_operation_log_entry_dbtx_with_creation_time(
+            self,
+            dbtx,
+            operation_id,
+            operation_type,
+            operation_meta,
+            creation_time,
         )
         .await
     }

--- a/fedimint-client/src/oplog.rs
+++ b/fedimint-client/src/oplog.rs
@@ -206,6 +206,23 @@ impl OperationLog {
         dbtx.get_value(&OperationLogKey { operation_id }).await
     }
 
+    pub async fn operation_log_entry_exists(&self, operation_id: OperationId) -> bool {
+        Self::operation_log_entry_exists_dbtx(
+            &mut self.db.begin_transaction_nc().await.into_nc(),
+            operation_id,
+        )
+        .await
+    }
+
+    pub async fn operation_log_entry_exists_dbtx(
+        dbtx: &mut DatabaseTransaction<'_>,
+        operation_id: OperationId,
+    ) -> bool {
+        dbtx.get_value(&OperationLogKey { operation_id })
+            .await
+            .is_some()
+    }
+
     /// Sets the outcome of an operation
     #[instrument(target = LOG_CLIENT, skip(db), level = "debug")]
     pub async fn set_operation_outcome(
@@ -320,6 +337,18 @@ impl IOperationLog for OperationLog {
         OperationLog::get_operation_dbtx(dbtx, operation_id).await
     }
 
+    async fn operation_log_entry_exists(&self, operation_id: OperationId) -> bool {
+        OperationLog::operation_log_entry_exists(self, operation_id).await
+    }
+
+    async fn operation_log_entry_exists_dbtx(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        operation_id: OperationId,
+    ) -> bool {
+        OperationLog::operation_log_entry_exists_dbtx(dbtx, operation_id).await
+    }
+
     async fn add_operation_log_entry_dbtx(
         &self,
         dbtx: &mut DatabaseTransaction<'_>,
@@ -333,6 +362,25 @@ impl IOperationLog for OperationLog {
             operation_id,
             operation_type,
             operation_meta,
+        )
+        .await
+    }
+
+    async fn add_operation_log_entry_dbtx_with_creation_time(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        operation_id: OperationId,
+        operation_type: &str,
+        operation_meta: serde_json::Value,
+        creation_time: SystemTime,
+    ) {
+        OperationLog::add_operation_log_entry_dbtx_with_creation_time(
+            self,
+            dbtx,
+            operation_id,
+            operation_type,
+            operation_meta,
+            creation_time,
         )
         .await
     }

--- a/fedimint-client/src/oplog/tests.rs
+++ b/fedimint-client/src/oplog/tests.rs
@@ -295,26 +295,17 @@ async fn test_pagination_empty_then_not() {
     let page = op_log.paginate_operations_rev(10, None).await;
     assert_eq!(page.len(), 1);
 }
-
 #[tokio::test]
-async fn test_pagination_sees_historical_insert_after_oldest_cache_is_initialized() {
+async fn test_pagination_sees_newer_insert_after_oldest_cache_is_initialized() {
     let db = Database::new(MemDatabase::new(), ModuleRegistry::default());
     let op_log = OperationLog::new(db.clone());
 
-    let recent_op_id = OperationId([1; 32]);
-    let older_op_id = OperationId([2; 32]);
-    let recent_time = SystemTime::UNIX_EPOCH + Duration::from_secs(60 * 60 * 24 * 14);
-    let older_time = SystemTime::UNIX_EPOCH + Duration::from_secs(60 * 60 * 24 * 7);
+    let first_op_id = OperationId([1; 32]);
+    let second_op_id = OperationId([2; 32]);
 
     let mut dbtx = db.begin_transaction().await;
     op_log
-        .add_operation_log_entry_dbtx_with_creation_time(
-            &mut dbtx.to_ref_nc(),
-            recent_op_id,
-            "foo",
-            "recent",
-            recent_time,
-        )
+        .add_operation_log_entry_dbtx(&mut dbtx.to_ref_nc(), first_op_id, "foo", "first")
         .await;
     dbtx.commit_tx().await;
 
@@ -323,13 +314,7 @@ async fn test_pagination_sees_historical_insert_after_oldest_cache_is_initialize
 
     let mut dbtx = db.begin_transaction().await;
     op_log
-        .add_operation_log_entry_dbtx_with_creation_time(
-            &mut dbtx.to_ref_nc(),
-            older_op_id,
-            "foo",
-            "older",
-            older_time,
-        )
+        .add_operation_log_entry_dbtx(&mut dbtx.to_ref_nc(), second_op_id, "foo", "second")
         .await;
     dbtx.commit_tx().await;
 
@@ -338,6 +323,6 @@ async fn test_pagination_sees_historical_insert_after_oldest_cache_is_initialize
         page.iter()
             .map(|(key, _entry)| key.operation_id)
             .collect::<Vec<_>>(),
-        vec![recent_op_id, older_op_id]
+        vec![second_op_id, first_op_id]
     );
 }

--- a/fedimint-client/src/oplog/tests.rs
+++ b/fedimint-client/src/oplog/tests.rs
@@ -295,3 +295,49 @@ async fn test_pagination_empty_then_not() {
     let page = op_log.paginate_operations_rev(10, None).await;
     assert_eq!(page.len(), 1);
 }
+
+#[tokio::test]
+async fn test_pagination_sees_historical_insert_after_oldest_cache_is_initialized() {
+    let db = Database::new(MemDatabase::new(), ModuleRegistry::default());
+    let op_log = OperationLog::new(db.clone());
+
+    let recent_op_id = OperationId([1; 32]);
+    let older_op_id = OperationId([2; 32]);
+    let recent_time = SystemTime::UNIX_EPOCH + Duration::from_secs(60 * 60 * 24 * 14);
+    let older_time = SystemTime::UNIX_EPOCH + Duration::from_secs(60 * 60 * 24 * 7);
+
+    let mut dbtx = db.begin_transaction().await;
+    op_log
+        .add_operation_log_entry_dbtx_with_creation_time(
+            &mut dbtx.to_ref_nc(),
+            recent_op_id,
+            "foo",
+            "recent",
+            recent_time,
+        )
+        .await;
+    dbtx.commit_tx().await;
+
+    let page = op_log.paginate_operations_rev(10, None).await;
+    assert_eq!(page.len(), 1);
+
+    let mut dbtx = db.begin_transaction().await;
+    op_log
+        .add_operation_log_entry_dbtx_with_creation_time(
+            &mut dbtx.to_ref_nc(),
+            older_op_id,
+            "foo",
+            "older",
+            older_time,
+        )
+        .await;
+    dbtx.commit_tx().await;
+
+    let page = op_log.paginate_operations_rev(10, None).await;
+    assert_eq!(
+        page.iter()
+            .map(|(key, _entry)| key.operation_id)
+            .collect::<Vec<_>>(),
+        vec![recent_op_id, older_op_id]
+    );
+}

--- a/modules/fedimint-wallet-client/src/cli.rs
+++ b/modules/fedimint-wallet-client/src/cli.rs
@@ -29,6 +29,11 @@ enum Opts {
         #[arg(long, default_value = "1")]
         num: usize,
     },
+    /// Return the final outcome for an old deposit-address operation
+    LegacyDepositOutcome {
+        #[arg(long)]
+        operation_id: OperationId,
+    },
     GetConsensusBlockCount,
     /// Returns the Bitcoin RPC kind
     GetBitcoinRpcKind {
@@ -157,6 +162,10 @@ pub(crate) async fn handle_cli_command(
         } => {
             await_deposit(module, addr, operation_id, tweak_idx, num).await?;
             serde_json::Value::Bool(true)
+        }
+        Opts::LegacyDepositOutcome { operation_id } => {
+            serde_json::to_value(module.get_legacy_deposit_outcome(operation_id).await?)
+                .expect("JSON serialization failed")
         }
         Opts::GetBitcoinRpcKind { peer_id } => {
             let kind = module

--- a/modules/fedimint-wallet-client/src/cli.rs
+++ b/modules/fedimint-wallet-client/src/cli.rs
@@ -29,6 +29,11 @@ enum Opts {
         #[arg(long, default_value = "1")]
         num: usize,
     },
+    /// Return the final outcome for an old deposit-address operation
+    LegacyDepositOutcome {
+        #[arg(long)]
+        operation_id: OperationId,
+    },
     GetConsensusBlockCount,
     /// Returns the Bitcoin RPC kind
     GetBitcoinRpcKind {
@@ -160,6 +165,10 @@ pub(crate) async fn handle_cli_command(
         } => {
             await_deposit(module, addr, operation_id, tweak_idx, num).await?;
             serde_json::Value::Bool(true)
+        }
+        Opts::LegacyDepositOutcome { operation_id } => {
+            serde_json::to_value(module.get_legacy_deposit_outcome(operation_id).await?)
+                .expect("JSON serialization failed")
         }
         Opts::GetBitcoinRpcKind { peer_id } => {
             let kind = module

--- a/modules/fedimint-wallet-client/src/client_db.rs
+++ b/modules/fedimint-wallet-client/src/client_db.rs
@@ -22,6 +22,7 @@ pub enum DbKeyPrefix {
     SupportsSafeDeposit = 0x31,
     PegInPoolCursor = 0x32,
     ReceiveOperationsBackfilled = 0x33,
+    ReceiveOperation = 0x34,
     /// Prefixes between 0xb0..=0xcf shall all be considered allocated for
     /// historical and future external use
     ExternalReservedStart = 0xb0,
@@ -171,6 +172,32 @@ impl_db_record!(
     notify_on_modify = true,
 );
 impl_db_lookup!(key = ClaimedPegInKey, query_prefix = ClaimedPegInPrefix);
+
+/// Index of receive operations observed for a peg-in address.
+///
+/// This lets the address-operation compatibility path discover receive
+/// operations before they are claimed, including mempool/non-final deposits.
+#[derive(Clone, Debug, Encodable, Decodable, Serialize)]
+pub struct ReceiveOperationKey {
+    /// Peg-in address index that observed the receive.
+    pub peg_in_index: TweakIdx,
+    /// Bitcoin outpoint identifying the receive operation.
+    pub btc_out_point: bitcoin::OutPoint,
+}
+
+#[derive(Clone, Debug, Encodable, Decodable, Serialize)]
+pub struct ReceiveOperationPrefix;
+
+impl_db_record!(
+    key = ReceiveOperationKey,
+    value = SystemTime,
+    db_prefix = DbKeyPrefix::ReceiveOperation,
+);
+
+impl_db_lookup!(
+    key = ReceiveOperationKey,
+    query_prefix = ReceiveOperationPrefix
+);
 
 #[derive(Debug, Clone, Encodable, Decodable, Serialize)]
 pub struct RecoveryFinalizedKey;

--- a/modules/fedimint-wallet-client/src/client_db.rs
+++ b/modules/fedimint-wallet-client/src/client_db.rs
@@ -21,6 +21,7 @@ pub enum DbKeyPrefix {
     RecoveryState = 0x30,
     SupportsSafeDeposit = 0x31,
     PegInPoolCursor = 0x32,
+    ReceiveOperationsBackfilled = 0x33,
     /// Prefixes between 0xb0..=0xcf shall all be considered allocated for
     /// historical and future external use
     ExternalReservedStart = 0xb0,
@@ -210,6 +211,18 @@ impl_db_record!(
 impl_db_lookup!(
     key = SupportsSafeDepositKey,
     query_prefix = SupportsSafeDepositPrefix
+);
+
+/// Marker set once the one-time backfill of per-UTXO receive operation log
+/// entries (see `WalletClientModule::backfill_receive_operations`) has
+/// completed.
+#[derive(Clone, Debug, Encodable, Decodable, Serialize)]
+pub struct ReceiveOperationsBackfilledKey;
+
+impl_db_record!(
+    key = ReceiveOperationsBackfilledKey,
+    value = (),
+    db_prefix = DbKeyPrefix::ReceiveOperationsBackfilled,
 );
 
 /// Round-robin cursor for

--- a/modules/fedimint-wallet-client/src/client_db.rs
+++ b/modules/fedimint-wallet-client/src/client_db.rs
@@ -27,6 +27,7 @@ pub enum DbKeyPrefix {
     RecoveryState = 0x30,
     SupportsSafeDeposit = 0x31,
     PegInPoolCursor = 0x32,
+    ReceiveOperationsBackfilled = 0x33,
     /// Prefixes between 0xb0..=0xcf shall all be considered allocated for
     /// historical and future external use
     ExternalReservedStart = 0xb0,
@@ -258,6 +259,18 @@ impl_db_record!(
 impl_db_lookup!(
     key = SupportsSafeDepositKey,
     query_prefix = SupportsSafeDepositPrefix
+);
+
+/// Marker set once the one-time backfill of per-UTXO receive operation log
+/// entries (see `WalletClientModule::backfill_receive_operations`) has
+/// completed.
+#[derive(Clone, Debug, Encodable, Decodable, Serialize)]
+pub struct ReceiveOperationsBackfilledKey;
+
+impl_db_record!(
+    key = ReceiveOperationsBackfilledKey,
+    value = (),
+    db_prefix = DbKeyPrefix::ReceiveOperationsBackfilled,
 );
 
 /// Round-robin cursor for

--- a/modules/fedimint-wallet-client/src/client_db.rs
+++ b/modules/fedimint-wallet-client/src/client_db.rs
@@ -28,6 +28,7 @@ pub enum DbKeyPrefix {
     SupportsSafeDeposit = 0x31,
     PegInPoolCursor = 0x32,
     ReceiveOperationsBackfilled = 0x33,
+    ReceiveOperation = 0x34,
     /// Prefixes between 0xb0..=0xcf shall all be considered allocated for
     /// historical and future external use
     ExternalReservedStart = 0xb0,
@@ -219,6 +220,32 @@ impl_db_record!(
     notify_on_modify = true,
 );
 impl_db_lookup!(key = ClaimedPegInKey, query_prefix = ClaimedPegInPrefix);
+
+/// Index of receive operations observed for a peg-in address.
+///
+/// This lets the address-operation compatibility path discover receive
+/// operations before they are claimed, including mempool/non-final deposits.
+#[derive(Clone, Debug, Encodable, Decodable, Serialize)]
+pub struct ReceiveOperationKey {
+    /// Peg-in address index that observed the receive.
+    pub peg_in_index: TweakIdx,
+    /// Bitcoin outpoint identifying the receive operation.
+    pub btc_out_point: bitcoin::OutPoint,
+}
+
+#[derive(Clone, Debug, Encodable, Decodable, Serialize)]
+pub struct ReceiveOperationPrefix;
+
+impl_db_record!(
+    key = ReceiveOperationKey,
+    value = u64,
+    db_prefix = DbKeyPrefix::ReceiveOperation,
+);
+
+impl_db_lookup!(
+    key = ReceiveOperationKey,
+    query_prefix = ReceiveOperationPrefix
+);
 
 #[derive(Debug, Clone, Encodable, Decodable, Serialize)]
 pub struct RecoveryFinalizedKey;

--- a/modules/fedimint-wallet-client/src/events.rs
+++ b/modules/fedimint-wallet-client/src/events.rs
@@ -76,7 +76,12 @@ impl Event for SendPaymentStatusEvent {
 // Emitted when a deposit is confirmed
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct ReceivePaymentEvent {
-    pub operation_id: OperationId,
+    /// Operation id of the deposit address allocation.
+    // Renamed from `operation_id` in 0.12.
+    #[serde(alias = "operation_id")]
+    pub address_operation_id: OperationId,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub receive_operation_id: Option<OperationId>,
     pub amount: Amount,
     pub txid: Txid,
 }

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -39,7 +39,9 @@ use fedimint_client_module::module::init::{
     ClientModuleInit, ClientModuleInitArgs, ClientModuleRecoverArgs,
 };
 use fedimint_client_module::module::recovery::RecoveryProgress;
-use fedimint_client_module::module::{ClientContext, ClientModule, IClientModule, OutPointRange};
+use fedimint_client_module::module::{
+    ClientContext, ClientModule, ClientModulePreStartMigrationContext, IClientModule, OutPointRange,
+};
 use fedimint_client_module::oplog::{OperationLogEntry, UpdateStreamOrOutcome};
 use fedimint_client_module::sm::{Context, DynState, ModuleNotifier, State, StateTransition};
 use fedimint_client_module::transaction::{
@@ -638,15 +640,18 @@ impl ClientModule for WalletClientModule {
         }
     }
 
-    async fn start(&self) {
-        if let Err(error) = self.backfill_receive_operations().await {
-            tracing::warn!(
-                target: LOG_CLIENT_MODULE_WALLET,
-                err = %error.fmt_compact_anyhow(),
-                "Failed to backfill wallet receive operation log entries"
-            );
-        }
+    async fn pre_start_migration(
+        &self,
+        pre_start_ctx: &ClientModulePreStartMigrationContext<'_>,
+    ) -> anyhow::Result<()> {
+        self.backfill_receive_operations(pre_start_ctx)
+            .await
+            .context("failed to backfill wallet receive operation log entries")?;
 
+        Ok(())
+    }
+
+    async fn start(&self) {
         self.task_group
             .spawn_cancellable_with_span(self.client_span.clone(), "peg-in monitor", {
                 let client_ctx = self.client_ctx.clone();
@@ -877,7 +882,10 @@ impl WalletClientModule {
     /// [`WalletOperationMetaVariant::Receive`] operation-log entry for deposits
     /// that were already claimed before receive operations were tracked
     /// individually.
-    async fn backfill_receive_operations(&self) -> anyhow::Result<()> {
+    async fn backfill_receive_operations(
+        &self,
+        pre_start_ctx: &ClientModulePreStartMigrationContext<'_>,
+    ) -> anyhow::Result<()> {
         /// Scans the event log for [`DepositConfirmed`] events, returning the
         /// deposited amount and confirmation time keyed by the on-chain
         /// outpoint. Walking the whole (potentially large) event log is
@@ -965,6 +973,7 @@ impl WalletClientModule {
                 pegin_monitor::ensure_receive_operation(
                     &mut dbtx.to_ref_nc(),
                     &self.client_ctx,
+                    Some(pre_start_ctx),
                     receive_operation_id,
                     WalletOperationMetaVariant::Receive {
                         address_operation_id: peg_in_data.operation_id,

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -16,15 +16,15 @@ pub mod client_db;
 /// but retained for time being to ensure existing peg-ins complete.
 mod deposit;
 pub mod events;
-use events::SendPaymentEvent;
+use events::{DepositConfirmed, SendPaymentEvent};
 /// Peg-in monitor: a task monitoring deposit addresses for peg-ins.
 mod pegin_monitor;
 mod withdraw;
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::future;
 use std::sync::Arc;
-use std::time::{Duration, SystemTime};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context as AnyhowContext, anyhow, bail, ensure};
 use async_stream::{stream, try_stream};
@@ -57,13 +57,13 @@ use fedimint_core::module::{
     ModuleInit, MultiApiVersion,
 };
 use fedimint_core::task::{MaybeSend, MaybeSync, TaskGroup, sleep};
-use fedimint_core::util::backoff_util::background_backoff;
-use fedimint_core::util::{BoxStream, backoff_util, retry};
+use fedimint_core::util::{BoxStream, FmtCompactAnyhow as _, backoff_util};
 use fedimint_core::{
     BitcoinHash, OutPoint, TransactionId, apply, async_trait_maybe_send, push_db_pair_items,
     runtime, secp256k1,
 };
 use fedimint_derive_secret::{ChildId, DerivableSecret};
+use fedimint_eventlog::Event as _;
 use fedimint_logging::LOG_CLIENT_MODULE_WALLET;
 pub use fedimint_wallet_common as common;
 use fedimint_wallet_common::config::{FeeConsensus, WalletClientConfig};
@@ -81,35 +81,18 @@ use crate::api::WalletFederationApi;
 use crate::backup::{FEDERATION_RECOVER_MAX_GAP, RecoveryStateV2, WalletRecovery};
 use crate::client_db::{
     ClaimedPegInData, ClaimedPegInKey, ClaimedPegInPrefix, NextPegInTweakIndexKey,
-    PegInPoolCursorKey, PegInTweakIndexData, PegInTweakIndexPrefix, RecoveryFinalizedKey,
-    RecoveryStateKey, SupportsSafeDepositPrefix,
+    PegInPoolCursorKey, PegInTweakIndexData, PegInTweakIndexPrefix, ReceiveOperationsBackfilledKey,
+    RecoveryFinalizedKey, RecoveryStateKey, SupportsSafeDepositPrefix,
 };
 use crate::deposit::DepositStateMachine;
 use crate::withdraw::{CreatedWithdrawState, WithdrawStateMachine, WithdrawStates};
 
 const WALLET_TWEAK_CHILD_ID: ChildId = ChildId(0);
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
-pub struct BitcoinTransactionData {
-    /// The bitcoin transaction is saved as soon as we see it so the transaction
-    /// can be re-transmitted if it's evicted from the mempool.
-    pub btc_transaction: bitcoin::Transaction,
-    /// Index of the deposit output
-    pub out_idx: u32,
-}
-
+/// State of a single on-chain receive (peg-in of one UTXO), as streamed by
+/// [`WalletClientModule::subscribe_receive`].
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
-pub enum DepositStateV1 {
-    WaitingForTransaction,
-    WaitingForConfirmation(BitcoinTransactionData),
-    Confirmed(BitcoinTransactionData),
-    Claimed(BitcoinTransactionData),
-    Failed(String),
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
-pub enum DepositStateV2 {
-    WaitingForTransaction,
+pub enum ReceiveState {
     WaitingForConfirmation {
         #[serde(with = "bitcoin::amount::serde::as_sat")]
         btc_deposited: bitcoin::Amount,
@@ -125,6 +108,32 @@ pub enum DepositStateV2 {
         btc_deposited: bitcoin::Amount,
         btc_out_point: bitcoin::OutPoint,
     },
+    IgnoredDust {
+        #[serde(with = "bitcoin::amount::serde::as_sat")]
+        btc_deposited: bitcoin::Amount,
+        btc_out_point: bitcoin::OutPoint,
+    },
+    Failed(String),
+}
+
+/// Final state of a legacy deposit, returned by
+/// [`WalletClientModule::get_legacy_deposit_outcome`]. Legacy deposits only
+/// ever reached a claimed or failed terminal state, so only those are
+/// represented here.
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LegacyDepositOutcome {
+    /// This deposit's UTXO has been migrated to a per-UTXO `Receive` operation.
+    /// Pass `receive_operation_id` to [`WalletClientModule::subscribe_receive`]
+    /// instead of reading the legacy outcome.
+    Migrated { receive_operation_id: OperationId },
+    /// The deposit was claimed.
+    Claimed {
+        #[serde(with = "bitcoin::amount::serde::as_sat")]
+        btc_deposited: bitcoin::Amount,
+        btc_out_point: bitcoin::OutPoint,
+    },
+    /// The deposit failed.
     Failed(String),
 }
 
@@ -329,6 +338,12 @@ impl ModuleInit for WalletClientInit {
                         wallet_client_items.insert("PegInPoolCursor".to_string(), Box::new(cursor));
                     }
                 }
+                DbKeyPrefix::ReceiveOperationsBackfilled => {
+                    if let Some(val) = dbtx.get_value(&ReceiveOperationsBackfilledKey).await {
+                        wallet_client_items
+                            .insert("ReceiveOperationsBackfilled".to_string(), Box::new(val));
+                    }
+                }
                 DbKeyPrefix::RecoveryState
                 | DbKeyPrefix::ExternalReservedStart
                 | DbKeyPrefix::CoreInternalReservedStart
@@ -459,7 +474,9 @@ pub struct WalletOperationMeta {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum WalletOperationMetaVariant {
-    Deposit {
+    // Renamed from `deposit` in 0.12.
+    #[serde(alias = "deposit")]
+    DepositAddress {
         address: Address<NetworkUnchecked>,
         /// Added in 0.4.2, can be `None` for old deposits or `Some` for ones
         /// using the pegin monitor. The value is the child index of the key
@@ -469,6 +486,19 @@ pub enum WalletOperationMetaVariant {
         tweak_idx: Option<TweakIdx>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         expires_at: Option<SystemTime>,
+    },
+    Receive {
+        /// Operation for the static address allocation this receive belongs to.
+        address_operation_id: OperationId,
+        /// Operation that owns the claim transaction/state machines. For new
+        /// receives this is the receive operation itself. For receives
+        /// backfilled from old storage this can be the address operation id.
+        claim_operation_id: OperationId,
+        address: Address<NetworkUnchecked>,
+        tweak_idx: TweakIdx,
+        btc_out_point: bitcoin::OutPoint,
+        #[serde(with = "bitcoin::amount::serde::as_sat")]
+        btc_deposited: bitcoin::Amount,
     },
     Withdraw {
         address: Address<NetworkUnchecked>,
@@ -492,6 +522,17 @@ pub struct WalletClientModuleData {
 }
 
 impl WalletClientModuleData {
+    pub(crate) fn receive_operation_id(
+        address_operation_id: OperationId,
+        btc_out_point: bitcoin::OutPoint,
+    ) -> OperationId {
+        OperationId::from_encodable(&(
+            b"wallet-v1-receive".to_vec(),
+            address_operation_id,
+            btc_out_point,
+        ))
+    }
+
     fn derive_deposit_address(
         &self,
         idx: TweakIdx,
@@ -575,6 +616,14 @@ impl ClientModule for WalletClientModule {
     }
 
     async fn start(&self) {
+        if let Err(error) = self.backfill_receive_operations().await {
+            tracing::warn!(
+                target: LOG_CLIENT_MODULE_WALLET,
+                err = %error.fmt_compact_anyhow(),
+                "Failed to backfill wallet receive operation log entries"
+            );
+        }
+
         self.task_group
             .spawn_cancellable_with_span(self.client_span.clone(), "peg-in monitor", {
                 let client_ctx = self.client_ctx.clone();
@@ -692,9 +741,9 @@ impl ClientModule for WalletClientModule {
                     let result = serde_json::to_value(&response)?;
                     yield result;
                 },
-                "subscribe_deposit" => {
-                    let req: SubscribeDepositRequest = serde_json::from_value(request)?;
-                    for await state in self.subscribe_deposit(req.operation_id).await?.into_stream() {
+                "subscribe_receive" => {
+                    let req: SubscribeReceiveRequest = serde_json::from_value(request)?;
+                    for await state in self.subscribe_receive(req.operation_id).await?.into_stream() {
                         yield serde_json::to_value(state)?;
                     }
                 },
@@ -738,7 +787,7 @@ pub struct PegInRequest {
 }
 
 #[derive(Deserialize)]
-struct SubscribeDepositRequest {
+struct SubscribeReceiveRequest {
     operation_id: OperationId,
 }
 
@@ -799,6 +848,122 @@ impl WalletClientModule {
 
     pub fn get_fee_consensus(&self) -> FeeConsensus {
         self.cfg().fee_consensus
+    }
+
+    /// One-time migration that creates a per-UTXO
+    /// [`WalletOperationMetaVariant::Receive`] operation-log entry for deposits
+    /// that were already claimed before receive operations were tracked
+    /// individually.
+    async fn backfill_receive_operations(&self) -> anyhow::Result<()> {
+        /// Scans the event log for [`DepositConfirmed`] events, returning the
+        /// deposited amount and confirmation time keyed by the on-chain
+        /// outpoint. Walking the whole (potentially large) event log is
+        /// acceptable because the backfill only runs once.
+        async fn collect_deposit_confirmed_amounts(
+            dbtx: &mut DatabaseTransaction<'_>,
+            client_ctx: &ClientContext<WalletClientModule>,
+        ) -> anyhow::Result<HashMap<bitcoin::OutPoint, (bitcoin::Amount, SystemTime)>> {
+            const PAGE_SIZE: u64 = 1000;
+
+            let mut cursor = None;
+            let mut amounts = HashMap::new();
+
+            loop {
+                let events = client_ctx.get_event_log_dbtx(dbtx, cursor, PAGE_SIZE).await;
+                if events.is_empty() {
+                    break;
+                }
+
+                for entry in &events {
+                    let entry = entry.as_raw();
+                    if entry.kind == DepositConfirmed::KIND
+                        && entry.module_kind() == DepositConfirmed::MODULE.as_ref()
+                        && let Some(event) = entry.to_event::<DepositConfirmed>()
+                    {
+                        amounts.insert(
+                            bitcoin::OutPoint {
+                                txid: event.txid,
+                                vout: event.out_idx,
+                            },
+                            (
+                                bitcoin::Amount::from_sat(event.amount.try_into_sats()?),
+                                UNIX_EPOCH + Duration::from_micros(entry.ts_usecs),
+                            ),
+                        );
+                    }
+                }
+
+                cursor = events.last().map(|entry| entry.id().next());
+            }
+
+            Ok(amounts)
+        }
+
+        let mut dbtx = self.db.begin_transaction().await;
+
+        if dbtx
+            .get_value(&ReceiveOperationsBackfilledKey)
+            .await
+            .is_some()
+        {
+            return Ok(());
+        }
+
+        let deposit_amounts =
+            collect_deposit_confirmed_amounts(&mut dbtx.to_ref_nc(), &self.client_ctx).await?;
+
+        let peg_in_entries = dbtx
+            .find_by_prefix(&PegInTweakIndexPrefix)
+            .await
+            .collect::<Vec<_>>()
+            .await;
+
+        for (key, peg_in_data) in peg_in_entries {
+            let tweak_idx = key.0;
+            let (_script, address, _tweak_key, derived_address_operation_id) =
+                self.data.derive_peg_in_script(tweak_idx);
+            debug_assert_eq!(derived_address_operation_id, peg_in_data.operation_id);
+
+            for btc_out_point in peg_in_data.claimed {
+                // Dust deposits are never claimed and don't emit a
+                // `DepositConfirmed` event, so a missing entry here also filters
+                // them out (just like the live path's `IgnoredDust` handling).
+                let Some((btc_deposited, creation_time)) =
+                    deposit_amounts.get(&btc_out_point).copied()
+                else {
+                    continue;
+                };
+
+                let receive_operation_id = WalletClientModuleData::receive_operation_id(
+                    peg_in_data.operation_id,
+                    btc_out_point,
+                );
+
+                pegin_monitor::ensure_receive_operation(
+                    &mut dbtx.to_ref_nc(),
+                    &self.client_ctx,
+                    receive_operation_id,
+                    WalletOperationMetaVariant::Receive {
+                        address_operation_id: peg_in_data.operation_id,
+                        // Old claims ran under the address operation, so that's
+                        // the operation that owns the claim transaction.
+                        claim_operation_id: peg_in_data.operation_id,
+                        address: address.clone().into_unchecked(),
+                        tweak_idx,
+                        btc_out_point,
+                        btc_deposited,
+                    },
+                    creation_time,
+                )
+                .await;
+            }
+        }
+
+        dbtx.insert_entry(&ReceiveOperationsBackfilledKey, &())
+            .await;
+        dbtx.commit_tx().await;
+
+        Ok(())
     }
 
     async fn allocate_deposit_address_inner(
@@ -1084,7 +1249,7 @@ impl WalletClientModule {
                                 deposit_address.operation_id,
                                 WalletCommonInit::KIND.as_str(),
                                 WalletOperationMeta {
-                                    variant: WalletOperationMetaVariant::Deposit {
+                                    variant: WalletOperationMetaVariant::DepositAddress {
                                         address: deposit_address.address.clone().into_unchecked(),
                                         tweak_idx: Some(deposit_address.tweak_idx),
                                         expires_at: None,
@@ -1210,7 +1375,7 @@ impl WalletClientModule {
                                 deposit_address.operation_id,
                                 WalletCommonInit::KIND.as_str(),
                                 WalletOperationMeta {
-                                    variant: WalletOperationMetaVariant::Deposit {
+                                    variant: WalletOperationMetaVariant::DepositAddress {
                                         address: deposit_address.address.clone().into_unchecked(),
                                         tweak_idx: Some(deposit_address.tweak_idx),
                                         expires_at: None,
@@ -1398,15 +1563,11 @@ impl WalletClientModule {
         Ok(result)
     }
 
-    /// Returns a stream of updates about an ongoing deposit operation created
-    /// with [`WalletClientModule::allocate_deposit_address_expert_only`].
-    /// Returns an error for old deposit operations created prior to the 0.4
-    /// release and not driven to completion yet. This should be rare enough
-    /// that an indeterminate state is ok here.
-    pub async fn subscribe_deposit(
+    /// Returns a stream of updates about a concrete receive operation.
+    pub async fn subscribe_receive(
         &self,
         operation_id: OperationId,
-    ) -> anyhow::Result<UpdateStreamOrOutcome<DepositStateV2>> {
+    ) -> anyhow::Result<UpdateStreamOrOutcome<ReceiveState>> {
         let operation = self
             .client_ctx
             .get_operation(operation_id)
@@ -1419,100 +1580,182 @@ impl WalletClientModule {
 
         let operation_meta = operation.meta::<WalletOperationMeta>();
 
-        let WalletOperationMetaVariant::Deposit {
-            address, tweak_idx, ..
+        let WalletOperationMetaVariant::Receive {
+            claim_operation_id,
+            tweak_idx,
+            btc_out_point,
+            btc_deposited,
+            ..
         } = operation_meta.variant
         else {
-            bail!("Operation is not a deposit operation");
-        };
-
-        let address = address.require_network(self.cfg().network.0)?;
-
-        // The old deposit operations don't have tweak_idx set
-        let Some(tweak_idx) = tweak_idx else {
-            // In case we are dealing with an old deposit that still uses state machines we
-            // don't have the logic here anymore to subscribe to updates. We can still read
-            // the final state though if it reached any.
-            let outcome_v1 = operation
-                .outcome::<DepositStateV1>()
-                .context("Old pending deposit, can't subscribe to updates")?;
-
-            let outcome_v2 = match outcome_v1 {
-                DepositStateV1::Claimed(tx_info) => DepositStateV2::Claimed {
-                    btc_deposited: tx_info.btc_transaction.output[tx_info.out_idx as usize].value,
-                    btc_out_point: bitcoin::OutPoint {
-                        txid: tx_info.btc_transaction.compute_txid(),
-                        vout: tx_info.out_idx,
-                    },
-                },
-                DepositStateV1::Failed(error) => DepositStateV2::Failed(error),
-                _ => bail!("Non-final outcome in operation log"),
-            };
-
-            return Ok(UpdateStreamOrOutcome::Outcome(outcome_v2));
+            bail!("Operation is not a receive operation");
         };
 
         Ok(self.client_ctx.outcome_or_updates(operation, operation_id, {
-            let stream_rpc = self.rpc.clone();
             let stream_client_ctx = self.client_ctx.clone();
-            let stream_script_pub_key = address.script_pubkey();
             move || {
 
             stream! {
-                yield DepositStateV2::WaitingForTransaction;
-
-                retry(
-                    "subscribe script history",
-                    background_backoff(),
-                    || stream_rpc.watch_script_history(&stream_script_pub_key)
-                ).await.expect("Will never give up");
-                let (btc_out_point, btc_deposited) = retry(
-                    "fetch history",
-                    background_backoff(),
-                    || async {
-                        let history = stream_rpc.get_script_history(&stream_script_pub_key).await?;
-                        history.first().and_then(|tx| {
-                            let (out_idx, amount) = tx.output
-                                .iter()
-                                .enumerate()
-                                .find_map(|(idx, output)| (output.script_pubkey == stream_script_pub_key).then_some((idx, output.value)))?;
-                            let txid = tx.compute_txid();
-
-                            Some((
-                                bitcoin::OutPoint {
-                                    txid,
-                                    vout: out_idx as u32,
-                                },
-                                amount
-                            ))
-                        }).context("No deposit transaction found")
-                    }
-                ).await.expect("Will never give up");
-
-                yield DepositStateV2::WaitingForConfirmation {
-                    btc_deposited,
-                    btc_out_point
-                };
-
-                let claim_data = stream_client_ctx.module_db().wait_key_exists(&ClaimedPegInKey {
+                let claimed_peg_in_key = ClaimedPegInKey {
                     peg_in_index: tweak_idx,
                     btc_out_point,
-                }).await;
+                };
 
-                yield DepositStateV2::Confirmed {
+                yield ReceiveState::WaitingForConfirmation {
                     btc_deposited,
                     btc_out_point
                 };
 
-                match stream_client_ctx.await_primary_module_outputs(operation_id, claim_data.change).await {
-                    Ok(()) => yield DepositStateV2::Claimed {
+                let claim_data = stream_client_ctx.module_db().wait_key_exists(&claimed_peg_in_key).await;
+
+                if claim_data.claim_txid == TransactionId::from_byte_array([0; 32]) && claim_data.change.is_empty() {
+                    yield ReceiveState::IgnoredDust {
+                        btc_deposited,
+                        btc_out_point
+                    };
+                    return;
+                }
+
+                yield ReceiveState::Confirmed {
+                    btc_deposited,
+                    btc_out_point
+                };
+
+                match stream_client_ctx.await_primary_module_outputs(claim_operation_id, claim_data.change).await {
+                    Ok(()) => yield ReceiveState::Claimed {
                         btc_deposited,
                         btc_out_point
                     },
-                    Err(e) => yield DepositStateV2::Failed(e.to_string())
+                    Err(e) => yield ReceiveState::Failed(e.to_string())
                 }
             }
         }}))
+    }
+
+    /// Reads the final outcome of a *legacy* deposit operation — a
+    /// [`WalletOperationMetaVariant::DepositAddress`] operation from before
+    /// receives were tracked as their own per-UTXO operations.
+    ///
+    /// This is the back-compat counterpart to [`Self::subscribe_receive`] for
+    /// older deposits that predate per-UTXO receive operations and so can't be
+    /// subscribed to. Such a deposit can no longer be driven to completion, but
+    /// the final state it reached can still be surfaced.
+    ///
+    /// If this deposit's UTXO has since been migrated to a per-UTXO `Receive`
+    /// operation, returns [`LegacyDepositOutcome::Migrated`] with the operation
+    /// id to pass to [`Self::subscribe_receive`] instead.
+    ///
+    /// Returns `Ok(None)` if the deposit has no recorded final outcome (e.g. an
+    /// old deposit that never completed), and an error if `operation_id` is not
+    /// a legacy deposit operation.
+    pub async fn get_legacy_deposit_outcome(
+        &self,
+        operation_id: OperationId,
+    ) -> anyhow::Result<Option<LegacyDepositOutcome>> {
+        // Pre-0.4.2 state-machine deposit outcome. Only the terminal variants
+        // we can act on are kept; anything else fails to decode and is treated
+        // as "no usable outcome".
+        #[derive(Deserialize)]
+        enum DepositFinalStateV1 {
+            Claimed {
+                btc_transaction: bitcoin::Transaction,
+                out_idx: u32,
+            },
+            Failed(String),
+        }
+
+        // 0.4.2–0.5 pegin-monitor deposit outcome (the pre-rename
+        // `DepositStateV2`), again only the terminal variants.
+        #[derive(Deserialize)]
+        enum DepositFinalStateV2 {
+            Claimed {
+                #[serde(with = "bitcoin::amount::serde::as_sat")]
+                btc_deposited: bitcoin::Amount,
+                btc_out_point: bitcoin::OutPoint,
+            },
+            Failed(String),
+        }
+
+        let operation = self
+            .client_ctx
+            .get_operation(operation_id)
+            .await
+            .with_context(|| anyhow!("Operation not found: {}", operation_id.fmt_short()))?;
+
+        let WalletOperationMetaVariant::DepositAddress { .. } =
+            operation.meta::<WalletOperationMeta>().variant
+        else {
+            bail!("Operation is not a legacy deposit operation");
+        };
+
+        // 0.5–0.11 deposits cached a `DepositStateV2` outcome; pre-0.4.2
+        // state-machine deposits cached a `DepositStateV1` outcome (which fails
+        // to decode as the former and falls through to the conversion below).
+        let outcome = if let Ok(Some(outcome)) = operation.try_outcome::<DepositFinalStateV2>() {
+            match outcome {
+                DepositFinalStateV2::Claimed {
+                    btc_deposited,
+                    btc_out_point,
+                } => LegacyDepositOutcome::Claimed {
+                    btc_deposited,
+                    btc_out_point,
+                },
+                DepositFinalStateV2::Failed(error) => LegacyDepositOutcome::Failed(error),
+            }
+        } else {
+            // No cached outcome means the deposit never reached a terminal
+            // state we recorded.
+            let Some(outcome) = operation
+                .try_outcome::<DepositFinalStateV1>()
+                .context("Failed to decode legacy deposit outcome")?
+            else {
+                return Ok(None);
+            };
+
+            match outcome {
+                DepositFinalStateV1::Claimed {
+                    btc_transaction,
+                    out_idx,
+                } => {
+                    let txid = btc_transaction.compute_txid();
+                    let btc_deposited = btc_transaction
+                        .output
+                        .get(out_idx as usize)
+                        .with_context(|| {
+                            format!("Legacy deposit outcome references missing output {out_idx} of {txid}")
+                        })?
+                        .value;
+
+                    LegacyDepositOutcome::Claimed {
+                        btc_deposited,
+                        btc_out_point: bitcoin::OutPoint {
+                            txid,
+                            vout: out_idx,
+                        },
+                    }
+                }
+                DepositFinalStateV1::Failed(error) => LegacyDepositOutcome::Failed(error),
+            }
+        };
+
+        // If this deposit's own UTXO already has a per-UTXO `Receive` operation
+        // (created by the live monitor or the one-time backfill), the legacy
+        // outcome is superseded; point the caller at `subscribe_receive`.
+        if let LegacyDepositOutcome::Claimed { btc_out_point, .. } = &outcome {
+            let receive_operation_id =
+                WalletClientModuleData::receive_operation_id(operation_id, *btc_out_point);
+            if self
+                .client_ctx
+                .operation_log_entry_exists(receive_operation_id)
+                .await
+            {
+                return Ok(Some(LegacyDepositOutcome::Migrated {
+                    receive_operation_id,
+                }));
+            }
+        }
+
+        Ok(Some(outcome))
     }
 
     pub async fn list_peg_in_tweak_idxes(&self) -> BTreeMap<TweakIdx, PegInTweakIndexData> {
@@ -1723,14 +1966,31 @@ impl WalletClientModule {
 
             debug!(target: LOG_CLIENT_MODULE_WALLET, has=pegins.len(), "Enough deposits detected");
 
-            for (_outpoint, transaction_id, change) in pegins {
+            for (btc_out_point, transaction_id, change) in pegins {
                 if transaction_id == TransactionId::from_byte_array([0; 32]) && change.is_empty() {
                     debug!(target: LOG_CLIENT_MODULE_WALLET, "Deposited amount was too low, skipping");
                     continue;
                 }
 
+                let receive_operation_id =
+                    WalletClientModuleData::receive_operation_id(operation_id, btc_out_point);
+                let claim_operation_id = match self
+                    .client_ctx
+                    .get_operation(receive_operation_id)
+                    .await
+                    .map(|operation| operation.meta::<WalletOperationMeta>().variant)
+                {
+                    Ok(WalletOperationMetaVariant::Receive {
+                        claim_operation_id, ..
+                    }) => claim_operation_id,
+                    Ok(_) | Err(_) => operation_id,
+                };
+
                 debug!(target: LOG_CLIENT_MODULE_WALLET, out_points=?change, "Ensuring deposists claimed");
-                let tx_subscriber = self.client_ctx.transaction_updates(operation_id).await;
+                let tx_subscriber = self
+                    .client_ctx
+                    .transaction_updates(claim_operation_id)
+                    .await;
 
                 if let Err(e) = tx_subscriber.await_tx_accepted(transaction_id).await {
                     bail!("{e}");
@@ -1738,7 +1998,7 @@ impl WalletClientModule {
 
                 debug!(target: LOG_CLIENT_MODULE_WALLET, out_points=?change, "Ensuring outputs claimed");
                 self.client_ctx
-                    .await_primary_module_outputs(operation_id, change)
+                    .await_primary_module_outputs(claim_operation_id, change)
                     .await
                     .expect("Cannot fail if tx was accepted and federation is honest");
             }

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -40,7 +40,7 @@ use fedimint_client_module::module::init::{
 };
 use fedimint_client_module::module::recovery::RecoveryProgress;
 use fedimint_client_module::module::{ClientContext, ClientModule, IClientModule, OutPointRange};
-use fedimint_client_module::oplog::UpdateStreamOrOutcome;
+use fedimint_client_module::oplog::{OperationLogEntry, UpdateStreamOrOutcome};
 use fedimint_client_module::sm::{Context, DynState, ModuleNotifier, State, StateTransition};
 use fedimint_client_module::transaction::{
     ClientOutput, ClientOutputBundle, ClientOutputSM, FeeQuote, FeeQuoteRequest, TransactionBuilder,
@@ -1580,56 +1580,33 @@ impl WalletClientModule {
 
         let operation_meta = operation.meta::<WalletOperationMeta>();
 
-        let WalletOperationMetaVariant::Receive {
-            claim_operation_id,
-            tweak_idx,
-            btc_out_point,
-            btc_deposited,
-            ..
-        } = operation_meta.variant
-        else {
-            bail!("Operation is not a receive operation");
-        };
-
-        Ok(self.client_ctx.outcome_or_updates(operation, operation_id, {
-            let stream_client_ctx = self.client_ctx.clone();
-            move || {
-
-            stream! {
-                let claimed_peg_in_key = ClaimedPegInKey {
-                    peg_in_index: tweak_idx,
-                    btc_out_point,
-                };
-
-                yield ReceiveState::WaitingForConfirmation {
-                    btc_deposited,
-                    btc_out_point
-                };
-
-                let claim_data = stream_client_ctx.module_db().wait_key_exists(&claimed_peg_in_key).await;
-
-                if claim_data.claim_txid == TransactionId::from_byte_array([0; 32]) && claim_data.change.is_empty() {
-                    yield ReceiveState::IgnoredDust {
-                        btc_deposited,
-                        btc_out_point
-                    };
-                    return;
-                }
-
-                yield ReceiveState::Confirmed {
-                    btc_deposited,
-                    btc_out_point
-                };
-
-                match stream_client_ctx.await_primary_module_outputs(claim_operation_id, claim_data.change).await {
-                    Ok(()) => yield ReceiveState::Claimed {
-                        btc_deposited,
-                        btc_out_point
-                    },
-                    Err(e) => yield ReceiveState::Failed(e.to_string())
-                }
+        match operation_meta.variant {
+            WalletOperationMetaVariant::Receive { .. } => receive_updates_for_operation(
+                &self.client_ctx,
+                operation,
+                operation_id,
+                &operation_meta.variant,
+            ),
+            WalletOperationMetaVariant::DepositAddress {
+                tweak_idx: Some(tweak_idx),
+                ..
+            } => Ok(UpdateStreamOrOutcome::UpdateStream(Box::pin(
+                bridge_deposit_address_to_receive_updates(
+                    self.client_ctx.clone(),
+                    self.db.clone(),
+                    self.pegin_monitor_wakeup_sender.clone(),
+                    self.pegin_claimed_receiver.clone(),
+                    operation_id,
+                    tweak_idx,
+                ),
+            ))),
+            WalletOperationMetaVariant::DepositAddress {
+                tweak_idx: None, ..
+            } => {
+                bail!("Deposit address operation has no tweak index and cannot be subscribed to")
             }
-        }}))
+            _ => bail!("Operation is not a receive operation"),
+        }
     }
 
     /// Reads the final outcome of a *legacy* deposit operation — a
@@ -1884,38 +1861,12 @@ impl WalletClientModule {
 
     /// Schedule given address for immediate re-check for deposits
     pub async fn recheck_pegin_address(&self, tweak_idx: TweakIdx) -> anyhow::Result<()> {
-        self.db
-            .autocommit(
-                |dbtx, _| {
-                    Box::pin(async {
-                        let db_key = PegInTweakIndexKey(tweak_idx);
-                        let db_val = dbtx
-                            .get_value(&db_key)
-                            .await
-                            .ok_or_else(|| anyhow::format_err!("DBKey not found"))?;
-
-                        dbtx.insert_entry(
-                            &db_key,
-                            &PegInTweakIndexData {
-                                next_check_time: Some(fedimint_core::time::now()),
-                                ..db_val
-                            },
-                        )
-                        .await;
-
-                        let sender = self.pegin_monitor_wakeup_sender.clone();
-                        dbtx.on_commit(move || {
-                            sender.send_replace(());
-                        });
-
-                        Ok::<_, anyhow::Error>(())
-                    })
-                },
-                Some(100),
-            )
-            .await?;
-
-        Ok(())
+        schedule_pegin_recheck(
+            &self.db,
+            self.pegin_monitor_wakeup_sender.clone(),
+            tweak_idx,
+        )
+        .await
     }
 
     /// Await for num deposit by [`OperationId`]
@@ -2224,6 +2175,206 @@ async fn get_next_peg_in_tweak_child_id(dbtx: &mut DatabaseTransaction<'_>) -> T
     dbtx.insert_entry(&NextPegInTweakIndexKey, &(index.next()))
         .await;
     index
+}
+
+async fn schedule_pegin_recheck(
+    db: &Database,
+    pegin_monitor_wakeup_sender: watch::Sender<()>,
+    tweak_idx: TweakIdx,
+) -> anyhow::Result<()> {
+    db.autocommit(
+        |dbtx, _| {
+            let pegin_monitor_wakeup_sender = pegin_monitor_wakeup_sender.clone();
+            Box::pin(async move {
+                let db_key = PegInTweakIndexKey(tweak_idx);
+                let db_val = dbtx
+                    .get_value(&db_key)
+                    .await
+                    .ok_or_else(|| anyhow::format_err!("DBKey not found"))?;
+
+                dbtx.insert_entry(
+                    &db_key,
+                    &PegInTweakIndexData {
+                        next_check_time: Some(fedimint_core::time::now()),
+                        ..db_val
+                    },
+                )
+                .await;
+
+                dbtx.on_commit(move || {
+                    pegin_monitor_wakeup_sender.send_replace(());
+                });
+
+                Ok::<_, anyhow::Error>(())
+            })
+        },
+        Some(100),
+    )
+    .await?;
+
+    Ok(())
+}
+
+fn receive_updates_for_operation(
+    client_ctx: &ClientContext<WalletClientModule>,
+    operation: OperationLogEntry,
+    operation_id: OperationId,
+    operation_meta_variant: &WalletOperationMetaVariant,
+) -> anyhow::Result<UpdateStreamOrOutcome<ReceiveState>> {
+    let &WalletOperationMetaVariant::Receive {
+        claim_operation_id,
+        tweak_idx,
+        btc_out_point,
+        btc_deposited,
+        ..
+    } = operation_meta_variant
+    else {
+        bail!("Operation is not a receive operation");
+    };
+
+    Ok(client_ctx.outcome_or_updates(operation, operation_id, {
+        let stream_client_ctx = client_ctx.clone();
+        move || {
+            stream! {
+                let claimed_peg_in_key = ClaimedPegInKey {
+                    peg_in_index: tweak_idx,
+                    btc_out_point,
+                };
+
+                yield ReceiveState::WaitingForConfirmation {
+                    btc_deposited,
+                    btc_out_point,
+                };
+
+                let claim_data = stream_client_ctx
+                    .module_db()
+                    .wait_key_exists(&claimed_peg_in_key)
+                    .await;
+
+                if claim_data.claim_txid == TransactionId::from_byte_array([0; 32])
+                    && claim_data.change.is_empty()
+                {
+                    yield ReceiveState::IgnoredDust {
+                        btc_deposited,
+                        btc_out_point,
+                    };
+                    return;
+                }
+
+                yield ReceiveState::Confirmed {
+                    btc_deposited,
+                    btc_out_point,
+                };
+
+                match stream_client_ctx
+                    .await_primary_module_outputs(claim_operation_id, claim_data.change)
+                    .await
+                {
+                    Ok(()) => yield ReceiveState::Claimed {
+                        btc_deposited,
+                        btc_out_point,
+                    },
+                    Err(e) => yield ReceiveState::Failed(e.to_string()),
+                }
+            }
+        }
+    }))
+}
+
+async fn first_receive_operation_for_address(
+    client_ctx: &ClientContext<WalletClientModule>,
+    db: &Database,
+    address_operation_id: OperationId,
+    tweak_idx: TweakIdx,
+) -> Option<OperationId> {
+    let claimed = db
+        .begin_transaction_nc()
+        .await
+        .get_value(&PegInTweakIndexKey(tweak_idx))
+        .await
+        .map(|data| data.claimed)
+        .unwrap_or_default();
+
+    for btc_out_point in claimed {
+        let receive_operation_id =
+            WalletClientModuleData::receive_operation_id(address_operation_id, btc_out_point);
+        if client_ctx
+            .operation_log_entry_exists(receive_operation_id)
+            .await
+        {
+            return Some(receive_operation_id);
+        }
+    }
+
+    None
+}
+
+fn bridge_deposit_address_to_receive_updates(
+    client_ctx: ClientContext<WalletClientModule>,
+    db: Database,
+    pegin_monitor_wakeup_sender: watch::Sender<()>,
+    mut pegin_claimed_receiver: watch::Receiver<()>,
+    address_operation_id: OperationId,
+    tweak_idx: TweakIdx,
+) -> BoxStream<'static, ReceiveState> {
+    Box::pin(stream! {
+        let receive_operation_id = loop {
+            if let Some(receive_operation_id) = first_receive_operation_for_address(
+                &client_ctx,
+                &db,
+                address_operation_id,
+                tweak_idx,
+            )
+            .await
+            {
+                break receive_operation_id;
+            }
+
+            if let Err(error) = schedule_pegin_recheck(
+                &db,
+                pegin_monitor_wakeup_sender.clone(),
+                tweak_idx,
+            )
+            .await
+            {
+                yield ReceiveState::Failed(error.to_string());
+                return;
+            }
+
+            if pegin_claimed_receiver.changed().await.is_err() {
+                yield ReceiveState::Failed(
+                    "Peg-in monitor stopped before receive was found".to_owned(),
+                );
+                return;
+            }
+        };
+
+        let operation = match client_ctx.get_operation(receive_operation_id).await {
+            Ok(operation) => operation,
+            Err(error) => {
+                yield ReceiveState::Failed(error.to_string());
+                return;
+            }
+        };
+        let operation_meta = operation.meta::<WalletOperationMeta>();
+
+        let updates = match receive_updates_for_operation(
+            &client_ctx,
+            operation,
+            receive_operation_id,
+            &operation_meta.variant,
+        ) {
+            Ok(updates) => updates,
+            Err(error) => {
+                yield ReceiveState::Failed(error.to_string());
+                return;
+            }
+        };
+
+        for await update in updates.into_stream() {
+            yield update;
+        }
+    })
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -75,14 +75,15 @@ use secp256k1::Keypair;
 use serde::{Deserialize, Serialize};
 use strum::IntoEnumIterator;
 use tokio::sync::watch;
-use tracing::{debug, instrument};
+use tracing::{debug, instrument, warn};
 
 use crate::api::WalletFederationApi;
 use crate::backup::{FEDERATION_RECOVER_MAX_GAP, RecoveryStateV2, WalletRecovery};
 use crate::client_db::{
     ClaimedPegInData, ClaimedPegInKey, ClaimedPegInPrefix, NextPegInTweakIndexKey,
-    PegInPoolCursorKey, PegInTweakIndexData, PegInTweakIndexPrefix, ReceiveOperationsBackfilledKey,
-    RecoveryFinalizedKey, RecoveryStateKey, SupportsSafeDepositPrefix,
+    PegInPoolCursorKey, PegInTweakIndexData, PegInTweakIndexPrefix, ReceiveOperationPrefix,
+    ReceiveOperationsBackfilledKey, RecoveryFinalizedKey, RecoveryStateKey,
+    SupportsSafeDepositPrefix,
 };
 use crate::deposit::DepositStateMachine;
 use crate::withdraw::{CreatedWithdrawState, WithdrawStateMachine, WithdrawStates};
@@ -109,6 +110,18 @@ pub enum ReceiveState {
         btc_out_point: bitcoin::OutPoint,
     },
     IgnoredDust {
+        #[serde(with = "bitcoin::amount::serde::as_sat")]
+        btc_deposited: bitcoin::Amount,
+        btc_out_point: bitcoin::OutPoint,
+    },
+    /// The transaction disappeared from watched script history before claim.
+    ///
+    /// This state is recoverable: if the same transaction/outpoint later
+    /// reappears the stream returns to
+    /// [`ReceiveState::WaitingForConfirmation`], and if it gets claimed the
+    /// stream continues to [`ReceiveState::Confirmed`] /
+    /// [`ReceiveState::Claimed`].
+    OutOfMempool {
         #[serde(with = "bitcoin::amount::serde::as_sat")]
         btc_deposited: bitcoin::Amount,
         btc_out_point: bitcoin::OutPoint,
@@ -343,6 +356,16 @@ impl ModuleInit for WalletClientInit {
                         wallet_client_items
                             .insert("ReceiveOperationsBackfilled".to_string(), Box::new(val));
                     }
+                }
+                DbKeyPrefix::ReceiveOperation => {
+                    push_db_pair_items!(
+                        dbtx,
+                        ReceiveOperationPrefix,
+                        crate::client_db::ReceiveOperationKey,
+                        SystemTime,
+                        wallet_client_items,
+                        "Receive Operation"
+                    );
                 }
                 DbKeyPrefix::RecoveryState
                 | DbKeyPrefix::ExternalReservedStart
@@ -1579,10 +1602,15 @@ impl WalletClientModule {
         }
 
         let operation_meta = operation.meta::<WalletOperationMeta>();
+        let receive_update_context = ReceiveUpdateContext {
+            client_ctx: self.client_ctx.clone(),
+            rpc: self.rpc.clone(),
+            network: self.cfg().network.0,
+        };
 
         match operation_meta.variant {
             WalletOperationMetaVariant::Receive { .. } => receive_updates_for_operation(
-                &self.client_ctx,
+                &receive_update_context,
                 operation,
                 operation_id,
                 &operation_meta.variant,
@@ -1592,7 +1620,7 @@ impl WalletClientModule {
                 ..
             } => Ok(UpdateStreamOrOutcome::UpdateStream(Box::pin(
                 bridge_deposit_address_to_receive_updates(
-                    self.client_ctx.clone(),
+                    receive_update_context,
                     self.db.clone(),
                     self.pegin_monitor_wakeup_sender.clone(),
                     self.pegin_claimed_receiver.clone(),
@@ -2215,13 +2243,61 @@ async fn schedule_pegin_recheck(
     Ok(())
 }
 
+#[derive(Clone)]
+struct ReceiveUpdateContext {
+    client_ctx: ClientContext<WalletClientModule>,
+    rpc: DynBitcoindRpc,
+    network: Network,
+}
+
+fn history_contains_outpoint(
+    history: &[bitcoin::Transaction],
+    script_pubkey: &ScriptBuf,
+    btc_out_point: bitcoin::OutPoint,
+) -> bool {
+    history.iter().any(|tx| {
+        tx.compute_txid() == btc_out_point.txid
+            && tx
+                .output
+                .get(btc_out_point.vout as usize)
+                .is_some_and(|output| output.script_pubkey == *script_pubkey)
+    })
+}
+
+fn receive_history_transition(
+    reported_out_of_mempool: &mut bool,
+    still_in_history: bool,
+    btc_deposited: bitcoin::Amount,
+    btc_out_point: bitcoin::OutPoint,
+) -> Option<ReceiveState> {
+    if still_in_history {
+        if *reported_out_of_mempool {
+            *reported_out_of_mempool = false;
+            return Some(ReceiveState::WaitingForConfirmation {
+                btc_deposited,
+                btc_out_point,
+            });
+        }
+    } else if !*reported_out_of_mempool {
+        *reported_out_of_mempool = true;
+        return Some(ReceiveState::OutOfMempool {
+            btc_deposited,
+            btc_out_point,
+        });
+    }
+
+    None
+}
+
+#[allow(clippy::too_many_lines)]
 fn receive_updates_for_operation(
-    client_ctx: &ClientContext<WalletClientModule>,
+    context: &ReceiveUpdateContext,
     operation: OperationLogEntry,
     operation_id: OperationId,
     operation_meta_variant: &WalletOperationMetaVariant,
 ) -> anyhow::Result<UpdateStreamOrOutcome<ReceiveState>> {
     let &WalletOperationMetaVariant::Receive {
+        ref address,
         claim_operation_id,
         tweak_idx,
         btc_out_point,
@@ -2232,8 +2308,19 @@ fn receive_updates_for_operation(
         bail!("Operation is not a receive operation");
     };
 
-    Ok(client_ctx.outcome_or_updates(operation, operation_id, {
-        let stream_client_ctx = client_ctx.clone();
+    let script_pubkey = address
+        .clone()
+        .require_network(context.network)?
+        .script_pubkey();
+    let poll_interval = if is_running_in_test_env() {
+        Duration::from_millis(100)
+    } else {
+        Duration::from_secs(30)
+    };
+
+    Ok(context.client_ctx.outcome_or_updates(operation, operation_id, {
+        let stream_client_ctx = context.client_ctx.clone();
+        let stream_rpc = context.rpc.clone();
         move || {
             stream! {
                 let claimed_peg_in_key = ClaimedPegInKey {
@@ -2246,10 +2333,63 @@ fn receive_updates_for_operation(
                     btc_out_point,
                 };
 
-                let claim_data = stream_client_ctx
-                    .module_db()
-                    .wait_key_exists(&claimed_peg_in_key)
-                    .await;
+                let mut script_history_watched = false;
+                let mut reported_out_of_mempool = false;
+
+                let claim_data = loop {
+                    if let Some(claim_data) = stream_client_ctx
+                        .module_db()
+                        .begin_transaction_nc()
+                        .await
+                        .get_value(&claimed_peg_in_key)
+                        .await
+                    {
+                        break claim_data;
+                    }
+
+                    if !script_history_watched {
+                        match stream_rpc.watch_script_history(&script_pubkey).await {
+                            Ok(()) => {
+                                script_history_watched = true;
+                            }
+                            Err(error) => {
+                                warn!(
+                                    target: LOG_CLIENT_MODULE_WALLET,
+                                    err = %error.fmt_compact_anyhow(),
+                                    %btc_out_point,
+                                    "Failed to watch script history while waiting for receive confirmation"
+                                );
+                                sleep(poll_interval).await;
+                                continue;
+                            }
+                        }
+                    }
+
+                    match stream_rpc.get_script_history(&script_pubkey).await {
+                        Ok(history) => {
+                            let still_in_history =
+                                history_contains_outpoint(&history, &script_pubkey, btc_out_point);
+                            if let Some(state) = receive_history_transition(
+                                &mut reported_out_of_mempool,
+                                still_in_history,
+                                btc_deposited,
+                                btc_out_point,
+                            ) {
+                                yield state;
+                            }
+                        }
+                        Err(error) => {
+                            warn!(
+                                target: LOG_CLIENT_MODULE_WALLET,
+                                err = %error.fmt_compact_anyhow(),
+                                %btc_out_point,
+                                "Failed to refresh script history while waiting for receive confirmation"
+                            );
+                        }
+                    }
+
+                    sleep(poll_interval).await;
+                };
 
                 if claim_data.claim_txid == TransactionId::from_byte_array([0; 32])
                     && claim_data.change.is_empty()
@@ -2287,6 +2427,28 @@ async fn first_receive_operation_for_address(
     address_operation_id: OperationId,
     tweak_idx: TweakIdx,
 ) -> Option<OperationId> {
+    let mut indexed_receives = db
+        .begin_transaction_nc()
+        .await
+        .find_by_prefix(&ReceiveOperationPrefix)
+        .await
+        .filter(|(key, _creation_time)| futures::future::ready(key.peg_in_index == tweak_idx))
+        .collect::<Vec<_>>()
+        .await;
+
+    indexed_receives.sort_by_key(|(_key, creation_time)| *creation_time);
+
+    for (key, _creation_time) in indexed_receives.into_iter().rev() {
+        let receive_operation_id =
+            WalletClientModuleData::receive_operation_id(address_operation_id, key.btc_out_point);
+        if client_ctx
+            .operation_log_entry_exists(receive_operation_id)
+            .await
+        {
+            return Some(receive_operation_id);
+        }
+    }
+
     let claimed = db
         .begin_transaction_nc()
         .await
@@ -2310,7 +2472,7 @@ async fn first_receive_operation_for_address(
 }
 
 fn bridge_deposit_address_to_receive_updates(
-    client_ctx: ClientContext<WalletClientModule>,
+    context: ReceiveUpdateContext,
     db: Database,
     pegin_monitor_wakeup_sender: watch::Sender<()>,
     mut pegin_claimed_receiver: watch::Receiver<()>,
@@ -2320,7 +2482,7 @@ fn bridge_deposit_address_to_receive_updates(
     Box::pin(stream! {
         let receive_operation_id = loop {
             if let Some(receive_operation_id) = first_receive_operation_for_address(
-                &client_ctx,
+                &context.client_ctx,
                 &db,
                 address_operation_id,
                 tweak_idx,
@@ -2349,7 +2511,7 @@ fn bridge_deposit_address_to_receive_updates(
             }
         };
 
-        let operation = match client_ctx.get_operation(receive_operation_id).await {
+        let operation = match context.client_ctx.get_operation(receive_operation_id).await {
             Ok(operation) => operation,
             Err(error) => {
                 yield ReceiveState::Failed(error.to_string());
@@ -2359,7 +2521,7 @@ fn bridge_deposit_address_to_receive_updates(
         let operation_meta = operation.meta::<WalletOperationMeta>();
 
         let updates = match receive_updates_for_operation(
-            &client_ctx,
+            &context,
             operation,
             receive_operation_id,
             &operation_meta.variant,
@@ -2432,6 +2594,66 @@ mod tests {
     use crate::backup::{
         RECOVER_NUM_IDX_ADD_TO_LAST_USED, RecoverScanOutcome, recover_scan_idxes_for_activity,
     };
+
+    #[test]
+    fn receive_history_transition_is_recoverable() {
+        let btc_deposited = bitcoin::Amount::from_sat(42);
+        let btc_out_point = bitcoin::OutPoint {
+            txid: bitcoin::Txid::from_byte_array([1; 32]),
+            vout: 0,
+        };
+        let mut reported_out_of_mempool = false;
+
+        assert_eq!(
+            receive_history_transition(
+                &mut reported_out_of_mempool,
+                true,
+                btc_deposited,
+                btc_out_point,
+            ),
+            None
+        );
+        assert!(!reported_out_of_mempool);
+
+        assert_eq!(
+            receive_history_transition(
+                &mut reported_out_of_mempool,
+                false,
+                btc_deposited,
+                btc_out_point,
+            ),
+            Some(ReceiveState::OutOfMempool {
+                btc_deposited,
+                btc_out_point,
+            })
+        );
+        assert!(reported_out_of_mempool);
+
+        assert_eq!(
+            receive_history_transition(
+                &mut reported_out_of_mempool,
+                false,
+                btc_deposited,
+                btc_out_point,
+            ),
+            None
+        );
+        assert!(reported_out_of_mempool);
+
+        assert_eq!(
+            receive_history_transition(
+                &mut reported_out_of_mempool,
+                true,
+                btc_deposited,
+                btc_out_point,
+            ),
+            Some(ReceiveState::WaitingForConfirmation {
+                btc_deposited,
+                btc_out_point,
+            })
+        );
+        assert!(!reported_out_of_mempool);
+    }
 
     #[allow(clippy::too_many_lines)] // shut-up clippy, it's a test
     #[tokio::test(flavor = "multi_thread")]

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -118,10 +118,11 @@ pub enum ReceiveState {
     },
     /// The transaction disappeared from watched script history before claim.
     ///
-    /// This state is recoverable: if the same transaction/outpoint later
-    /// reappears the stream returns to
-    /// [`ReceiveState::WaitingForConfirmation`], and if it gets claimed the
-    /// stream continues to [`ReceiveState::Confirmed`] /
+    /// This state is recoverable and non-terminal. While out of mempool the
+    /// subscription parks on peg-in monitor notifications instead of polling
+    /// Bitcoin RPC itself. If the same transaction/outpoint later reappears the
+    /// stream returns to [`ReceiveState::WaitingForConfirmation`], and if it
+    /// gets claimed the stream continues to [`ReceiveState::Confirmed`] /
     /// [`ReceiveState::Claimed`].
     OutOfMempool {
         #[serde(with = "bitcoin::amount::serde::as_sat")]
@@ -424,7 +425,7 @@ impl ClientModuleInit for WalletClientInit {
 
         let module_api = args.module_api().clone();
 
-        let (pegin_claimed_sender, pegin_claimed_receiver) = watch::channel(());
+        let (pegin_monitor_update_sender, pegin_monitor_update_receiver) = watch::channel(());
         let (pegin_monitor_wakeup_sender, pegin_monitor_wakeup_receiver) = watch::channel(());
 
         Ok(WalletClientModule {
@@ -436,8 +437,8 @@ impl ClientModuleInit for WalletClientInit {
             client_ctx: args.context(),
             pegin_monitor_wakeup_sender,
             pegin_monitor_wakeup_receiver,
-            pegin_claimed_receiver,
-            pegin_claimed_sender,
+            pegin_monitor_update_receiver,
+            pegin_monitor_update_sender,
             task_group: args.task_group().clone(),
             client_span: args.client_span().clone(),
             admin_auth: args.admin_auth().cloned(),
@@ -614,9 +615,13 @@ pub struct WalletClientModule {
     /// Updated to wake up pegin monitor
     pegin_monitor_wakeup_sender: watch::Sender<()>,
     pegin_monitor_wakeup_receiver: watch::Receiver<()>,
-    /// Called every time a peg-in was claimed
-    pegin_claimed_sender: watch::Sender<()>,
-    pegin_claimed_receiver: watch::Receiver<()>,
+    /// Notifies receive subscriptions after the peg-in monitor checks deposits.
+    ///
+    /// This is broader than claim notifications: out-of-mempool receive streams
+    /// park on this channel and re-check their operation when the monitor makes
+    /// progress.
+    pegin_monitor_update_sender: watch::Sender<()>,
+    pegin_monitor_update_receiver: watch::Receiver<()>,
     task_group: TaskGroup,
     client_span: tracing::Span,
     admin_auth: Option<ApiAuth>,
@@ -659,7 +664,7 @@ impl ClientModule for WalletClientModule {
                 let btc_rpc = self.rpc.clone();
                 let module_api = self.module_api.clone();
                 let data = self.data.clone();
-                let pegin_claimed_sender = self.pegin_claimed_sender.clone();
+                let pegin_monitor_update_sender = self.pegin_monitor_update_sender.clone();
                 let pegin_monitor_wakeup_receiver = self.pegin_monitor_wakeup_receiver.clone();
                 pegin_monitor::run_peg_in_monitor(
                     client_ctx,
@@ -667,7 +672,7 @@ impl ClientModule for WalletClientModule {
                     btc_rpc,
                     module_api,
                     data,
-                    pegin_claimed_sender,
+                    pegin_monitor_update_sender,
                     pegin_monitor_wakeup_receiver,
                 )
             });
@@ -1615,6 +1620,7 @@ impl WalletClientModule {
             client_ctx: self.client_ctx.clone(),
             rpc: self.rpc.clone(),
             network: self.cfg().network.0,
+            pegin_monitor_update_receiver: self.pegin_monitor_update_receiver.clone(),
         };
 
         match operation_meta.variant {
@@ -1632,7 +1638,7 @@ impl WalletClientModule {
                     receive_update_context,
                     self.db.clone(),
                     self.pegin_monitor_wakeup_sender.clone(),
-                    self.pegin_claimed_receiver.clone(),
+                    self.pegin_monitor_update_receiver.clone(),
                     operation_id,
                     tweak_idx,
                 ),
@@ -1933,7 +1939,7 @@ impl WalletClientModule {
     ) -> anyhow::Result<()> {
         let operation_id = self.get_pegin_tweak_idx(tweak_idx).await?.operation_id;
 
-        let mut receiver = self.pegin_claimed_receiver.clone();
+        let mut receiver = self.pegin_monitor_update_receiver.clone();
         let mut backoff = backoff_util::aggressive_backoff();
 
         loop {
@@ -2257,6 +2263,7 @@ struct ReceiveUpdateContext {
     client_ctx: ClientContext<WalletClientModule>,
     rpc: DynBitcoindRpc,
     network: Network,
+    pegin_monitor_update_receiver: watch::Receiver<()>,
 }
 
 fn history_contains_outpoint(
@@ -2330,6 +2337,7 @@ fn receive_updates_for_operation(
     Ok(context.client_ctx.outcome_or_updates(operation, operation_id, {
         let stream_client_ctx = context.client_ctx.clone();
         let stream_rpc = context.rpc.clone();
+        let mut stream_pegin_monitor_update_receiver = context.pegin_monitor_update_receiver.clone();
         move || {
             stream! {
                 let claimed_peg_in_key = ClaimedPegInKey {
@@ -2397,7 +2405,24 @@ fn receive_updates_for_operation(
                         }
                     }
 
-                    sleep(poll_interval).await;
+                    if reported_out_of_mempool {
+                        // Once a receive transaction disappears, do not keep one
+                        // Bitcoin RPC polling loop per subscriber alive. The
+                        // peg-in monitor already owns the persisted, decaying
+                        // recheck schedule for deposit addresses, so park this
+                        // recoverable operation until the monitor reports that
+                        // it checked peg-ins again. This keeps `OutOfMempool`
+                        // non-terminal without turning it into permanent
+                        // per-subscription polling.
+                        if stream_pegin_monitor_update_receiver.changed().await.is_err() {
+                            yield ReceiveState::Failed(
+                                "Peg-in monitor stopped before receive was claimed".to_owned(),
+                            );
+                            return;
+                        }
+                    } else {
+                        sleep(poll_interval).await;
+                    }
                 };
 
                 if claim_data.claim_txid == TransactionId::from_byte_array([0; 32])
@@ -2484,7 +2509,7 @@ fn bridge_deposit_address_to_receive_updates(
     context: ReceiveUpdateContext,
     db: Database,
     pegin_monitor_wakeup_sender: watch::Sender<()>,
-    mut pegin_claimed_receiver: watch::Receiver<()>,
+    mut pegin_monitor_update_receiver: watch::Receiver<()>,
     address_operation_id: OperationId,
     tweak_idx: TweakIdx,
 ) -> BoxStream<'static, ReceiveState> {
@@ -2512,7 +2537,7 @@ fn bridge_deposit_address_to_receive_updates(
                 return;
             }
 
-            if pegin_claimed_receiver.changed().await.is_err() {
+            if pegin_monitor_update_receiver.changed().await.is_err() {
                 yield ReceiveState::Failed(
                     "Peg-in monitor stopped before receive was found".to_owned(),
                 );

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -39,12 +39,14 @@ use fedimint_client_module::module::init::{
     ClientModuleInit, ClientModuleInitArgs, ClientModuleRecoverArgs,
 };
 use fedimint_client_module::module::recovery::RecoveryProgress;
-use fedimint_client_module::module::{ClientContext, ClientModule, IClientModule, OutPointRange};
+use fedimint_client_module::module::{
+    ClientContext, ClientModule, ClientModulePreStartMigrationContext, IClientModule, OutPointRange,
+};
 use fedimint_client_module::oplog::{OperationLogEntry, UpdateStreamOrOutcome};
 use fedimint_client_module::sm::{Context, DynState, ModuleNotifier, State, StateTransition};
 use fedimint_client_module::transaction::{
-    ClientOutput, ClientOutputBundle, ClientOutputSM, FeeQuote, FeeQuoteRequest, TransactionBuilder,
-    max_affordable_send_amount,
+    ClientOutput, ClientOutputBundle, ClientOutputSM, FeeQuote, FeeQuoteRequest,
+    TransactionBuilder, max_affordable_send_amount,
 };
 use fedimint_client_module::{DynGlobalClientContext, sm_enum_variant_translation};
 use fedimint_core::core::{Decoder, IntoDynInstance, ModuleInstanceId, ModuleKind, OperationId};
@@ -642,15 +644,18 @@ impl ClientModule for WalletClientModule {
         }
     }
 
-    async fn start(&self) {
-        if let Err(error) = self.backfill_receive_operations().await {
-            tracing::warn!(
-                target: LOG_CLIENT_MODULE_WALLET,
-                err = %error.fmt_compact_anyhow(),
-                "Failed to backfill wallet receive operation log entries"
-            );
-        }
+    async fn pre_start_migration(
+        &self,
+        pre_start_ctx: &ClientModulePreStartMigrationContext<'_>,
+    ) -> anyhow::Result<()> {
+        self.backfill_receive_operations(pre_start_ctx)
+            .await
+            .context("failed to backfill wallet receive operation log entries")?;
 
+        Ok(())
+    }
+
+    async fn start(&self) {
         self.task_group
             .spawn_cancellable_with_span(self.client_span.clone(), "peg-in monitor", {
                 let client_ctx = self.client_ctx.clone();
@@ -881,7 +886,10 @@ impl WalletClientModule {
     /// [`WalletOperationMetaVariant::Receive`] operation-log entry for deposits
     /// that were already claimed before receive operations were tracked
     /// individually.
-    async fn backfill_receive_operations(&self) -> anyhow::Result<()> {
+    async fn backfill_receive_operations(
+        &self,
+        pre_start_ctx: &ClientModulePreStartMigrationContext<'_>,
+    ) -> anyhow::Result<()> {
         /// Scans the event log for [`DepositConfirmed`] events, returning the
         /// deposited amount and confirmation time keyed by the on-chain
         /// outpoint. Walking the whole (potentially large) event log is
@@ -969,6 +977,7 @@ impl WalletClientModule {
                 pegin_monitor::ensure_receive_operation(
                     &mut dbtx.to_ref_nc(),
                     &self.client_ctx,
+                    Some(pre_start_ctx),
                     receive_operation_id,
                     WalletOperationMetaVariant::Receive {
                         address_operation_id: peg_in_data.operation_id,

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -5,9 +5,6 @@
 #![allow(clippy::module_name_repetitions)]
 #![allow(clippy::must_use_candidate)]
 
-#[cfg(feature = "uniffi")]
-::uniffi::setup_scaffolding!();
-
 pub mod api;
 #[cfg(feature = "cli")]
 mod cli;
@@ -19,8 +16,6 @@ pub mod client_db;
 /// but retained for time being to ensure existing peg-ins complete.
 mod deposit;
 pub mod events;
-#[cfg(feature = "uniffi")]
-pub mod ffi;
 use events::{DepositConfirmed, SendPaymentEvent};
 /// Peg-in monitor: a task monitoring deposit addresses for peg-ins.
 mod pegin_monitor;
@@ -41,15 +36,15 @@ use client_db::{DbKeyPrefix, PegInTweakIndexKey, SupportsSafeDepositKey, TweakId
 use fedimint_api_client::api::{DynModuleApi, FederationResult};
 use fedimint_bitcoind::{BitcoindTracked, DynBitcoindRpc, IBitcoindRpc, create_esplora_rpc};
 use fedimint_client_module::module::init::{
-    ClientModuleInit, ClientModuleInitArgs, ClientModuleRecoverArgs, RecoveryMode,
+    ClientModuleInit, ClientModuleInitArgs, ClientModuleRecoverArgs,
 };
 use fedimint_client_module::module::recovery::RecoveryProgress;
 use fedimint_client_module::module::{ClientContext, ClientModule, IClientModule, OutPointRange};
-use fedimint_client_module::oplog::UpdateStreamOrOutcome;
+use fedimint_client_module::oplog::{OperationLogEntry, UpdateStreamOrOutcome};
 use fedimint_client_module::sm::{Context, DynState, ModuleNotifier, State, StateTransition};
 use fedimint_client_module::transaction::{
-    ClientOutput, ClientOutputBundle, ClientOutputSM, FeeQuote, FeeQuoteRequest,
-    TransactionBuilder, max_affordable_send_amount,
+    ClientOutput, ClientOutputBundle, ClientOutputSM, FeeQuote, FeeQuoteRequest, TransactionBuilder,
+    max_affordable_send_amount,
 };
 use fedimint_client_module::{DynGlobalClientContext, sm_enum_variant_translation};
 use fedimint_core::core::{Decoder, IntoDynInstance, ModuleInstanceId, ModuleKind, OperationId};
@@ -94,46 +89,6 @@ use crate::deposit::DepositStateMachine;
 use crate::withdraw::{CreatedWithdrawState, WithdrawStateMachine, WithdrawStates};
 
 const WALLET_TWEAK_CHILD_ID: ChildId = ChildId(0);
-
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
-pub struct BitcoinTransactionData {
-    /// The bitcoin transaction is saved as soon as we see it so the transaction
-    /// can be re-transmitted if it's evicted from the mempool.
-    pub btc_transaction: bitcoin::Transaction,
-    /// Index of the deposit output
-    pub out_idx: u32,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
-pub enum DepositStateV1 {
-    WaitingForTransaction,
-    WaitingForConfirmation(BitcoinTransactionData),
-    Confirmed(BitcoinTransactionData),
-    Claimed(BitcoinTransactionData),
-    Failed(String),
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
-#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
-pub enum DepositStateV2 {
-    WaitingForTransaction,
-    WaitingForConfirmation {
-        #[serde(with = "bitcoin::amount::serde::as_sat")]
-        btc_deposited: bitcoin::Amount,
-        btc_out_point: bitcoin::OutPoint,
-    },
-    Confirmed {
-        #[serde(with = "bitcoin::amount::serde::as_sat")]
-        btc_deposited: bitcoin::Amount,
-        btc_out_point: bitcoin::OutPoint,
-    },
-    Claimed {
-        #[serde(with = "bitcoin::amount::serde::as_sat")]
-        btc_deposited: bitcoin::Amount,
-        btc_out_point: bitcoin::OutPoint,
-    },
-    Failed(String),
-}
 
 /// State of a single on-chain receive (peg-in of one UTXO), as streamed by
 /// [`WalletClientModule::subscribe_receive`].
@@ -223,7 +178,6 @@ pub enum AllocateDepositOutcome {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
-#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
 pub enum WithdrawState {
     Created,
     Succeeded(bitcoin::Txid),
@@ -469,10 +423,6 @@ impl ClientModuleInit for WalletClientInit {
         })
     }
 
-    fn recovery_mode(&self) -> RecoveryMode {
-        RecoveryMode::Unusable
-    }
-
     /// Wallet recovery
     ///
     /// Uses slice-based recovery if supported by the federation, otherwise
@@ -633,7 +583,6 @@ impl WalletClientModuleData {
 }
 
 #[derive(Debug)]
-#[cfg_attr(feature = "uniffi", derive(uniffi::Object))]
 pub struct WalletClientModule {
     data: WalletClientModuleData,
     db: Database,
@@ -841,12 +790,6 @@ pub struct PegInRequest {
     pub extra_meta: serde_json::Value,
 }
 
-#[cfg(feature = "uniffi")]
-uniffi::custom_type!(PegInRequest, String, {
-    lower: |v| serde_json::to_string(&v).expect("PegInRequest serialization cannot fail"),
-    try_lift: |s| serde_json::from_str::<PegInRequest>(&s).map_err(|e| anyhow!("Failed to parse PegInRequest: {e}")),
-});
-
 #[derive(Deserialize)]
 struct SubscribeReceiveRequest {
     operation_id: OperationId,
@@ -858,14 +801,12 @@ struct SubscribeWithdrawRequest {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct PegInResponse {
     pub deposit_address: Address<NetworkUnchecked>,
     pub operation_id: OperationId,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct PegOutRequest {
     pub amount_sat: u64,
     pub destination_address: Address<NetworkUnchecked>,
@@ -873,7 +814,6 @@ pub struct PegOutRequest {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct PegOutResponse {
     pub operation_id: OperationId,
 }
@@ -1107,46 +1047,13 @@ impl WalletClientModule {
             .await
     }
 
-    /// Finds the largest amount that can be withdrawn in full out of
-    /// `balance` — the amount a "withdraw everything" sweep should use —
-    /// together with the peg-out fees to submit it with.
-    ///
-    /// Withdrawing `amount` submits a peg-out output worth `amount +
-    /// peg_out_fees` (the on-chain miner fee is carried inside the output, see
-    /// [`WalletOutputV0::amount`]) and funding that output costs an additional
-    /// federation fee — the peg-out output fee, the mint input fees on the
-    /// funding notes, any mint change output fees and sub-denomination dust —
-    /// as quoted by [`Self::send_fee_quote`].
-    ///
-    /// Both returned values must be passed to [`Self::withdraw`] together. The
-    /// federation rebuilds the peg-out for the exact amount submitted and
-    /// rejects it unless the declared `total_weight` matches what it computed
-    /// (`WalletOutputError::TxWeightIncorrect`), so the fees are re-quoted here
-    /// at the amount being returned rather than at the balance.
-    ///
-    /// This costs exactly two [`Self::get_withdraw_fees`] round trips. The
-    /// first, at the full balance, is an upper bound on the miner fee — the
-    /// federation selects UTXOs until they cover the amount, so the weight is
-    /// monotone in it — and sizing the withdrawal against that upper bound can
-    /// only leave the result more affordable once the true, smaller fee
-    /// replaces it. The maximum itself is then found by binary search over the
-    /// real fee quote (see [`max_affordable_send_amount`]), which needs no
-    /// further round trips because [`Self::send_fee_quote`] is a local dry-run.
-    ///
-    /// Sizing against the upper bound means a sweep may leave a small
-    /// remainder behind. The quote is point-in-time: if the federation's UTXO
-    /// set or feerate moves before the peg-out is processed it is rejected, and
-    /// the caller should retry with a fresh quote.
-    ///
-    /// Returns an error if the balance cannot cover the destination's dust
-    /// limit plus fees.
+    /// Finds the largest whole-satoshi amount that can be withdrawn from
+    /// `balance`, together with the matching peg-out fee quote.
     pub async fn max_withdrawable_amount(
         &self,
         address: &bitcoin::Address,
         balance: fedimint_core::Amount,
     ) -> anyhow::Result<(bitcoin::Amount, PegOutFees)> {
-        // Upper bound on the miner fee: the weight only grows as the federation
-        // has to reach for more UTXOs, so no smaller withdrawal costs more.
         let max_fees = self
             .get_withdraw_fees(
                 address,
@@ -1159,9 +1066,6 @@ impl WalletClientModule {
             balance,
             fedimint_core::Amount::from_sats(address.script_pubkey().minimal_non_dust().to_sat()),
             balance,
-            // A peg-out funds a whole number of sats, so round the probe up to
-            // the next sat before adding the miner fee; the solver searches
-            // millisatoshis.
             |amount: fedimint_core::Amount| {
                 fedimint_core::Amount::from_sats(amount.msats.div_ceil(1000)) + max_fee_msats
             },
@@ -1172,14 +1076,7 @@ impl WalletClientModule {
         .await
         .ok_or_else(|| anyhow!("Balance is too low to withdraw any amount after fees"))?;
 
-        // `gross_up` rounded up to whole satoshis, so the largest affordable
-        // amount already sits on a satoshi boundary; no value is lost here.
         let amount = bitcoin::Amount::from_sat(max.msats.div_ceil(1000));
-
-        // Re-quote at the amount actually being withdrawn. This is the fee the
-        // federation recomputes for that amount, so the declared weight
-        // matches; it is at most `max_fees`, which is what keeps `amount`
-        // affordable.
         let fees = self.get_withdraw_fees(address, amount).await?;
 
         Ok((amount, fees))
@@ -1722,65 +1619,33 @@ impl WalletClientModule {
 
         let operation_meta = operation.meta::<WalletOperationMeta>();
 
-        let WalletOperationMetaVariant::Receive {
-            claim_operation_id,
-            tweak_idx,
-            btc_out_point,
-            btc_deposited,
-            ..
-        } = operation_meta.variant
-        else {
-            bail!("Operation is not a receive operation");
-        };
-
-        Ok(self.client_ctx.outcome_or_updates(
-            &operation,
-            operation_id,
-            |state| matches!(
-                state,
-                ReceiveState::Claimed { .. }
-                    | ReceiveState::IgnoredDust { .. }
-                    | ReceiveState::Failed(_)
+        match operation_meta.variant {
+            WalletOperationMetaVariant::Receive { .. } => receive_updates_for_operation(
+                &self.client_ctx,
+                &operation,
+                operation_id,
+                &operation_meta.variant,
             ),
-            {
-            let stream_client_ctx = self.client_ctx.clone();
-            move || {
-
-            stream! {
-                let claimed_peg_in_key = ClaimedPegInKey {
-                    peg_in_index: tweak_idx,
-                    btc_out_point,
-                };
-
-                yield ReceiveState::WaitingForConfirmation {
-                    btc_deposited,
-                    btc_out_point
-                };
-
-                let claim_data = stream_client_ctx.module_db().wait_key_exists(&claimed_peg_in_key).await;
-
-                if claim_data.claim_txid == TransactionId::from_byte_array([0; 32]) && claim_data.change.is_empty() {
-                    yield ReceiveState::IgnoredDust {
-                        btc_deposited,
-                        btc_out_point
-                    };
-                    return;
-                }
-
-                yield ReceiveState::Confirmed {
-                    btc_deposited,
-                    btc_out_point
-                };
-
-                match stream_client_ctx.await_primary_module_outputs(claim_operation_id, claim_data.change).await {
-                    Ok(()) => yield ReceiveState::Claimed {
-                        btc_deposited,
-                        btc_out_point
-                    },
-                    Err(e) => yield ReceiveState::Failed(e.to_string())
-                }
+            WalletOperationMetaVariant::DepositAddress {
+                tweak_idx: Some(tweak_idx),
+                ..
+            } => Ok(UpdateStreamOrOutcome::UpdateStream(Box::pin(
+                bridge_deposit_address_to_receive_updates(
+                    self.client_ctx.clone(),
+                    self.db.clone(),
+                    self.pegin_monitor_wakeup_sender.clone(),
+                    self.pegin_claimed_receiver.clone(),
+                    operation_id,
+                    tweak_idx,
+                ),
+            ))),
+            WalletOperationMetaVariant::DepositAddress {
+                tweak_idx: None, ..
+            } => {
+                bail!("Deposit address operation has no tweak index and cannot be subscribed to")
             }
-        }}))
+            _ => bail!("Operation is not a receive operation"),
+        }
     }
 
     /// Reads the final outcome of a *legacy* deposit operation — a
@@ -2035,38 +1900,12 @@ impl WalletClientModule {
 
     /// Schedule given address for immediate re-check for deposits
     pub async fn recheck_pegin_address(&self, tweak_idx: TweakIdx) -> anyhow::Result<()> {
-        self.db
-            .autocommit(
-                |dbtx, _| {
-                    Box::pin(async {
-                        let db_key = PegInTweakIndexKey(tweak_idx);
-                        let db_val = dbtx
-                            .get_value(&db_key)
-                            .await
-                            .ok_or_else(|| anyhow::format_err!("DBKey not found"))?;
-
-                        dbtx.insert_entry(
-                            &db_key,
-                            &PegInTweakIndexData {
-                                next_check_time: Some(fedimint_core::time::now()),
-                                ..db_val
-                            },
-                        )
-                        .await;
-
-                        let sender = self.pegin_monitor_wakeup_sender.clone();
-                        dbtx.on_commit(move || {
-                            sender.send_replace(());
-                        });
-
-                        Ok::<_, anyhow::Error>(())
-                    })
-                },
-                Some(100),
-            )
-            .await?;
-
-        Ok(())
+        schedule_pegin_recheck(
+            &self.db,
+            self.pegin_monitor_wakeup_sender.clone(),
+            tweak_idx,
+        )
+        .await
     }
 
     /// Await for num deposit by [`OperationId`]
@@ -2381,6 +2220,216 @@ async fn get_next_peg_in_tweak_child_id(dbtx: &mut DatabaseTransaction<'_>) -> T
     dbtx.insert_entry(&NextPegInTweakIndexKey, &(index.next()))
         .await;
     index
+}
+
+async fn schedule_pegin_recheck(
+    db: &Database,
+    pegin_monitor_wakeup_sender: watch::Sender<()>,
+    tweak_idx: TweakIdx,
+) -> anyhow::Result<()> {
+    db.autocommit(
+        |dbtx, _| {
+            let pegin_monitor_wakeup_sender = pegin_monitor_wakeup_sender.clone();
+            Box::pin(async move {
+                let db_key = PegInTweakIndexKey(tweak_idx);
+                let db_val = dbtx
+                    .get_value(&db_key)
+                    .await
+                    .ok_or_else(|| anyhow::format_err!("DBKey not found"))?;
+
+                dbtx.insert_entry(
+                    &db_key,
+                    &PegInTweakIndexData {
+                        next_check_time: Some(fedimint_core::time::now()),
+                        ..db_val
+                    },
+                )
+                .await;
+
+                dbtx.on_commit(move || {
+                    pegin_monitor_wakeup_sender.send_replace(());
+                });
+
+                Ok::<_, anyhow::Error>(())
+            })
+        },
+        Some(100),
+    )
+    .await?;
+
+    Ok(())
+}
+
+fn receive_updates_for_operation(
+    client_ctx: &ClientContext<WalletClientModule>,
+    operation: &OperationLogEntry,
+    operation_id: OperationId,
+    operation_meta_variant: &WalletOperationMetaVariant,
+) -> anyhow::Result<UpdateStreamOrOutcome<ReceiveState>> {
+    let &WalletOperationMetaVariant::Receive {
+        claim_operation_id,
+        tweak_idx,
+        btc_out_point,
+        btc_deposited,
+        ..
+    } = operation_meta_variant
+    else {
+        bail!("Operation is not a receive operation");
+    };
+
+    Ok(client_ctx.outcome_or_updates(
+        operation,
+        operation_id,
+        |state| matches!(
+            state,
+            ReceiveState::Claimed { .. }
+                | ReceiveState::IgnoredDust { .. }
+                | ReceiveState::Failed(_)
+        ),
+        {
+            let stream_client_ctx = client_ctx.clone();
+            move || {
+            stream! {
+                let claimed_peg_in_key = ClaimedPegInKey {
+                    peg_in_index: tweak_idx,
+                    btc_out_point,
+                };
+
+                yield ReceiveState::WaitingForConfirmation {
+                    btc_deposited,
+                    btc_out_point,
+                };
+
+                let claim_data = stream_client_ctx
+                    .module_db()
+                    .wait_key_exists(&claimed_peg_in_key)
+                    .await;
+
+                if claim_data.claim_txid == TransactionId::from_byte_array([0; 32])
+                    && claim_data.change.is_empty()
+                {
+                    yield ReceiveState::IgnoredDust {
+                        btc_deposited,
+                        btc_out_point,
+                    };
+                    return;
+                }
+
+                yield ReceiveState::Confirmed {
+                    btc_deposited,
+                    btc_out_point,
+                };
+
+                match stream_client_ctx
+                    .await_primary_module_outputs(claim_operation_id, claim_data.change)
+                    .await
+                {
+                    Ok(()) => yield ReceiveState::Claimed {
+                        btc_deposited,
+                        btc_out_point,
+                    },
+                    Err(e) => yield ReceiveState::Failed(e.to_string()),
+                }
+            }
+            }
+        },
+    ))
+}
+
+async fn first_receive_operation_for_address(
+    client_ctx: &ClientContext<WalletClientModule>,
+    db: &Database,
+    address_operation_id: OperationId,
+    tweak_idx: TweakIdx,
+) -> Option<OperationId> {
+    let claimed = db
+        .begin_transaction_nc()
+        .await
+        .get_value(&PegInTweakIndexKey(tweak_idx))
+        .await
+        .map(|data| data.claimed)
+        .unwrap_or_default();
+
+    for btc_out_point in claimed {
+        let receive_operation_id =
+            WalletClientModuleData::receive_operation_id(address_operation_id, btc_out_point);
+        if client_ctx
+            .operation_log_entry_exists(receive_operation_id)
+            .await
+        {
+            return Some(receive_operation_id);
+        }
+    }
+
+    None
+}
+
+fn bridge_deposit_address_to_receive_updates(
+    client_ctx: ClientContext<WalletClientModule>,
+    db: Database,
+    pegin_monitor_wakeup_sender: watch::Sender<()>,
+    mut pegin_claimed_receiver: watch::Receiver<()>,
+    address_operation_id: OperationId,
+    tweak_idx: TweakIdx,
+) -> BoxStream<'static, ReceiveState> {
+    Box::pin(stream! {
+        let receive_operation_id = loop {
+            if let Some(receive_operation_id) = first_receive_operation_for_address(
+                &client_ctx,
+                &db,
+                address_operation_id,
+                tweak_idx,
+            )
+            .await
+            {
+                break receive_operation_id;
+            }
+
+            if let Err(error) = schedule_pegin_recheck(
+                &db,
+                pegin_monitor_wakeup_sender.clone(),
+                tweak_idx,
+            )
+            .await
+            {
+                yield ReceiveState::Failed(error.to_string());
+                return;
+            }
+
+            if pegin_claimed_receiver.changed().await.is_err() {
+                yield ReceiveState::Failed(
+                    "Peg-in monitor stopped before receive was found".to_owned(),
+                );
+                return;
+            }
+        };
+
+        let operation = match client_ctx.get_operation(receive_operation_id).await {
+            Ok(operation) => operation,
+            Err(error) => {
+                yield ReceiveState::Failed(error.to_string());
+                return;
+            }
+        };
+        let operation_meta = operation.meta::<WalletOperationMeta>();
+
+        let updates = match receive_updates_for_operation(
+            &client_ctx,
+            &operation,
+            receive_operation_id,
+            &operation_meta.variant,
+        ) {
+            Ok(updates) => updates,
+            Err(error) => {
+                yield ReceiveState::Failed(error.to_string());
+                return;
+            }
+        };
+
+        for await update in updates.into_stream() {
+            yield update;
+        }
+    })
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -84,8 +84,8 @@ use crate::api::WalletFederationApi;
 use crate::backup::{FEDERATION_RECOVER_MAX_GAP, RecoveryStateV2, WalletRecovery};
 use crate::client_db::{
     ClaimedPegInData, ClaimedPegInKey, ClaimedPegInPrefix, NextPegInTweakIndexKey,
-    PegInPoolCursorKey, PegInTweakIndexData, PegInTweakIndexPrefix, ReceiveOperationPrefix,
-    ReceiveOperationsBackfilledKey, RecoveryFinalizedKey, RecoveryStateKey,
+    PegInPoolCursorKey, PegInTweakIndexData, PegInTweakIndexPrefix, ReceiveOperationKey,
+    ReceiveOperationPrefix, ReceiveOperationsBackfilledKey, RecoveryFinalizedKey, RecoveryStateKey,
     SupportsSafeDepositPrefix,
 };
 use crate::deposit::DepositStateMachine;
@@ -119,10 +119,11 @@ pub enum ReceiveState {
     },
     /// The transaction disappeared from watched script history before claim.
     ///
-    /// This state is recoverable: if the same transaction/outpoint later
-    /// reappears the stream returns to
-    /// [`ReceiveState::WaitingForConfirmation`], and if it gets claimed the
-    /// stream continues to [`ReceiveState::Confirmed`] /
+    /// This state is recoverable and non-terminal. While out of mempool the
+    /// subscription parks on peg-in monitor notifications instead of polling
+    /// Bitcoin RPC itself. If the same transaction/outpoint later reappears the
+    /// stream returns to [`ReceiveState::WaitingForConfirmation`], and if it
+    /// gets claimed the stream continues to [`ReceiveState::Confirmed`] /
     /// [`ReceiveState::Claimed`].
     OutOfMempool {
         #[serde(with = "bitcoin::amount::serde::as_sat")]
@@ -428,7 +429,7 @@ impl ClientModuleInit for WalletClientInit {
 
         let module_api = args.module_api().clone();
 
-        let (pegin_claimed_sender, pegin_claimed_receiver) = watch::channel(());
+        let (pegin_monitor_update_sender, pegin_monitor_update_receiver) = watch::channel(());
         let (pegin_monitor_wakeup_sender, pegin_monitor_wakeup_receiver) = watch::channel(());
 
         Ok(WalletClientModule {
@@ -440,8 +441,8 @@ impl ClientModuleInit for WalletClientInit {
             client_ctx: args.context(),
             pegin_monitor_wakeup_sender,
             pegin_monitor_wakeup_receiver,
-            pegin_claimed_receiver,
-            pegin_claimed_sender,
+            pegin_monitor_update_receiver,
+            pegin_monitor_update_sender,
             task_group: args.task_group().clone(),
             client_span: args.client_span().clone(),
             admin_auth: args.admin_auth().cloned(),
@@ -618,9 +619,13 @@ pub struct WalletClientModule {
     /// Updated to wake up pegin monitor
     pegin_monitor_wakeup_sender: watch::Sender<()>,
     pegin_monitor_wakeup_receiver: watch::Receiver<()>,
-    /// Called every time a peg-in was claimed
-    pegin_claimed_sender: watch::Sender<()>,
-    pegin_claimed_receiver: watch::Receiver<()>,
+    /// Notifies receive subscriptions after the peg-in monitor checks deposits.
+    ///
+    /// This is broader than claim notifications: out-of-mempool receive streams
+    /// park on this channel and re-check their operation when the monitor makes
+    /// progress.
+    pegin_monitor_update_sender: watch::Sender<()>,
+    pegin_monitor_update_receiver: watch::Receiver<()>,
     task_group: TaskGroup,
     client_span: tracing::Span,
     admin_auth: Option<ApiAuth>,
@@ -663,7 +668,7 @@ impl ClientModule for WalletClientModule {
                 let btc_rpc = self.rpc.clone();
                 let module_api = self.module_api.clone();
                 let data = self.data.clone();
-                let pegin_claimed_sender = self.pegin_claimed_sender.clone();
+                let pegin_monitor_update_sender = self.pegin_monitor_update_sender.clone();
                 let pegin_monitor_wakeup_receiver = self.pegin_monitor_wakeup_receiver.clone();
                 pegin_monitor::run_peg_in_monitor(
                     client_ctx,
@@ -671,7 +676,7 @@ impl ClientModule for WalletClientModule {
                     btc_rpc,
                     module_api,
                     data,
-                    pegin_claimed_sender,
+                    pegin_monitor_update_sender,
                     pegin_monitor_wakeup_receiver,
                 )
             });
@@ -851,6 +856,47 @@ impl Context for WalletClientContext {
 }
 
 impl WalletClientModule {
+    async fn receive_operations_need_backfill(
+        dbtx: &mut DatabaseTransaction<'_>,
+        peg_in_entries: &[(PegInTweakIndexKey, PegInTweakIndexData)],
+    ) -> bool {
+        for (key, peg_in_data) in peg_in_entries {
+            for btc_out_point in &peg_in_data.claimed {
+                if dbtx
+                    .get_value(&ReceiveOperationKey {
+                        peg_in_index: key.0,
+                        btc_out_point: *btc_out_point,
+                    })
+                    .await
+                    .is_none()
+                {
+                    return true;
+                }
+            }
+        }
+
+        false
+    }
+
+    async fn mark_receive_backfill_inspected(
+        dbtx: &mut DatabaseTransaction<'_>,
+        tweak_idx: TweakIdx,
+        btc_out_point: bitcoin::OutPoint,
+        creation_time: SystemTime,
+    ) {
+        dbtx.insert_entry(
+            &ReceiveOperationKey {
+                peg_in_index: tweak_idx,
+                btc_out_point,
+            },
+            &creation_time
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs(),
+        )
+        .await;
+    }
+
     fn cfg(&self) -> &WalletClientConfig {
         &self.data.cfg
     }
@@ -882,7 +928,7 @@ impl WalletClientModule {
         self.cfg().fee_consensus
     }
 
-    /// One-time migration that creates a per-UTXO
+    /// Startup migration that creates a per-UTXO
     /// [`WalletOperationMetaVariant::Receive`] operation-log entry for deposits
     /// that were already claimed before receive operations were tracked
     /// individually.
@@ -936,22 +982,28 @@ impl WalletClientModule {
 
         let mut dbtx = self.db.begin_transaction().await;
 
-        if dbtx
+        let backfill_was_completed = dbtx
             .get_value(&ReceiveOperationsBackfilledKey)
             .await
-            .is_some()
-        {
-            return Ok(());
-        }
-
-        let deposit_amounts =
-            collect_deposit_confirmed_amounts(&mut dbtx.to_ref_nc(), &self.client_ctx).await?;
+            .is_some();
 
         let peg_in_entries = dbtx
             .find_by_prefix(&PegInTweakIndexPrefix)
             .await
             .collect::<Vec<_>>()
             .await;
+
+        if backfill_was_completed
+            && !Self::receive_operations_need_backfill(&mut dbtx.to_ref_nc(), &peg_in_entries).await
+        {
+            return Ok(());
+        }
+
+        // Recovery can populate peg-in records after an earlier startup marked
+        // the migration complete. Only rescan the event log when a claimed
+        // outpoint is missing its receive operation.
+        let deposit_amounts =
+            collect_deposit_confirmed_amounts(&mut dbtx.to_ref_nc(), &self.client_ctx).await?;
 
         for (key, peg_in_data) in peg_in_entries {
             let tweak_idx = key.0;
@@ -966,6 +1018,17 @@ impl WalletClientModule {
                 let Some((btc_deposited, creation_time)) =
                     deposit_amounts.get(&btc_out_point).copied()
                 else {
+                    // Persist that this outpoint was inspected even though old
+                    // clients did not emit enough event data to reconstruct a
+                    // receive operation. Otherwise every startup would rescan
+                    // the entire event log for the same legacy or dust outpoint.
+                    Self::mark_receive_backfill_inspected(
+                        &mut dbtx.to_ref_nc(),
+                        tweak_idx,
+                        btc_out_point,
+                        peg_in_data.creation_time,
+                    )
+                    .await;
                     continue;
                 };
 
@@ -1654,6 +1717,7 @@ impl WalletClientModule {
             client_ctx: self.client_ctx.clone(),
             rpc: self.rpc.clone(),
             network: self.cfg().network.0,
+            pegin_monitor_update_receiver: self.pegin_monitor_update_receiver.clone(),
         };
 
         match operation_meta.variant {
@@ -1671,7 +1735,7 @@ impl WalletClientModule {
                     receive_update_context,
                     self.db.clone(),
                     self.pegin_monitor_wakeup_sender.clone(),
-                    self.pegin_claimed_receiver.clone(),
+                    self.pegin_monitor_update_receiver.clone(),
                     operation_id,
                     tweak_idx,
                 ),
@@ -1851,7 +1915,7 @@ impl WalletClientModule {
         &self,
         operation_id: OperationId,
     ) -> anyhow::Result<TweakIdx> {
-        Ok(self
+        if let Some((key, _)) = self
             .client_ctx
             .module_db()
             .clone()
@@ -1862,9 +1926,50 @@ impl WalletClientModule {
             .filter(|(_k, v)| future::ready(v.operation_id == operation_id))
             .next()
             .await
-            .ok_or_else(|| anyhow::format_err!("OperationId not found"))?
-            .0
-            .0)
+        {
+            return Ok(key.0);
+        }
+
+        // A restore without a backup only persists indices observed in
+        // federation history. A deposit address handed out immediately before
+        // the restore can therefore be inside the recovery gap without having a
+        // DB record yet. Recover that deterministic index on demand so legacy
+        // `await-deposit --operation-id` callers can continue monitoring it.
+        let mut dbtx = self.db.begin_transaction().await;
+        let next_tweak_idx = dbtx
+            .get_value(&NextPegInTweakIndexKey)
+            .await
+            .unwrap_or_default();
+        let search_end = next_tweak_idx.0.saturating_add(FEDERATION_RECOVER_MAX_GAP);
+        let recovered_tweak_idx = (0..=search_end)
+            .map(TweakIdx)
+            .find(|tweak_idx| self.data.derive_deposit_address(*tweak_idx).3 == operation_id)
+            .ok_or_else(|| anyhow::format_err!("OperationId not found"))?;
+
+        let now = fedimint_core::time::now();
+        dbtx.insert_entry(
+            &PegInTweakIndexKey(recovered_tweak_idx),
+            &PegInTweakIndexData {
+                creation_time: now,
+                next_check_time: Some(now),
+                last_check_time: None,
+                operation_id,
+                claimed: vec![],
+            },
+        )
+        .await;
+
+        if next_tweak_idx.0 <= recovered_tweak_idx.0 {
+            dbtx.insert_entry(
+                &NextPegInTweakIndexKey,
+                &TweakIdx(recovered_tweak_idx.0.saturating_add(1)),
+            )
+            .await;
+        }
+
+        dbtx.commit_tx().await;
+
+        Ok(recovered_tweak_idx)
     }
 
     pub async fn get_pegin_tweak_idx(
@@ -1972,7 +2077,7 @@ impl WalletClientModule {
     ) -> anyhow::Result<()> {
         let operation_id = self.get_pegin_tweak_idx(tweak_idx).await?.operation_id;
 
-        let mut receiver = self.pegin_claimed_receiver.clone();
+        let mut receiver = self.pegin_monitor_update_receiver.clone();
         let mut backoff = backoff_util::aggressive_backoff();
 
         loop {
@@ -2019,8 +2124,22 @@ impl WalletClientModule {
                     .transaction_updates(claim_operation_id)
                     .await;
 
-                if let Err(e) = tx_subscriber.await_tx_accepted(transaction_id).await {
-                    bail!("{e}");
+                if let Err(error) = tx_subscriber.await_tx_accepted(transaction_id).await {
+                    // A backup can be restored after another client using the
+                    // same seed already claimed this outpoint. Recovery still
+                    // discovers the Bitcoin output, but the replacement claim
+                    // is correctly rejected by the federation. Treat that
+                    // authoritative rejection as completed instead of failing
+                    // the legacy address-level wait.
+                    if error.contains("peg-in was already claimed") {
+                        debug!(
+                            target: LOG_CLIENT_MODULE_WALLET,
+                            %btc_out_point,
+                            "Peg-in was already claimed before this client restored it"
+                        );
+                        continue;
+                    }
+                    bail!("{error}");
                 }
 
                 debug!(target: LOG_CLIENT_MODULE_WALLET, out_points=?change, "Ensuring outputs claimed");
@@ -2302,6 +2421,7 @@ struct ReceiveUpdateContext {
     client_ctx: ClientContext<WalletClientModule>,
     rpc: DynBitcoindRpc,
     network: Network,
+    pegin_monitor_update_receiver: watch::Receiver<()>,
 }
 
 fn history_contains_outpoint(
@@ -2384,6 +2504,8 @@ fn receive_updates_for_operation(
         {
             let stream_client_ctx = context.client_ctx.clone();
             let stream_rpc = context.rpc.clone();
+            let mut stream_pegin_monitor_update_receiver =
+                context.pegin_monitor_update_receiver.clone();
             move || {
             stream! {
                 let claimed_peg_in_key = ClaimedPegInKey {
@@ -2451,7 +2573,24 @@ fn receive_updates_for_operation(
                         }
                     }
 
-                    sleep(poll_interval).await;
+                    if reported_out_of_mempool {
+                        // Once a receive transaction disappears, do not keep one
+                        // Bitcoin RPC polling loop per subscriber alive. The
+                        // peg-in monitor already owns the persisted, decaying
+                        // recheck schedule for deposit addresses, so park this
+                        // recoverable operation until the monitor reports that
+                        // it checked peg-ins again. This keeps `OutOfMempool`
+                        // non-terminal without turning it into permanent
+                        // per-subscription polling.
+                        if stream_pegin_monitor_update_receiver.changed().await.is_err() {
+                            yield ReceiveState::Failed(
+                                "Peg-in monitor stopped before receive was claimed".to_owned(),
+                            );
+                            return;
+                        }
+                    } else {
+                        sleep(poll_interval).await;
+                    }
                 };
 
                 if claim_data.claim_txid == TransactionId::from_byte_array([0; 32])
@@ -2539,7 +2678,7 @@ fn bridge_deposit_address_to_receive_updates(
     context: ReceiveUpdateContext,
     db: Database,
     pegin_monitor_wakeup_sender: watch::Sender<()>,
-    mut pegin_claimed_receiver: watch::Receiver<()>,
+    mut pegin_monitor_update_receiver: watch::Receiver<()>,
     address_operation_id: OperationId,
     tweak_idx: TweakIdx,
 ) -> BoxStream<'static, ReceiveState> {
@@ -2567,7 +2706,7 @@ fn bridge_deposit_address_to_receive_updates(
                 return;
             }
 
-            if pegin_claimed_receiver.changed().await.is_err() {
+            if pegin_monitor_update_receiver.changed().await.is_err() {
                 yield ReceiveState::Failed(
                     "Peg-in monitor stopped before receive was found".to_owned(),
                 );

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -19,17 +19,17 @@ pub mod client_db;
 /// but retained for time being to ensure existing peg-ins complete.
 mod deposit;
 pub mod events;
-use events::SendPaymentEvent;
 #[cfg(feature = "uniffi")]
 pub mod ffi;
+use events::{DepositConfirmed, SendPaymentEvent};
 /// Peg-in monitor: a task monitoring deposit addresses for peg-ins.
 mod pegin_monitor;
 mod withdraw;
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::future;
 use std::sync::Arc;
-use std::time::{Duration, SystemTime};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context as AnyhowContext, anyhow, bail, ensure};
 use async_stream::{stream, try_stream};
@@ -63,13 +63,13 @@ use fedimint_core::module::{
     ModuleInit, MultiApiVersion,
 };
 use fedimint_core::task::{MaybeSend, MaybeSync, TaskGroup, sleep};
-use fedimint_core::util::backoff_util::background_backoff;
-use fedimint_core::util::{BoxStream, backoff_util, retry};
+use fedimint_core::util::{BoxStream, FmtCompactAnyhow as _, backoff_util};
 use fedimint_core::{
     BitcoinHash, OutPoint, TransactionId, apply, async_trait_maybe_send, push_db_pair_items,
     runtime, secp256k1,
 };
 use fedimint_derive_secret::{ChildId, DerivableSecret};
+use fedimint_eventlog::Event as _;
 use fedimint_logging::LOG_CLIENT_MODULE_WALLET;
 pub use fedimint_wallet_common as common;
 use fedimint_wallet_common::config::{FeeConsensus, WalletClientConfig};
@@ -87,8 +87,8 @@ use crate::api::WalletFederationApi;
 use crate::backup::{FEDERATION_RECOVER_MAX_GAP, RecoveryStateV2, WalletRecovery};
 use crate::client_db::{
     ClaimedPegInData, ClaimedPegInKey, ClaimedPegInPrefix, NextPegInTweakIndexKey,
-    PegInPoolCursorKey, PegInTweakIndexData, PegInTweakIndexPrefix, RecoveryFinalizedKey,
-    RecoveryStateKey, SupportsSafeDepositPrefix,
+    PegInPoolCursorKey, PegInTweakIndexData, PegInTweakIndexPrefix, ReceiveOperationsBackfilledKey,
+    RecoveryFinalizedKey, RecoveryStateKey, SupportsSafeDepositPrefix,
 };
 use crate::deposit::DepositStateMachine;
 use crate::withdraw::{CreatedWithdrawState, WithdrawStateMachine, WithdrawStates};
@@ -132,6 +132,54 @@ pub enum DepositStateV2 {
         btc_deposited: bitcoin::Amount,
         btc_out_point: bitcoin::OutPoint,
     },
+    Failed(String),
+}
+
+/// State of a single on-chain receive (peg-in of one UTXO), as streamed by
+/// [`WalletClientModule::subscribe_receive`].
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+pub enum ReceiveState {
+    WaitingForConfirmation {
+        #[serde(with = "bitcoin::amount::serde::as_sat")]
+        btc_deposited: bitcoin::Amount,
+        btc_out_point: bitcoin::OutPoint,
+    },
+    Confirmed {
+        #[serde(with = "bitcoin::amount::serde::as_sat")]
+        btc_deposited: bitcoin::Amount,
+        btc_out_point: bitcoin::OutPoint,
+    },
+    Claimed {
+        #[serde(with = "bitcoin::amount::serde::as_sat")]
+        btc_deposited: bitcoin::Amount,
+        btc_out_point: bitcoin::OutPoint,
+    },
+    IgnoredDust {
+        #[serde(with = "bitcoin::amount::serde::as_sat")]
+        btc_deposited: bitcoin::Amount,
+        btc_out_point: bitcoin::OutPoint,
+    },
+    Failed(String),
+}
+
+/// Final state of a legacy deposit, returned by
+/// [`WalletClientModule::get_legacy_deposit_outcome`]. Legacy deposits only
+/// ever reached a claimed or failed terminal state, so only those are
+/// represented here.
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LegacyDepositOutcome {
+    /// This deposit's UTXO has been migrated to a per-UTXO `Receive` operation.
+    /// Pass `receive_operation_id` to [`WalletClientModule::subscribe_receive`]
+    /// instead of reading the legacy outcome.
+    Migrated { receive_operation_id: OperationId },
+    /// The deposit was claimed.
+    Claimed {
+        #[serde(with = "bitcoin::amount::serde::as_sat")]
+        btc_deposited: bitcoin::Amount,
+        btc_out_point: bitcoin::OutPoint,
+    },
+    /// The deposit failed.
     Failed(String),
 }
 
@@ -340,6 +388,12 @@ impl ModuleInit for WalletClientInit {
                         wallet_client_items.insert("PegInPoolCursor".to_string(), Box::new(cursor));
                     }
                 }
+                DbKeyPrefix::ReceiveOperationsBackfilled => {
+                    if let Some(val) = dbtx.get_value(&ReceiveOperationsBackfilledKey).await {
+                        wallet_client_items
+                            .insert("ReceiveOperationsBackfilled".to_string(), Box::new(val));
+                    }
+                }
                 DbKeyPrefix::RecoveryState
                 | DbKeyPrefix::ExternalReservedStart
                 | DbKeyPrefix::CoreInternalReservedStart
@@ -474,7 +528,9 @@ pub struct WalletOperationMeta {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum WalletOperationMetaVariant {
-    Deposit {
+    // Renamed from `deposit` in 0.12.
+    #[serde(alias = "deposit")]
+    DepositAddress {
         address: Address<NetworkUnchecked>,
         /// Added in 0.4.2, can be `None` for old deposits or `Some` for ones
         /// using the pegin monitor. The value is the child index of the key
@@ -484,6 +540,19 @@ pub enum WalletOperationMetaVariant {
         tweak_idx: Option<TweakIdx>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         expires_at: Option<SystemTime>,
+    },
+    Receive {
+        /// Operation for the static address allocation this receive belongs to.
+        address_operation_id: OperationId,
+        /// Operation that owns the claim transaction/state machines. For new
+        /// receives this is the receive operation itself. For receives
+        /// backfilled from old storage this can be the address operation id.
+        claim_operation_id: OperationId,
+        address: Address<NetworkUnchecked>,
+        tweak_idx: TweakIdx,
+        btc_out_point: bitcoin::OutPoint,
+        #[serde(with = "bitcoin::amount::serde::as_sat")]
+        btc_deposited: bitcoin::Amount,
     },
     Withdraw {
         address: Address<NetworkUnchecked>,
@@ -507,6 +576,17 @@ pub struct WalletClientModuleData {
 }
 
 impl WalletClientModuleData {
+    pub(crate) fn receive_operation_id(
+        address_operation_id: OperationId,
+        btc_out_point: bitcoin::OutPoint,
+    ) -> OperationId {
+        OperationId::from_encodable(&(
+            b"wallet-v1-receive".to_vec(),
+            address_operation_id,
+            btc_out_point,
+        ))
+    }
+
     fn derive_deposit_address(
         &self,
         idx: TweakIdx,
@@ -591,6 +671,14 @@ impl ClientModule for WalletClientModule {
     }
 
     async fn start(&self) {
+        if let Err(error) = self.backfill_receive_operations().await {
+            tracing::warn!(
+                target: LOG_CLIENT_MODULE_WALLET,
+                err = %error.fmt_compact_anyhow(),
+                "Failed to backfill wallet receive operation log entries"
+            );
+        }
+
         self.task_group
             .spawn_cancellable_with_span(self.client_span.clone(), "peg-in monitor", {
                 let client_ctx = self.client_ctx.clone();
@@ -708,9 +796,9 @@ impl ClientModule for WalletClientModule {
                     let result = serde_json::to_value(&response)?;
                     yield result;
                 },
-                "subscribe_deposit" => {
-                    let req: SubscribeDepositRequest = serde_json::from_value(request)?;
-                    for await state in self.subscribe_deposit(req.operation_id).await?.into_stream() {
+                "subscribe_receive" => {
+                    let req: SubscribeReceiveRequest = serde_json::from_value(request)?;
+                    for await state in self.subscribe_receive(req.operation_id).await?.into_stream() {
                         yield serde_json::to_value(state)?;
                     }
                 },
@@ -760,7 +848,7 @@ uniffi::custom_type!(PegInRequest, String, {
 });
 
 #[derive(Deserialize)]
-struct SubscribeDepositRequest {
+struct SubscribeReceiveRequest {
     operation_id: OperationId,
 }
 
@@ -824,6 +912,122 @@ impl WalletClientModule {
 
     pub fn get_fee_consensus(&self) -> FeeConsensus {
         self.cfg().fee_consensus
+    }
+
+    /// One-time migration that creates a per-UTXO
+    /// [`WalletOperationMetaVariant::Receive`] operation-log entry for deposits
+    /// that were already claimed before receive operations were tracked
+    /// individually.
+    async fn backfill_receive_operations(&self) -> anyhow::Result<()> {
+        /// Scans the event log for [`DepositConfirmed`] events, returning the
+        /// deposited amount and confirmation time keyed by the on-chain
+        /// outpoint. Walking the whole (potentially large) event log is
+        /// acceptable because the backfill only runs once.
+        async fn collect_deposit_confirmed_amounts(
+            dbtx: &mut DatabaseTransaction<'_>,
+            client_ctx: &ClientContext<WalletClientModule>,
+        ) -> anyhow::Result<HashMap<bitcoin::OutPoint, (bitcoin::Amount, SystemTime)>> {
+            const PAGE_SIZE: u64 = 1000;
+
+            let mut cursor = None;
+            let mut amounts = HashMap::new();
+
+            loop {
+                let events = client_ctx.get_event_log_dbtx(dbtx, cursor, PAGE_SIZE).await;
+                if events.is_empty() {
+                    break;
+                }
+
+                for entry in &events {
+                    let entry = entry.as_raw();
+                    if entry.kind == DepositConfirmed::KIND
+                        && entry.module_kind() == DepositConfirmed::MODULE.as_ref()
+                        && let Some(event) = entry.to_event::<DepositConfirmed>()
+                    {
+                        amounts.insert(
+                            bitcoin::OutPoint {
+                                txid: event.txid,
+                                vout: event.out_idx,
+                            },
+                            (
+                                bitcoin::Amount::from_sat(event.amount.try_into_sats()?),
+                                UNIX_EPOCH + Duration::from_micros(entry.ts_usecs),
+                            ),
+                        );
+                    }
+                }
+
+                cursor = events.last().map(|entry| entry.id().next());
+            }
+
+            Ok(amounts)
+        }
+
+        let mut dbtx = self.db.begin_transaction().await;
+
+        if dbtx
+            .get_value(&ReceiveOperationsBackfilledKey)
+            .await
+            .is_some()
+        {
+            return Ok(());
+        }
+
+        let deposit_amounts =
+            collect_deposit_confirmed_amounts(&mut dbtx.to_ref_nc(), &self.client_ctx).await?;
+
+        let peg_in_entries = dbtx
+            .find_by_prefix(&PegInTweakIndexPrefix)
+            .await
+            .collect::<Vec<_>>()
+            .await;
+
+        for (key, peg_in_data) in peg_in_entries {
+            let tweak_idx = key.0;
+            let (_script, address, _tweak_key, derived_address_operation_id) =
+                self.data.derive_peg_in_script(tweak_idx);
+            debug_assert_eq!(derived_address_operation_id, peg_in_data.operation_id);
+
+            for btc_out_point in peg_in_data.claimed {
+                // Dust deposits are never claimed and don't emit a
+                // `DepositConfirmed` event, so a missing entry here also filters
+                // them out (just like the live path's `IgnoredDust` handling).
+                let Some((btc_deposited, creation_time)) =
+                    deposit_amounts.get(&btc_out_point).copied()
+                else {
+                    continue;
+                };
+
+                let receive_operation_id = WalletClientModuleData::receive_operation_id(
+                    peg_in_data.operation_id,
+                    btc_out_point,
+                );
+
+                pegin_monitor::ensure_receive_operation(
+                    &mut dbtx.to_ref_nc(),
+                    &self.client_ctx,
+                    receive_operation_id,
+                    WalletOperationMetaVariant::Receive {
+                        address_operation_id: peg_in_data.operation_id,
+                        // Old claims ran under the address operation, so that's
+                        // the operation that owns the claim transaction.
+                        claim_operation_id: peg_in_data.operation_id,
+                        address: address.clone().into_unchecked(),
+                        tweak_idx,
+                        btc_out_point,
+                        btc_deposited,
+                    },
+                    creation_time,
+                )
+                .await;
+            }
+        }
+
+        dbtx.insert_entry(&ReceiveOperationsBackfilledKey, &())
+            .await;
+        dbtx.commit_tx().await;
+
+        Ok(())
     }
 
     async fn allocate_deposit_address_inner(
@@ -1187,7 +1391,7 @@ impl WalletClientModule {
                                 deposit_address.operation_id,
                                 WalletCommonInit::KIND.as_str(),
                                 WalletOperationMeta {
-                                    variant: WalletOperationMetaVariant::Deposit {
+                                    variant: WalletOperationMetaVariant::DepositAddress {
                                         address: deposit_address.address.clone().into_unchecked(),
                                         tweak_idx: Some(deposit_address.tweak_idx),
                                         expires_at: None,
@@ -1313,7 +1517,7 @@ impl WalletClientModule {
                                 deposit_address.operation_id,
                                 WalletCommonInit::KIND.as_str(),
                                 WalletOperationMeta {
-                                    variant: WalletOperationMetaVariant::Deposit {
+                                    variant: WalletOperationMetaVariant::DepositAddress {
                                         address: deposit_address.address.clone().into_unchecked(),
                                         tweak_idx: Some(deposit_address.tweak_idx),
                                         expires_at: None,
@@ -1501,15 +1705,11 @@ impl WalletClientModule {
         Ok(result)
     }
 
-    /// Returns a stream of updates about an ongoing deposit operation created
-    /// with [`WalletClientModule::allocate_deposit_address_expert_only`].
-    /// Returns an error for old deposit operations created prior to the 0.4
-    /// release and not driven to completion yet. This should be rare enough
-    /// that an indeterminate state is ok here.
-    pub async fn subscribe_deposit(
+    /// Returns a stream of updates about a concrete receive operation.
+    pub async fn subscribe_receive(
         &self,
         operation_id: OperationId,
-    ) -> anyhow::Result<UpdateStreamOrOutcome<DepositStateV2>> {
+    ) -> anyhow::Result<UpdateStreamOrOutcome<ReceiveState>> {
         let operation = self
             .client_ctx
             .get_operation(operation_id)
@@ -1522,109 +1722,191 @@ impl WalletClientModule {
 
         let operation_meta = operation.meta::<WalletOperationMeta>();
 
-        let WalletOperationMetaVariant::Deposit {
-            address, tweak_idx, ..
+        let WalletOperationMetaVariant::Receive {
+            claim_operation_id,
+            tweak_idx,
+            btc_out_point,
+            btc_deposited,
+            ..
         } = operation_meta.variant
         else {
-            bail!("Operation is not a deposit operation");
-        };
-
-        let address = address.require_network(self.cfg().network.0)?;
-
-        // The old deposit operations don't have tweak_idx set
-        let Some(tweak_idx) = tweak_idx else {
-            // In case we are dealing with an old deposit that still uses state machines we
-            // don't have the logic here anymore to subscribe to updates. We can still read
-            // the final state though if it reached any.
-            let outcome_v1 = operation
-                .outcome::<DepositStateV1>()
-                .context("Old pending deposit, can't subscribe to updates")?;
-
-            let outcome_v2 = match outcome_v1 {
-                DepositStateV1::Claimed(tx_info) => DepositStateV2::Claimed {
-                    btc_deposited: tx_info.btc_transaction.output[tx_info.out_idx as usize].value,
-                    btc_out_point: bitcoin::OutPoint {
-                        txid: tx_info.btc_transaction.compute_txid(),
-                        vout: tx_info.out_idx,
-                    },
-                },
-                DepositStateV1::Failed(error) => DepositStateV2::Failed(error),
-                _ => bail!("Non-final outcome in operation log"),
-            };
-
-            return Ok(UpdateStreamOrOutcome::Outcome(outcome_v2));
+            bail!("Operation is not a receive operation");
         };
 
         Ok(self.client_ctx.outcome_or_updates(
             &operation,
             operation_id,
-            |state| match state {
-                DepositStateV2::WaitingForTransaction
-                | DepositStateV2::WaitingForConfirmation { .. }
-                | DepositStateV2::Confirmed { .. } => false,
-                DepositStateV2::Claimed { .. } | DepositStateV2::Failed(_) => true,
-            },
+            |state| matches!(
+                state,
+                ReceiveState::Claimed { .. }
+                    | ReceiveState::IgnoredDust { .. }
+                    | ReceiveState::Failed(_)
+            ),
             {
-            let stream_rpc = self.rpc.clone();
             let stream_client_ctx = self.client_ctx.clone();
-            let stream_script_pub_key = address.script_pubkey();
             move || {
 
             stream! {
-                yield DepositStateV2::WaitingForTransaction;
-
-                retry(
-                    "subscribe script history",
-                    background_backoff(),
-                    || stream_rpc.watch_script_history(&stream_script_pub_key)
-                ).await.expect("Will never give up");
-                let (btc_out_point, btc_deposited) = retry(
-                    "fetch history",
-                    background_backoff(),
-                    || async {
-                        let history = stream_rpc.get_script_history(&stream_script_pub_key).await?;
-                        history.first().and_then(|tx| {
-                            let (out_idx, amount) = tx.output
-                                .iter()
-                                .enumerate()
-                                .find_map(|(idx, output)| (output.script_pubkey == stream_script_pub_key).then_some((idx, output.value)))?;
-                            let txid = tx.compute_txid();
-
-                            Some((
-                                bitcoin::OutPoint {
-                                    txid,
-                                    vout: out_idx as u32,
-                                },
-                                amount
-                            ))
-                        }).context("No deposit transaction found")
-                    }
-                ).await.expect("Will never give up");
-
-                yield DepositStateV2::WaitingForConfirmation {
-                    btc_deposited,
-                    btc_out_point
-                };
-
-                let claim_data = stream_client_ctx.module_db().wait_key_exists(&ClaimedPegInKey {
+                let claimed_peg_in_key = ClaimedPegInKey {
                     peg_in_index: tweak_idx,
                     btc_out_point,
-                }).await;
+                };
 
-                yield DepositStateV2::Confirmed {
+                yield ReceiveState::WaitingForConfirmation {
                     btc_deposited,
                     btc_out_point
                 };
 
-                match stream_client_ctx.await_primary_module_outputs(operation_id, claim_data.change).await {
-                    Ok(()) => yield DepositStateV2::Claimed {
+                let claim_data = stream_client_ctx.module_db().wait_key_exists(&claimed_peg_in_key).await;
+
+                if claim_data.claim_txid == TransactionId::from_byte_array([0; 32]) && claim_data.change.is_empty() {
+                    yield ReceiveState::IgnoredDust {
+                        btc_deposited,
+                        btc_out_point
+                    };
+                    return;
+                }
+
+                yield ReceiveState::Confirmed {
+                    btc_deposited,
+                    btc_out_point
+                };
+
+                match stream_client_ctx.await_primary_module_outputs(claim_operation_id, claim_data.change).await {
+                    Ok(()) => yield ReceiveState::Claimed {
                         btc_deposited,
                         btc_out_point
                     },
-                    Err(e) => yield DepositStateV2::Failed(e.to_string())
+                    Err(e) => yield ReceiveState::Failed(e.to_string())
                 }
             }
         }}))
+    }
+
+    /// Reads the final outcome of a *legacy* deposit operation — a
+    /// [`WalletOperationMetaVariant::DepositAddress`] operation from before
+    /// receives were tracked as their own per-UTXO operations.
+    ///
+    /// This is the back-compat counterpart to [`Self::subscribe_receive`] for
+    /// older deposits that predate per-UTXO receive operations and so can't be
+    /// subscribed to. Such a deposit can no longer be driven to completion, but
+    /// the final state it reached can still be surfaced.
+    ///
+    /// If this deposit's UTXO has since been migrated to a per-UTXO `Receive`
+    /// operation, returns [`LegacyDepositOutcome::Migrated`] with the operation
+    /// id to pass to [`Self::subscribe_receive`] instead.
+    ///
+    /// Returns `Ok(None)` if the deposit has no recorded final outcome (e.g. an
+    /// old deposit that never completed), and an error if `operation_id` is not
+    /// a legacy deposit operation.
+    pub async fn get_legacy_deposit_outcome(
+        &self,
+        operation_id: OperationId,
+    ) -> anyhow::Result<Option<LegacyDepositOutcome>> {
+        // Pre-0.4.2 state-machine deposit outcome. Only the terminal variants
+        // we can act on are kept; anything else fails to decode and is treated
+        // as "no usable outcome".
+        #[derive(Deserialize)]
+        enum DepositFinalStateV1 {
+            Claimed {
+                btc_transaction: bitcoin::Transaction,
+                out_idx: u32,
+            },
+            Failed(String),
+        }
+
+        // 0.4.2–0.5 pegin-monitor deposit outcome (the pre-rename
+        // `DepositStateV2`), again only the terminal variants.
+        #[derive(Deserialize)]
+        enum DepositFinalStateV2 {
+            Claimed {
+                #[serde(with = "bitcoin::amount::serde::as_sat")]
+                btc_deposited: bitcoin::Amount,
+                btc_out_point: bitcoin::OutPoint,
+            },
+            Failed(String),
+        }
+
+        let operation = self
+            .client_ctx
+            .get_operation(operation_id)
+            .await
+            .with_context(|| anyhow!("Operation not found: {}", operation_id.fmt_short()))?;
+
+        let WalletOperationMetaVariant::DepositAddress { .. } =
+            operation.meta::<WalletOperationMeta>().variant
+        else {
+            bail!("Operation is not a legacy deposit operation");
+        };
+
+        // 0.5–0.11 deposits cached a `DepositStateV2` outcome; pre-0.4.2
+        // state-machine deposits cached a `DepositStateV1` outcome (which fails
+        // to decode as the former and falls through to the conversion below).
+        let outcome = if let Ok(Some(outcome)) = operation.try_outcome::<DepositFinalStateV2>() {
+            match outcome {
+                DepositFinalStateV2::Claimed {
+                    btc_deposited,
+                    btc_out_point,
+                } => LegacyDepositOutcome::Claimed {
+                    btc_deposited,
+                    btc_out_point,
+                },
+                DepositFinalStateV2::Failed(error) => LegacyDepositOutcome::Failed(error),
+            }
+        } else {
+            // No cached outcome means the deposit never reached a terminal
+            // state we recorded.
+            let Some(outcome) = operation
+                .try_outcome::<DepositFinalStateV1>()
+                .context("Failed to decode legacy deposit outcome")?
+            else {
+                return Ok(None);
+            };
+
+            match outcome {
+                DepositFinalStateV1::Claimed {
+                    btc_transaction,
+                    out_idx,
+                } => {
+                    let txid = btc_transaction.compute_txid();
+                    let btc_deposited = btc_transaction
+                        .output
+                        .get(out_idx as usize)
+                        .with_context(|| {
+                            format!("Legacy deposit outcome references missing output {out_idx} of {txid}")
+                        })?
+                        .value;
+
+                    LegacyDepositOutcome::Claimed {
+                        btc_deposited,
+                        btc_out_point: bitcoin::OutPoint {
+                            txid,
+                            vout: out_idx,
+                        },
+                    }
+                }
+                DepositFinalStateV1::Failed(error) => LegacyDepositOutcome::Failed(error),
+            }
+        };
+
+        // If this deposit's own UTXO already has a per-UTXO `Receive` operation
+        // (created by the live monitor or the one-time backfill), the legacy
+        // outcome is superseded; point the caller at `subscribe_receive`.
+        if let LegacyDepositOutcome::Claimed { btc_out_point, .. } = &outcome {
+            let receive_operation_id =
+                WalletClientModuleData::receive_operation_id(operation_id, *btc_out_point);
+            if self
+                .client_ctx
+                .operation_log_entry_exists(receive_operation_id)
+                .await
+            {
+                return Ok(Some(LegacyDepositOutcome::Migrated {
+                    receive_operation_id,
+                }));
+            }
+        }
+
+        Ok(Some(outcome))
     }
 
     pub async fn list_peg_in_tweak_idxes(&self) -> BTreeMap<TweakIdx, PegInTweakIndexData> {
@@ -1835,14 +2117,31 @@ impl WalletClientModule {
 
             debug!(target: LOG_CLIENT_MODULE_WALLET, has=pegins.len(), "Enough deposits detected");
 
-            for (_outpoint, transaction_id, change) in pegins {
+            for (btc_out_point, transaction_id, change) in pegins {
                 if transaction_id == TransactionId::from_byte_array([0; 32]) && change.is_empty() {
                     debug!(target: LOG_CLIENT_MODULE_WALLET, "Deposited amount was too low, skipping");
                     continue;
                 }
 
+                let receive_operation_id =
+                    WalletClientModuleData::receive_operation_id(operation_id, btc_out_point);
+                let claim_operation_id = match self
+                    .client_ctx
+                    .get_operation(receive_operation_id)
+                    .await
+                    .map(|operation| operation.meta::<WalletOperationMeta>().variant)
+                {
+                    Ok(WalletOperationMetaVariant::Receive {
+                        claim_operation_id, ..
+                    }) => claim_operation_id,
+                    Ok(_) | Err(_) => operation_id,
+                };
+
                 debug!(target: LOG_CLIENT_MODULE_WALLET, out_points=?change, "Ensuring deposists claimed");
-                let tx_subscriber = self.client_ctx.transaction_updates(operation_id).await;
+                let tx_subscriber = self
+                    .client_ctx
+                    .transaction_updates(claim_operation_id)
+                    .await;
 
                 if let Err(e) = tx_subscriber.await_tx_accepted(transaction_id).await {
                     bail!("{e}");
@@ -1850,7 +2149,7 @@ impl WalletClientModule {
 
                 debug!(target: LOG_CLIENT_MODULE_WALLET, out_points=?change, "Ensuring outputs claimed");
                 self.client_ctx
-                    .await_primary_module_outputs(operation_id, change)
+                    .await_primary_module_outputs(claim_operation_id, change)
                     .await
                     .expect("Cannot fail if tx was accepted and federation is honest");
             }

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -76,14 +76,15 @@ use secp256k1::Keypair;
 use serde::{Deserialize, Serialize};
 use strum::IntoEnumIterator;
 use tokio::sync::watch;
-use tracing::{debug, instrument};
+use tracing::{debug, instrument, warn};
 
 use crate::api::WalletFederationApi;
 use crate::backup::{FEDERATION_RECOVER_MAX_GAP, RecoveryStateV2, WalletRecovery};
 use crate::client_db::{
     ClaimedPegInData, ClaimedPegInKey, ClaimedPegInPrefix, NextPegInTweakIndexKey,
-    PegInPoolCursorKey, PegInTweakIndexData, PegInTweakIndexPrefix, ReceiveOperationsBackfilledKey,
-    RecoveryFinalizedKey, RecoveryStateKey, SupportsSafeDepositPrefix,
+    PegInPoolCursorKey, PegInTweakIndexData, PegInTweakIndexPrefix, ReceiveOperationPrefix,
+    ReceiveOperationsBackfilledKey, RecoveryFinalizedKey, RecoveryStateKey,
+    SupportsSafeDepositPrefix,
 };
 use crate::deposit::DepositStateMachine;
 use crate::withdraw::{CreatedWithdrawState, WithdrawStateMachine, WithdrawStates};
@@ -110,6 +111,18 @@ pub enum ReceiveState {
         btc_out_point: bitcoin::OutPoint,
     },
     IgnoredDust {
+        #[serde(with = "bitcoin::amount::serde::as_sat")]
+        btc_deposited: bitcoin::Amount,
+        btc_out_point: bitcoin::OutPoint,
+    },
+    /// The transaction disappeared from watched script history before claim.
+    ///
+    /// This state is recoverable: if the same transaction/outpoint later
+    /// reappears the stream returns to
+    /// [`ReceiveState::WaitingForConfirmation`], and if it gets claimed the
+    /// stream continues to [`ReceiveState::Confirmed`] /
+    /// [`ReceiveState::Claimed`].
+    OutOfMempool {
         #[serde(with = "bitcoin::amount::serde::as_sat")]
         btc_deposited: bitcoin::Amount,
         btc_out_point: bitcoin::OutPoint,
@@ -347,6 +360,16 @@ impl ModuleInit for WalletClientInit {
                         wallet_client_items
                             .insert("ReceiveOperationsBackfilled".to_string(), Box::new(val));
                     }
+                }
+                DbKeyPrefix::ReceiveOperation => {
+                    push_db_pair_items!(
+                        dbtx,
+                        ReceiveOperationPrefix,
+                        crate::client_db::ReceiveOperationKey,
+                        u64,
+                        wallet_client_items,
+                        "Receive Operation"
+                    );
                 }
                 DbKeyPrefix::RecoveryState
                 | DbKeyPrefix::ExternalReservedStart
@@ -1618,10 +1641,15 @@ impl WalletClientModule {
         }
 
         let operation_meta = operation.meta::<WalletOperationMeta>();
+        let receive_update_context = ReceiveUpdateContext {
+            client_ctx: self.client_ctx.clone(),
+            rpc: self.rpc.clone(),
+            network: self.cfg().network.0,
+        };
 
         match operation_meta.variant {
             WalletOperationMetaVariant::Receive { .. } => receive_updates_for_operation(
-                &self.client_ctx,
+                &receive_update_context,
                 &operation,
                 operation_id,
                 &operation_meta.variant,
@@ -1631,7 +1659,7 @@ impl WalletClientModule {
                 ..
             } => Ok(UpdateStreamOrOutcome::UpdateStream(Box::pin(
                 bridge_deposit_address_to_receive_updates(
-                    self.client_ctx.clone(),
+                    receive_update_context,
                     self.db.clone(),
                     self.pegin_monitor_wakeup_sender.clone(),
                     self.pegin_claimed_receiver.clone(),
@@ -2260,13 +2288,61 @@ async fn schedule_pegin_recheck(
     Ok(())
 }
 
+#[derive(Clone)]
+struct ReceiveUpdateContext {
+    client_ctx: ClientContext<WalletClientModule>,
+    rpc: DynBitcoindRpc,
+    network: Network,
+}
+
+fn history_contains_outpoint(
+    history: &[bitcoin::Transaction],
+    script_pubkey: &ScriptBuf,
+    btc_out_point: bitcoin::OutPoint,
+) -> bool {
+    history.iter().any(|tx| {
+        tx.compute_txid() == btc_out_point.txid
+            && tx
+                .output
+                .get(btc_out_point.vout as usize)
+                .is_some_and(|output| output.script_pubkey == *script_pubkey)
+    })
+}
+
+fn receive_history_transition(
+    reported_out_of_mempool: &mut bool,
+    still_in_history: bool,
+    btc_deposited: bitcoin::Amount,
+    btc_out_point: bitcoin::OutPoint,
+) -> Option<ReceiveState> {
+    if still_in_history {
+        if *reported_out_of_mempool {
+            *reported_out_of_mempool = false;
+            return Some(ReceiveState::WaitingForConfirmation {
+                btc_deposited,
+                btc_out_point,
+            });
+        }
+    } else if !*reported_out_of_mempool {
+        *reported_out_of_mempool = true;
+        return Some(ReceiveState::OutOfMempool {
+            btc_deposited,
+            btc_out_point,
+        });
+    }
+
+    None
+}
+
+#[allow(clippy::too_many_lines)]
 fn receive_updates_for_operation(
-    client_ctx: &ClientContext<WalletClientModule>,
+    context: &ReceiveUpdateContext,
     operation: &OperationLogEntry,
     operation_id: OperationId,
     operation_meta_variant: &WalletOperationMetaVariant,
 ) -> anyhow::Result<UpdateStreamOrOutcome<ReceiveState>> {
     let &WalletOperationMetaVariant::Receive {
+        ref address,
         claim_operation_id,
         tweak_idx,
         btc_out_point,
@@ -2277,7 +2353,17 @@ fn receive_updates_for_operation(
         bail!("Operation is not a receive operation");
     };
 
-    Ok(client_ctx.outcome_or_updates(
+    let script_pubkey = address
+        .clone()
+        .require_network(context.network)?
+        .script_pubkey();
+    let poll_interval = if is_running_in_test_env() {
+        Duration::from_millis(100)
+    } else {
+        Duration::from_secs(30)
+    };
+
+    Ok(context.client_ctx.outcome_or_updates(
         operation,
         operation_id,
         |state| matches!(
@@ -2287,7 +2373,8 @@ fn receive_updates_for_operation(
                 | ReceiveState::Failed(_)
         ),
         {
-            let stream_client_ctx = client_ctx.clone();
+            let stream_client_ctx = context.client_ctx.clone();
+            let stream_rpc = context.rpc.clone();
             move || {
             stream! {
                 let claimed_peg_in_key = ClaimedPegInKey {
@@ -2300,10 +2387,63 @@ fn receive_updates_for_operation(
                     btc_out_point,
                 };
 
-                let claim_data = stream_client_ctx
-                    .module_db()
-                    .wait_key_exists(&claimed_peg_in_key)
-                    .await;
+                let mut script_history_watched = false;
+                let mut reported_out_of_mempool = false;
+
+                let claim_data = loop {
+                    if let Some(claim_data) = stream_client_ctx
+                        .module_db()
+                        .begin_transaction_nc()
+                        .await
+                        .get_value(&claimed_peg_in_key)
+                        .await
+                    {
+                        break claim_data;
+                    }
+
+                    if !script_history_watched {
+                        match stream_rpc.watch_script_history(&script_pubkey).await {
+                            Ok(()) => {
+                                script_history_watched = true;
+                            }
+                            Err(error) => {
+                                warn!(
+                                    target: LOG_CLIENT_MODULE_WALLET,
+                                    err = %error.fmt_compact_anyhow(),
+                                    %btc_out_point,
+                                    "Failed to watch script history while waiting for receive confirmation"
+                                );
+                                sleep(poll_interval).await;
+                                continue;
+                            }
+                        }
+                    }
+
+                    match stream_rpc.get_script_history(&script_pubkey).await {
+                        Ok(history) => {
+                            let still_in_history =
+                                history_contains_outpoint(&history, &script_pubkey, btc_out_point);
+                            if let Some(state) = receive_history_transition(
+                                &mut reported_out_of_mempool,
+                                still_in_history,
+                                btc_deposited,
+                                btc_out_point,
+                            ) {
+                                yield state;
+                            }
+                        }
+                        Err(error) => {
+                            warn!(
+                                target: LOG_CLIENT_MODULE_WALLET,
+                                err = %error.fmt_compact_anyhow(),
+                                %btc_out_point,
+                                "Failed to refresh script history while waiting for receive confirmation"
+                            );
+                        }
+                    }
+
+                    sleep(poll_interval).await;
+                };
 
                 if claim_data.claim_txid == TransactionId::from_byte_array([0; 32])
                     && claim_data.change.is_empty()
@@ -2342,6 +2482,28 @@ async fn first_receive_operation_for_address(
     address_operation_id: OperationId,
     tweak_idx: TweakIdx,
 ) -> Option<OperationId> {
+    let mut indexed_receives = db
+        .begin_transaction_nc()
+        .await
+        .find_by_prefix(&ReceiveOperationPrefix)
+        .await
+        .filter(|(key, _creation_time)| futures::future::ready(key.peg_in_index == tweak_idx))
+        .collect::<Vec<_>>()
+        .await;
+
+    indexed_receives.sort_by_key(|(_key, creation_time)| *creation_time);
+
+    for (key, _creation_time) in indexed_receives.into_iter().rev() {
+        let receive_operation_id =
+            WalletClientModuleData::receive_operation_id(address_operation_id, key.btc_out_point);
+        if client_ctx
+            .operation_log_entry_exists(receive_operation_id)
+            .await
+        {
+            return Some(receive_operation_id);
+        }
+    }
+
     let claimed = db
         .begin_transaction_nc()
         .await
@@ -2365,7 +2527,7 @@ async fn first_receive_operation_for_address(
 }
 
 fn bridge_deposit_address_to_receive_updates(
-    client_ctx: ClientContext<WalletClientModule>,
+    context: ReceiveUpdateContext,
     db: Database,
     pegin_monitor_wakeup_sender: watch::Sender<()>,
     mut pegin_claimed_receiver: watch::Receiver<()>,
@@ -2375,7 +2537,7 @@ fn bridge_deposit_address_to_receive_updates(
     Box::pin(stream! {
         let receive_operation_id = loop {
             if let Some(receive_operation_id) = first_receive_operation_for_address(
-                &client_ctx,
+                &context.client_ctx,
                 &db,
                 address_operation_id,
                 tweak_idx,
@@ -2404,7 +2566,7 @@ fn bridge_deposit_address_to_receive_updates(
             }
         };
 
-        let operation = match client_ctx.get_operation(receive_operation_id).await {
+        let operation = match context.client_ctx.get_operation(receive_operation_id).await {
             Ok(operation) => operation,
             Err(error) => {
                 yield ReceiveState::Failed(error.to_string());
@@ -2414,7 +2576,7 @@ fn bridge_deposit_address_to_receive_updates(
         let operation_meta = operation.meta::<WalletOperationMeta>();
 
         let updates = match receive_updates_for_operation(
-            &client_ctx,
+            &context,
             &operation,
             receive_operation_id,
             &operation_meta.variant,
@@ -2487,6 +2649,66 @@ mod tests {
     use crate::backup::{
         RECOVER_NUM_IDX_ADD_TO_LAST_USED, RecoverScanOutcome, recover_scan_idxes_for_activity,
     };
+
+    #[test]
+    fn receive_history_transition_is_recoverable() {
+        let btc_deposited = bitcoin::Amount::from_sat(42);
+        let btc_out_point = bitcoin::OutPoint {
+            txid: bitcoin::Txid::from_byte_array([1; 32]),
+            vout: 0,
+        };
+        let mut reported_out_of_mempool = false;
+
+        assert_eq!(
+            receive_history_transition(
+                &mut reported_out_of_mempool,
+                true,
+                btc_deposited,
+                btc_out_point,
+            ),
+            None
+        );
+        assert!(!reported_out_of_mempool);
+
+        assert_eq!(
+            receive_history_transition(
+                &mut reported_out_of_mempool,
+                false,
+                btc_deposited,
+                btc_out_point,
+            ),
+            Some(ReceiveState::OutOfMempool {
+                btc_deposited,
+                btc_out_point,
+            })
+        );
+        assert!(reported_out_of_mempool);
+
+        assert_eq!(
+            receive_history_transition(
+                &mut reported_out_of_mempool,
+                false,
+                btc_deposited,
+                btc_out_point,
+            ),
+            None
+        );
+        assert!(reported_out_of_mempool);
+
+        assert_eq!(
+            receive_history_transition(
+                &mut reported_out_of_mempool,
+                true,
+                btc_deposited,
+                btc_out_point,
+            ),
+            Some(ReceiveState::WaitingForConfirmation {
+                btc_deposited,
+                btc_out_point,
+            })
+        );
+        assert!(!reported_out_of_mempool);
+    }
 
     #[allow(clippy::too_many_lines)] // shut-up clippy, it's a test
     #[tokio::test(flavor = "multi_thread")]

--- a/modules/fedimint-wallet-client/src/pegin_monitor.rs
+++ b/modules/fedimint-wallet-client/src/pegin_monitor.rs
@@ -99,7 +99,7 @@ pub(crate) async fn run_peg_in_monitor(
     btc_rpc: DynBitcoindRpc,
     module_api: DynModuleApi,
     data: WalletClientModuleData,
-    pegin_claimed_sender: watch::Sender<()>,
+    pegin_monitor_update_sender: watch::Sender<()>,
     mut wakeup_receiver: watch::Receiver<()>,
 ) {
     let min_sleep: Duration = if is_running_in_test_env() {
@@ -137,7 +137,7 @@ pub(crate) async fn run_peg_in_monitor(
             &btc_rpc,
             &module_api,
             &client_ctx,
-            &pegin_claimed_sender,
+            &pegin_monitor_update_sender,
         )
         .await
         {
@@ -175,7 +175,7 @@ async fn check_for_deposits(
     btc_rpc: &DynBitcoindRpc,
     module_api: &DynModuleApi,
     client_ctx: &ClientContext<WalletClientModule>,
-    pengin_claimed_sender: &watch::Sender<()>,
+    pegin_monitor_update_sender: &watch::Sender<()>,
 ) -> Result<(), anyhow::Error> {
     let due = NextActions::from_db_state(db).await.due;
     trace!(target: LOG_CLIENT_MODULE_WALLET, ?due, "Checking for deposists");
@@ -188,7 +188,7 @@ async fn check_for_deposits(
             db,
             client_ctx,
             due_val,
-            pengin_claimed_sender,
+            pegin_monitor_update_sender,
         )
         .await?;
     }
@@ -205,7 +205,7 @@ async fn check_and_claim_idx_pegins(
     db: &Database,
     client_ctx: &ClientContext<WalletClientModule>,
     due_val: PegInTweakIndexData,
-    pengin_claimed_sender: &watch::Sender<()>,
+    pegin_monitor_update_sender: &watch::Sender<()>,
 ) -> Result<(), anyhow::Error> {
     let now = time::now();
     match check_idx_pegins(data, due_key.0, btc_rpc, module_api, db, client_ctx).await {
@@ -244,9 +244,12 @@ async fn check_and_claim_idx_pegins(
 
                             let claimed_now = CheckOutcome::get_claimed_now_outpoints(&outcomes);
 
-                            let claimed_sender = pengin_claimed_sender.clone();
+                            // Notify receive subscriptions after every successful check,
+                            // even when no claim was created. Out-of-mempool
+                            // subscriptions park on this instead of polling RPC.
+                            let monitor_update_sender = pegin_monitor_update_sender.clone();
                             dbtx.on_commit(move || {
-                                claimed_sender.send_replace(());
+                                monitor_update_sender.send_replace(());
                             });
 
                             let peg_in_tweak_index_data = PegInTweakIndexData {

--- a/modules/fedimint-wallet-client/src/pegin_monitor.rs
+++ b/modules/fedimint-wallet-client/src/pegin_monitor.rs
@@ -5,7 +5,9 @@ use anyhow::anyhow;
 use bitcoin::ScriptBuf;
 use fedimint_api_client::api::DynModuleApi;
 use fedimint_bitcoind::DynBitcoindRpc;
-use fedimint_client_module::module::{ClientContext, OutPointRange};
+use fedimint_client_module::module::{
+    ClientContext, ClientModulePreStartMigrationContext, OutPointRange,
+};
 use fedimint_client_module::transaction::{ClientInput, ClientInputBundle};
 use fedimint_core::core::OperationId;
 use fedimint_core::db::{
@@ -413,6 +415,7 @@ async fn check_idx_pegins(
         ensure_receive_operation(
             &mut dbtx.to_ref_nc(),
             client_ctx,
+            None,
             receive_operation_id,
             WalletOperationMetaVariant::Receive {
                 address_operation_id,
@@ -475,6 +478,7 @@ async fn check_idx_pegins(
 pub(crate) async fn ensure_receive_operation(
     dbtx: &mut DatabaseTransaction<'_>,
     client_ctx: &ClientContext<WalletClientModule>,
+    pre_start_ctx: Option<&ClientModulePreStartMigrationContext<'_>>,
     receive_operation_id: OperationId,
     variant: WalletOperationMetaVariant,
     creation_time: SystemTime,
@@ -498,25 +502,56 @@ pub(crate) async fn ensure_receive_operation(
         .await;
     }
 
-    if client_ctx
-        .operation_log_entry_exists_dbtx(dbtx, receive_operation_id)
-        .await
-    {
+    let operation_exists = match pre_start_ctx {
+        Some(pre_start_ctx) => {
+            client_ctx
+                .pre_start_operation_log_entry_exists_dbtx(
+                    pre_start_ctx,
+                    dbtx,
+                    receive_operation_id,
+                )
+                .await
+        }
+        None => {
+            client_ctx
+                .operation_log_entry_exists_dbtx(dbtx, receive_operation_id)
+                .await
+        }
+    };
+
+    if operation_exists {
         return;
     }
 
-    client_ctx
-        .add_operation_log_entry_dbtx_with_creation_time(
-            dbtx,
-            receive_operation_id,
-            fedimint_wallet_common::KIND.as_str(),
-            WalletOperationMeta {
-                variant,
-                extra_meta: serde_json::Value::Null,
-            },
-            creation_time,
-        )
-        .await;
+    let operation_meta = WalletOperationMeta {
+        variant,
+        extra_meta: serde_json::Value::Null,
+    };
+
+    if let Some(pre_start_ctx) = pre_start_ctx {
+        client_ctx
+            .pre_start_add_operation_log_entry_dbtx_with_creation_time(
+                pre_start_ctx,
+                dbtx,
+                receive_operation_id,
+                fedimint_wallet_common::KIND.as_str(),
+                operation_meta,
+                creation_time,
+            )
+            .await;
+    } else {
+        // Live receive operations are created immediately, so they use the
+        // normal operation-log insertion path. Only pre-start backfill uses
+        // historical creation times.
+        client_ctx
+            .add_operation_log_entry_dbtx(
+                dbtx,
+                receive_operation_id,
+                fedimint_wallet_common::KIND.as_str(),
+                operation_meta,
+            )
+            .await;
+    }
 }
 
 #[allow(clippy::too_many_arguments, clippy::too_many_lines)]

--- a/modules/fedimint-wallet-client/src/pegin_monitor.rs
+++ b/modules/fedimint-wallet-client/src/pegin_monitor.rs
@@ -31,7 +31,9 @@ use crate::client_db::{
     PegInTweakIndexPrefix, TweakIdx,
 };
 use crate::events::{DepositConfirmed, ReceivePaymentEvent};
-use crate::{WalletClientModule, WalletClientModuleData};
+use crate::{
+    WalletClientModule, WalletClientModuleData, WalletOperationMeta, WalletOperationMetaVariant,
+};
 
 /// A helper struct meant to combined data from all addresses/records
 /// into a single struct with all actionable data.
@@ -373,7 +375,7 @@ async fn check_idx_pegins(
     client_ctx: &ClientContext<WalletClientModule>,
 ) -> Result<Vec<CheckOutcome>, anyhow::Error> {
     let current_consensus_block_count = module_rpc.fetch_consensus_block_count().await?;
-    let (script, address, tweak_key, operation_id) = data.derive_peg_in_script(tweak_idx);
+    let (script, address, tweak_key, address_operation_id) = data.derive_peg_in_script(tweak_idx);
     btc_rpc.watch_script_history(&script).await?;
 
     let history = btc_rpc.get_script_history(&script).await?;
@@ -388,6 +390,8 @@ async fn check_idx_pegins(
             txid,
             vout: out_idx,
         };
+        let receive_operation_id =
+            WalletClientModuleData::receive_operation_id(address_operation_id, outpoint);
 
         let claimed_peg_in_key = ClaimedPegInKey {
             peg_in_index: tweak_idx,
@@ -405,6 +409,25 @@ async fn check_idx_pegins(
             outcomes.push(CheckOutcome::AlreadyClaimed);
             continue;
         }
+
+        let mut dbtx = db.begin_transaction().await;
+        ensure_receive_operation(
+            &mut dbtx.to_ref_nc(),
+            client_ctx,
+            receive_operation_id,
+            WalletOperationMetaVariant::Receive {
+                address_operation_id,
+                claim_operation_id: receive_operation_id,
+                address: address.clone().into_unchecked(),
+                tweak_idx,
+                btc_out_point: outpoint,
+                btc_deposited: transaction.output[out_idx as usize].value,
+            },
+            time::now(),
+        )
+        .await;
+        dbtx.commit_tx().await;
+
         let finality_delay = u64::from(data.cfg.finality_delay);
 
         let tx_block_count =
@@ -436,7 +459,8 @@ async fn check_idx_pegins(
             tweak_idx,
             tweak_key,
             &transaction,
-            operation_id,
+            address_operation_id,
+            receive_operation_id,
             outpoint,
             tx_out_proof,
             federation_knows_utxo,
@@ -447,13 +471,44 @@ async fn check_idx_pegins(
     Ok(outcomes)
 }
 
+/// Creates the receive operation-log entry for `receive_operation_id` (with
+/// metadata `variant` and the given `creation_time`) unless it already exists.
+pub(crate) async fn ensure_receive_operation(
+    dbtx: &mut DatabaseTransaction<'_>,
+    client_ctx: &ClientContext<WalletClientModule>,
+    receive_operation_id: OperationId,
+    variant: WalletOperationMetaVariant,
+    creation_time: SystemTime,
+) {
+    if client_ctx
+        .operation_log_entry_exists_dbtx(dbtx, receive_operation_id)
+        .await
+    {
+        return;
+    }
+
+    client_ctx
+        .add_operation_log_entry_dbtx_with_creation_time(
+            dbtx,
+            receive_operation_id,
+            fedimint_wallet_common::KIND.as_str(),
+            WalletOperationMeta {
+                variant,
+                extra_meta: serde_json::Value::Null,
+            },
+            creation_time,
+        )
+        .await;
+}
+
 #[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 async fn claim_peg_in(
     client_ctx: &ClientContext<WalletClientModule>,
     tweak_idx: TweakIdx,
     tweak_key: Keypair,
     transaction: &bitcoin::Transaction,
-    operation_id: OperationId,
+    address_operation_id: OperationId,
+    receive_operation_id: OperationId,
     out_point: bitcoin::OutPoint,
     tx_out_proof: TxOutProof,
     federation_knows_utxo: bool,
@@ -467,7 +522,8 @@ async fn claim_peg_in(
         out_idx: u32,
         tweak_key: Keypair,
         txout_proof: TxOutProof,
-        operation_id: OperationId,
+        address_operation_id: OperationId,
+        receive_operation_id: OperationId,
         federation_knows_utxo: bool,
     ) -> Option<OutPointRange> {
         let pegin_proof = PegInProof::new(
@@ -513,7 +569,8 @@ async fn claim_peg_in(
             .log_event(
                 dbtx,
                 ReceivePaymentEvent {
-                    operation_id,
+                    address_operation_id,
+                    receive_operation_id: Some(receive_operation_id),
                     amount,
                     txid,
                 },
@@ -525,7 +582,7 @@ async fn claim_peg_in(
                 .claim_inputs(
                     dbtx,
                     ClientInputBundle::new_no_sm(vec![client_input]),
-                    operation_id,
+                    receive_operation_id,
                 )
                 .await
                 .expect("Cannot claim input, additional funding needed"),
@@ -548,7 +605,8 @@ async fn claim_peg_in(
                         out_point.vout,
                         tweak_key,
                         tx_out_proof.clone(),
-                        operation_id,
+                        address_operation_id,
+                        receive_operation_id,
                         federation_knows_utxo,
                     )
                     .await;

--- a/modules/fedimint-wallet-client/src/pegin_monitor.rs
+++ b/modules/fedimint-wallet-client/src/pegin_monitor.rs
@@ -28,7 +28,7 @@ use tracing::{debug, instrument, trace, warn};
 use crate::api::WalletFederationApi as _;
 use crate::client_db::{
     ClaimedPegInData, ClaimedPegInKey, PegInTweakIndexData, PegInTweakIndexKey,
-    PegInTweakIndexPrefix, TweakIdx,
+    PegInTweakIndexPrefix, ReceiveOperationKey, TweakIdx,
 };
 use crate::events::{DepositConfirmed, ReceivePaymentEvent};
 use crate::{
@@ -390,9 +390,6 @@ async fn check_idx_pegins(
             txid,
             vout: out_idx,
         };
-        let receive_operation_id =
-            WalletClientModuleData::receive_operation_id(address_operation_id, outpoint);
-
         let claimed_peg_in_key = ClaimedPegInKey {
             peg_in_index: tweak_idx,
             btc_out_point: outpoint,
@@ -410,6 +407,8 @@ async fn check_idx_pegins(
             continue;
         }
 
+        let receive_operation_id =
+            WalletClientModuleData::receive_operation_id(address_operation_id, outpoint);
         let mut dbtx = db.begin_transaction().await;
         ensure_receive_operation(
             &mut dbtx.to_ref_nc(),
@@ -480,6 +479,25 @@ pub(crate) async fn ensure_receive_operation(
     variant: WalletOperationMetaVariant,
     creation_time: SystemTime,
 ) {
+    if let WalletOperationMetaVariant::Receive {
+        tweak_idx,
+        btc_out_point,
+        ..
+    } = &variant
+    {
+        // Maintain the receive index even if the operation log entry already
+        // exists, so older receive entries or interrupted writes can be
+        // rediscovered by the address-operation compatibility bridge.
+        dbtx.insert_entry(
+            &ReceiveOperationKey {
+                peg_in_index: *tweak_idx,
+                btc_out_point: *btc_out_point,
+            },
+            &creation_time,
+        )
+        .await;
+    }
+
     if client_ctx
         .operation_log_entry_exists_dbtx(dbtx, receive_operation_id)
         .await

--- a/modules/fedimint-wallet-client/src/pegin_monitor.rs
+++ b/modules/fedimint-wallet-client/src/pegin_monitor.rs
@@ -5,7 +5,9 @@ use anyhow::anyhow;
 use bitcoin::ScriptBuf;
 use fedimint_api_client::api::DynModuleApi;
 use fedimint_bitcoind::DynBitcoindRpc;
-use fedimint_client_module::module::{ClientContext, OutPointRange};
+use fedimint_client_module::module::{
+    ClientContext, ClientModulePreStartMigrationContext, OutPointRange,
+};
 use fedimint_client_module::transaction::{ClientInput, ClientInputBundle};
 use fedimint_core::core::OperationId;
 use fedimint_core::db::{
@@ -413,6 +415,7 @@ async fn check_idx_pegins(
         ensure_receive_operation(
             &mut dbtx.to_ref_nc(),
             client_ctx,
+            None,
             receive_operation_id,
             WalletOperationMetaVariant::Receive {
                 address_operation_id,
@@ -475,6 +478,7 @@ async fn check_idx_pegins(
 pub(crate) async fn ensure_receive_operation(
     dbtx: &mut DatabaseTransaction<'_>,
     client_ctx: &ClientContext<WalletClientModule>,
+    pre_start_ctx: Option<&ClientModulePreStartMigrationContext<'_>>,
     receive_operation_id: OperationId,
     variant: WalletOperationMetaVariant,
     creation_time: SystemTime,
@@ -501,25 +505,56 @@ pub(crate) async fn ensure_receive_operation(
         .await;
     }
 
-    if client_ctx
-        .operation_log_entry_exists_dbtx(dbtx, receive_operation_id)
-        .await
-    {
+    let operation_exists = match pre_start_ctx {
+        Some(pre_start_ctx) => {
+            client_ctx
+                .pre_start_operation_log_entry_exists_dbtx(
+                    pre_start_ctx,
+                    dbtx,
+                    receive_operation_id,
+                )
+                .await
+        }
+        None => {
+            client_ctx
+                .operation_log_entry_exists_dbtx(dbtx, receive_operation_id)
+                .await
+        }
+    };
+
+    if operation_exists {
         return;
     }
 
-    client_ctx
-        .add_operation_log_entry_dbtx_with_creation_time(
-            dbtx,
-            receive_operation_id,
-            fedimint_wallet_common::KIND.as_str(),
-            WalletOperationMeta {
-                variant,
-                extra_meta: serde_json::Value::Null,
-            },
-            creation_time,
-        )
-        .await;
+    let operation_meta = WalletOperationMeta {
+        variant,
+        extra_meta: serde_json::Value::Null,
+    };
+
+    if let Some(pre_start_ctx) = pre_start_ctx {
+        client_ctx
+            .pre_start_add_operation_log_entry_dbtx_with_creation_time(
+                pre_start_ctx,
+                dbtx,
+                receive_operation_id,
+                fedimint_wallet_common::KIND.as_str(),
+                operation_meta,
+                creation_time,
+            )
+            .await;
+    } else {
+        // Live receive operations are created immediately, so they use the
+        // normal operation-log insertion path. Only pre-start backfill uses
+        // historical creation times.
+        client_ctx
+            .add_operation_log_entry_dbtx(
+                dbtx,
+                receive_operation_id,
+                fedimint_wallet_common::KIND.as_str(),
+                operation_meta,
+            )
+            .await;
+    }
 }
 
 #[allow(clippy::too_many_arguments, clippy::too_many_lines)]

--- a/modules/fedimint-wallet-client/src/pegin_monitor.rs
+++ b/modules/fedimint-wallet-client/src/pegin_monitor.rs
@@ -28,7 +28,7 @@ use tracing::{debug, instrument, trace, warn};
 use crate::api::WalletFederationApi as _;
 use crate::client_db::{
     ClaimedPegInData, ClaimedPegInKey, PegInTweakIndexData, PegInTweakIndexKey,
-    PegInTweakIndexPrefix, TweakIdx,
+    PegInTweakIndexPrefix, ReceiveOperationKey, TweakIdx,
 };
 use crate::events::{DepositConfirmed, ReceivePaymentEvent};
 use crate::{
@@ -390,9 +390,6 @@ async fn check_idx_pegins(
             txid,
             vout: out_idx,
         };
-        let receive_operation_id =
-            WalletClientModuleData::receive_operation_id(address_operation_id, outpoint);
-
         let claimed_peg_in_key = ClaimedPegInKey {
             peg_in_index: tweak_idx,
             btc_out_point: outpoint,
@@ -410,6 +407,8 @@ async fn check_idx_pegins(
             continue;
         }
 
+        let receive_operation_id =
+            WalletClientModuleData::receive_operation_id(address_operation_id, outpoint);
         let mut dbtx = db.begin_transaction().await;
         ensure_receive_operation(
             &mut dbtx.to_ref_nc(),
@@ -480,6 +479,28 @@ pub(crate) async fn ensure_receive_operation(
     variant: WalletOperationMetaVariant,
     creation_time: SystemTime,
 ) {
+    if let WalletOperationMetaVariant::Receive {
+        tweak_idx,
+        btc_out_point,
+        ..
+    } = &variant
+    {
+        // Maintain the receive index even if the operation log entry already
+        // exists, so older receive entries or interrupted writes can be
+        // rediscovered by the address-operation compatibility bridge.
+        dbtx.insert_entry(
+            &ReceiveOperationKey {
+                peg_in_index: *tweak_idx,
+                btc_out_point: *btc_out_point,
+            },
+            &creation_time
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs(),
+        )
+        .await;
+    }
+
     if client_ctx
         .operation_log_entry_exists_dbtx(dbtx, receive_operation_id)
         .await

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -27,8 +27,8 @@ use fedimint_testing::fixtures::Fixtures;
 use fedimint_testing_core::config::API_AUTH;
 use fedimint_wallet_client::api::WalletFederationApi;
 use fedimint_wallet_client::{
-    AllocateDepositOutcome, DepositStateV2, MaybeNewAddress, WalletClientInit, WalletClientModule,
-    WithdrawState,
+    AllocateDepositOutcome, MaybeNewAddress, ReceiveState, WalletClientInit, WalletClientModule,
+    WalletOperationMeta, WalletOperationMetaVariant, WithdrawState,
 };
 use fedimint_wallet_common::config::WalletConfig;
 use fedimint_wallet_common::tweakable::Tweakable;
@@ -37,7 +37,6 @@ use fedimint_wallet_common::{PegOutFees, Rbf, TxOutputSummary};
 use fedimint_wallet_server::WalletInit;
 use futures::stream::StreamExt;
 use secp256k1::rand::rngs::OsRng;
-use tokio::select;
 use tracing::{info, warn};
 
 fn fixtures() -> Fixtures {
@@ -286,20 +285,10 @@ async fn on_chain_peg_in_and_peg_out_happy_case() -> anyhow::Result<()> {
         deposit_operation
             .meta::<serde_json::Value>()
             .get("variant")
-            .and_then(|v| v.get("deposit"))
+            .and_then(|v| v.get("deposit_address"))
             .and_then(|d| d.get("address"))
             .is_some(),
         "Peg-in operation meta data should contain address"
-    );
-
-    // Test update stream returns expected updates
-    let mut deposit_updates = wallet_module
-        .subscribe_deposit(deposit_operation_id)
-        .await?
-        .into_stream();
-    assert_eq!(
-        deposit_updates.next().await.unwrap(),
-        DepositStateV2::WaitingForTransaction
     );
 
     info!(?address, "Peg-in address generated");
@@ -311,10 +300,31 @@ async fn on_chain_peg_in_and_peg_out_happy_case() -> anyhow::Result<()> {
         )
         .await;
 
-    info!("Waiting for confirmation");
+    wallet_module.recheck_pegin_address_by_op_id(op).await?;
+    let operations = client
+        .operation_log()
+        .paginate_operations_rev(10, None)
+        .await;
+    let (receive_operation_id, _) = operations
+        .iter()
+        .find(|(_, operation)| {
+            matches!(
+                operation.meta::<WalletOperationMeta>().variant,
+                WalletOperationMetaVariant::Receive { btc_out_point, .. }
+                    if btc_out_point.txid == tx.compute_txid()
+            )
+        })
+        .map(|(key, operation)| (key.operation_id, operation))
+        .expect("receive operation exists");
+
+    let mut receive_updates = wallet_module
+        .subscribe_receive(receive_operation_id)
+        .await?
+        .into_stream();
+
     assert_matches!(
-        deposit_updates.next().await.unwrap(),
-        DepositStateV2::WaitingForConfirmation { btc_out_point, .. } if btc_out_point.txid == tx.compute_txid()
+        receive_updates.next().await.unwrap(),
+        ReceiveState::WaitingForConfirmation { btc_out_point, .. } if btc_out_point.txid == tx.compute_txid()
     );
 
     bitcoin.mine_blocks(finality_delay).await;
@@ -327,25 +337,27 @@ async fn on_chain_peg_in_and_peg_out_happy_case() -> anyhow::Result<()> {
                 .recheck_pegin_address_by_op_id(op)
                 .await
                 .expect("Operation exists");
-            select! {
-                update = deposit_updates.next() => {
-                    break update;
-                },
-                _ = sleep_in_test("Waiting for address recheck", Duration::from_millis(100)) => { }
+            if wallet_module
+                .await_num_deposits_by_operation_id(op, 1)
+                .await
+                .is_ok()
+            {
+                break;
             }
+            sleep_in_test("Waiting for address recheck", Duration::from_millis(100)).await;
         }
     };
 
     info!("Waiting for claim tx");
-    assert_matches!(
-        await_update_while_rechecking.await.unwrap(),
-        DepositStateV2::Confirmed { btc_out_point, .. } if btc_out_point.txid == tx.compute_txid()
-    );
+    await_update_while_rechecking.await;
 
-    info!("Waiting for e-cash");
     assert_matches!(
-        deposit_updates.next().await.unwrap(),
-        DepositStateV2::Claimed { btc_out_point, .. } if btc_out_point.txid == tx.compute_txid()
+        receive_updates.next().await.unwrap(),
+        ReceiveState::Confirmed { btc_out_point, .. } if btc_out_point.txid == tx.compute_txid()
+    );
+    assert_matches!(
+        receive_updates.next().await.unwrap(),
+        ReceiveState::Claimed { btc_out_point, .. } if btc_out_point.txid == tx.compute_txid()
     );
 
     info!("Checking balance after deposit");
@@ -356,7 +368,7 @@ async fn on_chain_peg_in_and_peg_out_happy_case() -> anyhow::Result<()> {
     );
     assert_eq!(balance_sub.ok().await?, sats(PEG_IN_AMOUNT_SATS));
 
-    assert_eq!(deposit_updates.next().await, None);
+    assert_eq!(receive_updates.next().await, None);
 
     info!("Peg-in finished for test on_chain_peg_in_and_peg_out_happy_case");
     // Peg-out test, requires block to recognize change UTXOs
@@ -890,47 +902,40 @@ async fn dust_deposits_are_ignored() -> anyhow::Result<()> {
         )
         .await;
 
-    let mut deposit_updates = wallet_module.subscribe_deposit(op).await?.into_stream();
-    info!("Waiting for transaction");
-    assert_matches!(
-        deposit_updates.next().await.unwrap(),
-        DepositStateV2::WaitingForTransaction
-    );
-    info!("Waiting for confirmation");
-    assert_matches!(
-        deposit_updates.next().await.unwrap(),
-        DepositStateV2::WaitingForConfirmation { btc_out_point, .. } if btc_out_point.txid == tx.compute_txid()
-    );
-
     bitcoin.mine_blocks(finality_delay).await;
 
-    // Afaik technically not necessary, but useful to speed up test (should probably
-    // just poll more often in tests?)
-    let await_update_while_rechecking = async {
-        loop {
-            wallet_module
-                .recheck_pegin_address_by_op_id(op)
-                .await
-                .expect("Operation exists");
-            select! {
-                update = deposit_updates.next() => {
-                    break update;
-                },
-                _ = sleep_in_test("Waiting for address recheck", Duration::from_millis(100)) => { }
-            }
-        }
-    };
+    wallet_module
+        .await_num_deposits_by_operation_id(op, 1)
+        .await?;
 
-    info!("Waiting for claim tx");
+    let operations = client
+        .operation_log()
+        .paginate_operations_rev(10, None)
+        .await;
+    let (receive_operation_id, _) = operations
+        .iter()
+        .find(|(_, operation)| {
+            matches!(
+                operation.meta::<WalletOperationMeta>().variant,
+                WalletOperationMetaVariant::Receive { btc_out_point, .. }
+                    if btc_out_point.txid == tx.compute_txid()
+            )
+        })
+        .map(|(key, operation)| (key.operation_id, operation))
+        .expect("receive operation exists");
+
+    let mut receive_updates = wallet_module
+        .subscribe_receive(receive_operation_id)
+        .await?
+        .into_stream();
+
     assert_matches!(
-        await_update_while_rechecking.await.unwrap(),
-        DepositStateV2::Confirmed { btc_out_point, .. } if btc_out_point.txid == tx.compute_txid()
+        receive_updates.next().await.unwrap(),
+        ReceiveState::WaitingForConfirmation { btc_out_point, .. } if btc_out_point.txid == tx.compute_txid()
     );
-
-    info!("Waiting for e-cash");
     assert_matches!(
-        deposit_updates.next().await.unwrap(),
-        DepositStateV2::Claimed { btc_out_point, .. } if btc_out_point.txid == tx.compute_txid()
+        receive_updates.next().await.unwrap(),
+        ReceiveState::IgnoredDust { btc_out_point, .. } if btc_out_point.txid == tx.compute_txid()
     );
 
     info!("Checking balance after deposit");
@@ -1922,6 +1927,7 @@ mod fedimint_migration_tests {
                         client_db::DbKeyPrefix::RecoveryState => {}
                         client_db::DbKeyPrefix::SupportsSafeDeposit => {}
                         client_db::DbKeyPrefix::PegInPoolCursor => {}
+                        client_db::DbKeyPrefix::ReceiveOperationsBackfilled => {}
                         client_db::DbKeyPrefix::ExternalReservedStart
                         | client_db::DbKeyPrefix::CoreInternalReservedStart
                         | client_db::DbKeyPrefix::CoreInternalReservedEnd => {}

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -123,6 +123,35 @@ async fn peg_in<'a>(
     Ok((balance_sub, tx))
 }
 
+async fn receive_operation_id_for_tx(
+    client: &ClientHandleArc,
+    txid: bitcoin::Txid,
+) -> anyhow::Result<fedimint_core::core::OperationId> {
+    retry(
+        "waiting for receive operation",
+        fedimint_core::util::backoff_util::aggressive_backoff(),
+        || async {
+            let operations = client
+                .operation_log()
+                .paginate_operations_rev(10, None)
+                .await;
+            operations
+                .iter()
+                .find(|(_, operation)| {
+                    operation.operation_module_kind() == "wallet"
+                        && matches!(
+                            operation.meta::<WalletOperationMeta>().variant,
+                            WalletOperationMetaVariant::Receive { btc_out_point, .. }
+                                if btc_out_point.txid == txid
+                        )
+                })
+                .map(|(key, _)| key.operation_id)
+                .ok_or_else(|| anyhow!("receive operation not found yet"))
+        },
+    )
+    .await
+}
+
 async fn await_consensus_to_catch_up(
     client: &ClientHandleArc,
     block_count: u64,
@@ -301,21 +330,7 @@ async fn on_chain_peg_in_and_peg_out_happy_case() -> anyhow::Result<()> {
         .await;
 
     wallet_module.recheck_pegin_address_by_op_id(op).await?;
-    let operations = client
-        .operation_log()
-        .paginate_operations_rev(10, None)
-        .await;
-    let (receive_operation_id, _) = operations
-        .iter()
-        .find(|(_, operation)| {
-            matches!(
-                operation.meta::<WalletOperationMeta>().variant,
-                WalletOperationMetaVariant::Receive { btc_out_point, .. }
-                    if btc_out_point.txid == tx.compute_txid()
-            )
-        })
-        .map(|(key, operation)| (key.operation_id, operation))
-        .expect("receive operation exists");
+    let receive_operation_id = receive_operation_id_for_tx(&client, tx.compute_txid()).await?;
 
     let mut receive_updates = wallet_module
         .subscribe_receive(receive_operation_id)
@@ -369,6 +384,13 @@ async fn on_chain_peg_in_and_peg_out_happy_case() -> anyhow::Result<()> {
     assert_eq!(balance_sub.ok().await?, sats(PEG_IN_AMOUNT_SATS));
 
     assert_eq!(receive_updates.next().await, None);
+
+    let mut address_receive_updates = wallet_module.subscribe_receive(op).await?.into_stream();
+    assert_matches!(
+        address_receive_updates.next().await.unwrap(),
+        ReceiveState::Claimed { btc_out_point, .. } if btc_out_point.txid == tx.compute_txid()
+    );
+    assert_eq!(address_receive_updates.next().await, None);
 
     info!("Peg-in finished for test on_chain_peg_in_and_peg_out_happy_case");
     // Peg-out test, requires block to recognize change UTXOs
@@ -908,21 +930,7 @@ async fn dust_deposits_are_ignored() -> anyhow::Result<()> {
         .await_num_deposits_by_operation_id(op, 1)
         .await?;
 
-    let operations = client
-        .operation_log()
-        .paginate_operations_rev(10, None)
-        .await;
-    let (receive_operation_id, _) = operations
-        .iter()
-        .find(|(_, operation)| {
-            matches!(
-                operation.meta::<WalletOperationMeta>().variant,
-                WalletOperationMetaVariant::Receive { btc_out_point, .. }
-                    if btc_out_point.txid == tx.compute_txid()
-            )
-        })
-        .map(|(key, operation)| (key.operation_id, operation))
-        .expect("receive operation exists");
+    let receive_operation_id = receive_operation_id_for_tx(&client, tx.compute_txid()).await?;
 
     let mut receive_updates = wallet_module
         .subscribe_receive(receive_operation_id)

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -332,6 +332,13 @@ async fn on_chain_peg_in_and_peg_out_happy_case() -> anyhow::Result<()> {
     wallet_module.recheck_pegin_address_by_op_id(op).await?;
     let receive_operation_id = receive_operation_id_for_tx(&client, tx.compute_txid()).await?;
 
+    let mut address_receive_updates = wallet_module.subscribe_receive(op).await?.into_stream();
+    assert_matches!(
+        address_receive_updates.next().await.unwrap(),
+        ReceiveState::WaitingForConfirmation { btc_out_point, .. } if btc_out_point.txid == tx.compute_txid()
+    );
+    drop(address_receive_updates);
+
     let mut receive_updates = wallet_module
         .subscribe_receive(receive_operation_id)
         .await?
@@ -1936,6 +1943,7 @@ mod fedimint_migration_tests {
                         client_db::DbKeyPrefix::SupportsSafeDeposit => {}
                         client_db::DbKeyPrefix::PegInPoolCursor => {}
                         client_db::DbKeyPrefix::ReceiveOperationsBackfilled => {}
+                        client_db::DbKeyPrefix::ReceiveOperation => {}
                         client_db::DbKeyPrefix::ExternalReservedStart
                         | client_db::DbKeyPrefix::CoreInternalReservedStart
                         | client_db::DbKeyPrefix::CoreInternalReservedEnd => {}

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -337,6 +337,13 @@ async fn on_chain_peg_in_and_peg_out_happy_case() -> anyhow::Result<()> {
     wallet_module.recheck_pegin_address_by_op_id(op).await?;
     let receive_operation_id = receive_operation_id_for_tx(&client, tx.compute_txid()).await?;
 
+    let mut address_receive_updates = wallet_module.subscribe_receive(op).await?.into_stream();
+    assert_matches!(
+        address_receive_updates.next().await.unwrap(),
+        ReceiveState::WaitingForConfirmation { btc_out_point, .. } if btc_out_point.txid == tx.compute_txid()
+    );
+    drop(address_receive_updates);
+
     let mut receive_updates = wallet_module
         .subscribe_receive(receive_operation_id)
         .await?
@@ -2451,6 +2458,7 @@ mod fedimint_migration_tests {
                         client_db::DbKeyPrefix::SupportsSafeDeposit => {}
                         client_db::DbKeyPrefix::PegInPoolCursor => {}
                         client_db::DbKeyPrefix::ReceiveOperationsBackfilled => {}
+                        client_db::DbKeyPrefix::ReceiveOperation => {}
                         client_db::DbKeyPrefix::ExternalReservedStart
                         | client_db::DbKeyPrefix::CoreInternalReservedStart
                         | client_db::DbKeyPrefix::CoreInternalReservedEnd => {}

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -128,6 +128,35 @@ async fn peg_in<'a>(
     Ok((balance_sub, tx))
 }
 
+async fn receive_operation_id_for_tx(
+    client: &ClientHandleArc,
+    txid: bitcoin::Txid,
+) -> anyhow::Result<fedimint_core::core::OperationId> {
+    retry(
+        "waiting for receive operation",
+        fedimint_core::util::backoff_util::aggressive_backoff(),
+        || async {
+            let operations = client
+                .operation_log()
+                .paginate_operations_rev(10, None)
+                .await;
+            operations
+                .iter()
+                .find(|(_, operation)| {
+                    operation.operation_module_kind() == "wallet"
+                        && matches!(
+                            operation.meta::<WalletOperationMeta>().variant,
+                            WalletOperationMetaVariant::Receive { btc_out_point, .. }
+                                if btc_out_point.txid == txid
+                        )
+                })
+                .map(|(key, _)| key.operation_id)
+                .ok_or_else(|| anyhow!("receive operation not found yet"))
+        },
+    )
+    .await
+}
+
 async fn await_consensus_to_catch_up(
     client: &ClientHandleArc,
     block_count: u64,
@@ -306,21 +335,7 @@ async fn on_chain_peg_in_and_peg_out_happy_case() -> anyhow::Result<()> {
         .await;
 
     wallet_module.recheck_pegin_address_by_op_id(op).await?;
-    let operations = client
-        .operation_log()
-        .paginate_operations_rev(10, None)
-        .await;
-    let (receive_operation_id, _) = operations
-        .iter()
-        .find(|(_, operation)| {
-            matches!(
-                operation.meta::<WalletOperationMeta>().variant,
-                WalletOperationMetaVariant::Receive { btc_out_point, .. }
-                    if btc_out_point.txid == tx.compute_txid()
-            )
-        })
-        .map(|(key, operation)| (key.operation_id, operation))
-        .expect("receive operation exists");
+    let receive_operation_id = receive_operation_id_for_tx(&client, tx.compute_txid()).await?;
 
     let mut receive_updates = wallet_module
         .subscribe_receive(receive_operation_id)
@@ -374,6 +389,13 @@ async fn on_chain_peg_in_and_peg_out_happy_case() -> anyhow::Result<()> {
     assert_eq!(balance_sub.ok().await?, sats(PEG_IN_AMOUNT_SATS));
 
     assert_eq!(receive_updates.next().await, None);
+
+    let mut address_receive_updates = wallet_module.subscribe_receive(op).await?.into_stream();
+    assert_matches!(
+        address_receive_updates.next().await.unwrap(),
+        ReceiveState::Claimed { btc_out_point, .. } if btc_out_point.txid == tx.compute_txid()
+    );
+    assert_eq!(address_receive_updates.next().await, None);
 
     info!("Peg-in finished for test on_chain_peg_in_and_peg_out_happy_case");
     // Peg-out test, requires block to recognize change UTXOs
@@ -1266,21 +1288,7 @@ async fn dust_deposits_are_ignored() -> anyhow::Result<()> {
         .await_num_deposits_by_operation_id(op, 1)
         .await?;
 
-    let operations = client
-        .operation_log()
-        .paginate_operations_rev(10, None)
-        .await;
-    let (receive_operation_id, _) = operations
-        .iter()
-        .find(|(_, operation)| {
-            matches!(
-                operation.meta::<WalletOperationMeta>().variant,
-                WalletOperationMetaVariant::Receive { btc_out_point, .. }
-                    if btc_out_point.txid == tx.compute_txid()
-            )
-        })
-        .map(|(key, operation)| (key.operation_id, operation))
-        .expect("receive operation exists");
+    let receive_operation_id = receive_operation_id_for_tx(&client, tx.compute_txid()).await?;
 
     let mut receive_updates = wallet_module
         .subscribe_receive(receive_operation_id)

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -27,8 +27,8 @@ use fedimint_testing::fixtures::Fixtures;
 use fedimint_testing_core::config::API_AUTH;
 use fedimint_wallet_client::api::WalletFederationApi;
 use fedimint_wallet_client::{
-    AllocateDepositOutcome, DepositStateV2, MaybeNewAddress, WalletClientInit, WalletClientModule,
-    WithdrawState,
+    AllocateDepositOutcome, MaybeNewAddress, ReceiveState, WalletClientInit, WalletClientModule,
+    WalletOperationMeta, WalletOperationMetaVariant, WithdrawState,
 };
 use fedimint_wallet_common::config::WalletConfig;
 use fedimint_wallet_common::tweakable::Tweakable;
@@ -42,7 +42,6 @@ use fedimint_wallet_server::db::{
 use fedimint_wallet_server::{PEG_OUT_CHANGE_VOUT, WalletInit};
 use futures::stream::StreamExt;
 use secp256k1::rand::rngs::OsRng;
-use tokio::select;
 use tracing::{info, warn};
 
 fn fixtures() -> Fixtures {
@@ -291,20 +290,10 @@ async fn on_chain_peg_in_and_peg_out_happy_case() -> anyhow::Result<()> {
         deposit_operation
             .meta::<serde_json::Value>()
             .get("variant")
-            .and_then(|v| v.get("deposit"))
+            .and_then(|v| v.get("deposit_address"))
             .and_then(|d| d.get("address"))
             .is_some(),
         "Peg-in operation meta data should contain address"
-    );
-
-    // Test update stream returns expected updates
-    let mut deposit_updates = wallet_module
-        .subscribe_deposit(deposit_operation_id)
-        .await?
-        .into_stream();
-    assert_eq!(
-        deposit_updates.next().await.unwrap(),
-        DepositStateV2::WaitingForTransaction
     );
 
     info!(?address, "Peg-in address generated");
@@ -316,10 +305,31 @@ async fn on_chain_peg_in_and_peg_out_happy_case() -> anyhow::Result<()> {
         )
         .await;
 
-    info!("Waiting for confirmation");
+    wallet_module.recheck_pegin_address_by_op_id(op).await?;
+    let operations = client
+        .operation_log()
+        .paginate_operations_rev(10, None)
+        .await;
+    let (receive_operation_id, _) = operations
+        .iter()
+        .find(|(_, operation)| {
+            matches!(
+                operation.meta::<WalletOperationMeta>().variant,
+                WalletOperationMetaVariant::Receive { btc_out_point, .. }
+                    if btc_out_point.txid == tx.compute_txid()
+            )
+        })
+        .map(|(key, operation)| (key.operation_id, operation))
+        .expect("receive operation exists");
+
+    let mut receive_updates = wallet_module
+        .subscribe_receive(receive_operation_id)
+        .await?
+        .into_stream();
+
     assert_matches!(
-        deposit_updates.next().await.unwrap(),
-        DepositStateV2::WaitingForConfirmation { btc_out_point, .. } if btc_out_point.txid == tx.compute_txid()
+        receive_updates.next().await.unwrap(),
+        ReceiveState::WaitingForConfirmation { btc_out_point, .. } if btc_out_point.txid == tx.compute_txid()
     );
 
     bitcoin.mine_blocks(finality_delay).await;
@@ -332,25 +342,27 @@ async fn on_chain_peg_in_and_peg_out_happy_case() -> anyhow::Result<()> {
                 .recheck_pegin_address_by_op_id(op)
                 .await
                 .expect("Operation exists");
-            select! {
-                update = deposit_updates.next() => {
-                    break update;
-                },
-                _ = sleep_in_test("Waiting for address recheck", Duration::from_millis(100)) => { }
+            if wallet_module
+                .await_num_deposits_by_operation_id(op, 1)
+                .await
+                .is_ok()
+            {
+                break;
             }
+            sleep_in_test("Waiting for address recheck", Duration::from_millis(100)).await;
         }
     };
 
     info!("Waiting for claim tx");
-    assert_matches!(
-        await_update_while_rechecking.await.unwrap(),
-        DepositStateV2::Confirmed { btc_out_point, .. } if btc_out_point.txid == tx.compute_txid()
-    );
+    await_update_while_rechecking.await;
 
-    info!("Waiting for e-cash");
     assert_matches!(
-        deposit_updates.next().await.unwrap(),
-        DepositStateV2::Claimed { btc_out_point, .. } if btc_out_point.txid == tx.compute_txid()
+        receive_updates.next().await.unwrap(),
+        ReceiveState::Confirmed { btc_out_point, .. } if btc_out_point.txid == tx.compute_txid()
+    );
+    assert_matches!(
+        receive_updates.next().await.unwrap(),
+        ReceiveState::Claimed { btc_out_point, .. } if btc_out_point.txid == tx.compute_txid()
     );
 
     info!("Checking balance after deposit");
@@ -361,7 +373,7 @@ async fn on_chain_peg_in_and_peg_out_happy_case() -> anyhow::Result<()> {
     );
     assert_eq!(balance_sub.ok().await?, sats(PEG_IN_AMOUNT_SATS));
 
-    assert_eq!(deposit_updates.next().await, None);
+    assert_eq!(receive_updates.next().await, None);
 
     info!("Peg-in finished for test on_chain_peg_in_and_peg_out_happy_case");
     // Peg-out test, requires block to recognize change UTXOs
@@ -1248,47 +1260,40 @@ async fn dust_deposits_are_ignored() -> anyhow::Result<()> {
         )
         .await;
 
-    let mut deposit_updates = wallet_module.subscribe_deposit(op).await?.into_stream();
-    info!("Waiting for transaction");
-    assert_matches!(
-        deposit_updates.next().await.unwrap(),
-        DepositStateV2::WaitingForTransaction
-    );
-    info!("Waiting for confirmation");
-    assert_matches!(
-        deposit_updates.next().await.unwrap(),
-        DepositStateV2::WaitingForConfirmation { btc_out_point, .. } if btc_out_point.txid == tx.compute_txid()
-    );
-
     bitcoin.mine_blocks(finality_delay).await;
 
-    // Afaik technically not necessary, but useful to speed up test (should probably
-    // just poll more often in tests?)
-    let await_update_while_rechecking = async {
-        loop {
-            wallet_module
-                .recheck_pegin_address_by_op_id(op)
-                .await
-                .expect("Operation exists");
-            select! {
-                update = deposit_updates.next() => {
-                    break update;
-                },
-                _ = sleep_in_test("Waiting for address recheck", Duration::from_millis(100)) => { }
-            }
-        }
-    };
+    wallet_module
+        .await_num_deposits_by_operation_id(op, 1)
+        .await?;
 
-    info!("Waiting for claim tx");
+    let operations = client
+        .operation_log()
+        .paginate_operations_rev(10, None)
+        .await;
+    let (receive_operation_id, _) = operations
+        .iter()
+        .find(|(_, operation)| {
+            matches!(
+                operation.meta::<WalletOperationMeta>().variant,
+                WalletOperationMetaVariant::Receive { btc_out_point, .. }
+                    if btc_out_point.txid == tx.compute_txid()
+            )
+        })
+        .map(|(key, operation)| (key.operation_id, operation))
+        .expect("receive operation exists");
+
+    let mut receive_updates = wallet_module
+        .subscribe_receive(receive_operation_id)
+        .await?
+        .into_stream();
+
     assert_matches!(
-        await_update_while_rechecking.await.unwrap(),
-        DepositStateV2::Confirmed { btc_out_point, .. } if btc_out_point.txid == tx.compute_txid()
+        receive_updates.next().await.unwrap(),
+        ReceiveState::WaitingForConfirmation { btc_out_point, .. } if btc_out_point.txid == tx.compute_txid()
     );
-
-    info!("Waiting for e-cash");
     assert_matches!(
-        deposit_updates.next().await.unwrap(),
-        DepositStateV2::Claimed { btc_out_point, .. } if btc_out_point.txid == tx.compute_txid()
+        receive_updates.next().await.unwrap(),
+        ReceiveState::IgnoredDust { btc_out_point, .. } if btc_out_point.txid == tx.compute_txid()
     );
 
     info!("Checking balance after deposit");
@@ -2437,6 +2442,7 @@ mod fedimint_migration_tests {
                         client_db::DbKeyPrefix::RecoveryState => {}
                         client_db::DbKeyPrefix::SupportsSafeDeposit => {}
                         client_db::DbKeyPrefix::PegInPoolCursor => {}
+                        client_db::DbKeyPrefix::ReceiveOperationsBackfilled => {}
                         client_db::DbKeyPrefix::ExternalReservedStart
                         | client_db::DbKeyPrefix::CoreInternalReservedStart
                         | client_db::DbKeyPrefix::CoreInternalReservedEnd => {}


### PR DESCRIPTION
*Posted by Tau*

### Summary

Track wallet on-chain receives as per-UTXO operations instead of treating the deposit-address allocation as the receive operation. This preserves early mempool visibility while giving every UTXO its own operation metadata and update stream. A recoverable `OutOfMempool` state prevents subscriptions from hanging when an unconfirmed transaction disappears, and startup backfill keeps existing clients discoverable after upgrade.

### Details

The previous wallet API tied receive progress to the operation that allocated an address, even though one address can receive multiple UTXOs. The new flow creates a deterministic operation for each observed outpoint, exposes it through `subscribe_receive`, records an index for the legacy address-operation bridge, and backfills historical receives from deposit events.

If an observed transaction disappears from watched script history before claim, the stream emits non-terminal `OutOfMempool`. It returns to `WaitingForConfirmation` if the outpoint reappears. While parked, the subscriber waits for the persisted peg-in monitor instead of running its own Bitcoin RPC polling loop.

The backfill runs through a restricted pre-start migration context. Module `start()` calls still complete before the final client is published, preserving the invariant that any module which observes the final client can rely on every module being started. Historical operation inserts preserve master’s mutable `Arc<RwLock>` oldest-entry cache refresh behavior.

The downstream `subscribe_receive_operations` follow-up is not included. The receive index and `subscribe_receive(address_operation_id)` compatibility bridge already provide the discoverability this PR requires; a separate enumeration API is not necessary for correctness and would expand the public API without a demonstrated caller need.

### Reviewing

Please focus on legacy address-operation compatibility, the recoverable `OutOfMempool` lifecycle, historical backfill idempotence, and the pre-start/final-client ordering boundary.

### Testing

- `just format`
- `cargo check -q -p fedimint-wallet-client --all-features`
- `cargo check -q -p fedimint-client -p fedimint-wallet-client`
- `cargo test -q -p fedimint-wallet-client receive_history_transition_is_recoverable`
- `cargo test -q -p fedimint-client oplog`
- `scripts/tests/wallet-recovery-test.sh` with the v1 module matrix
- `scripts/tests/wallet-recovery-test-2.sh` with the v1 module matrix
- `just final-lint`

### Reviews

An external semantic review first found two rebase regressions: an intermediate commit temporarily removed master’s `max_withdrawable_amount`, and stale migration docs incorrectly described a `OnceCell` cache and claimed new test coverage already present on master. The stack now preserves that API in every commit, retains the mutable `Arc<RwLock>` cache, and describes the existing cache-refresh behavior accurately. GitHub CI then exposed recovery gaps: restores without a backup could lose a recently allocated address index, and stale backups could retry an already-claimed historical outpoint. The updated recovery compatibility paths repair deterministic indices within the recovery gap, rerun backfill only for unprocessed recovered outpoints, persist processed tombstones for intentionally unbackfillable legacy/dust claims, and accept the federation’s authoritative already-claimed result in legacy waits. The reviewer re-reviewed exact head `d2ea32e96186467a45ee5d0b8ee1e20e93753a3a` and passed it.