### PR TITLE
feat: custom LND routing timeout

### DIFF
--- a/fedimint-testing/src/fixtures.rs
+++ b/fedimint-testing/src/fixtures.rs
@@ -17,7 +17,10 @@ use fedimint_core::db::mem_impl::MemDatabase;
 use fedimint_core::envs::BitcoinRpcConfig;
 use fedimint_core::task::{MaybeSend, MaybeSync};
 use fedimint_core::util::SafeUrl;
-use fedimint_gateway_common::{ChainSource, LND_DEFAULT_TIME_PREF, LightningInfo, LightningMode};
+use fedimint_gateway_common::{
+    ChainSource, LND_DEFAULT_PAYMENT_TIMEOUT_SECS, LND_DEFAULT_TIME_PREF, LightningInfo,
+    LightningMode,
+};
 use fedimint_gateway_server::Gateway;
 use fedimint_gateway_server::client::GatewayClientBuilder;
 use fedimint_gateway_server::config::DatabaseBackend;
@@ -272,6 +275,7 @@ impl Fixtures {
                 lnd_tls_cert: "FakeTlsCert".to_string(),
                 lnd_macaroon: "FakeMacaroon".to_string(),
                 lnd_time_pref: LND_DEFAULT_TIME_PREF,
+                lnd_payment_timeout_secs: LND_DEFAULT_PAYMENT_TIMEOUT_SECS,
             },
             client_builder,
             gateway_db,

--- a/gateway/fedimint-gateway-common/src/envs.rs
+++ b/gateway/fedimint-gateway-common/src/envs.rs
@@ -24,3 +24,9 @@ pub const FM_GATEWAY_IROH_SECRET_KEY_OVERRIDE_ENV: &str = "FM_GATEWAY_IROH_SECRE
 /// `SendPaymentRequest`. Must parse as an f64 in the range [-1.0, 1.0], where
 /// -1 optimizes for fees and 1 optimizes for reliability.
 pub const FM_LND_TIME_PREF_ENV: &str = "FM_LND_TIME_PREF";
+
+/// Environment variable that specifies how long (in seconds) LND will keep
+/// trying to route an outgoing payment before giving up. Passed as
+/// `timeout_seconds` in LND `SendPaymentRequest`. Must parse as an i32 in the
+/// range [1, 600].
+pub const FM_LND_PAYMENT_TIMEOUT_SECS_ENV: &str = "FM_LND_PAYMENT_TIMEOUT_SECS";

--- a/gateway/fedimint-gateway-common/src/lib.rs
+++ b/gateway/fedimint-gateway-common/src/lib.rs
@@ -9,8 +9,8 @@ use bitcoin::secp256k1::PublicKey;
 use bitcoin::{Address, Network, OutPoint};
 use clap::Subcommand;
 use envs::{
-    FM_LDK_ALIAS_ENV, FM_LND_MACAROON_ENV, FM_LND_RPC_ADDR_ENV, FM_LND_TIME_PREF_ENV,
-    FM_LND_TLS_CERT_ENV, FM_PORT_LDK,
+    FM_LDK_ALIAS_ENV, FM_LND_MACAROON_ENV, FM_LND_PAYMENT_TIMEOUT_SECS_ENV, FM_LND_RPC_ADDR_ENV,
+    FM_LND_TIME_PREF_ENV, FM_LND_TLS_CERT_ENV, FM_PORT_LDK,
 };
 use fedimint_core::config::{FederationId, JsonClientConfig};
 use fedimint_core::encoding::{Decodable, Encodable};
@@ -649,6 +649,23 @@ fn parse_lnd_time_pref(s: &str) -> Result<f64, String> {
     Ok(parsed)
 }
 
+/// Default value for LND's `SendPaymentRequest::timeout_seconds`, i.e. how long
+/// LND keeps trying to route an outgoing payment before giving up. This does
+/// not cancel an HTLC that is already in flight; it bounds pathfinding/retry.
+pub const LND_DEFAULT_PAYMENT_TIMEOUT_SECS: i32 = 180;
+pub const LND_PAYMENT_TIMEOUT_SECS_MIN: i32 = 1;
+pub const LND_PAYMENT_TIMEOUT_SECS_MAX: i32 = 600;
+
+fn parse_lnd_payment_timeout_secs(s: &str) -> Result<i32, String> {
+    let parsed: i32 = s.parse().map_err(|e| format!("invalid i32: {e}"))?;
+    if !(LND_PAYMENT_TIMEOUT_SECS_MIN..=LND_PAYMENT_TIMEOUT_SECS_MAX).contains(&parsed) {
+        return Err(format!(
+            "must be an integer in [{LND_PAYMENT_TIMEOUT_SECS_MIN}, {LND_PAYMENT_TIMEOUT_SECS_MAX}]"
+        ));
+    }
+    Ok(parsed)
+}
+
 #[derive(Debug, Clone, Subcommand, Serialize, Deserialize, PartialEq)]
 pub enum LightningMode {
     #[clap(name = "lnd")]
@@ -674,6 +691,17 @@ pub enum LightningMode {
             value_parser = parse_lnd_time_pref,
         )]
         lnd_time_pref: f64,
+
+        /// How long (in seconds) LND keeps trying to route an outgoing payment
+        /// before giving up. Passed as `timeout_seconds` to LND
+        /// `SendPaymentRequest`. Must be in [1, 600].
+        #[arg(
+            long = "lnd-payment-timeout",
+            env = FM_LND_PAYMENT_TIMEOUT_SECS_ENV,
+            default_value_t = LND_DEFAULT_PAYMENT_TIMEOUT_SECS,
+            value_parser = parse_lnd_payment_timeout_secs,
+        )]
+        lnd_payment_timeout_secs: i32,
     },
     #[clap(name = "ldk")]
     Ldk {

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -1909,6 +1909,7 @@ impl Gateway {
                 lnd_tls_cert,
                 lnd_macaroon,
                 lnd_time_pref,
+                lnd_payment_timeout_secs,
             } => {
                 // The LND backend uses this to ignore HOLD invoices on the
                 // shared LND node that aren't federation-bound. Returns true
@@ -1932,6 +1933,7 @@ impl Gateway {
                     lnd_tls_cert,
                     lnd_macaroon,
                     lnd_time_pref,
+                    lnd_payment_timeout_secs,
                     None,
                     lnv2_filter,
                 ))

--- a/gateway/fedimint-lightning/src/lib.rs
+++ b/gateway/fedimint-lightning/src/lib.rs
@@ -153,9 +153,6 @@ pub trait ILnRpcClient: Debug + Send + Sync {
     /// This is more private than [`ILnRpcClient::pay`], as it does not require
     /// the invoice description. If this is implemented,
     /// [`ILnRpcClient::supports_private_payments`] must return true.
-    ///
-    /// Note: This is only used for outbound LNv1 payments and will be removed
-    /// when we switch to LNv2.
     async fn pay_private(
         &self,
         _invoice: PrunedInvoice,

--- a/gateway/fedimint-lightning/src/lnd.rs
+++ b/gateway/fedimint-lightning/src/lnd.rs
@@ -64,8 +64,6 @@ use crate::{
 
 type HtlcSubscriptionSender = mpsc::Sender<InterceptPaymentRequest>;
 
-const LND_PAYMENT_TIMEOUT_SECONDS: i32 = 180;
-
 #[derive(Clone)]
 pub struct GatewayLndClient {
     /// LND client
@@ -73,6 +71,9 @@ pub struct GatewayLndClient {
     tls_cert: String,
     macaroon: String,
     time_pref: f64,
+    /// How long (in seconds) LND keeps trying to route an outgoing payment
+    /// before giving up. Passed as `timeout_seconds` in `SendPaymentRequest`.
+    payment_timeout_secs: i32,
     lnd_sender: Option<mpsc::Sender<ForwardHtlcInterceptResponse>>,
     /// Predicate used to distinguish HOLD invoices the gateway created
     /// (federation-bound) from unrelated HOLD invoices on the same LND node.
@@ -88,6 +89,7 @@ impl GatewayLndClient {
         tls_cert: String,
         macaroon: String,
         time_pref: f64,
+        payment_timeout_secs: i32,
         lnd_sender: Option<mpsc::Sender<ForwardHtlcInterceptResponse>>,
         lnv2_filter: Lnv2HoldInvoiceFilter,
     ) -> Self {
@@ -97,6 +99,7 @@ impl GatewayLndClient {
             tls_cert_path = %tls_cert,
             macaroon = %macaroon,
             time_pref,
+            payment_timeout_secs,
             "Gateway configured to connect to LND LnRpcClient",
         );
         GatewayLndClient {
@@ -104,6 +107,7 @@ impl GatewayLndClient {
             tls_cert,
             macaroon,
             time_pref,
+            payment_timeout_secs,
             lnd_sender,
             lnv2_filter,
         }
@@ -991,7 +995,7 @@ impl ILnRpcClient for GatewayLndClient {
                         final_cltv_delta,
                         cltv_limit,
                         no_inflight_updates: false,
-                        timeout_seconds: LND_PAYMENT_TIMEOUT_SECONDS,
+                        timeout_seconds: self.payment_timeout_secs,
                         fee_limit_msat,
                         time_pref: self.time_pref,
                         ..Default::default()
@@ -1113,6 +1117,7 @@ impl ILnRpcClient for GatewayLndClient {
             tls_cert: self.tls_cert.clone(),
             macaroon: self.macaroon.clone(),
             time_pref: self.time_pref,
+            payment_timeout_secs: self.payment_timeout_secs,
             lnd_sender: Some(lnd_sender.clone()),
             lnv2_filter: self.lnv2_filter.clone(),
         });


### PR DESCRIPTION
Right now in our LND implementation, we have a hardcoded timeout of 180 seconds for routing. This PR allows gateway operators to customize it via a CLI or environment variable, so that operators can tradeoff latency/stuck payments with waiting longer for finding a route.

Eventually, we might want to allow users to request a timeout value. But right now I think that's probably too much to expose to users and easier to expose to gateway operators.