### PR TITLE
fix(gateway): persist peers connected via connect_peer

### DIFF
--- a/gateway/fedimint-lightning/src/ldk.rs
+++ b/gateway/fedimint-lightning/src/ldk.rs
@@ -792,7 +792,12 @@ impl ILnRpcClient for GatewayLdkClient {
 
     async fn connect_peer(&self, payload: ConnectPeerRequest) -> Result<(), LightningRpcError> {
         let NodeAddress { pubkey, address } = payload.node_address;
-        self.node.connect(pubkey, address, false).map_err(|e| {
+        // Persist the peer so ldk-node automatically reconnects after restarts
+        // and connection drops. Without this a gateway whose only channel was
+        // opened inbound (e.g. bought from an LSP) has no stored peer address
+        // and the channel stays inactive after any disconnect until an
+        // operator manually reconnects.
+        self.node.connect(pubkey, address, true).map_err(|e| {
             LightningRpcError::FailedToConnectToPeer {
                 failure_reason: e.to_string(),
             }


### PR DESCRIPTION
## Problem

`LdkLightningClient::connect_peer` calls `Node::connect` with `persist=false`, so a peer connection established through the `/v1/connect_peer` API (or the UI action from #8795) is forgotten on the next `gatewayd` restart or connection drop — ldk-node only auto-reconnects to persisted peers.

This bites hardest for gateways whose only channel was opened *inbound*, e.g. bought from an LSP:

- inbound connections are never persisted, so after a restart the node has an empty peer list and dials no one;
- the node can't be re-discovered by the counterparty either, since `listening_addresses` is hardcoded to `0.0.0.0:<port>` (`ldk.rs`) and an unannounced-channel-only node has no gossip presence.

Net effect: after any disconnect the channel shows `is_active: false` indefinitely until an operator manually calls `connect_peer` again. Observed in production on a gateway with a single LSP-purchased channel; reconnecting via the API immediately restored the channel to active.

## Fix

Pass `persist=true` so ldk-node stores the peer address and automatically re-establishes the connection on disconnect and across restarts.

## Notes / open questions

- Should the gateway additionally attempt to reconnect to all channel counterparties on startup (using last-known addresses or gossip lookup)? That would also cover peers that were never connected via the API. Happy to do that as a follow-up if there's interest.
- No automated test: exercising persistence would need a restart-the-node harness; existing integration tests don't cover `connect_peer` yet. Verified the underlying behavior manually against a live gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLPemt9NwzQUWSKLUFoHBR