### PR TITLE
ci: add distilled-diff PR job

### DIFF
--- a/.github/agents/distilled-diff.md
+++ b/.github/agents/distilled-diff.md
@@ -1,0 +1,173 @@
+# Distilled Diff Instructions
+
+You produce a **distilled diff** of a pull request: the change re-expressed as
+the smallest amount of code a reviewer must read to rebuild their mental model
+of *what changed*. It is a map for deciding where to look closer — not a
+replacement for the real diff, and NOT a prose write-up.
+
+This is not "summarization" in the usual sense. Do not narrate the change in
+English. The distilled code IS the description. Output Rust (and diff markers),
+not paragraphs.
+
+## What you are optimizing
+
+Understanding per unit of reading effort. A reader fluent in Rust reads familiar
+code in large chunks almost for free; dense prose and boilerplate are expensive.
+So surface the high-signal shape of the change and fold the low-signal noise
+into counts. Length is not the metric — *surprisal* is. Keep what a reader
+cannot predict; drop what they can.
+
+The failure mode to avoid above all: a distillation so terse or so bloated that
+the reader has to open the full diff anyway. That is negative value — they paid
+reading time and gained nothing. Optimize for understanding *minus residual
+doubt*.
+
+## The one rule (default-deny)
+
+Do NOT start from the full diff and look for things to drop — you will always
+find a reason to keep "helpful context," and the output will bloat. Start from
+**nothing** and admit a line only if it passes this test:
+
+> Include a line ONLY if omitting it would change what a **caller** believes
+> about the code — its types, function/method signatures, visibility, trait
+> bounds, enum variants, or externally observable behavior.
+>
+> **If you are unsure, LEAVE IT OUT.**
+
+Rule of thumb: keep anything that changes the API or behavior a caller sees;
+drop anything that is only *how*.
+
+## Never include (not "usually" — never, unless that IS the change)
+
+- Function / method **bodies** (show the signature only).
+- Tests and `#[cfg(test)]` blocks.
+- Doc comments (`///`, `//!`) and newly added explanatory comments.
+- `use` / import churn.
+- Formatting-only or whitespace-only hunks.
+- Generated code, lockfiles, snapshots.
+
+The single exception is when the change *is* one of these (e.g. a PR whose whole
+point is a behavior change inside a body, or a test that pins a new invariant).
+Then show the minimal slice that carries the change, and nothing around it.
+
+## Shape of the output
+
+Group changes by file with a short `# path` heading. Within each file, choose
+the fence per block by this rule — the point is to get Rust syntax highlighting
+wherever there is no "before" to contrast against, and diff coloring only where a
+before/after actually matters:
+
+- **Wholly new items → ` ```rust ` fence, no `+`/`-` markers.** When you are
+  showing a brand-new item in its entirety (a new `struct`/`enum`/`trait`/`fn`/
+  type alias/module), there is no prior version to contrast — so render it as
+  plain Rust and let GitHub syntax-highlight it. Everything in such a block is,
+  by convention, newly added; do not prefix lines with `+`.
+- **Modifications and removals → ` ```diff ` fence with `+`/`-` markers.** When
+  the change is a rename, a signature change, a changed field type, a removal, or
+  an addition *into existing surrounding context* (e.g. one new field in an
+  existing struct), use a diff fence so the reader sees the exact before/after
+  or which specific line is new. Keep markers at **item granularity**: a renamed
+  field is one `-`/`+` pair, not a rewritten block.
+
+Do not mix new-item and modified-item lines in the same fence — split them into a
+` ```rust ` block and a ` ```diff ` block so each gets the right coloring.
+
+Other rules, regardless of fence:
+
+- **Show the enclosing item header for context.** When a changed function,
+  method, or associated item lives inside an `impl` or `trait` block, include the
+  enclosing header line as unchanged context — `impl OobNotes`,
+  `impl Encodable for OobNotes`, `trait ClientModule` — so the reader knows what
+  the signature belongs to. An inherent method, a trait implementation, and a
+  trait definition are very different things to a caller, and a bare signature
+  hides which one it is. Show the header once and group all changed items from
+  that block under it; elide the body with `…` and close with `}`.
+- When a body genuinely changed behavior a caller can observe, keep the
+  signature and add a single trailing `// ` note on the changed line stating the
+  observable shift (e.g. `// now returns Err on empty input`). One line, not a
+  paragraph.
+- **Fold, don't hide.** Collapse everything you dropped into a running count so
+  nothing is silently missing, e.g.:
+  `// folded: +4 imports, 3 fn bodies, 12 test lines, fmt-only in 2 files`
+- Never write prose describing the diff outside the fenced blocks. A single
+  leading line naming the theme of the change is allowed only if it is one
+  short sentence.
+
+## Diagrams (rare — same rule, higher bar)
+
+A Mermaid diagram (GitHub renders ` ```mermaid ` blocks) can carry more
+understanding per reading-token than code when the change introduces *structure
+a reader must hold in their head*: a new protocol / message exchange, a new
+state machine, or a new interaction between components. There, a small diagram
+is allowed and encouraged.
+
+But a diagram is a re-description — the one thing this format otherwise forbids —
+so it is held to a HIGHER bar than code, not a lower one:
+
+- Include one ONLY when the change adds genuinely new structure (protocol,
+  state machine, multi-component flow). NEVER for renames, signature tweaks,
+  added fields, or single-function changes — there is no structure to draw.
+- Diagram ONLY what the diff literally introduces. Do not infer, complete, or
+  illustrate surrounding architecture that did not change. If you cannot draw it
+  faithfully from the diff alone, draw nothing.
+- Keep it minimal: the fewest nodes/edges that convey the new shape. A sprawling
+  diagram is bloat like any other.
+- If unsure whether it helps, DON'T. A wrong or vague diagram is worse than
+  none, because the reader must open the full diff to check it — the exact
+  residual-doubt failure this format exists to avoid.
+
+Prefer `sequenceDiagram` for protocols / message flows and `stateDiagram-v2`
+for state machines. At most one diagram, unless the change truly spans two
+independent new structures. A diagram is the only permitted non-code element —
+it replaces prose, it does not accompany it.
+
+## Worked example
+
+Input diff (abridged): a method is renamed and made async, a struct gains a
+field, a brand-new error enum is introduced, a large body is rewritten to fix a
+bug, imports shuffle, tests updated.
+
+Distilled output — note the fence per block: wholly-new items go in a ` ```rust `
+block (syntax-highlighted, no markers), modifications go in a ` ```diff ` block:
+
+New items — plain Rust so GitHub highlights it:
+
+```rust
+// fedimint-client/src/error.rs  (new)
+pub enum SendError {
+    QueueFull,
+    Encoding(EncodingError),
+}
+```
+
+Modifications — diff fence so before/after and the in-place field addition read
+at a glance:
+
+```diff
+# fedimint-client/src/lib.rs
+-    pub fn send_user_message(&self, msg: Msg) -> Result<()>
++    pub async fn queue_user_message(&self, msg: Msg) -> Result<MsgId, SendError>
+
+# fedimint-core/src/config.rs
+ pub struct ClientConfig {
+     pub api_endpoints: BTreeMap<PeerId, Url>,
++    pub max_notes: usize,
+ }
+
+# fedimint-mint-client/src/oob.rs
+ impl OobNotes {
+     fn select_notes(&self, amount: Amount) -> Result<Notes>  // now errors if amount exceeds max_notes, was silently clamped
+ }
+```
+
+```
+// folded: +6 imports, 2 fn bodies, 40 test lines, fmt-only in 3 files
+```
+
+Notice the fence split: the new `SendError` enum has no "before," so it goes in a
+` ```rust ` block and reads as highlighted Rust; the rename, the new return type,
+and the in-place field addition each need a before/after or a pinpointed new
+line, so they stay in a ` ```diff ` block. Notice also the `impl OobNotes` header
+kept as context around `select_notes`, so it is clear the method is an inherent
+one, not a trait implementation. Notice too what was dropped: the rewritten body
+internals, imports, and tests — all folded into a count.

--- a/.github/workflows/codex-distilled-diff.yml
+++ b/.github/workflows/codex-distilled-diff.yml
@@ -1,0 +1,237 @@
+name: "Codex Distilled Diff"
+
+on:
+  # Use pull_request_target so secrets are available for fork PRs.
+  # Safety: we checkout the base branch (trusted) and only fetch the PR
+  # diff as text — no untrusted code is checked out or executed.
+  pull_request_target:
+    types: [opened, synchronize, ready_for_review]
+
+# One distillation per PR at a time; a new push supersedes an in-flight run.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  distill:
+    # Run on PR open / new push / ready-for-review, skipping drafts.
+    if: >-
+      github.repository == 'fedimint/fedimint' &&
+      !github.event.pull_request.draft
+    name: Distilled Diff
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Resolve PR metadata
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.BACKPORT_TOKEN }}
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+
+          PR_JSON=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}")
+
+          {
+            echo "number=${PR_NUMBER}"
+            echo "base_ref=$(echo "$PR_JSON" | jq -r '.base.ref')"
+            echo "base_sha=$(echo "$PR_JSON" | jq -r '.base.sha')"
+            echo "head_sha=$(echo "$PR_JSON" | jq -r '.head.sha')"
+            echo "title=$(echo "$PR_JSON" | jq -r '.title')"
+          } >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Checkout the base branch (trusted code only)
+          ref: ${{ steps.pr.outputs.base_ref }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Fetch PR head
+        run: |
+          # Fetch the PR head commit without checking it out
+          git fetch origin "${{ steps.pr.outputs.head_sha }}"
+
+      - name: Get diff to distill
+        id: diff
+        run: |
+          BASE_SHA=${{ steps.pr.outputs.base_sha }}
+          HEAD_SHA=${{ steps.pr.outputs.head_sha }}
+
+          git diff "$BASE_SHA"..."$HEAD_SHA" > /tmp/pr_diff.patch
+
+          DIFF_SIZE=$(wc -c < /tmp/pr_diff.patch)
+          MAX_SIZE=300000
+          if [ "$DIFF_SIZE" -gt "$MAX_SIZE" ]; then
+            truncate -s "$MAX_SIZE" /tmp/pr_diff.patch
+            echo -e "\n\n... [diff truncated at ${MAX_SIZE} bytes, full diff is ${DIFF_SIZE} bytes] ..." >> /tmp/pr_diff.patch
+            echo "truncated=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "truncated=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install Codex CLI
+        run: npm install -g @openai/codex
+
+      - name: Build distillation prompt
+        env:
+          PR_TITLE: ${{ steps.pr.outputs.title }}
+        run: |
+          TRUNCATED="${{ steps.diff.outputs.truncated }}"
+
+          # Prepend the distilled-diff instructions so Codex has them in context
+          cat .github/agents/distilled-diff.md > /tmp/distill_prompt.txt
+
+          cat >> /tmp/distill_prompt.txt <<'PROMPT_HEADER'
+
+          ---
+
+          Produce a distilled diff of the following pull request, following the
+          instructions above. Output ONLY the distilled diff (fenced blocks, the
+          folded-count line, and — only if the strict bar in the Diagrams section
+          is met — at most one Mermaid diagram). No preamble, no closing remarks,
+          no prose describing the change beyond at most one short leading theme
+          line.
+          PROMPT_HEADER
+
+          printf '\nPR Title: %s\n' "$PR_TITLE" >> /tmp/distill_prompt.txt
+
+          if [ "$TRUNCATED" = "true" ]; then
+            cat >> /tmp/distill_prompt.txt <<'EOF'
+
+          NOTE: The diff below was truncated due to size. Distill what is shown
+          and end with a folded-count line noting that the tail was truncated.
+          EOF
+          fi
+
+          printf '\nDiff:\n' >> /tmp/distill_prompt.txt
+          cat /tmp/pr_diff.patch >> /tmp/distill_prompt.txt
+
+      - name: Run Codex distillation
+        id: codex
+        env:
+          PPQ_KEY: ${{ secrets.PPQ_KEY }}
+          PPQ_MODEL: ${{ vars.PPQ_MODEL || 'openai/gpt-5.5' }}
+        run: |
+          set -euo pipefail
+
+          export CODEX_HOME="${RUNNER_TEMP}/codex-distill-home"
+          mkdir -p "$CODEX_HOME"
+          path_toml=$(jq -Rn --arg value "$PATH" '$value')
+          {
+            printf 'model = "%s"\n' "$PPQ_MODEL"
+            printf '%s\n' \
+              'model_provider = "ppq"' \
+              'model_reasoning_effort = "medium"' \
+              'sandbox_mode = "read-only"' \
+              'approval_policy = "never"' \
+              'hide_agent_reasoning = true' \
+              '' \
+              '[model_providers.ppq]' \
+              'name = "PPQ"' \
+              'base_url = "https://api.ppq.ai/v1"' \
+              'env_key = "PPQ_KEY"' \
+              'wire_api = "responses"' \
+              '' \
+              '[history]' \
+              'persistence = "none"' \
+              '' \
+              '[shell_environment_policy]' \
+              'inherit = "all"' \
+              'ignore_default_excludes = false'
+            printf 'set = { PATH = %s }\n' "$path_toml"
+            printf '%s\n' \
+              'include_only = [' \
+              '  "PATH",' \
+              '  "HOME",' \
+              '  "CODEX_HOME",' \
+              '  "CI",' \
+              '  "TMPDIR",' \
+              '  "TEMP",' \
+              '  "TMP",' \
+              '  "LANG",' \
+              '  "LC_*",' \
+              ']'
+          } > "$CODEX_HOME/config.toml"
+
+          print_codex_log_tail() {
+            local log_file="$1"
+            if [ ! -s "$log_file" ]; then
+              echo "Codex log is empty or missing: $log_file"
+              return
+            fi
+            echo "::group::codex log tail"
+            sed -E \
+              -e "s/(Authorization: Bearer )[A-Za-z0-9._-]+/\\1<redacted>/g" \
+              -e "s/(api[_-]?key[=:] ?)[A-Za-z0-9._-]+/\\1<redacted>/Ig" \
+              "$log_file" | tail -n 120
+            echo "::endgroup::"
+          }
+
+          if ! codex exec \
+            --ephemeral \
+            --output-last-message /tmp/distilled.md \
+            - < /tmp/distill_prompt.txt > /tmp/codex.log 2>&1; then
+            echo "Codex distillation failed"
+            print_codex_log_tail /tmp/codex.log
+            exit 1
+          fi
+
+          if [ ! -s /tmp/distilled.md ]; then
+            echo "Codex produced no output"
+            print_codex_log_tail /tmp/codex.log
+            exit 1
+          fi
+
+      - name: Upsert distilled-diff comment
+        env:
+          GH_TOKEN: ${{ secrets.BACKPORT_TOKEN }}
+        run: |
+          set -euo pipefail
+          PR_NUMBER="${{ steps.pr.outputs.number }}"
+          HEAD_SHA="${{ steps.pr.outputs.head_sha }}"
+          MARKER="<!-- distilled-diff-bot -->"
+
+          # Wrap the distillation in a collapsed-by-default <details> block so it
+          # never dominates the PR conversation. The marker (an HTML comment) lets
+          # us find and update this comment on the next push instead of stacking.
+          {
+            echo "$MARKER"
+            echo "<details>"
+            printf '<summary>🔬 Distilled diff — the change at a glance (<code>%s</code>)</summary>\n' "${HEAD_SHA:0:7}"
+            echo ""
+            cat /tmp/distilled.md
+            echo ""
+            echo "</details>"
+            echo ""
+            echo "<sub>Distilled by fedimint-bot from the full diff — a map, not a replacement. Collapsed by default; expand for the shape of the change.</sub>"
+          } > /tmp/comment_body.md
+
+          # Find a prior distilled-diff comment by this bot (via the marker).
+          BOT_LOGIN=$(gh api user --jq '.login')
+          EXISTING_ID=$(gh api \
+            "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments?per_page=100" \
+            --jq "[.[] | select(.user.login == \"${BOT_LOGIN}\") | select(.body | contains(\"${MARKER}\")) | .id] | last // empty")
+
+          # Build the JSON payload from the file via jq (robust for arbitrary
+          # markdown/HTML) and pipe it in, matching the repo's other gh api usage.
+          jq -Rs '{body: .}' < /tmp/comment_body.md > /tmp/comment_payload.json
+
+          if [ -n "$EXISTING_ID" ]; then
+            gh api \
+              "repos/${{ github.repository }}/issues/comments/${EXISTING_ID}" \
+              --method PATCH \
+              --input /tmp/comment_payload.json
+            echo "Updated existing distilled-diff comment ${EXISTING_ID}"
+          else
+            gh api \
+              "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+              --method POST \
+              --input /tmp/comment_payload.json
+            echo "Posted new distilled-diff comment"
+          fi


### PR DESCRIPTION
### Summary

Add a CI job that posts a **distilled diff** of each PR — the change re-expressed at item granularity (types, signatures, visibility, variants, observable behavior), with bodies/tests/docs/import-churn folded into counts. It's a map for deciding where to read closer, collapsed by default so it never dominates the conversation. Not a replacement for the diff, and deliberately not a "review."

### Details

The job (`.github/workflows/codex-distilled-diff.yml`) mirrors the existing `codex-review` workflow so it reuses the same infrastructure — **no new secrets**:

- `pull_request_target` on `opened` / `synchronize` / `ready_for_review` (drafts skipped), one run per PR with `cancel-in-progress`.
- Safe fork handling: checks out the **trusted base branch** and fetches the PR head as text only — no untrusted code is executed. The diff is fed to the Codex CLI running against PPQ in a `read-only` sandbox (`PPQ_KEY` / `PPQ_MODEL` / `BACKPORT_TOKEN`, all already present).
- Output is wrapped in a collapsed `<details>` block and **upserted into a single PR comment** keyed by a hidden HTML marker, so each push refreshes it in place instead of stacking new comments.

The prompt (`.github/agents/distilled-diff.md`) is **default-deny**: start from nothing and admit a line only if omitting it would change what a *caller* believes about the code, with an explicit "if unsure, leave it out" tiebreaker. Bodies, tests, docs, and import churn are never included unless they *are* the change; everything dropped is folded into a running count so nothing is silently missing.

**Syntax highlighting via hybrid fences.** GitHub renders one lexer per code fence, so you can't get diff coloring and Rust token coloring in a single block. The prompt therefore splits by intent: wholly-new items (which dominate a distilled diff) go in a ` ```rust ` fence and get full syntax highlighting, while genuine before/after changes (renames, signature changes, in-place field additions) stay in a ` ```diff ` fence so the red/green survives. This keeps everything as copyable text (preserving the click-to-definition idea from the discussion) rather than falling back to a rendered image.

Diagrams (Mermaid) are permitted only under a strict, *higher* bar — genuinely new structure like a protocol, state machine, or cross-component flow — never for renames or signature tweaks. The naming avoids the overloaded words "summary" and "review," which trigger generic model behaviors.

### Reviewing

- The prompt is where the quality lives — the `distilled-diff.md` default-deny framing, the `rust`/`diff` fence-selection rule, and the diagram gate are the parts most worth an opinion.
- `model_reasoning_effort` is set to `medium` (vs codex-review's `xhigh`) since distillation is lighter; easy to bump.
- Not included: a self-critique/self-edit second pass. Kept as a lean one-shot to control cost; trivial to add later if output quality warrants.

### Testing

Validated locally with `actionlint` (clean) and `just typos` (clean). The comment-assembly, JSON payload, and marker-based upsert logic were dry-run locally against a sample GitHub API response. End-to-end behavior (Codex output quality, comment posting) needs a live PR against the fedimint repo, which is why this is opened as a draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
