### PR TITLE
fix(client): only cache terminal updates as operation outcomes

### DIFF
--- a/fedimint-client-module/src/module/mod.rs
+++ b/fedimint-client-module/src/module/mod.rs
@@ -19,7 +19,7 @@ use fedimint_core::invite_code::InviteCode;
 use fedimint_core::module::registry::{ModuleDecoderRegistry, ModuleRegistry};
 use fedimint_core::module::{AmountUnit, Amounts, CommonModuleInit, ModuleCommon, ModuleInit};
 use fedimint_core::task::{MaybeSend, MaybeSync};
-use fedimint_core::util::BoxStream;
+use fedimint_core::util::{BoxStream, FmtCompact as _};
 use fedimint_core::{
     Amount, OutPoint, PeerId, apply, async_trait_maybe_send, dyn_newtype_define, maybe_add_send,
     maybe_add_send_sync,
@@ -712,35 +712,63 @@ where
         Ok(())
     }
 
+    /// Resolve an operation to its cached outcome, or to a caching update
+    /// stream built by `stream_gen`.
+    ///
+    /// `is_terminal` reports whether an update is a final state of the
+    /// operation; only terminal updates are cached as the durable outcome (a
+    /// stream that ends early on a non-terminal update caches nothing). A
+    /// cached outcome that fails to deserialize into `U` (e.g. one written by
+    /// an incompatible earlier version) is discarded with a warning and the
+    /// state is rebuilt from the update stream instead of panicking.
     pub fn outcome_or_updates<U, S>(
         &self,
-        operation: OperationLogEntry,
+        operation: &OperationLogEntry,
         operation_id: OperationId,
-        stream_gen: impl FnOnce() -> S + 'static,
+        is_terminal: impl Fn(&U) -> bool + MaybeSend + MaybeSync + 'static,
+        stream_gen: impl FnOnce() -> S + MaybeSend + 'static,
     ) -> UpdateStreamOrOutcome<U>
     where
         U: Clone + Serialize + DeserializeOwned + Debug + MaybeSend + MaybeSync + 'static,
         S: Stream<Item = U> + MaybeSend + 'static,
     {
         use futures::StreamExt;
-        match self.client.get().operation_log().outcome_or_updates(
-            &self.global_db(),
-            operation_id,
-            operation,
-            Box::new(move || {
-                let stream_gen = stream_gen();
-                Box::pin(
-                    stream_gen.map(move |item| serde_json::to_value(item).expect("Can't fail")),
-                )
-            }),
-        ) {
-            UpdateStreamOrOutcome::UpdateStream(stream) => UpdateStreamOrOutcome::UpdateStream(
-                Box::pin(stream.map(|u| serde_json::from_value(u).expect("Can't fail"))),
-            ),
-            UpdateStreamOrOutcome::Outcome(o) => {
-                UpdateStreamOrOutcome::Outcome(serde_json::from_value(o).expect("Can't fail"))
+        match operation.try_outcome::<U>() {
+            Ok(Some(outcome)) => return UpdateStreamOrOutcome::Outcome(outcome),
+            Ok(None) => {}
+            Err(err) => {
+                warn!(
+                    target: LOG_CLIENT,
+                    err = %err.fmt_compact(),
+                    "Cached operation outcome failed to deserialize; rebuilding it from the update stream"
+                );
             }
         }
+        let stream = self
+            .client
+            .get()
+            .operation_log()
+            .caching_operation_update_stream(
+                operation_id,
+                Box::new(move || {
+                    let stream_gen = stream_gen();
+                    Box::pin(
+                        stream_gen.map(move |item| serde_json::to_value(item).expect("Can't fail")),
+                    )
+                }),
+                Box::new(move |update| {
+                    // The update was serialized from a `U` moments ago in this
+                    // process, so deserialization only fails if `U` is not
+                    // round-trip-safe; treat that conservatively as non-terminal
+                    // (skip caching) rather than panicking inside the stream.
+                    serde_json::from_value::<U>(update.clone())
+                        .map(|update| is_terminal(&update))
+                        .unwrap_or(false)
+                }),
+            );
+        UpdateStreamOrOutcome::UpdateStream(Box::pin(
+            stream.map(|u| serde_json::from_value::<U>(u).expect("Can't fail")),
+        ))
     }
 
     pub async fn claim_inputs<I, S>(

--- a/fedimint-client-module/src/module/mod.rs
+++ b/fedimint-client-module/src/module/mod.rs
@@ -717,10 +717,14 @@ where
     ///
     /// `is_terminal` reports whether an update is a final state of the
     /// operation; only terminal updates are cached as the durable outcome (a
-    /// stream that ends early on a non-terminal update caches nothing). A
-    /// cached outcome that fails to deserialize into `U` (e.g. one written by
-    /// an incompatible earlier version) is discarded with a warning and the
-    /// state is rebuilt from the update stream instead of panicking.
+    /// stream that ends early on a non-terminal update caches nothing). The
+    /// same predicate also validates outcomes READ from the cache: a cached
+    /// outcome that fails to deserialize into `U` (e.g. one written by an
+    /// incompatible earlier version) or that is non-terminal (one frozen by a
+    /// previous version that cached whatever update a stream ended on) is
+    /// discarded with a warning and the state is rebuilt from the update
+    /// stream — whose terminal end then overwrites the stale cache — instead
+    /// of short-circuiting subscribers to it or panicking.
     pub fn outcome_or_updates<U, S>(
         &self,
         operation: &OperationLogEntry,
@@ -734,7 +738,16 @@ where
     {
         use futures::StreamExt;
         match operation.try_outcome::<U>() {
-            Ok(Some(outcome)) => return UpdateStreamOrOutcome::Outcome(outcome),
+            Ok(Some(outcome)) if is_terminal(&outcome) => {
+                return UpdateStreamOrOutcome::Outcome(outcome);
+            }
+            Ok(Some(_non_terminal)) => {
+                warn!(
+                    target: LOG_CLIENT,
+                    "Cached operation outcome is not a terminal update (cached by a previous \
+                     version); rebuilding it from the update stream"
+                );
+            }
             Ok(None) => {}
             Err(err) => {
                 warn!(

--- a/fedimint-client-module/src/oplog.rs
+++ b/fedimint-client-module/src/oplog.rs
@@ -3,12 +3,12 @@ use std::future;
 use std::time::SystemTime;
 
 use fedimint_core::core::OperationId;
-use fedimint_core::db::{Database, DatabaseTransaction};
+use fedimint_core::db::DatabaseTransaction;
 use fedimint_core::encoding::{Decodable, DecodeError, Encodable};
 use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_core::task::{MaybeSend, MaybeSync};
 use fedimint_core::util::BoxStream;
-use fedimint_core::{apply, async_trait_maybe_send};
+use fedimint_core::{apply, async_trait_maybe_send, maybe_add_send, maybe_add_send_sync};
 use futures::{StreamExt, stream};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -54,13 +54,19 @@ pub trait IOperationLog {
         operation_meta: serde_json::Value,
     );
 
-    fn outcome_or_updates(
+    /// Wrap a module's operation update stream so that its last update is
+    /// cached as the operation's outcome — only when `is_terminal` reports
+    /// that update as a final state of the operation. Outcome resolution
+    /// (returning a cached outcome instead of a stream) happens in the typed
+    /// caller ([`crate::module::ClientContext::outcome_or_updates`]), which
+    /// can deserialize the cached value into the module's update type and
+    /// fall back to this stream when that fails.
+    fn caching_operation_update_stream(
         &self,
-        db: &Database,
         operation_id: OperationId,
-        operation_log_entry: OperationLogEntry,
-        stream_gen: Box<dyn FnOnce() -> BoxStream<'static, serde_json::Value>>,
-    ) -> UpdateStreamOrOutcome<serde_json::Value>;
+        stream_gen: Box<maybe_add_send!(dyn FnOnce() -> BoxStream<'static, serde_json::Value>)>,
+        is_terminal: Box<maybe_add_send_sync!(dyn Fn(&serde_json::Value) -> bool)>,
+    ) -> BoxStream<'static, serde_json::Value>;
 }
 
 /// Represents the outcome of an operation, combining both the outcome value and

--- a/fedimint-client/src/oplog.rs
+++ b/fedimint-client/src/oplog.rs
@@ -241,10 +241,14 @@ impl OperationLog {
     /// updates are cached as the operation's outcome — an update stream that
     /// ends early (a consumer-side error path) must not persist a
     /// non-terminal update as the durable outcome, since later subscribers
-    /// would then be short-circuited to it forever. A cached outcome that no
+    /// would then be short-circuited to it forever. The same predicate also
+    /// validates outcomes READ from the cache: a cached outcome that no
     /// longer deserializes (e.g. written by an older version with a different
-    /// update type) is discarded with a warning and the outcome is rebuilt
-    /// from the update stream instead of panicking.
+    /// update type) or that is non-terminal (frozen by a previous version
+    /// that cached whatever update a stream ended on) is discarded with a
+    /// warning and the outcome is rebuilt from the update stream — whose
+    /// terminal end then overwrites the stale cache — instead of
+    /// short-circuiting subscribers to it or panicking.
     pub fn outcome_or_updates<U, S>(
         db: &Database,
         operation_id: OperationId,
@@ -257,7 +261,16 @@ impl OperationLog {
         S: futures::Stream<Item = U> + MaybeSend + 'static,
     {
         match operation_log_entry.try_outcome::<U>() {
-            Ok(Some(outcome)) => return UpdateStreamOrOutcome::Outcome(outcome),
+            Ok(Some(outcome)) if is_terminal(&outcome) => {
+                return UpdateStreamOrOutcome::Outcome(outcome);
+            }
+            Ok(Some(_non_terminal)) => {
+                warn!(
+                    target: LOG_CLIENT,
+                    "Cached operation outcome is not a terminal update (cached by a previous \
+                     version); rebuilding it from the update stream"
+                );
+            }
             Ok(None) => {}
             Err(err) => {
                 warn!(

--- a/fedimint-client/src/oplog.rs
+++ b/fedimint-client/src/oplog.rs
@@ -11,8 +11,8 @@ use fedimint_core::core::OperationId;
 use fedimint_core::db::{Database, DatabaseTransaction, IDatabaseTransactionOpsCoreTyped as _};
 use fedimint_core::task::{MaybeSend, MaybeSync};
 use fedimint_core::time::now;
-use fedimint_core::util::BoxStream;
-use fedimint_core::{apply, async_trait_maybe_send};
+use fedimint_core::util::{BoxStream, FmtCompact as _};
+use fedimint_core::{apply, async_trait_maybe_send, maybe_add_send, maybe_add_send_sync};
 use fedimint_logging::LOG_CLIENT;
 use futures::StreamExt as _;
 use serde::Serialize;
@@ -235,24 +235,44 @@ impl OperationLog {
     /// an update stream for easier handling using
     /// [`UpdateStreamOrOutcome::into_stream`] but can also be matched over to
     /// shortcut the handling of final outcomes.
+    ///
+    /// `is_terminal` reports whether a given update is a final state of the
+    /// operation (no further update will ever follow it). Only terminal
+    /// updates are cached as the operation's outcome — an update stream that
+    /// ends early (a consumer-side error path) must not persist a
+    /// non-terminal update as the durable outcome, since later subscribers
+    /// would then be short-circuited to it forever. A cached outcome that no
+    /// longer deserializes (e.g. written by an older version with a different
+    /// update type) is discarded with a warning and the outcome is rebuilt
+    /// from the update stream instead of panicking.
     pub fn outcome_or_updates<U, S>(
         db: &Database,
         operation_id: OperationId,
-        operation_log_entry: OperationLogEntry,
+        operation_log_entry: &OperationLogEntry,
+        is_terminal: impl Fn(&U) -> bool + MaybeSend + MaybeSync + 'static,
         stream_gen: impl FnOnce() -> S,
     ) -> UpdateStreamOrOutcome<U>
     where
         U: Clone + Serialize + DeserializeOwned + Debug + MaybeSend + MaybeSync + 'static,
         S: futures::Stream<Item = U> + MaybeSend + 'static,
     {
-        match operation_log_entry.outcome::<U>() {
-            Some(outcome) => UpdateStreamOrOutcome::Outcome(outcome),
-            None => UpdateStreamOrOutcome::UpdateStream(caching_operation_update_stream(
-                db.clone(),
-                operation_id,
-                stream_gen(),
-            )),
+        match operation_log_entry.try_outcome::<U>() {
+            Ok(Some(outcome)) => return UpdateStreamOrOutcome::Outcome(outcome),
+            Ok(None) => {}
+            Err(err) => {
+                warn!(
+                    target: LOG_CLIENT,
+                    err = %err.fmt_compact(),
+                    "Cached operation outcome failed to deserialize; rebuilding it from the update stream"
+                );
+            }
         }
+        UpdateStreamOrOutcome::UpdateStream(caching_operation_update_stream(
+            db.clone(),
+            operation_id,
+            stream_gen(),
+            is_terminal,
+        ))
     }
 
     /// Tries to set the outcome of an operation, but only logs an error if it
@@ -304,19 +324,13 @@ impl IOperationLog for OperationLog {
         .await
     }
 
-    fn outcome_or_updates(
+    fn caching_operation_update_stream(
         &self,
-        db: &Database,
         operation_id: OperationId,
-        operation: OperationLogEntry,
-        stream_gen: Box<dyn FnOnce() -> BoxStream<'static, serde_json::Value>>,
-    ) -> UpdateStreamOrOutcome<serde_json::Value> {
-        match OperationLog::outcome_or_updates(db, operation_id, operation, stream_gen) {
-            UpdateStreamOrOutcome::UpdateStream(pin) => UpdateStreamOrOutcome::UpdateStream(pin),
-            UpdateStreamOrOutcome::Outcome(o) => {
-                UpdateStreamOrOutcome::Outcome(serde_json::from_value(o).expect("Can't fail"))
-            }
-        }
+        stream_gen: Box<maybe_add_send!(dyn FnOnce() -> BoxStream<'static, serde_json::Value>)>,
+        is_terminal: Box<maybe_add_send_sync!(dyn Fn(&serde_json::Value) -> bool)>,
+    ) -> BoxStream<'static, serde_json::Value> {
+        caching_operation_update_stream(self.db.clone(), operation_id, stream_gen(), is_terminal)
     }
 }
 
@@ -386,11 +400,18 @@ fn rev_epoch_ranges(
 }
 
 /// Wraps an operation update stream such that the last update before it closes
-/// is tried to be written to the operation log entry as its outcome.
+/// is tried to be written to the operation log entry as its outcome — but only
+/// if `is_terminal` reports it as a final state of the operation. A stream
+/// that ends on a non-terminal update (e.g. an error-path early return in the
+/// stream generator) must not have that update cached as the outcome:
+/// [`OperationLog::outcome_or_updates`] short-circuits every later subscriber
+/// to the cached value, so caching a non-terminal update would freeze the
+/// operation's observable state before its actual end.
 pub fn caching_operation_update_stream<'a, U, S>(
     db: Database,
     operation_id: OperationId,
     stream: S,
+    is_terminal: impl Fn(&U) -> bool + MaybeSend + 'a,
 ) -> BoxStream<'a, U>
 where
     U: Clone + Serialize + Debug + MaybeSend + MaybeSync + 'static,
@@ -411,6 +432,15 @@ where
             );
             return;
         };
+
+        if !is_terminal(&last_update) {
+            warn!(
+                target: LOG_CLIENT,
+                ?last_update,
+                "Operation update stream ended on a non-terminal update; not caching an outcome"
+            );
+            return;
+        }
 
         OperationLog::optimistically_set_operation_outcome(&db, operation_id, &last_update).await;
     })

--- a/fedimint-client/src/oplog/tests.rs
+++ b/fedimint-client/src/oplog/tests.rs
@@ -190,6 +190,61 @@ async fn test_no_outcome_cached_for_non_terminal_stream_end() {
     assert_eq!(op.outcome::<String>(), Some("final".to_owned()));
 }
 
+/// A cached outcome that is NOT a terminal update — one frozen by a previous
+/// version that cached whatever update a stream ended on — must not
+/// short-circuit subscribers: it is discarded and the state is rebuilt from
+/// the update stream, whose terminal end then overwrites the stale cache.
+#[tokio::test]
+async fn test_non_terminal_cached_outcome_falls_back_to_update_stream() {
+    let op_id = OperationId([0x32; 32]);
+
+    let db = MemDatabase::new().into_database();
+    let op_log = OperationLog::new(db.clone());
+
+    let mut dbtx = db.begin_transaction().await;
+    op_log
+        .add_operation_log_entry_dbtx(&mut dbtx.to_ref_nc(), op_id, "foo", "bar")
+        .await;
+    dbtx.commit_tx().await;
+
+    // A previous version cached a non-terminal update as the outcome.
+    OperationLog::set_operation_outcome(&db, op_id, &"pending")
+        .await
+        .unwrap();
+
+    let op = op_log.get_operation(op_id).await.expect("op exists");
+    let update_stream = OperationLog::outcome_or_updates::<String, _>(
+        &db,
+        op_id,
+        &op,
+        |update| update == "final",
+        || futures::stream::iter(vec!["pending".to_owned(), "final".to_owned()]),
+    );
+    assert_matches!(
+        &update_stream,
+        UpdateStreamOrOutcome::UpdateStream(_),
+        "a non-terminal cached outcome must not short-circuit subscribers"
+    );
+    let received = update_stream.into_stream().collect::<Vec<_>>().await;
+    assert_eq!(received, vec!["pending".to_owned(), "final".to_owned()]);
+
+    // The re-derived terminal has overwritten the stale cache, so the next
+    // subscriber short-circuits to the true outcome.
+    let op = op_log.get_operation(op_id).await.expect("op exists");
+    assert_eq!(op.outcome::<String>(), Some("final".to_owned()));
+    let update_stream = OperationLog::outcome_or_updates::<String, _>(
+        &db,
+        op_id,
+        &op,
+        |update| update == "final",
+        futures::stream::empty,
+    );
+    assert_matches!(
+        &update_stream,
+        UpdateStreamOrOutcome::Outcome(o) if o == "final"
+    );
+}
+
 /// A cached outcome that no longer deserializes into the expected update type
 /// (e.g. written by an older version with a different update enum) must not
 /// panic: it is discarded and the state is rebuilt from the update stream,

--- a/fedimint-client/src/oplog/tests.rs
+++ b/fedimint-client/src/oplog/tests.rs
@@ -75,8 +75,13 @@ async fn test_operation_log_update() {
     assert_eq!(op.outcome::<String>(), Some("baz".to_string()));
     assert!(op.outcome_time().is_some(), "outcome_time should be set");
 
-    let update_stream_or_outcome =
-        OperationLog::outcome_or_updates::<String, _>(&db, op_id, op, futures::stream::empty);
+    let update_stream_or_outcome = OperationLog::outcome_or_updates::<String, _>(
+        &db,
+        op_id,
+        &op,
+        |_| true,
+        futures::stream::empty,
+    );
 
     assert_matches!(
         &update_stream_or_outcome,
@@ -106,9 +111,13 @@ async fn test_operation_log_update_from_stream() {
     let op = op_log.get_operation(op_id).await.expect("op exists");
 
     let updates = vec!["bar".to_owned(), "bob".to_owned(), "baz".to_owned()];
-    let update_stream = OperationLog::outcome_or_updates::<String, _>(&db, op_id, op, || {
-        futures::stream::iter(updates.clone())
-    });
+    let update_stream = OperationLog::outcome_or_updates::<String, _>(
+        &db,
+        op_id,
+        &op,
+        |_| true,
+        || futures::stream::iter(updates.clone()),
+    );
 
     let received_updates = update_stream.into_stream().collect::<Vec<_>>().await;
     assert_eq!(received_updates, updates);
@@ -118,6 +127,108 @@ async fn test_operation_log_update_from_stream() {
     assert!(
         op_updated.outcome_time().is_some(),
         "outcome_time should be set after stream completion"
+    );
+}
+
+/// A stream that ends on a NON-terminal update must not cache that update as
+/// the operation's outcome: [`OperationLog::outcome_or_updates`]
+/// short-circuits every later subscriber to a cached outcome, so caching a
+/// non-terminal update would freeze the operation's observable state before
+/// its actual end (e.g. an error-path early return in a module's stream
+/// generator).
+#[tokio::test]
+async fn test_no_outcome_cached_for_non_terminal_stream_end() {
+    let op_id = OperationId([0x32; 32]);
+
+    let db = MemDatabase::new().into_database();
+    let op_log = OperationLog::new(db.clone());
+
+    let mut dbtx = db.begin_transaction().await;
+    op_log
+        .add_operation_log_entry_dbtx(&mut dbtx.to_ref_nc(), op_id, "foo", "bar")
+        .await;
+    dbtx.commit_tx().await;
+
+    let op = op_log.get_operation(op_id).await.expect("op exists");
+
+    // "pending" is not terminal, and the stream ends right after it.
+    let update_stream = OperationLog::outcome_or_updates::<String, _>(
+        &db,
+        op_id,
+        &op,
+        |update| update == "final",
+        || futures::stream::iter(vec!["created".to_owned(), "pending".to_owned()]),
+    );
+    let received = update_stream.into_stream().collect::<Vec<_>>().await;
+    assert_eq!(received, vec!["created".to_owned(), "pending".to_owned()]);
+
+    let op = op_log.get_operation(op_id).await.expect("op exists");
+    assert_eq!(
+        op.outcome::<String>(),
+        None,
+        "a non-terminal last update must not be cached as the outcome"
+    );
+
+    // A later subscription re-derives the full sequence and, once the stream
+    // ends on a terminal update, caches it.
+    let update_stream = OperationLog::outcome_or_updates::<String, _>(
+        &db,
+        op_id,
+        &op,
+        |update| update == "final",
+        || {
+            futures::stream::iter(vec![
+                "created".to_owned(),
+                "pending".to_owned(),
+                "final".to_owned(),
+            ])
+        },
+    );
+    let _ = update_stream.into_stream().collect::<Vec<_>>().await;
+
+    let op = op_log.get_operation(op_id).await.expect("op exists");
+    assert_eq!(op.outcome::<String>(), Some("final".to_owned()));
+}
+
+/// A cached outcome that no longer deserializes into the expected update type
+/// (e.g. written by an older version with a different update enum) must not
+/// panic: it is discarded and the state is rebuilt from the update stream,
+/// whose terminal end then overwrites the stale outcome.
+#[tokio::test]
+async fn test_undeserializable_outcome_falls_back_to_update_stream() {
+    let op_id = OperationId([0x32; 32]);
+
+    let db = MemDatabase::new().into_database();
+    let op_log = OperationLog::new(db.clone());
+
+    let mut dbtx = db.begin_transaction().await;
+    op_log
+        .add_operation_log_entry_dbtx(&mut dbtx.to_ref_nc(), op_id, "foo", "bar")
+        .await;
+    dbtx.commit_tx().await;
+
+    // Cache an outcome of a shape the consumer type (String) cannot represent.
+    OperationLog::set_operation_outcome(&db, op_id, &serde_json::json!({"old": "schema"}))
+        .await
+        .unwrap();
+
+    let op = op_log.get_operation(op_id).await.expect("op exists");
+    let update_stream = OperationLog::outcome_or_updates::<String, _>(
+        &db,
+        op_id,
+        &op,
+        |_| true,
+        || futures::stream::iter(vec!["rebuilt".to_owned()]),
+    );
+    assert_matches!(&update_stream, UpdateStreamOrOutcome::UpdateStream(_));
+    let received = update_stream.into_stream().collect::<Vec<_>>().await;
+    assert_eq!(received, vec!["rebuilt".to_owned()]);
+
+    let op = op_log.get_operation(op_id).await.expect("op exists");
+    assert_eq!(
+        op.outcome::<String>(),
+        Some("rebuilt".to_owned()),
+        "the stale outcome is overwritten by the re-derived terminal"
     );
 }
 

--- a/modules/fedimint-gw-client/src/lib.rs
+++ b/modules/fedimint-gw-client/src/lib.rs
@@ -624,7 +624,13 @@ impl GatewayClientModule {
         let mut stream = self.notifier.subscribe(operation_id).await;
         let client_ctx = self.client_ctx.clone();
 
-        Ok(self.client_ctx.outcome_or_updates(operation, operation_id, move || {
+        Ok(self.client_ctx.outcome_or_updates(&operation, operation_id, |state| match state {
+                GatewayExtReceiveStates::Funding => false,
+                GatewayExtReceiveStates::Preimage(_)
+                | GatewayExtReceiveStates::RefundSuccess { .. }
+                | GatewayExtReceiveStates::RefundError { .. }
+                | GatewayExtReceiveStates::FundingFailed { .. } => true,
+            }, move || {
             stream! {
 
                 yield GatewayExtReceiveStates::Funding;
@@ -773,7 +779,13 @@ impl GatewayClientModule {
         let operation = self.client_ctx.get_operation(operation_id).await?;
         let client_ctx = self.client_ctx.clone();
 
-        Ok(self.client_ctx.outcome_or_updates(operation, operation_id, move || {
+        Ok(self.client_ctx.outcome_or_updates(&operation, operation_id, |state| match state {
+                GatewayExtPayStates::Created | GatewayExtPayStates::Preimage { .. } => false,
+                GatewayExtPayStates::Success { .. }
+                | GatewayExtPayStates::Canceled { .. }
+                | GatewayExtPayStates::Fail { .. }
+                | GatewayExtPayStates::OfferDoesNotExist { .. } => true,
+            }, move || {
             stream! {
                 yield GatewayExtPayStates::Created;
 

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -1525,7 +1525,14 @@ impl LightningClientModule {
         let mut stream = self.notifier.subscribe(operation_id).await;
         let client_ctx = self.client_ctx.clone();
 
-        Ok(self.client_ctx.outcome_or_updates(operation, operation_id, move || {
+        Ok(self.client_ctx.outcome_or_updates(&operation, operation_id, |state| match state {
+                InternalPayState::Funding => false,
+                InternalPayState::Preimage(_)
+                | InternalPayState::RefundSuccess { .. }
+                | InternalPayState::RefundError { .. }
+                | InternalPayState::FundingFailed { .. }
+                | InternalPayState::UnexpectedError(_) => true,
+            }, move || {
             stream! {
                 yield InternalPayState::Funding;
 
@@ -1591,7 +1598,16 @@ impl LightningClientModule {
 
         let client_ctx = self.client_ctx.clone();
 
-        Ok(self.client_ctx.outcome_or_updates(operation, operation_id, move || {
+        Ok(self.client_ctx.outcome_or_updates(&operation, operation_id, |state| match state {
+                LnPayState::Created
+                | LnPayState::Funded { .. }
+                | LnPayState::WaitingForRefund { .. }
+                | LnPayState::AwaitingChange => false,
+                LnPayState::Success { .. }
+                | LnPayState::Canceled
+                | LnPayState::Refunded { .. }
+                | LnPayState::UnexpectedError { .. } => true,
+            }, move || {
             stream! {
                 let self_ref = client_ctx.self_ref();
 
@@ -2097,7 +2113,13 @@ impl LightningClientModule {
 
         let client_ctx = self.client_ctx.clone();
 
-        Ok(self.client_ctx.outcome_or_updates(operation, operation_id, move || {
+        Ok(self.client_ctx.outcome_or_updates(&operation, operation_id, |state| match state {
+                LnReceiveState::Created
+                | LnReceiveState::WaitingForPayment { .. }
+                | LnReceiveState::Funded
+                | LnReceiveState::AwaitingFunds => false,
+                LnReceiveState::Canceled { .. } | LnReceiveState::Claimed => true,
+            }, move || {
             stream! {
                 yield LnReceiveState::AwaitingFunds;
 
@@ -2133,7 +2155,13 @@ impl LightningClientModule {
 
         let client_ctx = self.client_ctx.clone();
 
-        Ok(self.client_ctx.outcome_or_updates(operation, operation_id, move || {
+        Ok(self.client_ctx.outcome_or_updates(&operation, operation_id, |state| match state {
+                LnReceiveState::Created
+                | LnReceiveState::WaitingForPayment { .. }
+                | LnReceiveState::Funded
+                | LnReceiveState::AwaitingFunds => false,
+                LnReceiveState::Canceled { .. } | LnReceiveState::Claimed => true,
+            }, move || {
             stream! {
 
                 let self_ref = client_ctx.self_ref();

--- a/modules/fedimint-ln-client/src/recurring/mod.rs
+++ b/modules/fedimint-ln-client/src/recurring/mod.rs
@@ -368,7 +368,13 @@ impl LightningClientModule {
 
         let client_ctx = self.client_ctx.clone();
 
-        Ok(self.client_ctx.outcome_or_updates(operation, operation_id, move || {
+        Ok(self.client_ctx.outcome_or_updates(&operation, operation_id, |state| match state {
+                LnReceiveState::Created
+                | LnReceiveState::WaitingForPayment { .. }
+                | LnReceiveState::Funded
+                | LnReceiveState::AwaitingFunds => false,
+                LnReceiveState::Canceled { .. } | LnReceiveState::Claimed => true,
+            }, move || {
             stream! {
                 let self_ref = client_ctx.self_ref();
 

--- a/modules/fedimint-lnv2-client/src/lib.rs
+++ b/modules/fedimint-lnv2-client/src/lib.rs
@@ -688,7 +688,14 @@ impl LightningClientModule {
         let client_ctx = self.client_ctx.clone();
         let module_api = self.module_api.clone();
 
-        Ok(self.client_ctx.outcome_or_updates(operation, operation_id, move || {
+        Ok(self.client_ctx.outcome_or_updates(&operation, operation_id, |state| match state {
+                SendOperationState::Funding
+                | SendOperationState::Funded
+                | SendOperationState::Refunding => false,
+                SendOperationState::Success(_)
+                | SendOperationState::Refunded
+                | SendOperationState::Failure => true,
+            }, move || {
             stream! {
                 loop {
                     if let Some(LightningClientStateMachines::Send(state)) = stream.next().await {
@@ -1037,7 +1044,12 @@ impl LightningClientModule {
         let mut stream = self.notifier.subscribe(operation_id).await;
         let client_ctx = self.client_ctx.clone();
 
-        Ok(self.client_ctx.outcome_or_updates(operation, operation_id, move || {
+        Ok(self.client_ctx.outcome_or_updates(&operation, operation_id, |state| match state {
+                ReceiveOperationState::Pending | ReceiveOperationState::Claiming => false,
+                ReceiveOperationState::Expired
+                | ReceiveOperationState::Claimed
+                | ReceiveOperationState::Failure => true,
+            }, move || {
             stream! {
                 loop {
                     if let Some(LightningClientStateMachines::Receive(state)) = stream.next().await {

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -2059,7 +2059,14 @@ impl MintClientModule {
 
         let client_ctx = self.client_ctx.clone();
 
-        Ok(self.client_ctx.outcome_or_updates(operation, operation_id, move || {
+        Ok(self.client_ctx.outcome_or_updates(
+            &operation,
+            operation_id,
+            |state| match state {
+                ReissueExternalNotesState::Created | ReissueExternalNotesState::Issuing => false,
+                ReissueExternalNotesState::Done | ReissueExternalNotesState::Failed(_) => true,
+            },
+            move || {
             stream! {
                 yield ReissueExternalNotesState::Created;
 
@@ -2533,9 +2540,17 @@ impl MintClientModule {
 
         let client_ctx = self.client_ctx.clone();
 
-        Ok(self
-            .client_ctx
-            .outcome_or_updates(operation, operation_id, move || {
+        Ok(self.client_ctx.outcome_or_updates(
+            &operation,
+            operation_id,
+            |state| match state {
+                SpendOOBState::Created | SpendOOBState::UserCanceledProcessing => false,
+                SpendOOBState::UserCanceledSuccess
+                | SpendOOBState::UserCanceledFailure
+                | SpendOOBState::Success
+                | SpendOOBState::Refunded => true,
+            },
+            move || {
                 stream! {
                     yield SpendOOBState::Created;
 
@@ -2594,7 +2609,8 @@ impl MintClientModule {
                         }
                     }
                 }
-            }))
+            },
+        ))
     }
 
     async fn mint_operation(&self, operation_id: OperationId) -> anyhow::Result<OperationLogEntry> {

--- a/modules/fedimint-mintv2-client/src/lib.rs
+++ b/modules/fedimint-mintv2-client/src/lib.rs
@@ -1097,7 +1097,7 @@ impl MintClientModule {
 
         let mut stream = self
             .client_ctx
-            .outcome_or_updates(operation, operation_id, move || {
+            .outcome_or_updates(&operation, operation_id, |_| true, move || {
                 async_stream::stream! {
                     loop {
                         if let Some(MintClientStateMachines::Receive(state)) = stream.next().await {

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -1455,7 +1455,16 @@ impl WalletClientModule {
             return Ok(UpdateStreamOrOutcome::Outcome(outcome_v2));
         };
 
-        Ok(self.client_ctx.outcome_or_updates(operation, operation_id, {
+        Ok(self.client_ctx.outcome_or_updates(
+            &operation,
+            operation_id,
+            |state| match state {
+                DepositStateV2::WaitingForTransaction
+                | DepositStateV2::WaitingForConfirmation { .. }
+                | DepositStateV2::Confirmed { .. } => false,
+                DepositStateV2::Claimed { .. } | DepositStateV2::Failed(_) => true,
+            },
+            {
             let stream_rpc = self.rpc.clone();
             let stream_client_ctx = self.client_ctx.clone();
             let stream_script_pub_key = address.script_pubkey();
@@ -1873,9 +1882,14 @@ impl WalletClientModule {
         let mut operation_stream = self.notifier.subscribe(operation_id).await;
         let client_ctx = self.client_ctx.clone();
 
-        Ok(self
-            .client_ctx
-            .outcome_or_updates(operation, operation_id, move || {
+        Ok(self.client_ctx.outcome_or_updates(
+            &operation,
+            operation_id,
+            |state| match state {
+                WithdrawState::Created => false,
+                WithdrawState::Succeeded(_) | WithdrawState::Failed(_) => true,
+            },
+            move || {
                 stream! {
                     match next_withdraw_state(&mut operation_stream).await {
                         Some(WithdrawStates::Created(_)) => {
@@ -1909,7 +1923,8 @@ impl WalletClientModule {
                         None => {},
                     }
                 }
-            }))
+            },
+        ))
     }
 
     fn admin_auth(&self) -> anyhow::Result<ApiAuth> {

--- a/modules/fedimint-walletv2-client/src/lib.rs
+++ b/modules/fedimint-walletv2-client/src/lib.rs
@@ -416,7 +416,7 @@ impl WalletClientModule {
 
         let mut stream = self
             .client_ctx
-            .outcome_or_updates(operation, operation_id, move || {
+            .outcome_or_updates(&operation, operation_id, |_| true, move || {
                 async_stream::stream! {
                     loop {
                         if let Some(WalletClientStateMachines::Send(state)) = stream.next().await {
@@ -460,7 +460,7 @@ impl WalletClientModule {
 
         let mut stream = self
             .client_ctx
-            .outcome_or_updates(operation, operation_id, move || {
+            .outcome_or_updates(&operation, operation_id, |_| true, move || {
                 async_stream::stream! {
                     loop {
                         if let Some(WalletClientStateMachines::Receive(state)) = stream.next().await {


### PR DESCRIPTION
## Problem

Two related hazards in the operation-log outcome cache:

1. **Non-terminal outcomes can be cached.** `caching_operation_update_stream` writes the **last** update of a subscription stream as the operation's durable outcome whenever the stream ends — even when it ends on a non-terminal update. Module stream generators have early-return error paths (e.g. lnv1's `subscribe_ln_pay` returns right after yielding `Created`/`Funded` when the state sequence is unexpected), and `outcome_or_updates` short-circuits every later subscriber to the cached outcome — so one bad stream end permanently freezes the operation's observable state at a non-final update.
2. **Undeserializable cached outcomes panic.** A cached outcome written by an incompatible earlier version fails `OperationLogEntry::outcome`'s `expect` inside `outcome_or_updates`, so every later subscription of that operation panics; `try_outcome` exists but the hot path didn't use it.

## Change

- Thread an **`is_terminal` predicate** from each module subscription through `ClientContext::outcome_or_updates` into the caching wrapper. The last update is cached only when the module reports it terminal; otherwise a warning is logged and nothing is cached (later subscribers re-derive from the replayed state machine states, exactly as they do today for uncached operations). The predicate runs once, at stream end.
- Resolve cached outcomes in the **typed layer with `try_outcome`**: an outcome that fails to deserialize is discarded with a warning and the state is rebuilt from the update stream — whose terminal end then overwrites the stale outcome — instead of panicking.
- The `IOperationLog` dyn method becomes `caching_operation_update_stream` (stream construction only); outcome resolution lives with the typed update type where deserialization failures can be handled. Single implementor and single caller updated; no other users in-tree.
- **Exhaustive (no-wildcard) terminality predicates at all 16 module call sites** (ln, lnv2, gateway, mint, mintv2, wallet, walletv2, recurring), audited against each generator: every variant marked terminal is a genuine stream-ending yield, and every variant that can be followed by another update is non-terminal — so no module loses caching relative to master for streams that end on their true terminal.

## Notes for reviewers

- Follow-up commit (review-driven): cached outcomes are also validated with `is_terminal` on read, so entries frozen by previous versions are discarded and rebuilt. Precisely: healing happens on the first subscription that is **driven to the operation's terminal state** — the stale entry is ignored (not deleted) at detection, so raw `OperationLogEntry::outcome()` readers (e.g. the CLI operations list) continue to see it until a subscriber drives the rebuild to its terminal, which then overwrites the cache. Deleting the stale entry eagerly at detection would be a possible follow-up; it was left out to keep this change read-path-only.

- gw-pay's `Fail`/`OfferDoesNotExist` are marked terminal but currently unreachable at a stream end (the generator loops after yielding them); the marking is future-proofing, not a behavior change.
- The legacy `DepositStateV1` outcome read (`wallet-client/src/lib.rs` no-`tweak_idx` path) deliberately retains its existing behavior; it does not go through `outcome_or_updates`.
- `ClientContext::outcome_or_updates` now takes `&OperationLogEntry` plus the predicate, and `stream_gen` gains a `MaybeSend` bound — a source-breaking change for module authors; all in-tree callers updated.

## Testing

- New: a stream ending on a non-terminal update caches nothing, and a later terminal-ended subscription then caches; an undeserializable cached outcome falls back to the update stream (no panic) and is overwritten by the re-derived terminal. Both fail on master (the first caches the non-terminal update; the second panics in `outcome()`).
- Existing oplog unit tests and lnv1 integration tests pass unchanged; `cargo check --workspace --all-targets` clean; `fedimint-client`/`fedimint-client-module` compile clean for `wasm32-unknown-unknown`.
