### PR TITLE
fix(ln-client): check pay idempotency before invoice expiry

### DIFF
--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -1307,13 +1307,6 @@ impl LightningClientModule {
         invoice: Bolt11Invoice,
         extra_meta: M,
     ) -> anyhow::Result<OutgoingLightningPayment> {
-        if let Some(expires_at) = invoice.expires_at() {
-            ensure!(
-                expires_at.as_secs() > fedimint_core::time::duration_since_epoch().as_secs(),
-                "Invoice has expired"
-            );
-        }
-
         let mut dbtx = self.client_ctx.module_db().begin_transaction().await;
         let maybe_gateway_id = maybe_gateway.as_ref().map(|g| g.gateway_id);
         let prev_payment_result = self
@@ -1335,6 +1328,21 @@ impl LightningClientModule {
                     operation_id: prev_operation_id
                 }
             )
+        }
+
+        // Only a genuinely NEW payment attempt is refused for an expired invoice. This
+        // check deliberately runs AFTER the two idempotency checks above so
+        // that re-submitting an invoice that was already attempted keeps its
+        // idempotent answer even once the invoice lapses: a completed payment
+        // is returned as such, and a still-running attempt surfaces
+        // `PreviousPaymentAttemptStillInProgress` with its operation id.
+        // Checking expiry first would mask both answers behind "Invoice has
+        // expired".
+        if let Some(expires_at) = invoice.expires_at() {
+            ensure!(
+                expires_at.as_secs() > fedimint_core::time::duration_since_epoch().as_secs(),
+                "Invoice has expired"
+            );
         }
 
         let next_index = prev_payment_result.index + 1;

--- a/modules/fedimint-ln-tests/tests/tests.rs
+++ b/modules/fedimint-ln-tests/tests/tests.rs
@@ -794,9 +794,11 @@ async fn returns_completed_payment_for_expired_invoice_already_paid() -> anyhow:
         .subscribe_ln_receive(op)
         .await?
         .into_stream();
-    assert_eq!(sub1.ok().await?, LnReceiveState::Created);
-    assert_matches!(sub1.ok().await?, LnReceiveState::WaitingForPayment { .. });
 
+    // Pay FIRST, before consuming any receive-stream states: the pre-payment
+    // window against the short real-time expiry must stay minimal so a slow CI
+    // cannot expire the invoice before the first attempt. The receive stream
+    // replays all states in order, so the assertions below are unaffected.
     let OutgoingLightningPayment {
         payment_type: first_payment_type,
         contract_id: _,
@@ -811,6 +813,8 @@ async fn returns_completed_payment_for_expired_invoice_already_paid() -> anyhow:
                 .into_stream();
             assert_eq!(sub2.ok().await?, InternalPayState::Funding);
             assert_matches!(sub2.ok().await?, InternalPayState::Preimage { .. });
+            assert_eq!(sub1.ok().await?, LnReceiveState::Created);
+            assert_matches!(sub1.ok().await?, LnReceiveState::WaitingForPayment { .. });
             assert_eq!(sub1.ok().await?, LnReceiveState::Funded);
             assert_eq!(sub1.ok().await?, LnReceiveState::AwaitingFunds);
             assert_eq!(sub1.ok().await?, LnReceiveState::Claimed);

--- a/modules/fedimint-ln-tests/tests/tests.rs
+++ b/modules/fedimint-ln-tests/tests/tests.rs
@@ -766,6 +766,88 @@ async fn rejects_expired_invoice() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn returns_completed_payment_for_expired_invoice_already_paid() -> anyhow::Result<()> {
+    let fixtures = fixtures();
+    let fed = fixtures.new_fed_degraded().await;
+    let (client1, client2) = fed.two_clients().await;
+    let client2_dummy_module = client2.get_first_module::<DummyClientModule>()?;
+
+    // Give client2 initial balance
+    client2_dummy_module
+        .mock_receive(sats(1000), AmountUnit::BITCOIN)
+        .await?;
+
+    // An invoice with a short expiry, paid (internally) well before it lapses.
+    let desc = Description::new("paid-then-expired".to_string())?;
+    let (op, invoice, _) = client1
+        .get_first_module::<LightningClientModule>()?
+        .create_bolt11_invoice(
+            sats(250),
+            Bolt11InvoiceDescription::Direct(desc),
+            Some(5),
+            (),
+            None,
+        )
+        .await?;
+    let mut sub1 = client1
+        .get_first_module::<LightningClientModule>()?
+        .subscribe_ln_receive(op)
+        .await?
+        .into_stream();
+    assert_eq!(sub1.ok().await?, LnReceiveState::Created);
+    assert_matches!(sub1.ok().await?, LnReceiveState::WaitingForPayment { .. });
+
+    let OutgoingLightningPayment {
+        payment_type: first_payment_type,
+        contract_id: _,
+        fee: _,
+    } = pay_invoice(&client2, invoice.clone(), None).await?;
+    match first_payment_type {
+        PayType::Internal(op_id) => {
+            let mut sub2 = client2
+                .get_first_module::<LightningClientModule>()?
+                .subscribe_internal_pay(op_id)
+                .await?
+                .into_stream();
+            assert_eq!(sub2.ok().await?, InternalPayState::Funding);
+            assert_matches!(sub2.ok().await?, InternalPayState::Preimage { .. });
+            assert_eq!(sub1.ok().await?, LnReceiveState::Funded);
+            assert_eq!(sub1.ok().await?, LnReceiveState::AwaitingFunds);
+            assert_eq!(sub1.ok().await?, LnReceiveState::Claimed);
+        }
+        _ => panic!("Expected internal payment!"),
+    }
+
+    // Let the invoice lapse AFTER it was successfully paid.
+    fedimint_core::task::sleep_in_test(
+        "waiting for the paid invoice to expire",
+        std::time::Duration::from_secs(6),
+    )
+    .await;
+
+    // A caller recovering from a crash re-pays the same (now expired) invoice to
+    // learn what happened to its earlier attempt. The completed payment must be
+    // returned — not an "Invoice has expired" error, which would mask the
+    // successful payment and push the caller toward paying again through a
+    // fresh invoice.
+    let prev_balance = client2.get_balance_for_btc().await?;
+    let OutgoingLightningPayment {
+        payment_type,
+        contract_id: _,
+        fee: _,
+    } = pay_invoice(&client2, invoice, None).await?;
+    assert_eq!(
+        payment_type.operation_id(),
+        first_payment_type.operation_id(),
+        "the completed payment is returned; no new attempt is started"
+    );
+    let same_balance = client2.get_balance_for_btc().await?;
+    assert_eq!(prev_balance, same_balance);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn can_reclaim_receive_funded_after_invoice_expiry() -> anyhow::Result<()> {
     let fixtures = fixtures();
     let fed = fixtures.new_fed_degraded().await;


### PR DESCRIPTION
## Problem

`pay_bolt11_invoice` checks invoice expiry **before** its two per-payment-hash idempotency checks (the completed-payment short-circuit and the `PreviousPaymentAttemptStillInProgress` bail).

Expiry-first breaks the idempotency contract for retries: re-submitting an invoice that was already attempted answers `Invoice has expired` instead of the completed payment or the live attempt's operation id. A caller therefore cannot learn the outcome of its previous attempt once the invoice lapses — exactly the window where a retrying caller most needs the idempotent answer.

## Change

Reorder to **completed → active-attempt → expiry**:

- an expired invoice that was already paid returns the completed payment;
- an expired invoice with a still-running attempt surfaces `PreviousPaymentAttemptStillInProgress` with its operation id;
- only a genuinely **new** attempt at an expired invoice is refused, unchanged.

Non-expired flows are byte-identical. The expiry check still guards every path that creates a new operation (it runs before the attempt-index bump and both the internal/external output branches). This also matches the existing order elsewhere in the function: currency validation already runs after the idempotency short-circuits.

## Behavior change note

Callers that re-submit an invoice they already attempted and match on `Invoice has expired` will now receive the completed payment (`Ok`) or the in-progress error instead — the idempotent answer. A **never-attempted** expired invoice still fails with `Invoice has expired` exactly as before.

## Testing

- New integration test `returns_completed_payment_for_expired_invoice_already_paid`: pays a 5s-expiry invoice, waits past expiry, re-pays — asserts the completed payment is returned (same operation id, unchanged balance). Verified to **fail on current master** with `Invoice has expired` and pass with this change.
- Existing `rejects_expired_invoice`, `cannot_pay_same_internal_invoice_twice`, and `cannot_pay_same_external_invoice_twice` pass unchanged.
- `cargo check -p fedimint-ln-client` clean; rustfmt applied.