### PR TITLE
fix(lnv2): don't hold a db transaction across the lnurl receive long-poll

### DIFF
--- a/modules/fedimint-lnv2-client/src/lib.rs
+++ b/modules/fedimint-lnv2-client/src/lib.rs
@@ -1154,9 +1154,19 @@ impl LightningClientModule {
     }
 
     async fn receive_lnurl(&self, custom_meta: Value) {
-        let mut dbtx = self.client_ctx.module_db().begin_transaction().await;
-
-        let stream_index = dbtx
+        // Read the stream cursor with a short-lived transaction. It must NOT stay open
+        // across the long-poll below: RocksDB's optimistic transactions validate a
+        // commit against bounded memtable history, so a transaction held open
+        // for minutes fails with a spurious `WriteConflict` once enough
+        // concurrent writes flush that history — and the panicking
+        // `commit_tx()` then killed this task permanently, silently
+        // stalling every future receive for the lifetime of the process. Long-lived
+        // clients (daemons) hit this reproducibly under concurrent lnv2 activity.
+        let stream_index = self
+            .client_ctx
+            .module_db()
+            .begin_transaction_nc()
+            .await
             .get_value(&IncomingContractStreamIndexKey)
             .await
             .unwrap_or(0);
@@ -1184,10 +1194,36 @@ impl LightningClientModule {
             }
         }
 
-        dbtx.insert_entry(&IncomingContractStreamIndexKey, &next_index)
-            .await;
+        // Advance the cursor in its own short transaction, retrying transient write
+        // conflicts. The closure re-reads the current value and only ever moves the
+        // cursor FORWARD, so a concurrent writer can never be rewound by a stale
+        // `next_index` (a same-key conflict makes the loser retry and re-read).
+        // Ordering is unchanged: the cursor only moves after the batch above
+        // was processed, and a crash in between re-fetches the same batch on
+        // the next iteration exactly as it did when the write shared the read's
+        // transaction.
+        self.client_ctx
+            .module_db()
+            .autocommit(
+                |dbtx, _| {
+                    Box::pin(async move {
+                        let current = dbtx
+                            .get_value(&IncomingContractStreamIndexKey)
+                            .await
+                            .unwrap_or(0);
 
-        dbtx.commit_tx().await;
+                        if current < next_index {
+                            dbtx.insert_entry(&IncomingContractStreamIndexKey, &next_index)
+                                .await;
+                        }
+
+                        Result::<(), ()>::Ok(())
+                    })
+                },
+                None,
+            )
+            .await
+            .expect("Will never return an error");
     }
 }
 


### PR DESCRIPTION
## The bug

`receive_lnurl` opens a database transaction, reads `IncomingContractStreamIndexKey`, then keeps that transaction open across `await_incoming_contracts` — a long-poll that can block for minutes — and across the claim/await of every returned contract, before writing the advanced index and committing with the panicking `commit_tx()`.

RocksDB's optimistic transactions validate a commit against bounded memtable history (fedimint configures a 2MB write buffer with `max_write_buffer_number = 2` and no `max_write_buffer_size_to_maintain`), so a transaction held open that long fails with a spurious `WriteConflict` once enough concurrent writes flush that history — regardless of key overlap. The `commit_tx()` expect then panics:

```
thread 'tokio-rt-worker' panicked at fedimint-core/src/db/mod.rs:
Unrecoverable error occurred while committing to the database.: WriteConflict
INFO fm::task: Task shut down uncleanly name=receive_lnurl_task
```

and the shared `receive_lnurl_task` dies permanently: from that point on **no incoming contract is ever claimed again for the lifetime of the process**, with nothing but that one panic line to show for it.

Short-lived clients rarely notice (the next app start respawns the task). A long-lived client hits it reproducibly: a 24/7 daemon driving concurrent lnv2 operations with idle gaps between user operations (idle gap → the long-poll blocks → concurrent writes flush the memtable → the eventual commit conflicts) wedged its receive path within ~15 minutes, deterministically, across repeated soak runs. Fast cadences never trigger it — contracts keep arriving, the long-poll returns quickly, and the transaction stays short — which is why this stayed hidden.

## The fix

- Read the cursor with a short-lived nc transaction.
- Run the long-poll and the claims with **no transaction open**.
- Advance the cursor in its own transaction via `autocommit` (retrying transient write conflicts), matching how other background writers persist state (e.g. `store_api_announcement_updates`). The closure re-reads the current value and only moves the cursor forward, so a stale `next_index` can never rewind it.

Ordering is unchanged: the cursor still only advances after the batch is processed, and a crash in between re-fetches the same batch on the next iteration exactly as before (re-receiving an already-received contract is already a no-op).

## Notes

- A wider question this surfaces: any other long-held client transaction over the same store has the same failure mode, and `commit_tx()`'s panic turns a transient RocksDB condition into permanent task death. This PR fixes the one site we can deterministically wedge; happy to file the general issue separately if useful.