### PR TITLE
fix(gwv2-client): dedup outgoing claims in the gateway's global database

### DIFF
--- a/gateway/fedimint-gateway-server-db/src/lib.rs
+++ b/gateway/fedimint-gateway-server-db/src/lib.rs
@@ -4,6 +4,7 @@ use std::time::SystemTime;
 
 use bitcoin::hashes::{Hash, sha256};
 use fedimint_core::config::FederationId;
+use fedimint_core::core::OperationId;
 use fedimint_core::db::{
     Database, DatabaseTransaction, DatabaseVersion, GeneralDbMigrationFn,
     GeneralDbMigrationFnContext, IDatabaseTransactionOpsCore, IDatabaseTransactionOpsCoreTyped,
@@ -79,6 +80,17 @@ pub trait GatewayDbtxNcExt {
         &mut self,
         payment_image: PaymentImage,
     ) -> Option<RegisteredIncomingContract>;
+
+    /// Records `operation_id` as the claimer of `payment_image`, unless another
+    /// operation already claimed it, and returns the operation id that holds
+    /// the claim. Lets the gateway claim at most one outgoing contract per
+    /// payment image across all federations while tolerating retries of the
+    /// same operation.
+    async fn claim_outgoing_payment_image(
+        &mut self,
+        payment_image: PaymentImage,
+        operation_id: OperationId,
+    ) -> OperationId;
 
     /// Reads and serializes structures from the gateway's database for the
     /// purpose for serializing to JSON for inspection.
@@ -204,6 +216,26 @@ impl<Cap: Send> GatewayDbtxNcExt for DatabaseTransaction<'_, Cap> {
             .await
     }
 
+    async fn claim_outgoing_payment_image(
+        &mut self,
+        payment_image: PaymentImage,
+        operation_id: OperationId,
+    ) -> OperationId {
+        if let Some(existing) = self
+            .get_value(&ClaimedOutgoingPaymentImageKey(payment_image.clone()))
+            .await
+        {
+            existing
+        } else {
+            self.insert_entry(
+                &ClaimedOutgoingPaymentImageKey(payment_image),
+                &operation_id,
+            )
+            .await;
+            operation_id
+        }
+    }
+
     async fn dump_database(
         &mut self,
         prefix_names: Vec<String>,
@@ -294,6 +326,7 @@ enum DbKeyPrefix {
     ClientDatabase = 0x10,
     Iroh = 0x11,
     FederationBackup = 0x12,
+    ClaimedOutgoingPaymentImage = 0x13,
 }
 
 impl std::fmt::Display for DbKeyPrefix {
@@ -766,6 +799,20 @@ impl_db_record!(
     key = RegisteredIncomingContractKey,
     value = RegisteredIncomingContract,
     db_prefix = DbKeyPrefix::RegisteredIncomingContract,
+);
+
+/// Records which send operation claimed an outgoing contract for a given
+/// payment image. A single Lightning payment yields a single preimage, so the
+/// gateway may claim at most one outgoing contract per payment image across all
+/// of its federations; the value is the claiming operation so a retry of that
+/// same operation is not mistaken for a duplicate.
+#[derive(Debug, Encodable, Decodable)]
+struct ClaimedOutgoingPaymentImageKey(pub PaymentImage);
+
+impl_db_record!(
+    key = ClaimedOutgoingPaymentImageKey,
+    value = OperationId,
+    db_prefix = DbKeyPrefix::ClaimedOutgoingPaymentImage,
 );
 
 #[cfg(test)]

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -3410,6 +3410,31 @@ impl IGatewayClientV2 for Gateway {
 
         Ok(final_state)
     }
+
+    async fn claim_payment_image(
+        &self,
+        payment_image: &PaymentImage,
+        operation_id: OperationId,
+    ) -> bool {
+        // `autocommit` retries on write-write conflicts, so concurrent claims for
+        // the same payment image are serialized: exactly one records itself as the
+        // claimer, the rest observe it and forfeit.
+        self.gateway_db
+            .autocommit(
+                |dbtx, _| {
+                    let payment_image = payment_image.clone();
+                    Box::pin(async move {
+                        let claimer = dbtx
+                            .claim_outgoing_payment_image(payment_image, operation_id)
+                            .await;
+                        Ok::<_, std::convert::Infallible>(claimer == operation_id)
+                    })
+                },
+                None,
+            )
+            .await
+            .expect("Retries until the transaction commits")
+    }
 }
 
 #[async_trait]

--- a/modules/fedimint-gwv2-client/src/lib.rs
+++ b/modules/fedimint-gwv2-client/src/lib.rs
@@ -654,4 +654,21 @@ pub trait IGatewayClientV2: Debug + Send + Sync {
         client: &ClientHandleArc,
         invoice: &Bolt11Invoice,
     ) -> anyhow::Result<FinalReceiveState>;
+
+    /// Claims the given payment image for `operation_id` in the gateway's
+    /// global database, returning `true` if this operation may claim the
+    /// outgoing contract (the image was unclaimed, or already claimed by
+    /// this same operation) and `false` if another operation already
+    /// claimed it.
+    ///
+    /// A single Lightning payment yields a single preimage, so the gateway may
+    /// claim at most one outgoing contract per payment image. Unlike the
+    /// per-federation module database, this spans all of the gateway's
+    /// federations, so two clients in different federations paying the same
+    /// invoice cannot both be claimed.
+    async fn claim_payment_image(
+        &self,
+        payment_image: &PaymentImage,
+        operation_id: OperationId,
+    ) -> bool;
 }

--- a/modules/fedimint-gwv2-client/src/send_sm.rs
+++ b/modules/fedimint-gwv2-client/src/send_sm.rs
@@ -93,6 +93,7 @@ pub enum Cancelled {
     Refunded,
     Failure,
     LightningRpcError(String),
+    DuplicatePayment,
 }
 
 #[cfg_attr(doc, aquamarine::aquamarine)]
@@ -249,6 +250,36 @@ impl SendStateMachine {
     ) -> SendStateMachine {
         match result {
             Ok(payment_response) => {
+                // A single Lightning payment yields a single preimage, so the gateway
+                // must claim at most one outgoing contract per payment image. If another
+                // contract for the same invoice has already been claimed, e.g. two
+                // clients racing to pay it, forfeit this one so the sender is refunded
+                // rather than the gateway being reimbursed twice for a single payment.
+                // The claim is recorded in the gateway's global database so it spans all
+                // of the gateway's federations, not just the one funding this contract.
+                if !client_ctx
+                    .gateway
+                    .claim_payment_image(
+                        &old_state.common.contract.payment_image,
+                        old_state.common.operation_id,
+                    )
+                    .await
+                {
+                    client_ctx
+                        .module
+                        .client_ctx
+                        .log_event(
+                            &mut dbtx.module_tx(),
+                            OutgoingPaymentFailed {
+                                payment_image: old_state.common.contract.payment_image.clone(),
+                                error: Cancelled::DuplicatePayment,
+                            },
+                        )
+                        .await;
+
+                    return old_state.update(SendSMState::Cancelled(Cancelled::DuplicatePayment));
+                }
+
                 client_ctx
                     .module
                     .client_ctx

--- a/modules/fedimint-lnv2-tests/bin/tests.rs
+++ b/modules/fedimint-lnv2-tests/bin/tests.rs
@@ -2,9 +2,11 @@ use anyhow::ensure;
 use bitcoin::hashes::sha256;
 use clap::{Parser, Subcommand};
 use devimint::devfed::DevJitFed;
-use devimint::federation::Client;
-use devimint::util::almost_equal;
-use devimint::version_constants::{VERSION_0_10_0_ALPHA, VERSION_0_11_0_ALPHA};
+use devimint::federation::{Client, Federation};
+use devimint::util::{ProcessManager, almost_equal};
+use devimint::version_constants::{
+    VERSION_0_10_0_ALPHA, VERSION_0_11_0_ALPHA, VERSION_0_12_0_ALPHA,
+};
 use devimint::{Gatewayd, cmd, util};
 use fedimint_core::core::OperationId;
 use fedimint_core::encoding::Encodable;
@@ -57,14 +59,25 @@ enum Commands {
     LnurlPay,
     /// Test LNURL receives after recovery from seed
     LnurlRecovery,
+    /// Two clients racing to pay the same invoice settle exactly once
+    DuplicatePayment,
 }
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
+    // The duplicate-payment test needs a second federation; every other test
+    // uses a single one.
+    let num_feds = if matches!(cli.command, None | Some(Commands::DuplicatePayment)) {
+        2
+    } else {
+        1
+    };
+
     devimint::run_devfed_test()
-        .call(|dev_fed, _process_mgr| async move {
+        .num_feds(num_feds)
+        .call(|dev_fed, process_mgr| async move {
             if !devimint::util::supports_lnv2() {
                 info!("lnv2 is disabled, skipping");
                 return Ok(());
@@ -85,10 +98,15 @@ async fn main() -> anyhow::Result<()> {
                     pegin_gateways(&dev_fed).await?;
                     test_lnurl_recovery(&dev_fed).await?;
                 }
+                Some(Commands::DuplicatePayment) => {
+                    pegin_gateways(&dev_fed).await?;
+                    test_duplicate_payment(&dev_fed, &process_mgr).await?;
+                }
                 None => {
                     // Run all tests if no subcommand is specified
                     test_gateway_registration(&dev_fed).await?;
                     test_payments(&dev_fed).await?;
+                    test_duplicate_payment(&dev_fed, &process_mgr).await?;
                     test_lnurl_pay(&dev_fed).await?;
                     test_lnurl_recovery(&dev_fed).await?;
                 }
@@ -388,6 +406,141 @@ async fn test_payments(dev_fed: &DevJitFed) -> anyhow::Result<()> {
     assert!(ldk_payment_summary.outgoing.average_latency.is_some());
     assert!(ldk_payment_summary.incoming.median_latency.is_some());
     assert!(ldk_payment_summary.incoming.average_latency.is_some());
+
+    Ok(())
+}
+
+/// Creates a fresh client and joins it to the federation identified by
+/// `invite_code`, unlike `Federation::new_joined_client` which always joins
+/// whichever federation last wrote the shared invite-code file.
+async fn join_client(name: &str, invite_code: &str) -> anyhow::Result<Client> {
+    let client = Client::create(name).await?;
+    client.join_federation(invite_code.to_string()).await?;
+    Ok(client)
+}
+
+/// Three independent clients — two in the primary federation and one in a
+/// second federation, all served by the same gateway — race to pay the *same*
+/// invoice. The gateway pays the invoice only once, so it may claim only one of
+/// the three outgoing contracts regardless of which federation funded them; the
+/// other two must be forfeited and refunded. Exactly one payment settles.
+async fn test_duplicate_payment(
+    dev_fed: &DevJitFed,
+    process_mgr: &ProcessManager,
+) -> anyhow::Result<()> {
+    info!(
+        "Testing three clients across two federations paying the same invoice settle exactly once..."
+    );
+
+    // The LDK gateway is used to send: its `pay` is idempotent per payment hash,
+    // so all contracts share a single Lightning payment and preimage.
+    let gw_send = dev_fed.gw_ldk().await?;
+    let gw_receive = dev_fed.gw_lnd().await?;
+
+    // The cross-federation dedup lives in the gateway's global database, added in
+    // 0.12. Older gateways would claim both contracts, so skip against them.
+    if gw_send.gatewayd_version < *VERSION_0_12_0_ALPHA {
+        info!(
+            gatewayd_version = %gw_send.gatewayd_version,
+            "Skipping: gateway predates cross-federation outgoing payment dedup"
+        );
+        return Ok(());
+    }
+
+    let first_federation = dev_fed.fed().await?;
+
+    // `Federation::invite_code` reads a single shared invite-code file, so
+    // capture the primary federation's invite before spawning the second one
+    // overwrites it. Clients must be joined with the right invite explicitly;
+    // `new_joined_client` would join whichever federation wrote that file last.
+    let first_invite = first_federation.invite_code()?;
+
+    // A second federation, also served by the sending gateway, covers the
+    // cross-federation case: a contract funded in one federation must still
+    // block claiming a contract for the same invoice funded in another.
+    let second_federation = Federation::new(
+        process_mgr,
+        dev_fed.bitcoind().await?.clone(),
+        false,
+        false,
+        false,
+        1,
+        "lnv2-duplicate-payment".to_string(),
+    )
+    .await?;
+    let second_invite = second_federation.invite_code()?;
+
+    assert_ne!(
+        first_federation.calculate_federation_id(),
+        second_federation.calculate_federation_id(),
+        "the second federation must be distinct from the first"
+    );
+
+    gw_send.client().connect_fed(second_invite.clone()).await?;
+    second_federation
+        .pegin_gateways(1_000_000, vec![gw_send])
+        .await?;
+
+    let client_a = join_client("lnv2-duplicate-payment-a", &first_invite).await?;
+    let client_b = join_client("lnv2-duplicate-payment-b", &first_invite).await?;
+    let client_c = join_client("lnv2-duplicate-payment-c", &second_invite).await?;
+
+    first_federation.pegin_client(10_000, &client_a).await?;
+    first_federation.pegin_client(10_000, &client_b).await?;
+    second_federation.pegin_client(10_000, &client_c).await?;
+
+    // Control: the second-federation client can pay a *different* invoice through
+    // the gateway on its own. This proves the gateway serves the second
+    // federation, so any refund of the shared invoice below is caused by the
+    // duplicate payment rather than a second-federation setup problem.
+    let control_invoice = gw_receive
+        .client()
+        .create_invoice(1_000_000)
+        .await?
+        .to_string();
+    let control = common::send(&client_c, &gw_send.addr, &control_invoice).await?;
+    assert!(
+        matches!(control, FinalSendOperationState::Success(_)),
+        "second-federation control payment must succeed, got {control:?}"
+    );
+
+    let invoice = gw_receive
+        .client()
+        .create_invoice(1_000_000)
+        .await?
+        .to_string();
+
+    // The two clients in the first federation race for the invoice; the
+    // per-federation dedup settles exactly one of them and refunds the other.
+    let (state_a, state_b) = try_join!(
+        common::send(&client_a, &gw_send.addr, &invoice),
+        common::send(&client_b, &gw_send.addr, &invoice),
+    )?;
+
+    // The second-federation client then pays the same, now-settled invoice. The
+    // gateway already holds the preimage, so without cross-federation dedup it
+    // claims this contract too, being reimbursed twice for one Lightning payment.
+    let state_c = common::send(&client_c, &gw_send.addr, &invoice).await?;
+
+    let states = [state_a, state_b, state_c];
+
+    info!("shared-invoice send states: {states:?}");
+
+    let successes = states
+        .iter()
+        .filter(|state| matches!(state, FinalSendOperationState::Success(_)))
+        .count();
+
+    let refunds = states
+        .iter()
+        .filter(|state| matches!(state, FinalSendOperationState::Refunded))
+        .count();
+
+    assert_eq!(
+        (successes, refunds),
+        (1, 2),
+        "exactly one payment must settle and the other two be refunded, got {states:?}"
+    );
 
     Ok(())
 }

--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -158,6 +158,11 @@ function lnv2_module_payments() {
 }
 export -f lnv2_module_payments
 
+function lnv2_module_duplicate_payment() {
+  fm-run-test "${FUNCNAME[0]}" env FM_OFFLINE_NODES=0 ./scripts/tests/lnv2-module-test.sh duplicate-payment
+}
+export -f lnv2_module_duplicate_payment
+
 function lnv2_mintv2_walletv2_lightning_payments() {
   # v2 modules are not supported by older versions, so we skip for backwards-compatibility tests
   if [ -z "${FM_BACKWARDS_COMPATIBILITY_TEST:-}" ]; then
@@ -477,6 +482,7 @@ tests_to_run_in_parallel+=(
   "gw_liquidity_test_mintv2"
   "lnv2_module_gateway_registration"
   "lnv2_module_payments"
+  "lnv2_module_duplicate_payment"
   "lnv2_mintv2_walletv2_lightning_payments"
   "lnv2_module_lnurl_pay"
   "lnv2_module_lnurl_recovery"


### PR DESCRIPTION
A gateway pays each invoice at most once, so it must claim at most one outgoing contract per payment image. When two clients fund an outgoing contract for the same invoice, the gateway obtained one preimage but claimed both contracts, being reimbursed twice for a single Lightning payment.

The claim is now recorded in the gateway's **global** database (keyed by payment image, value = claiming operation id), via a new `IGatewayClientV2::claim_payment_image`. `autocommit` serializes concurrent claims so exactly one records itself and the rest forfeit; keying on the operation id lets a retry of the same send proceed rather than be treated as a duplicate.

Unlike the per-federation module database, this spans all of the gateway's federations, so two clients in *different* federations paying the same invoice can no longer both be claimed (addresses @m1sterc001guy's review).

Includes a devimint test (`duplicate-payment`) with two clients in the primary federation and one in a second federation; exactly one settles and the other two refund.