### PR TITLE
fix(iroh): recover a degraded long-poll path in minutes, not an hour

### DIFF
--- a/fedimint-connectors/src/iroh.rs
+++ b/fedimint-connectors/src/iroh.rs
@@ -4,6 +4,7 @@ use std::net::SocketAddr;
 use std::pin::Pin;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use anyhow::{Context, bail};
@@ -46,6 +47,61 @@ const IROH_REQUEST_TIMEOUT_DEFAULT: Duration = Duration::from_secs(60);
 /// `request_current_consensus_retry` loop will reconnect and retry.
 const IROH_REQUEST_TIMEOUT_LONG_POLL: Duration = Duration::from_secs(60 * 60);
 
+/// Shorter long-poll budget for the retry-safe lnv2 payment waits
+/// (`await_incoming_contract`, `await_incoming_contracts` and
+/// `decryption_key_share` on the receive path, `await_preimage` on the send
+/// path).
+///
+/// These block server-side until their event fires: `await_incoming_contracts`
+/// parks indefinitely on `wait_key_check`, `decryption_key_share` parks on
+/// `wait_key_exists` until the funding output is accepted, and
+/// `await_incoming_contract` and `await_preimage` poll until their contract
+/// expires — a wall-clock expiry for an incoming contract, a consensus block
+/// height for an outgoing one, and for an lnurl receive no real bound at all
+/// (its `expiration_or_fee` is fee-encoded near `u64::MAX`).
+///
+/// Either way the client's budget is effectively the bound on how long a
+/// *stalled* connection is kept before it is closed and the retry loop
+/// reconnects — a degraded path cannot deliver the expiration response any
+/// more than it can deliver a settlement. A degraded-but-not-dead
+/// QUIC path (keep-alives still pass, so the 60s idle timeout never fires, but
+/// request data no longer flows) otherwise pins the client for the full hour of
+/// [`IROH_REQUEST_TIMEOUT_LONG_POLL`] before it can recover — long enough to
+/// look like a stuck receive/send to a 24/7 client that mostly waits on these
+/// endpoints.
+///
+/// A 5-minute budget caps that degraded-path outage at ~5 min (plus the
+/// api-client retry backoff ceiling), while a *healthy* idle subscription only
+/// reconnects ~12×/hour. This tier is deliberately NOT applied to the
+/// consensus long-polls (`await_transaction`, `await_block_height`,
+/// `await_signed_session_outcome`, …): those keep the 1-hour bound so their
+/// healthy idle waits do not churn connections. Re-issuing these waits is
+/// safe — they are pure server-side reads, `await_incoming_contracts` is driven
+/// by the monotonic `IncomingContractStreamIndexKey` cursor (the client
+/// persists `next_index` only after processing a batch, so a retry replays but
+/// never skips), and a replayed incoming contract dedups on its stable
+/// operation id.
+const IROH_REQUEST_TIMEOUT_LNV2_WAIT: Duration = Duration::from_secs(5 * 60);
+
+/// The retry-safe lnv2 payment-wait endpoints that take the shorter
+/// [`IROH_REQUEST_TIMEOUT_LNV2_WAIT`] budget. Matched by exact name (not a
+/// prefix) so the shorter budget can never silently widen to an unrelated
+/// `await_*` method.
+///
+/// `decryption_key_share` is here despite not carrying an `await_`/`wait_`
+/// prefix: it long-polls on `wait_key_exists` exactly like the others (its own
+/// server-side comment says it "mirrors the AWAIT_INCOMING_CONTRACT and
+/// AWAIT_PREIMAGE endpoints"), and the gateway deliberately issues it *before*
+/// the funding output is accepted so the two overlap. It is therefore expected
+/// to block past the 60s prompt default, which without this entry closes the
+/// shared pooled connection once a minute for the whole wait.
+const IROH_LNV2_WAIT_METHODS: &[&str] = &[
+    "await_incoming_contract",
+    "await_incoming_contracts",
+    "await_preimage",
+    "decryption_key_share",
+];
+
 /// Application-level QUIC error code we use when closing a [`Connection`]
 /// after a request timeout. Recorded by the peer as the close reason; chosen
 /// arbitrarily but stable across stable and `iroh_next` impls so the two
@@ -68,10 +124,149 @@ fn request_timeout_for_method(method: &ApiMethod) -> Duration {
         ApiMethod::Core(name) => name.as_str(),
         ApiMethod::Module(_, name) => name.as_str(),
     };
-    if name.starts_with("await_") || name.starts_with("wait_") {
+    // Exact-name overrides come FIRST so the shorter budget is scoped to
+    // exactly the intended endpoints, then the generic prefix heuristic.
+    if IROH_LNV2_WAIT_METHODS.contains(&name) {
+        IROH_REQUEST_TIMEOUT_LNV2_WAIT
+    } else if name.starts_with("await_") || name.starts_with("wait_") {
         IROH_REQUEST_TIMEOUT_LONG_POLL
     } else {
         IROH_REQUEST_TIMEOUT_DEFAULT
+    }
+}
+
+/// Width of the window over which routine lnv2 wait expiries are spread. See
+/// [`request_timeout_for_method_spread`].
+const IROH_LNV2_WAIT_SPREAD: Duration = Duration::from_secs(60);
+
+/// Number of distinct millisecond slots in [`IROH_LNV2_WAIT_SPREAD`].
+const IROH_LNV2_WAIT_SPREAD_SLOTS: u64 = IROH_LNV2_WAIT_SPREAD.as_secs() * 1_000;
+
+/// Map a remote's node id to a stable spread offset in
+/// `0..IROH_LNV2_WAIT_SPREAD`.
+///
+/// The offset has to satisfy two constraints that rule out the more obvious
+/// sources:
+///
+/// - It must not depend on the ORDER waits are issued in. An issue-order
+///   counter looks like it staggers them, but the order peers re-issue in is
+///   itself the order they last expired in, so a per-rank offset step cancels
+///   against the per-rank expiry stagger and the fleet re-synchronizes.
+/// - It must not depend on the resolution of a platform facility. A sub-second
+///   wall-clock reading is nanosecond-grained only on some targets:
+///   [`fedimint_core::time::now`] is built from `js_sys::Date` on wasm
+///   (millisecond-quantised, coarser under fingerprinting resistance) and from
+///   `FILETIME` on Windows (100ns ticks, so `nanos % 60` cycles just three
+///   values). A fan-out issued inside one tick then reads one value and every
+///   peer draws the same offset — inert in exactly the case it exists for.
+///
+/// A node id has neither problem: it is a public key, so it is uniformly
+/// distributed and stable; it is known before the request is sent; and it is
+/// the same value on every platform. Each peer keeps a fixed slot in the
+/// window, and because the slot is a pure function of that id there is no
+/// feedback path from expiry order back into the offset — which is what made
+/// the counter re-synchronize.
+///
+/// This bounds clustering rather than eliminating it. Distinct offsets give
+/// distinct cycle periods (`300s - offset`), so peers that were re-issued
+/// together immediately fan out; but two periods still share a finite common
+/// multiple, so a pair does re-coincide eventually. With millisecond slots that
+/// is usually far out — random distinct pairs are typically months to years
+/// apart — while a specially aligned low-`lcm` pair (say 300.0s and 280.0s,
+/// meeting every 70min) can meet much sooner. Either way it is a transient
+/// one-cycle coincidence, not the sustained every-cycle lock the order-derived
+/// offset produced.
+///
+/// Slots are millisecond- rather than second-grained only to make exact
+/// collisions negligible: a 4-peer federation collides with p≈1e-4 over 60_000
+/// slots versus p≈0.1 over 60. Two peers that did collide share a period and so
+/// expire together indefinitely — i.e. exactly as they do with no spread at
+/// all, never worse.
+fn spread_offset_for_peer(node_id: &[u8; 32]) -> Duration {
+    // Fold the whole id through the splitmix64 finalizer rather than taking
+    // leading bytes directly. A public key should already be uniform, but that
+    // is an assumption about the key format; mixing avalanches every input bit
+    // so ids sharing a prefix still land far apart, and the spread stops
+    // depending on which bytes of the key happen to be well distributed.
+    fn mix(mut z: u64) -> u64 {
+        z = (z ^ (z >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+        z ^ (z >> 31)
+    }
+
+    let slot = node_id
+        .chunks_exact(8)
+        .map(|word| u64::from_be_bytes(word.try_into().expect("chunks_exact(8) yields 8 bytes")))
+        .fold(0u64, |acc, word| mix(acc ^ word));
+    Duration::from_millis(slot % IROH_LNV2_WAIT_SPREAD_SLOTS)
+}
+
+/// [`request_timeout_for_method`], with the routine expiry of the short lnv2
+/// tier spread over [`IROH_LNV2_WAIT_SPREAD`].
+///
+/// A client waiting on several peers issues one wait per peer at the same
+/// moment, so without this their budgets expire together and every pooled
+/// per-peer connection closes on the same tick. Those connections are shared
+/// with unrelated one-shot calls, and not every caller retries (lnv2
+/// `gateways()` uses `request_with_strategy`, not the retrying variant), so a
+/// synchronized close can surface a transient failure on a perfectly healthy
+/// network. Staggering the budgets keeps the closes from clustering.
+///
+/// Only the short tier is spread: the 1-hour tier expires rarely enough that
+/// clustering is not a concern, and the prompt tier must keep its exact bound.
+///
+/// `node_id` is the remote this request is bound for. `None` (the peer identity
+/// was not available) skips the spread and keeps the exact tier bound, which is
+/// the pre-spread behaviour. That should be unreachable — a pooled connection
+/// has completed a handshake that pins the dialed key — but it would disable
+/// the spread fleet-wide, so it is logged rather than silent.
+fn request_timeout_for_method_spread(method: &ApiMethod, node_id: Option<&[u8; 32]>) -> Duration {
+    let timeout = request_timeout_for_method(method);
+    if timeout != IROH_REQUEST_TIMEOUT_LNV2_WAIT {
+        return timeout;
+    }
+    let Some(node_id) = node_id else {
+        debug!(
+            target: LOG_NET_IROH,
+            "No peer identity for an lnv2 wait, using the unspread tier bound"
+        );
+        return timeout;
+    };
+    timeout.saturating_sub(spread_offset_for_peer(node_id))
+}
+
+/// Log a request-timeout-triggered connection close, shared by the stable and
+/// `iroh_next` request paths. A long-poll (budget above the prompt default)
+/// reaching its budget with no data is expected steady state, so it logs at
+/// `debug`; a prompt request exceeding the 60s default is unusual and warns.
+fn log_request_timeout(method_str: &str, timeout: Duration) {
+    // Three tiers, three levels. The short lnv2 tier expires every cycle on a
+    // perfectly healthy idle subscription, so it is pure noise at anything
+    // above `debug`. The 1-hour tier is different: an hour of a consensus
+    // long-poll producing nothing is the very degraded-path symptom this
+    // budget exists to bound, so it stays visible at default log levels. A
+    // prompt request exceeding the 60s default is genuinely unusual.
+    if timeout <= IROH_REQUEST_TIMEOUT_DEFAULT {
+        warn!(
+            target: LOG_NET_IROH,
+            method = %method_str,
+            timeout_secs = timeout.as_secs(),
+            "iroh request timed out, retiring connection",
+        );
+    } else if timeout <= IROH_REQUEST_TIMEOUT_LNV2_WAIT {
+        debug!(
+            target: LOG_NET_IROH,
+            method = %method_str,
+            timeout_secs = timeout.as_secs(),
+            "iroh payment-wait reached its budget, retiring connection to reconnect",
+        );
+    } else {
+        info!(
+            target: LOG_NET_IROH,
+            method = %method_str,
+            timeout_secs = timeout.as_secs(),
+            "iroh long-poll reached its budget with no data, retiring connection to reconnect",
+        );
     }
 }
 use fedimint_core::task::spawn;
@@ -86,7 +281,7 @@ use iroh::{Endpoint, NodeAddr, NodeId, PublicKey};
 use reqwest::{Method, StatusCode};
 use serde_json::Value;
 use tokio::sync::watch;
-use tracing::{debug, trace, warn};
+use tracing::{debug, info, trace, warn};
 
 use super::{DynGuaridianConnection, IGuardianConnection, ServerError, ServerResult};
 use crate::{Connectivity, DynGatewayConnection, IConnection, IGatewayConnection, IrohPeerInfo};
@@ -319,6 +514,7 @@ impl crate::Connector for IrohConnector {
                     self_clone
                         .make_new_connection_stable(node_id, connection_override)
                         .await
+                        .map(PooledGuardianConnection::new)
                         .map(super::IGuardianConnection::into_dyn),
                     "stable",
                 )
@@ -332,6 +528,7 @@ impl crate::Connector for IrohConnector {
                 self_clone
                     .make_new_connection_next(&endpoint_next, node_id, connection_override)
                     .await
+                    .map(PooledGuardianConnection::new)
                     .map(super::IGuardianConnection::into_dyn),
                 "next",
             )
@@ -655,6 +852,172 @@ fn node_addr_stable_to_next(stable: &iroh::NodeAddr) -> iroh_next::EndpointAddr 
     iroh_next::EndpointAddr::from_parts(next_node_id, relay_addrs.chain(direct_addrs))
 }
 
+/// The per-iroh-version pieces [`PooledGuardianConnection`] needs.
+///
+/// The stable and `iroh_next` connection types have the same shape but distinct
+/// concrete stream and error types, so this captures only the operations that
+/// differ and lets the pooled wrapper be written once for both.
+#[async_trait]
+trait IrohGuardianConn: fmt::Debug + Send + Sync + 'static {
+    /// The remote's 32-byte public key, if the handshake exposed one.
+    fn remote_id_bytes(&self) -> Option<[u8; 32]>;
+
+    /// Whether the underlying QUIC connection is still open.
+    fn is_open(&self) -> bool;
+
+    /// Close the underlying QUIC connection, recording our timeout as the
+    /// reason.
+    fn close_timed_out(&self);
+
+    /// Resolves once the underlying QUIC connection is closed.
+    async fn wait_closed(&self);
+
+    /// One request/response round trip on a fresh bi-stream.
+    async fn round_trip(&self, json: &[u8]) -> ServerResult<Vec<u8>>;
+}
+
+/// A pooled guardian connection that can be *retired* without being closed.
+///
+/// The pool drops an entry once [`IConnection::is_connected`] returns false,
+/// and on a bare iroh connection the only way to make that happen is to close
+/// it — which also aborts every other request in flight on that connection.
+/// Requests sharing a pooled connection are unrelated to one another, and not
+/// all of their callers retry (lnv2 `gateways()` uses `request_with_strategy`,
+/// not the retrying variant), so a routine long-poll refresh could fail a
+/// healthy one-shot call that merely overlapped it. A multi-guardian client
+/// absorbs that — losing one peer still leaves a threshold — but a
+/// single-guardian federation has no second peer to absorb anything, so the
+/// call just fails.
+///
+/// Retiring separates eviction from teardown: the entry stops being handed out
+/// for NEW requests, while requests already in flight run to completion on it.
+/// The connection is closed as soon as the last of them finishes, so it does
+/// not linger and the server-side cancellation still fires promptly.
+#[derive(Debug)]
+struct PooledGuardianConnection<C> {
+    conn: C,
+    /// Set once this connection should stop serving new requests. A watch (not
+    /// a plain flag) so [`IConnection::await_disconnection`] can wake on it.
+    retired: watch::Sender<bool>,
+    /// Requests currently in flight on `conn`.
+    in_flight: AtomicUsize,
+}
+
+/// Decrements the in-flight count on drop, closing the connection when the last
+/// request leaves a retired one.
+struct InFlightGuard<'a, C: IrohGuardianConn>(&'a PooledGuardianConnection<C>);
+
+impl<C: IrohGuardianConn> Drop for InFlightGuard<'_, C> {
+    fn drop(&mut self) {
+        // `fetch_sub` returns the PREVIOUS value, so exactly one dropping guard
+        // observes 1 and is therefore the last one out.
+        if self.0.in_flight.fetch_sub(1, Ordering::AcqRel) == 1 && *self.0.retired.borrow() {
+            self.0.conn.close_timed_out();
+        }
+    }
+}
+
+impl<C: IrohGuardianConn> PooledGuardianConnection<C> {
+    fn new(conn: C) -> Self {
+        Self {
+            conn,
+            retired: watch::Sender::new(false),
+            in_flight: AtomicUsize::new(0),
+        }
+    }
+
+    fn enter(&self) -> InFlightGuard<'_, C> {
+        self.in_flight.fetch_add(1, Ordering::AcqRel);
+        InFlightGuard(self)
+    }
+
+    /// Stop serving new requests.
+    ///
+    /// In practice the caller holds an [`InFlightGuard`], so the close happens
+    /// when that guard (or a later one) drops. The `in_flight == 0` branch is
+    /// defensive: without it a retire with nothing in flight would leave the
+    /// connection open until the pool entry was dropped.
+    ///
+    /// At least one of the two paths always closes, and the reason is subtler
+    /// than it looks. The interleaving to worry about is a last guard reading
+    /// `retired == false` while this reads `in_flight == 1`, so neither closes
+    /// and the connection leaks open. It cannot happen because
+    /// [`watch::Sender`] is `RwLock`-backed: `borrow` takes the read lock and
+    /// `send_replace` the write lock, so the two are ordered against each
+    /// other. If the guard's `borrow` reads `false` it precedes this
+    /// `send_replace`, so its `fetch_sub` also precedes the `load` below, which
+    /// therefore reads 0 and closes here.
+    ///
+    /// That means the flag may NOT be weakened to a plain `AtomicBool` with
+    /// these orderings — without the lock, the store-buffer interleaving is
+    /// real and would need `SeqCst`. Closing twice (guard drops between the
+    /// `send_replace` and the `load`) is possible and harmless; `close` is
+    /// idempotent on both iroh stacks.
+    fn retire(&self) {
+        self.retired.send_replace(true);
+        if self.in_flight.load(Ordering::Acquire) == 0 {
+            self.conn.close_timed_out();
+        }
+    }
+}
+
+#[apply(async_trait_maybe_send!)]
+impl<C: IrohGuardianConn> IConnection for PooledGuardianConnection<C> {
+    async fn await_disconnection(&self) {
+        let closed = std::pin::pin!(self.conn.wait_closed());
+        let retired = std::pin::pin!(async {
+            let mut rx = self.retired.subscribe();
+            let _ = rx.wait_for(|retired| *retired).await;
+        });
+        futures::future::select(closed, retired).await;
+    }
+
+    fn is_connected(&self) -> bool {
+        !*self.retired.borrow() && self.conn.is_open()
+    }
+}
+
+#[async_trait]
+impl<C: IrohGuardianConn> IGuardianConnection for PooledGuardianConnection<C> {
+    async fn request(&self, method: ApiMethod, request: ApiRequestErased) -> ServerResult<Value> {
+        let timeout =
+            request_timeout_for_method_spread(&method, self.conn.remote_id_bytes().as_ref());
+        let method_str = method.to_string();
+        let json = serde_json::to_vec(&IrohApiRequest { method, request })
+            .expect("Serialization to vec can't fail");
+
+        let response = {
+            let _guard = self.enter();
+            match fedimint_core::runtime::timeout(timeout, self.conn.round_trip(&json)).await {
+                Ok(Ok(bytes)) => bytes,
+                Ok(Err(err)) => return Err(err),
+                Err(_) => {
+                    // The bi-stream stalled past our budget. Retire the entry so
+                    // the pool stops handing it out and the upstream retry loop
+                    // gets a fresh connection, WITHOUT tearing down requests that
+                    // are still in flight on this one.
+                    //
+                    // A long-poll reaching its budget with no data is EXPECTED
+                    // steady state (idle subscription) — log it at debug. A
+                    // prompt request exceeding the 60s default is genuinely
+                    // unusual — warn.
+                    log_request_timeout(&method_str, timeout);
+                    self.retire();
+                    return Err(ServerError::Transport(anyhow::anyhow!(
+                        "iroh request {method_str} timed out after {timeout:?}"
+                    )));
+                }
+            }
+        };
+
+        // TODO: We should not be serializing Results on the wire
+        let response = serde_json::from_slice::<Result<Value, ApiError>>(&response)
+            .map_err(|e| ServerError::InvalidResponse(e.into()))?;
+
+        response.map_err(|e| ServerError::InvalidResponse(anyhow::anyhow!("Api Error: {:?}", e)))
+    }
+}
+
 #[apply(async_trait_maybe_send!)]
 impl IConnection for Connection {
     async fn await_disconnection(&self) {
@@ -667,64 +1030,43 @@ impl IConnection for Connection {
 }
 
 #[async_trait]
-impl IGuardianConnection for Connection {
-    async fn request(&self, method: ApiMethod, request: ApiRequestErased) -> ServerResult<Value> {
-        let timeout = request_timeout_for_method(&method);
-        let method_str = method.to_string();
-        let json = serde_json::to_vec(&IrohApiRequest { method, request })
-            .expect("Serialization to vec can't fail");
+impl IrohGuardianConn for Connection {
+    fn remote_id_bytes(&self) -> Option<[u8; 32]> {
+        self.remote_node_id().ok().map(|id| *id.as_bytes())
+    }
 
-        let result = fedimint_core::runtime::timeout(timeout, async {
-            let (mut sink, mut stream) = self
-                .open_bi()
-                .await
-                .map_err(|e| ServerError::Transport(e.into()))?;
+    fn is_open(&self) -> bool {
+        self.close_reason().is_none()
+    }
 
-            sink.write_all(&json)
-                .await
-                .map_err(|e| ServerError::Transport(e.into()))?;
+    fn close_timed_out(&self) {
+        self.close(
+            iroh::endpoint::VarInt::from_u32(IROH_REQUEST_TIMEOUT_ERROR_CODE),
+            IROH_REQUEST_TIMEOUT_ERROR_REASON,
+        );
+    }
 
-            sink.finish()
-                .map_err(|e| ServerError::Transport(e.into()))?;
+    async fn wait_closed(&self) {
+        self.closed().await;
+    }
 
-            stream
-                .read_to_end(IROH_MAX_RESPONSE_BYTES)
-                .await
-                .map_err(|e| ServerError::Transport(e.into()))
-        })
-        .await;
+    async fn round_trip(&self, json: &[u8]) -> ServerResult<Vec<u8>> {
+        let (mut sink, mut stream) = self
+            .open_bi()
+            .await
+            .map_err(|e| ServerError::Transport(e.into()))?;
 
-        let response = match result {
-            Ok(Ok(bytes)) => bytes,
-            Ok(Err(err)) => return Err(err),
-            Err(_) => {
-                // The bi-stream stalled past our budget. Close the QUIC
-                // connection so [`Self::is_connected`] (which reads
-                // `close_reason`) starts returning false; the connection
-                // pool's `get_or_init_pool_entry` will then evict this
-                // entry on the next access and the upstream retry loop
-                // will get a fresh connection.
-                warn!(
-                    target: LOG_NET_IROH,
-                    method = %method_str,
-                    timeout_secs = timeout.as_secs(),
-                    "iroh request timed out, closing connection",
-                );
-                self.close(
-                    iroh::endpoint::VarInt::from_u32(IROH_REQUEST_TIMEOUT_ERROR_CODE),
-                    IROH_REQUEST_TIMEOUT_ERROR_REASON,
-                );
-                return Err(ServerError::Transport(anyhow::anyhow!(
-                    "iroh request {method_str} timed out after {timeout:?}"
-                )));
-            }
-        };
+        sink.write_all(json)
+            .await
+            .map_err(|e| ServerError::Transport(e.into()))?;
 
-        // TODO: We should not be serializing Results on the wire
-        let response = serde_json::from_slice::<Result<Value, ApiError>>(&response)
-            .map_err(|e| ServerError::InvalidResponse(e.into()))?;
+        sink.finish()
+            .map_err(|e| ServerError::Transport(e.into()))?;
 
-        response.map_err(|e| ServerError::InvalidResponse(anyhow::anyhow!("Api Error: {:?}", e)))
+        stream
+            .read_to_end(IROH_MAX_RESPONSE_BYTES)
+            .await
+            .map_err(|e| ServerError::Transport(e.into()))
     }
 }
 
@@ -740,58 +1082,43 @@ impl IConnection for iroh_next::endpoint::Connection {
 }
 
 #[async_trait]
-impl IGuardianConnection for iroh_next::endpoint::Connection {
-    async fn request(&self, method: ApiMethod, request: ApiRequestErased) -> ServerResult<Value> {
-        let timeout = request_timeout_for_method(&method);
-        let method_str = method.to_string();
-        let json = serde_json::to_vec(&IrohApiRequest { method, request })
-            .expect("Serialization to vec can't fail");
+impl IrohGuardianConn for iroh_next::endpoint::Connection {
+    fn remote_id_bytes(&self) -> Option<[u8; 32]> {
+        Some(*self.remote_id().as_bytes())
+    }
 
-        let result = fedimint_core::runtime::timeout(timeout, async {
-            let (mut sink, mut stream) = self
-                .open_bi()
-                .await
-                .map_err(|e| ServerError::Transport(e.into()))?;
+    fn is_open(&self) -> bool {
+        self.close_reason().is_none()
+    }
 
-            sink.write_all(&json)
-                .await
-                .map_err(|e| ServerError::Transport(e.into()))?;
+    fn close_timed_out(&self) {
+        self.close(
+            iroh_next::endpoint::VarInt::from_u32(IROH_REQUEST_TIMEOUT_ERROR_CODE),
+            IROH_REQUEST_TIMEOUT_ERROR_REASON,
+        );
+    }
 
-            sink.finish()
-                .map_err(|e| ServerError::Transport(e.into()))?;
+    async fn wait_closed(&self) {
+        self.closed().await;
+    }
 
-            stream
-                .read_to_end(IROH_MAX_RESPONSE_BYTES)
-                .await
-                .map_err(|e| ServerError::Transport(e.into()))
-        })
-        .await;
+    async fn round_trip(&self, json: &[u8]) -> ServerResult<Vec<u8>> {
+        let (mut sink, mut stream) = self
+            .open_bi()
+            .await
+            .map_err(|e| ServerError::Transport(e.into()))?;
 
-        let response = match result {
-            Ok(Ok(bytes)) => bytes,
-            Ok(Err(err)) => return Err(err),
-            Err(_) => {
-                warn!(
-                    target: LOG_NET_IROH,
-                    method = %method_str,
-                    timeout_secs = timeout.as_secs(),
-                    "iroh request timed out, closing connection",
-                );
-                self.close(
-                    iroh_next::endpoint::VarInt::from_u32(IROH_REQUEST_TIMEOUT_ERROR_CODE),
-                    IROH_REQUEST_TIMEOUT_ERROR_REASON,
-                );
-                return Err(ServerError::Transport(anyhow::anyhow!(
-                    "iroh request {method_str} timed out after {timeout:?}"
-                )));
-            }
-        };
+        sink.write_all(json)
+            .await
+            .map_err(|e| ServerError::Transport(e.into()))?;
 
-        // TODO: We should not be serializing Results on the wire
-        let response = serde_json::from_slice::<Result<Value, ApiError>>(&response)
-            .map_err(|e| ServerError::InvalidResponse(e.into()))?;
+        sink.finish()
+            .map_err(|e| ServerError::Transport(e.into()))?;
 
-        response.map_err(|e| ServerError::InvalidResponse(anyhow::anyhow!("Api Error: {:?}", e)))
+        stream
+            .read_to_end(IROH_MAX_RESPONSE_BYTES)
+            .await
+            .map_err(|e| ServerError::Transport(e.into()))
     }
 }
 
@@ -844,17 +1171,23 @@ impl IGatewayConnection for Connection {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::Ordering;
+
+    use async_trait::async_trait;
     use fedimint_core::module::ApiMethod;
 
     use super::{
-        IROH_REQUEST_TIMEOUT_DEFAULT, IROH_REQUEST_TIMEOUT_LONG_POLL, request_timeout_for_method,
+        IROH_REQUEST_TIMEOUT_DEFAULT, IROH_REQUEST_TIMEOUT_LNV2_WAIT,
+        IROH_REQUEST_TIMEOUT_LONG_POLL, IrohGuardianConn, request_timeout_for_method,
     };
+    use crate::{IConnection, ServerResult};
 
-    /// Every `await_*` endpoint currently exposed by fedimint modules
-    /// should be classified as long-poll. If a new endpoint is added
-    /// without the prefix it will silently fall through to the default
-    /// 60s budget — this list documents the contract and will surface
-    /// renames as test churn.
+    /// `await_*` endpoints that take the generic 1-hour long-poll budget. If a
+    /// new endpoint is added without the prefix it will silently fall through
+    /// to the default 60s budget — this list documents the contract and will
+    /// surface renames as test churn. The lnv2 receive-side waits are
+    /// deliberately absent: they take the shorter tier (see
+    /// [`LNV2_WAIT_ENDPOINTS`]).
     const AWAIT_ENDPOINTS: &[&str] = &[
         // fedimint-core
         "await_output_outcome",
@@ -868,10 +1201,18 @@ mod tests {
         "await_offer",
         "await_outgoing_contract_cancelled",
         "await_preimage_decryption",
-        // fedimint-lnv2-common
+    ];
+
+    /// The lnv2 payment waits (receive claim + send proof-of-payment) that take
+    /// the shorter budget so a degraded connection recovers in minutes, not an
+    /// hour. `decryption_key_share` carries no `await_`/`wait_` prefix, so it
+    /// is the one entry here that the generic heuristic would otherwise
+    /// drop to the 60s prompt tier despite being a genuine long-poll.
+    const LNV2_WAIT_ENDPOINTS: &[&str] = &[
         "await_incoming_contract",
         "await_incoming_contracts",
         "await_preimage",
+        "decryption_key_share",
     ];
 
     /// A representative sample of prompt endpoints — anything that is
@@ -908,6 +1249,106 @@ mod tests {
     }
 
     #[test]
+    fn lnv2_payment_waits_get_the_shorter_long_poll_timeout() {
+        // These must map to the shorter tier, NOT the generic 1-hour bound, so a
+        // stalled receiving client recovers in minutes. Exact-name matched, and
+        // checked on both Core and Module method shapes.
+        for name in LNV2_WAIT_ENDPOINTS {
+            assert_eq!(
+                request_timeout_for_method(&ApiMethod::Core((*name).to_owned())),
+                IROH_REQUEST_TIMEOUT_LNV2_WAIT,
+                "core endpoint {name} should map to the lnv2 receive long-poll timeout"
+            );
+            assert_eq!(
+                request_timeout_for_method(&ApiMethod::Module(0, (*name).to_owned())),
+                IROH_REQUEST_TIMEOUT_LNV2_WAIT,
+                "module endpoint {name} should map to the lnv2 receive long-poll timeout"
+            );
+        }
+        // The shorter tier is a strictly tighter bound than the generic one.
+        assert!(IROH_REQUEST_TIMEOUT_LNV2_WAIT < IROH_REQUEST_TIMEOUT_LONG_POLL);
+    }
+
+    #[test]
+    fn lnv2_wait_budgets_are_spread_and_other_tiers_are_not() {
+        use std::collections::BTreeSet;
+
+        use super::{
+            IROH_LNV2_WAIT_SPREAD, request_timeout_for_method_spread, spread_offset_for_peer,
+        };
+
+        // A peer id stands in for a guardian. Vary only the low byte of the
+        // leading 8, so these are as adversarially close as distinct keys get.
+        let peer = |n: u8| {
+            let mut id = [0u8; 32];
+            id[7] = n;
+            id
+        };
+        let wait = || ApiMethod::Core("await_incoming_contracts".to_owned());
+
+        // The offset is a pure function of the peer id, so a given peer's
+        // budget is the same on every cycle and on every platform — it cannot
+        // silently degrade with the resolution of a clock, which is what a
+        // wall-clock source did on wasm and Windows.
+        let id = peer(3);
+        assert_eq!(
+            request_timeout_for_method_spread(&wait(), Some(&id)),
+            request_timeout_for_method_spread(&wait(), Some(&id)),
+            "a peer's spread budget must be stable across calls"
+        );
+
+        // Distinct peers must get distinct budgets, all inside (base - spread,
+        // base]. This is the property the spread exists for: one wait per peer
+        // issued at the same instant must not expire on the same tick.
+        let budgets: BTreeSet<_> = (0..16)
+            .map(|n| request_timeout_for_method_spread(&wait(), Some(&peer(n))))
+            .collect();
+        assert_eq!(budgets.len(), 16, "distinct peers collided on one budget");
+        for budget in &budgets {
+            assert!(
+                *budget <= IROH_REQUEST_TIMEOUT_LNV2_WAIT
+                    && *budget > IROH_REQUEST_TIMEOUT_LNV2_WAIT - IROH_LNV2_WAIT_SPREAD,
+                "spread budget {budget:?} outside its window"
+            );
+        }
+
+        // The offset spans the window rather than hugging one end.
+        let offsets: BTreeSet<_> = (0..=u8::MAX)
+            .map(|n| spread_offset_for_peer(&peer(n)))
+            .collect();
+        let lo = *offsets.iter().next().expect("non-empty");
+        let hi = *offsets.iter().next_back().expect("non-empty");
+        assert!(
+            lo < IROH_LNV2_WAIT_SPREAD / 4 && hi > IROH_LNV2_WAIT_SPREAD * 3 / 4,
+            "offsets {lo:?}..{hi:?} did not span the window"
+        );
+        assert!(hi < IROH_LNV2_WAIT_SPREAD, "offset escaped the window");
+
+        // A missing peer identity falls back to the exact tier bound.
+        assert_eq!(
+            request_timeout_for_method_spread(&wait(), None),
+            IROH_REQUEST_TIMEOUT_LNV2_WAIT
+        );
+
+        // The other tiers keep their exact bounds, spread or not.
+        let id = peer(9);
+        assert_eq!(
+            request_timeout_for_method_spread(
+                &ApiMethod::Core("await_transaction".to_owned()),
+                Some(&id)
+            ),
+            IROH_REQUEST_TIMEOUT_LONG_POLL
+        );
+        assert_eq!(
+            request_timeout_for_method_spread(
+                &ApiMethod::Core("block_count".to_owned()),
+                Some(&id)
+            ),
+            IROH_REQUEST_TIMEOUT_DEFAULT
+        );
+    }
+
+    #[test]
     fn wait_prefix_also_gets_long_poll_timeout() {
         // No fedimint endpoint currently uses this prefix, but the
         // selector accepts it so future additions following the
@@ -938,5 +1379,150 @@ mod tests {
             request_timeout_for_method(&ApiMethod::Core("submit_await_thing".to_owned())),
             IROH_REQUEST_TIMEOUT_DEFAULT,
         );
+    }
+
+    /// A stand-in guardian connection that records whether it was closed, so
+    /// the retire/drain semantics can be asserted without a live QUIC endpoint.
+    #[derive(Debug, Default)]
+    struct FakeConn {
+        closed: std::sync::atomic::AtomicBool,
+    }
+
+    #[async_trait]
+    impl IrohGuardianConn for FakeConn {
+        fn remote_id_bytes(&self) -> Option<[u8; 32]> {
+            Some([7u8; 32])
+        }
+
+        fn is_open(&self) -> bool {
+            !self.closed.load(Ordering::Acquire)
+        }
+
+        fn close_timed_out(&self) {
+            self.closed.store(true, Ordering::Release);
+        }
+
+        async fn wait_closed(&self) {
+            // Park unless the connection really is closed, so a test can tell
+            // "woke because retired" apart from "woke because closed".
+            if !self.closed.load(Ordering::Acquire) {
+                std::future::pending::<()>().await;
+            }
+        }
+
+        async fn round_trip(&self, _json: &[u8]) -> ServerResult<Vec<u8>> {
+            unreachable!("these tests exercise retirement, not the wire")
+        }
+    }
+
+    fn pooled() -> super::PooledGuardianConnection<FakeConn> {
+        super::PooledGuardianConnection::new(FakeConn::default())
+    }
+
+    #[test]
+    fn retiring_with_a_request_in_flight_does_not_close_the_connection() {
+        // The whole point: a timed-out long-poll must stop the pool handing this
+        // entry out WITHOUT aborting the unrelated requests riding on it. On a
+        // single-guardian federation there is no second peer to absorb that, so
+        // closing here would fail those calls outright.
+        let pooled = pooled();
+        let guard = pooled.enter();
+
+        pooled.retire();
+
+        assert!(!pooled.is_connected(), "a retired entry must not be reused");
+        assert!(
+            pooled.conn.is_open(),
+            "retiring must not tear down a connection with work still on it"
+        );
+
+        // ... and it closes as soon as that last request is done.
+        drop(guard);
+        assert!(
+            !pooled.conn.is_open(),
+            "the last request out of a retired connection must close it"
+        );
+    }
+
+    #[test]
+    fn a_retired_connection_closes_only_after_the_last_request_leaves() {
+        let pooled = pooled();
+        let first = pooled.enter();
+        let second = pooled.enter();
+
+        pooled.retire();
+        drop(first);
+        assert!(
+            pooled.conn.is_open(),
+            "a still-busy retired connection must stay open"
+        );
+
+        drop(second);
+        assert!(!pooled.conn.is_open(), "the last one out closes it");
+    }
+
+    #[test]
+    fn retiring_an_idle_connection_closes_it_immediately() {
+        // Defensive path: nothing in flight, so there is no guard drop coming
+        // that would otherwise close it.
+        let pooled = pooled();
+        pooled.retire();
+        assert!(!pooled.is_connected());
+        assert!(!pooled.conn.is_open());
+    }
+
+    #[test]
+    fn await_disconnection_wakes_on_retire_not_just_on_close() {
+        use std::future::Future as _;
+        use std::sync::Arc;
+        use std::task::{Context, Poll, Wake, Waker};
+
+        struct NoopWake;
+        impl Wake for NoopWake {
+            fn wake(self: Arc<Self>) {}
+        }
+
+        let pooled = pooled();
+        // Hold a request open so `retire()` does NOT close the connection —
+        // otherwise this could pass by waking on the close instead.
+        let _guard = pooled.enter();
+
+        let waker = Waker::from(Arc::new(NoopWake));
+        let mut cx = Context::from_waker(&waker);
+        let mut disconnected = std::pin::pin!(pooled.await_disconnection());
+
+        assert!(
+            matches!(disconnected.as_mut().poll(&mut cx), Poll::Pending),
+            "a healthy connection must not report a disconnection"
+        );
+
+        // Both reconnect loops (fedimint-connectors/src/lib.rs and
+        // fedimint-client/src/client.rs) drive pool refresh off this, so it has
+        // to fire on retire; waiting for the physical close would defer the
+        // refresh until the connection finished draining.
+        pooled.retire();
+        assert!(
+            pooled.conn.is_open(),
+            "precondition: retiring with a request in flight must not close"
+        );
+        assert!(
+            matches!(disconnected.as_mut().poll(&mut cx), Poll::Ready(())),
+            "await_disconnection must wake on retire, not only on close"
+        );
+    }
+
+    #[test]
+    fn a_healthy_connection_is_usable_and_stays_open() {
+        let pooled = pooled();
+        assert!(pooled.is_connected());
+        {
+            let _guard = pooled.enter();
+            assert!(pooled.is_connected());
+        }
+        assert!(
+            pooled.conn.is_open(),
+            "an ordinary request completing must not close the connection"
+        );
+        assert!(pooled.is_connected());
     }
 }

--- a/fedimint-connectors/src/iroh.rs
+++ b/fedimint-connectors/src/iroh.rs
@@ -4,6 +4,7 @@ use std::net::SocketAddr;
 use std::pin::Pin;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use anyhow::{Context, bail};
@@ -46,6 +47,61 @@ const IROH_REQUEST_TIMEOUT_DEFAULT: Duration = Duration::from_secs(60);
 /// `request_current_consensus_retry` loop will reconnect and retry.
 const IROH_REQUEST_TIMEOUT_LONG_POLL: Duration = Duration::from_secs(60 * 60);
 
+/// Shorter long-poll budget for the retry-safe lnv2 payment waits
+/// (`await_incoming_contract`, `await_incoming_contracts` and
+/// `decryption_key_share` on the receive path, `await_preimage` on the send
+/// path).
+///
+/// These block server-side until their event fires: `await_incoming_contracts`
+/// parks indefinitely on `wait_key_check`, `decryption_key_share` parks on
+/// `wait_key_exists` until the funding output is accepted, and
+/// `await_incoming_contract` and `await_preimage` poll until their contract
+/// expires — a wall-clock expiry for an incoming contract, a consensus block
+/// height for an outgoing one, and for an lnurl receive no real bound at all
+/// (its `expiration_or_fee` is fee-encoded near `u64::MAX`).
+///
+/// Either way the client's budget is effectively the bound on how long a
+/// *stalled* connection is kept before it is closed and the retry loop
+/// reconnects — a degraded path cannot deliver the expiration response any
+/// more than it can deliver a settlement. A degraded-but-not-dead
+/// QUIC path (keep-alives still pass, so the 60s idle timeout never fires, but
+/// request data no longer flows) otherwise pins the client for the full hour of
+/// [`IROH_REQUEST_TIMEOUT_LONG_POLL`] before it can recover — long enough to
+/// look like a stuck receive/send to a 24/7 client that mostly waits on these
+/// endpoints.
+///
+/// A 5-minute budget caps that degraded-path outage at ~5 min (plus the
+/// api-client retry backoff ceiling), while a *healthy* idle subscription only
+/// reconnects ~12×/hour. This tier is deliberately NOT applied to the
+/// consensus long-polls (`await_transaction`, `await_block_height`,
+/// `await_signed_session_outcome`, …): those keep the 1-hour bound so their
+/// healthy idle waits do not churn connections. Re-issuing these waits is
+/// safe — they are pure server-side reads, `await_incoming_contracts` is driven
+/// by the monotonic `IncomingContractStreamIndexKey` cursor (the client
+/// persists `next_index` only after processing a batch, so a retry replays but
+/// never skips), and a replayed incoming contract dedups on its stable
+/// operation id.
+const IROH_REQUEST_TIMEOUT_LNV2_WAIT: Duration = Duration::from_secs(5 * 60);
+
+/// The retry-safe lnv2 payment-wait endpoints that take the shorter
+/// [`IROH_REQUEST_TIMEOUT_LNV2_WAIT`] budget. Matched by exact name (not a
+/// prefix) so the shorter budget can never silently widen to an unrelated
+/// `await_*` method.
+///
+/// `decryption_key_share` is here despite not carrying an `await_`/`wait_`
+/// prefix: it long-polls on `wait_key_exists` exactly like the others (its own
+/// server-side comment says it "mirrors the AWAIT_INCOMING_CONTRACT and
+/// AWAIT_PREIMAGE endpoints"), and the gateway deliberately issues it *before*
+/// the funding output is accepted so the two overlap. It is therefore expected
+/// to block past the 60s prompt default, which without this entry closes the
+/// shared pooled connection once a minute for the whole wait.
+const IROH_LNV2_WAIT_METHODS: &[&str] = &[
+    "await_incoming_contract",
+    "await_incoming_contracts",
+    "await_preimage",
+    "decryption_key_share",
+];
+
 /// Application-level QUIC error code we use when closing a [`Connection`]
 /// after a request timeout. Recorded by the peer as the close reason; chosen
 /// arbitrarily but stable across stable and `iroh_next` impls so the two
@@ -68,10 +124,149 @@ fn request_timeout_for_method(method: &ApiMethod) -> Duration {
         ApiMethod::Core(name) => name.as_str(),
         ApiMethod::Module(_, name) => name.as_str(),
     };
-    if name.starts_with("await_") || name.starts_with("wait_") {
+    // Exact-name overrides come FIRST so the shorter budget is scoped to
+    // exactly the intended endpoints, then the generic prefix heuristic.
+    if IROH_LNV2_WAIT_METHODS.contains(&name) {
+        IROH_REQUEST_TIMEOUT_LNV2_WAIT
+    } else if name.starts_with("await_") || name.starts_with("wait_") {
         IROH_REQUEST_TIMEOUT_LONG_POLL
     } else {
         IROH_REQUEST_TIMEOUT_DEFAULT
+    }
+}
+
+/// Width of the window over which routine lnv2 wait expiries are spread. See
+/// [`request_timeout_for_method_spread`].
+const IROH_LNV2_WAIT_SPREAD: Duration = Duration::from_secs(60);
+
+/// Number of distinct millisecond slots in [`IROH_LNV2_WAIT_SPREAD`].
+const IROH_LNV2_WAIT_SPREAD_SLOTS: u64 = IROH_LNV2_WAIT_SPREAD.as_secs() * 1_000;
+
+/// Map a remote's node id to a stable spread offset in
+/// `0..IROH_LNV2_WAIT_SPREAD`.
+///
+/// The offset has to satisfy two constraints that rule out the more obvious
+/// sources:
+///
+/// - It must not depend on the ORDER waits are issued in. An issue-order
+///   counter looks like it staggers them, but the order peers re-issue in is
+///   itself the order they last expired in, so a per-rank offset step cancels
+///   against the per-rank expiry stagger and the fleet re-synchronizes.
+/// - It must not depend on the resolution of a platform facility. A sub-second
+///   wall-clock reading is nanosecond-grained only on some targets:
+///   [`fedimint_core::time::now`] is built from `js_sys::Date` on wasm
+///   (millisecond-quantised, coarser under fingerprinting resistance) and from
+///   `FILETIME` on Windows (100ns ticks, so `nanos % 60` cycles just three
+///   values). A fan-out issued inside one tick then reads one value and every
+///   peer draws the same offset — inert in exactly the case it exists for.
+///
+/// A node id has neither problem: it is a public key, so it is uniformly
+/// distributed and stable; it is known before the request is sent; and it is
+/// the same value on every platform. Each peer keeps a fixed slot in the
+/// window, and because the slot is a pure function of that id there is no
+/// feedback path from expiry order back into the offset — which is what made
+/// the counter re-synchronize.
+///
+/// This bounds clustering rather than eliminating it. Distinct offsets give
+/// distinct cycle periods (`300s - offset`), so peers that were re-issued
+/// together immediately fan out; but two periods still share a finite common
+/// multiple, so a pair does re-coincide eventually. With millisecond slots that
+/// is usually far out — random distinct pairs are typically months to years
+/// apart — while a specially aligned low-`lcm` pair (say 300.0s and 280.0s,
+/// meeting every 70min) can meet much sooner. Either way it is a transient
+/// one-cycle coincidence, not the sustained every-cycle lock the order-derived
+/// offset produced.
+///
+/// Slots are millisecond- rather than second-grained only to make exact
+/// collisions negligible: a 4-peer federation collides with p≈1e-4 over 60_000
+/// slots versus p≈0.1 over 60. Two peers that did collide share a period and so
+/// expire together indefinitely — i.e. exactly as they do with no spread at
+/// all, never worse.
+fn spread_offset_for_peer(node_id: &[u8; 32]) -> Duration {
+    // Fold the whole id through the splitmix64 finalizer rather than taking
+    // leading bytes directly. A public key should already be uniform, but that
+    // is an assumption about the key format; mixing avalanches every input bit
+    // so ids sharing a prefix still land far apart, and the spread stops
+    // depending on which bytes of the key happen to be well distributed.
+    fn mix(mut z: u64) -> u64 {
+        z = (z ^ (z >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+        z ^ (z >> 31)
+    }
+
+    let slot = node_id
+        .chunks_exact(8)
+        .map(|word| u64::from_be_bytes(word.try_into().expect("chunks_exact(8) yields 8 bytes")))
+        .fold(0u64, |acc, word| mix(acc ^ word));
+    Duration::from_millis(slot % IROH_LNV2_WAIT_SPREAD_SLOTS)
+}
+
+/// [`request_timeout_for_method`], with the routine expiry of the short lnv2
+/// tier spread over [`IROH_LNV2_WAIT_SPREAD`].
+///
+/// A client waiting on several peers issues one wait per peer at the same
+/// moment, so without this their budgets expire together and every pooled
+/// per-peer connection closes on the same tick. Those connections are shared
+/// with unrelated one-shot calls, and not every caller retries (lnv2
+/// `gateways()` uses `request_with_strategy`, not the retrying variant), so a
+/// synchronized close can surface a transient failure on a perfectly healthy
+/// network. Staggering the budgets keeps the closes from clustering.
+///
+/// Only the short tier is spread: the 1-hour tier expires rarely enough that
+/// clustering is not a concern, and the prompt tier must keep its exact bound.
+///
+/// `node_id` is the remote this request is bound for. `None` (the peer identity
+/// was not available) skips the spread and keeps the exact tier bound, which is
+/// the pre-spread behaviour. That should be unreachable — a pooled connection
+/// has completed a handshake that pins the dialed key — but it would disable
+/// the spread fleet-wide, so it is logged rather than silent.
+fn request_timeout_for_method_spread(method: &ApiMethod, node_id: Option<&[u8; 32]>) -> Duration {
+    let timeout = request_timeout_for_method(method);
+    if timeout != IROH_REQUEST_TIMEOUT_LNV2_WAIT {
+        return timeout;
+    }
+    let Some(node_id) = node_id else {
+        debug!(
+            target: LOG_NET_IROH,
+            "No peer identity for an lnv2 wait, using the unspread tier bound"
+        );
+        return timeout;
+    };
+    timeout.saturating_sub(spread_offset_for_peer(node_id))
+}
+
+/// Log a request-timeout-triggered connection close, shared by the stable and
+/// `iroh_next` request paths. A long-poll (budget above the prompt default)
+/// reaching its budget with no data is expected steady state, so it logs at
+/// `debug`; a prompt request exceeding the 60s default is unusual and warns.
+fn log_request_timeout(method_str: &str, timeout: Duration) {
+    // Three tiers, three levels. The short lnv2 tier expires every cycle on a
+    // perfectly healthy idle subscription, so it is pure noise at anything
+    // above `debug`. The 1-hour tier is different: an hour of a consensus
+    // long-poll producing nothing is the very degraded-path symptom this
+    // budget exists to bound, so it stays visible at default log levels. A
+    // prompt request exceeding the 60s default is genuinely unusual.
+    if timeout <= IROH_REQUEST_TIMEOUT_DEFAULT {
+        warn!(
+            target: LOG_NET_IROH,
+            method = %method_str,
+            timeout_secs = timeout.as_secs(),
+            "iroh request timed out, retiring connection",
+        );
+    } else if timeout <= IROH_REQUEST_TIMEOUT_LNV2_WAIT {
+        debug!(
+            target: LOG_NET_IROH,
+            method = %method_str,
+            timeout_secs = timeout.as_secs(),
+            "iroh payment-wait reached its budget, retiring connection to reconnect",
+        );
+    } else {
+        info!(
+            target: LOG_NET_IROH,
+            method = %method_str,
+            timeout_secs = timeout.as_secs(),
+            "iroh long-poll reached its budget with no data, retiring connection to reconnect",
+        );
     }
 }
 use fedimint_core::task::spawn;
@@ -86,7 +281,7 @@ use iroh::{Endpoint, NodeAddr, NodeId, PublicKey};
 use reqwest::{Method, StatusCode};
 use serde_json::Value;
 use tokio::sync::watch;
-use tracing::{debug, trace, warn};
+use tracing::{debug, info, trace, warn};
 
 use super::{DynGuaridianConnection, IGuardianConnection, ServerError, ServerResult};
 use crate::{Connectivity, DynGatewayConnection, IConnection, IGatewayConnection, IrohPeerInfo};
@@ -327,6 +522,7 @@ impl crate::Connector for IrohConnector {
             return self
                 .make_new_connection_next(&self.next, node_id, connection_override)
                 .await
+                .map(PooledGuardianConnection::new)
                 .map(super::IGuardianConnection::into_dyn);
         }
 
@@ -338,6 +534,7 @@ impl crate::Connector for IrohConnector {
                     self_clone
                         .make_new_connection_stable(node_id, connection_override)
                         .await
+                        .map(PooledGuardianConnection::new)
                         .map(super::IGuardianConnection::into_dyn),
                     "stable",
                 )
@@ -351,6 +548,7 @@ impl crate::Connector for IrohConnector {
                 self_clone
                     .make_new_connection_next(&endpoint_next, node_id, connection_override)
                     .await
+                    .map(PooledGuardianConnection::new)
                     .map(super::IGuardianConnection::into_dyn),
                 "next",
             )
@@ -674,6 +872,172 @@ fn node_addr_stable_to_next(stable: &iroh::NodeAddr) -> iroh_next::EndpointAddr 
     iroh_next::EndpointAddr::from_parts(next_node_id, relay_addrs.chain(direct_addrs))
 }
 
+/// The per-iroh-version pieces [`PooledGuardianConnection`] needs.
+///
+/// The stable and `iroh_next` connection types have the same shape but distinct
+/// concrete stream and error types, so this captures only the operations that
+/// differ and lets the pooled wrapper be written once for both.
+#[async_trait]
+trait IrohGuardianConn: fmt::Debug + Send + Sync + 'static {
+    /// The remote's 32-byte public key, if the handshake exposed one.
+    fn remote_id_bytes(&self) -> Option<[u8; 32]>;
+
+    /// Whether the underlying QUIC connection is still open.
+    fn is_open(&self) -> bool;
+
+    /// Close the underlying QUIC connection, recording our timeout as the
+    /// reason.
+    fn close_timed_out(&self);
+
+    /// Resolves once the underlying QUIC connection is closed.
+    async fn wait_closed(&self);
+
+    /// One request/response round trip on a fresh bi-stream.
+    async fn round_trip(&self, json: &[u8]) -> ServerResult<Vec<u8>>;
+}
+
+/// A pooled guardian connection that can be *retired* without being closed.
+///
+/// The pool drops an entry once [`IConnection::is_connected`] returns false,
+/// and on a bare iroh connection the only way to make that happen is to close
+/// it — which also aborts every other request in flight on that connection.
+/// Requests sharing a pooled connection are unrelated to one another, and not
+/// all of their callers retry (lnv2 `gateways()` uses `request_with_strategy`,
+/// not the retrying variant), so a routine long-poll refresh could fail a
+/// healthy one-shot call that merely overlapped it. A multi-guardian client
+/// absorbs that — losing one peer still leaves a threshold — but a
+/// single-guardian federation has no second peer to absorb anything, so the
+/// call just fails.
+///
+/// Retiring separates eviction from teardown: the entry stops being handed out
+/// for NEW requests, while requests already in flight run to completion on it.
+/// The connection is closed as soon as the last of them finishes, so it does
+/// not linger and the server-side cancellation still fires promptly.
+#[derive(Debug)]
+struct PooledGuardianConnection<C> {
+    conn: C,
+    /// Set once this connection should stop serving new requests. A watch (not
+    /// a plain flag) so [`IConnection::await_disconnection`] can wake on it.
+    retired: watch::Sender<bool>,
+    /// Requests currently in flight on `conn`.
+    in_flight: AtomicUsize,
+}
+
+/// Decrements the in-flight count on drop, closing the connection when the last
+/// request leaves a retired one.
+struct InFlightGuard<'a, C: IrohGuardianConn>(&'a PooledGuardianConnection<C>);
+
+impl<C: IrohGuardianConn> Drop for InFlightGuard<'_, C> {
+    fn drop(&mut self) {
+        // `fetch_sub` returns the PREVIOUS value, so exactly one dropping guard
+        // observes 1 and is therefore the last one out.
+        if self.0.in_flight.fetch_sub(1, Ordering::AcqRel) == 1 && *self.0.retired.borrow() {
+            self.0.conn.close_timed_out();
+        }
+    }
+}
+
+impl<C: IrohGuardianConn> PooledGuardianConnection<C> {
+    fn new(conn: C) -> Self {
+        Self {
+            conn,
+            retired: watch::Sender::new(false),
+            in_flight: AtomicUsize::new(0),
+        }
+    }
+
+    fn enter(&self) -> InFlightGuard<'_, C> {
+        self.in_flight.fetch_add(1, Ordering::AcqRel);
+        InFlightGuard(self)
+    }
+
+    /// Stop serving new requests.
+    ///
+    /// In practice the caller holds an [`InFlightGuard`], so the close happens
+    /// when that guard (or a later one) drops. The `in_flight == 0` branch is
+    /// defensive: without it a retire with nothing in flight would leave the
+    /// connection open until the pool entry was dropped.
+    ///
+    /// At least one of the two paths always closes, and the reason is subtler
+    /// than it looks. The interleaving to worry about is a last guard reading
+    /// `retired == false` while this reads `in_flight == 1`, so neither closes
+    /// and the connection leaks open. It cannot happen because
+    /// [`watch::Sender`] is `RwLock`-backed: `borrow` takes the read lock and
+    /// `send_replace` the write lock, so the two are ordered against each
+    /// other. If the guard's `borrow` reads `false` it precedes this
+    /// `send_replace`, so its `fetch_sub` also precedes the `load` below, which
+    /// therefore reads 0 and closes here.
+    ///
+    /// That means the flag may NOT be weakened to a plain `AtomicBool` with
+    /// these orderings — without the lock, the store-buffer interleaving is
+    /// real and would need `SeqCst`. Closing twice (guard drops between the
+    /// `send_replace` and the `load`) is possible and harmless; `close` is
+    /// idempotent on both iroh stacks.
+    fn retire(&self) {
+        self.retired.send_replace(true);
+        if self.in_flight.load(Ordering::Acquire) == 0 {
+            self.conn.close_timed_out();
+        }
+    }
+}
+
+#[apply(async_trait_maybe_send!)]
+impl<C: IrohGuardianConn> IConnection for PooledGuardianConnection<C> {
+    async fn await_disconnection(&self) {
+        let closed = std::pin::pin!(self.conn.wait_closed());
+        let retired = std::pin::pin!(async {
+            let mut rx = self.retired.subscribe();
+            let _ = rx.wait_for(|retired| *retired).await;
+        });
+        futures::future::select(closed, retired).await;
+    }
+
+    fn is_connected(&self) -> bool {
+        !*self.retired.borrow() && self.conn.is_open()
+    }
+}
+
+#[async_trait]
+impl<C: IrohGuardianConn> IGuardianConnection for PooledGuardianConnection<C> {
+    async fn request(&self, method: ApiMethod, request: ApiRequestErased) -> ServerResult<Value> {
+        let timeout =
+            request_timeout_for_method_spread(&method, self.conn.remote_id_bytes().as_ref());
+        let method_str = method.to_string();
+        let json = serde_json::to_vec(&IrohApiRequest { method, request })
+            .expect("Serialization to vec can't fail");
+
+        let response = {
+            let _guard = self.enter();
+            match fedimint_core::runtime::timeout(timeout, self.conn.round_trip(&json)).await {
+                Ok(Ok(bytes)) => bytes,
+                Ok(Err(err)) => return Err(err),
+                Err(_) => {
+                    // The bi-stream stalled past our budget. Retire the entry so
+                    // the pool stops handing it out and the upstream retry loop
+                    // gets a fresh connection, WITHOUT tearing down requests that
+                    // are still in flight on this one.
+                    //
+                    // A long-poll reaching its budget with no data is EXPECTED
+                    // steady state (idle subscription) — log it at debug. A
+                    // prompt request exceeding the 60s default is genuinely
+                    // unusual — warn.
+                    log_request_timeout(&method_str, timeout);
+                    self.retire();
+                    return Err(ServerError::Transport(anyhow::anyhow!(
+                        "iroh request {method_str} timed out after {timeout:?}"
+                    )));
+                }
+            }
+        };
+
+        // TODO: We should not be serializing Results on the wire
+        let response = serde_json::from_slice::<Result<Value, ApiError>>(&response)
+            .map_err(|e| ServerError::InvalidResponse(e.into()))?;
+
+        response.map_err(|e| ServerError::InvalidResponse(anyhow::anyhow!("Api Error: {:?}", e)))
+    }
+}
+
 #[apply(async_trait_maybe_send!)]
 impl IConnection for Connection {
     async fn await_disconnection(&self) {
@@ -686,64 +1050,43 @@ impl IConnection for Connection {
 }
 
 #[async_trait]
-impl IGuardianConnection for Connection {
-    async fn request(&self, method: ApiMethod, request: ApiRequestErased) -> ServerResult<Value> {
-        let timeout = request_timeout_for_method(&method);
-        let method_str = method.to_string();
-        let json = serde_json::to_vec(&IrohApiRequest { method, request })
-            .expect("Serialization to vec can't fail");
+impl IrohGuardianConn for Connection {
+    fn remote_id_bytes(&self) -> Option<[u8; 32]> {
+        self.remote_node_id().ok().map(|id| *id.as_bytes())
+    }
 
-        let result = fedimint_core::runtime::timeout(timeout, async {
-            let (mut sink, mut stream) = self
-                .open_bi()
-                .await
-                .map_err(|e| ServerError::Transport(e.into()))?;
+    fn is_open(&self) -> bool {
+        self.close_reason().is_none()
+    }
 
-            sink.write_all(&json)
-                .await
-                .map_err(|e| ServerError::Transport(e.into()))?;
+    fn close_timed_out(&self) {
+        self.close(
+            iroh::endpoint::VarInt::from_u32(IROH_REQUEST_TIMEOUT_ERROR_CODE),
+            IROH_REQUEST_TIMEOUT_ERROR_REASON,
+        );
+    }
 
-            sink.finish()
-                .map_err(|e| ServerError::Transport(e.into()))?;
+    async fn wait_closed(&self) {
+        self.closed().await;
+    }
 
-            stream
-                .read_to_end(IROH_MAX_RESPONSE_BYTES)
-                .await
-                .map_err(|e| ServerError::Transport(e.into()))
-        })
-        .await;
+    async fn round_trip(&self, json: &[u8]) -> ServerResult<Vec<u8>> {
+        let (mut sink, mut stream) = self
+            .open_bi()
+            .await
+            .map_err(|e| ServerError::Transport(e.into()))?;
 
-        let response = match result {
-            Ok(Ok(bytes)) => bytes,
-            Ok(Err(err)) => return Err(err),
-            Err(_) => {
-                // The bi-stream stalled past our budget. Close the QUIC
-                // connection so [`Self::is_connected`] (which reads
-                // `close_reason`) starts returning false; the connection
-                // pool's `get_or_init_pool_entry` will then evict this
-                // entry on the next access and the upstream retry loop
-                // will get a fresh connection.
-                warn!(
-                    target: LOG_NET_IROH,
-                    method = %method_str,
-                    timeout_secs = timeout.as_secs(),
-                    "iroh request timed out, closing connection",
-                );
-                self.close(
-                    iroh::endpoint::VarInt::from_u32(IROH_REQUEST_TIMEOUT_ERROR_CODE),
-                    IROH_REQUEST_TIMEOUT_ERROR_REASON,
-                );
-                return Err(ServerError::Transport(anyhow::anyhow!(
-                    "iroh request {method_str} timed out after {timeout:?}"
-                )));
-            }
-        };
+        sink.write_all(json)
+            .await
+            .map_err(|e| ServerError::Transport(e.into()))?;
 
-        // TODO: We should not be serializing Results on the wire
-        let response = serde_json::from_slice::<Result<Value, ApiError>>(&response)
-            .map_err(|e| ServerError::InvalidResponse(e.into()))?;
+        sink.finish()
+            .map_err(|e| ServerError::Transport(e.into()))?;
 
-        response.map_err(|e| ServerError::InvalidResponse(anyhow::anyhow!("Api Error: {:?}", e)))
+        stream
+            .read_to_end(IROH_MAX_RESPONSE_BYTES)
+            .await
+            .map_err(|e| ServerError::Transport(e.into()))
     }
 }
 
@@ -759,58 +1102,43 @@ impl IConnection for iroh_next::endpoint::Connection {
 }
 
 #[async_trait]
-impl IGuardianConnection for iroh_next::endpoint::Connection {
-    async fn request(&self, method: ApiMethod, request: ApiRequestErased) -> ServerResult<Value> {
-        let timeout = request_timeout_for_method(&method);
-        let method_str = method.to_string();
-        let json = serde_json::to_vec(&IrohApiRequest { method, request })
-            .expect("Serialization to vec can't fail");
+impl IrohGuardianConn for iroh_next::endpoint::Connection {
+    fn remote_id_bytes(&self) -> Option<[u8; 32]> {
+        Some(*self.remote_id().as_bytes())
+    }
 
-        let result = fedimint_core::runtime::timeout(timeout, async {
-            let (mut sink, mut stream) = self
-                .open_bi()
-                .await
-                .map_err(|e| ServerError::Transport(e.into()))?;
+    fn is_open(&self) -> bool {
+        self.close_reason().is_none()
+    }
 
-            sink.write_all(&json)
-                .await
-                .map_err(|e| ServerError::Transport(e.into()))?;
+    fn close_timed_out(&self) {
+        self.close(
+            iroh_next::endpoint::VarInt::from_u32(IROH_REQUEST_TIMEOUT_ERROR_CODE),
+            IROH_REQUEST_TIMEOUT_ERROR_REASON,
+        );
+    }
 
-            sink.finish()
-                .map_err(|e| ServerError::Transport(e.into()))?;
+    async fn wait_closed(&self) {
+        self.closed().await;
+    }
 
-            stream
-                .read_to_end(IROH_MAX_RESPONSE_BYTES)
-                .await
-                .map_err(|e| ServerError::Transport(e.into()))
-        })
-        .await;
+    async fn round_trip(&self, json: &[u8]) -> ServerResult<Vec<u8>> {
+        let (mut sink, mut stream) = self
+            .open_bi()
+            .await
+            .map_err(|e| ServerError::Transport(e.into()))?;
 
-        let response = match result {
-            Ok(Ok(bytes)) => bytes,
-            Ok(Err(err)) => return Err(err),
-            Err(_) => {
-                warn!(
-                    target: LOG_NET_IROH,
-                    method = %method_str,
-                    timeout_secs = timeout.as_secs(),
-                    "iroh request timed out, closing connection",
-                );
-                self.close(
-                    iroh_next::endpoint::VarInt::from_u32(IROH_REQUEST_TIMEOUT_ERROR_CODE),
-                    IROH_REQUEST_TIMEOUT_ERROR_REASON,
-                );
-                return Err(ServerError::Transport(anyhow::anyhow!(
-                    "iroh request {method_str} timed out after {timeout:?}"
-                )));
-            }
-        };
+        sink.write_all(json)
+            .await
+            .map_err(|e| ServerError::Transport(e.into()))?;
 
-        // TODO: We should not be serializing Results on the wire
-        let response = serde_json::from_slice::<Result<Value, ApiError>>(&response)
-            .map_err(|e| ServerError::InvalidResponse(e.into()))?;
+        sink.finish()
+            .map_err(|e| ServerError::Transport(e.into()))?;
 
-        response.map_err(|e| ServerError::InvalidResponse(anyhow::anyhow!("Api Error: {:?}", e)))
+        stream
+            .read_to_end(IROH_MAX_RESPONSE_BYTES)
+            .await
+            .map_err(|e| ServerError::Transport(e.into()))
     }
 }
 
@@ -864,7 +1192,9 @@ impl IGatewayConnection for Connection {
 #[cfg(test)]
 mod tests {
     use std::str::FromStr as _;
+    use std::sync::atomic::Ordering;
 
+    use async_trait::async_trait;
     use fedimint_core::PeerId;
     use fedimint_core::config::FederationId;
     use fedimint_core::invite_code::InviteCode;
@@ -872,9 +1202,13 @@ mod tests {
     use fedimint_core::util::SafeUrl;
 
     use super::{
-        IROH_REQUEST_TIMEOUT_DEFAULT, IROH_REQUEST_TIMEOUT_LONG_POLL, request_timeout_for_method,
+        IROH_REQUEST_TIMEOUT_DEFAULT, IROH_REQUEST_TIMEOUT_LNV2_WAIT,
+        IROH_REQUEST_TIMEOUT_LONG_POLL, IrohGuardianConn, request_timeout_for_method,
     };
-    use crate::{iroh_next_endpoint_url, is_iroh_next_endpoint_url, preserve_iroh_next_marker};
+    use crate::{
+        IConnection, ServerResult, iroh_next_endpoint_url, is_iroh_next_endpoint_url,
+        preserve_iroh_next_marker,
+    };
 
     const TEST_ENDPOINT_ID: &str =
         "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c";
@@ -907,11 +1241,12 @@ mod tests {
         assert!(is_iroh_next_endpoint_url(&url).is_err());
     }
 
-    /// Every `await_*` endpoint currently exposed by fedimint modules
-    /// should be classified as long-poll. If a new endpoint is added
-    /// without the prefix it will silently fall through to the default
-    /// 60s budget — this list documents the contract and will surface
-    /// renames as test churn.
+    /// `await_*` endpoints that take the generic 1-hour long-poll budget. If a
+    /// new endpoint is added without the prefix it will silently fall through
+    /// to the default 60s budget — this list documents the contract and will
+    /// surface renames as test churn. The lnv2 receive-side waits are
+    /// deliberately absent: they take the shorter tier (see
+    /// [`LNV2_WAIT_ENDPOINTS`]).
     const AWAIT_ENDPOINTS: &[&str] = &[
         // fedimint-core
         "await_output_outcome",
@@ -925,10 +1260,18 @@ mod tests {
         "await_offer",
         "await_outgoing_contract_cancelled",
         "await_preimage_decryption",
-        // fedimint-lnv2-common
+    ];
+
+    /// The lnv2 payment waits (receive claim + send proof-of-payment) that take
+    /// the shorter budget so a degraded connection recovers in minutes, not an
+    /// hour. `decryption_key_share` carries no `await_`/`wait_` prefix, so it
+    /// is the one entry here that the generic heuristic would otherwise
+    /// drop to the 60s prompt tier despite being a genuine long-poll.
+    const LNV2_WAIT_ENDPOINTS: &[&str] = &[
         "await_incoming_contract",
         "await_incoming_contracts",
         "await_preimage",
+        "decryption_key_share",
     ];
 
     /// A representative sample of prompt endpoints — anything that is
@@ -965,6 +1308,106 @@ mod tests {
     }
 
     #[test]
+    fn lnv2_payment_waits_get_the_shorter_long_poll_timeout() {
+        // These must map to the shorter tier, NOT the generic 1-hour bound, so a
+        // stalled receiving client recovers in minutes. Exact-name matched, and
+        // checked on both Core and Module method shapes.
+        for name in LNV2_WAIT_ENDPOINTS {
+            assert_eq!(
+                request_timeout_for_method(&ApiMethod::Core((*name).to_owned())),
+                IROH_REQUEST_TIMEOUT_LNV2_WAIT,
+                "core endpoint {name} should map to the lnv2 receive long-poll timeout"
+            );
+            assert_eq!(
+                request_timeout_for_method(&ApiMethod::Module(0, (*name).to_owned())),
+                IROH_REQUEST_TIMEOUT_LNV2_WAIT,
+                "module endpoint {name} should map to the lnv2 receive long-poll timeout"
+            );
+        }
+        // The shorter tier is a strictly tighter bound than the generic one.
+        assert!(IROH_REQUEST_TIMEOUT_LNV2_WAIT < IROH_REQUEST_TIMEOUT_LONG_POLL);
+    }
+
+    #[test]
+    fn lnv2_wait_budgets_are_spread_and_other_tiers_are_not() {
+        use std::collections::BTreeSet;
+
+        use super::{
+            IROH_LNV2_WAIT_SPREAD, request_timeout_for_method_spread, spread_offset_for_peer,
+        };
+
+        // A peer id stands in for a guardian. Vary only the low byte of the
+        // leading 8, so these are as adversarially close as distinct keys get.
+        let peer = |n: u8| {
+            let mut id = [0u8; 32];
+            id[7] = n;
+            id
+        };
+        let wait = || ApiMethod::Core("await_incoming_contracts".to_owned());
+
+        // The offset is a pure function of the peer id, so a given peer's
+        // budget is the same on every cycle and on every platform — it cannot
+        // silently degrade with the resolution of a clock, which is what a
+        // wall-clock source did on wasm and Windows.
+        let id = peer(3);
+        assert_eq!(
+            request_timeout_for_method_spread(&wait(), Some(&id)),
+            request_timeout_for_method_spread(&wait(), Some(&id)),
+            "a peer's spread budget must be stable across calls"
+        );
+
+        // Distinct peers must get distinct budgets, all inside (base - spread,
+        // base]. This is the property the spread exists for: one wait per peer
+        // issued at the same instant must not expire on the same tick.
+        let budgets: BTreeSet<_> = (0..16)
+            .map(|n| request_timeout_for_method_spread(&wait(), Some(&peer(n))))
+            .collect();
+        assert_eq!(budgets.len(), 16, "distinct peers collided on one budget");
+        for budget in &budgets {
+            assert!(
+                *budget <= IROH_REQUEST_TIMEOUT_LNV2_WAIT
+                    && *budget > IROH_REQUEST_TIMEOUT_LNV2_WAIT - IROH_LNV2_WAIT_SPREAD,
+                "spread budget {budget:?} outside its window"
+            );
+        }
+
+        // The offset spans the window rather than hugging one end.
+        let offsets: BTreeSet<_> = (0..=u8::MAX)
+            .map(|n| spread_offset_for_peer(&peer(n)))
+            .collect();
+        let lo = *offsets.iter().next().expect("non-empty");
+        let hi = *offsets.iter().next_back().expect("non-empty");
+        assert!(
+            lo < IROH_LNV2_WAIT_SPREAD / 4 && hi > IROH_LNV2_WAIT_SPREAD * 3 / 4,
+            "offsets {lo:?}..{hi:?} did not span the window"
+        );
+        assert!(hi < IROH_LNV2_WAIT_SPREAD, "offset escaped the window");
+
+        // A missing peer identity falls back to the exact tier bound.
+        assert_eq!(
+            request_timeout_for_method_spread(&wait(), None),
+            IROH_REQUEST_TIMEOUT_LNV2_WAIT
+        );
+
+        // The other tiers keep their exact bounds, spread or not.
+        let id = peer(9);
+        assert_eq!(
+            request_timeout_for_method_spread(
+                &ApiMethod::Core("await_transaction".to_owned()),
+                Some(&id)
+            ),
+            IROH_REQUEST_TIMEOUT_LONG_POLL
+        );
+        assert_eq!(
+            request_timeout_for_method_spread(
+                &ApiMethod::Core("block_count".to_owned()),
+                Some(&id)
+            ),
+            IROH_REQUEST_TIMEOUT_DEFAULT
+        );
+    }
+
+    #[test]
     fn wait_prefix_also_gets_long_poll_timeout() {
         // No fedimint endpoint currently uses this prefix, but the
         // selector accepts it so future additions following the
@@ -995,5 +1438,150 @@ mod tests {
             request_timeout_for_method(&ApiMethod::Core("submit_await_thing".to_owned())),
             IROH_REQUEST_TIMEOUT_DEFAULT,
         );
+    }
+
+    /// A stand-in guardian connection that records whether it was closed, so
+    /// the retire/drain semantics can be asserted without a live QUIC endpoint.
+    #[derive(Debug, Default)]
+    struct FakeConn {
+        closed: std::sync::atomic::AtomicBool,
+    }
+
+    #[async_trait]
+    impl IrohGuardianConn for FakeConn {
+        fn remote_id_bytes(&self) -> Option<[u8; 32]> {
+            Some([7u8; 32])
+        }
+
+        fn is_open(&self) -> bool {
+            !self.closed.load(Ordering::Acquire)
+        }
+
+        fn close_timed_out(&self) {
+            self.closed.store(true, Ordering::Release);
+        }
+
+        async fn wait_closed(&self) {
+            // Park unless the connection really is closed, so a test can tell
+            // "woke because retired" apart from "woke because closed".
+            if !self.closed.load(Ordering::Acquire) {
+                std::future::pending::<()>().await;
+            }
+        }
+
+        async fn round_trip(&self, _json: &[u8]) -> ServerResult<Vec<u8>> {
+            unreachable!("these tests exercise retirement, not the wire")
+        }
+    }
+
+    fn pooled() -> super::PooledGuardianConnection<FakeConn> {
+        super::PooledGuardianConnection::new(FakeConn::default())
+    }
+
+    #[test]
+    fn retiring_with_a_request_in_flight_does_not_close_the_connection() {
+        // The whole point: a timed-out long-poll must stop the pool handing this
+        // entry out WITHOUT aborting the unrelated requests riding on it. On a
+        // single-guardian federation there is no second peer to absorb that, so
+        // closing here would fail those calls outright.
+        let pooled = pooled();
+        let guard = pooled.enter();
+
+        pooled.retire();
+
+        assert!(!pooled.is_connected(), "a retired entry must not be reused");
+        assert!(
+            pooled.conn.is_open(),
+            "retiring must not tear down a connection with work still on it"
+        );
+
+        // ... and it closes as soon as that last request is done.
+        drop(guard);
+        assert!(
+            !pooled.conn.is_open(),
+            "the last request out of a retired connection must close it"
+        );
+    }
+
+    #[test]
+    fn a_retired_connection_closes_only_after_the_last_request_leaves() {
+        let pooled = pooled();
+        let first = pooled.enter();
+        let second = pooled.enter();
+
+        pooled.retire();
+        drop(first);
+        assert!(
+            pooled.conn.is_open(),
+            "a still-busy retired connection must stay open"
+        );
+
+        drop(second);
+        assert!(!pooled.conn.is_open(), "the last one out closes it");
+    }
+
+    #[test]
+    fn retiring_an_idle_connection_closes_it_immediately() {
+        // Defensive path: nothing in flight, so there is no guard drop coming
+        // that would otherwise close it.
+        let pooled = pooled();
+        pooled.retire();
+        assert!(!pooled.is_connected());
+        assert!(!pooled.conn.is_open());
+    }
+
+    #[test]
+    fn await_disconnection_wakes_on_retire_not_just_on_close() {
+        use std::future::Future as _;
+        use std::sync::Arc;
+        use std::task::{Context, Poll, Wake, Waker};
+
+        struct NoopWake;
+        impl Wake for NoopWake {
+            fn wake(self: Arc<Self>) {}
+        }
+
+        let pooled = pooled();
+        // Hold a request open so `retire()` does NOT close the connection —
+        // otherwise this could pass by waking on the close instead.
+        let _guard = pooled.enter();
+
+        let waker = Waker::from(Arc::new(NoopWake));
+        let mut cx = Context::from_waker(&waker);
+        let mut disconnected = std::pin::pin!(pooled.await_disconnection());
+
+        assert!(
+            matches!(disconnected.as_mut().poll(&mut cx), Poll::Pending),
+            "a healthy connection must not report a disconnection"
+        );
+
+        // Both reconnect loops (fedimint-connectors/src/lib.rs and
+        // fedimint-client/src/client.rs) drive pool refresh off this, so it has
+        // to fire on retire; waiting for the physical close would defer the
+        // refresh until the connection finished draining.
+        pooled.retire();
+        assert!(
+            pooled.conn.is_open(),
+            "precondition: retiring with a request in flight must not close"
+        );
+        assert!(
+            matches!(disconnected.as_mut().poll(&mut cx), Poll::Ready(())),
+            "await_disconnection must wake on retire, not only on close"
+        );
+    }
+
+    #[test]
+    fn a_healthy_connection_is_usable_and_stays_open() {
+        let pooled = pooled();
+        assert!(pooled.is_connected());
+        {
+            let _guard = pooled.enter();
+            assert!(pooled.is_connected());
+        }
+        assert!(
+            pooled.conn.is_open(),
+            "an ordinary request completing must not close the connection"
+        );
+        assert!(pooled.is_connected());
     }
 }

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -29,7 +29,7 @@ use fedimint_core::module::{
 use fedimint_core::net::iroh::build_iroh_endpoint;
 use fedimint_core::net::peers::DynP2PConnections;
 use fedimint_core::task::{TaskGroup, sleep};
-use fedimint_core::util::{FmtCompactAnyhow as _, SafeUrl};
+use fedimint_core::util::{FmtCompact as _, FmtCompactAnyhow as _, SafeUrl};
 use fedimint_logging::{LOG_CONSENSUS, LOG_CORE, LOG_NET_API};
 use fedimint_server_core::bitcoin_rpc::{DynServerBitcoinRpc, ServerBitcoinRpcMonitor};
 use fedimint_server_core::dashboard_ui::IDashboardApi;
@@ -37,7 +37,7 @@ use fedimint_server_core::migration::apply_migrations_server_dbtx;
 use fedimint_server_core::{DynServerModule, ServerModuleInitRegistry};
 use futures::FutureExt;
 use iroh::Endpoint;
-use iroh::endpoint::{Incoming, RecvStream, SendStream, VarInt};
+use iroh::endpoint::{ConnectionError, Incoming, RecvStream, SendStream, VarInt};
 use jsonrpsee::RpcModule;
 use jsonrpsee::server::ServerHandle;
 use serde_json::Value;
@@ -556,7 +556,32 @@ async fn handle_incoming(
         .await;
 
         let (send_stream, recv_stream) = match accept_result {
-            Ok(streams) => streams?,
+            Ok(Ok(streams)) => streams,
+            // A peer hanging up is the ordinary end of a connection, not a
+            // failure to report: clients close a connection whose request
+            // budget elapsed (routine for a long-poll refresh), and abrupt
+            // client death surfaces the same way once QUIC's idle timeout
+            // fires. Reporting these as errors would make the guardian log a
+            // warning for every routine client reconnect.
+            //
+            // `ConnectionClosed` is deliberately NOT in this set: it means the
+            // peer's QUIC stack aborted the connection, which is a transport
+            // fault rather than a client hanging up, and is exactly the signal
+            // an operator wants to keep at `warn`.
+            Ok(Err(
+                err @ (ConnectionError::ApplicationClosed(_)
+                | ConnectionError::LocallyClosed
+                | ConnectionError::TimedOut
+                | ConnectionError::Reset),
+            )) => {
+                tracing::debug!(
+                    target: LOG_NET_API,
+                    err = %err.fmt_compact(),
+                    "Iroh API connection closed by peer"
+                );
+                return Ok(());
+            }
+            Ok(Err(err)) => return Err(err.into()),
             Err(_)
                 if parallel_requests_limit.available_permits()
                     < iroh_api_max_requests_per_connection =>
@@ -590,21 +615,57 @@ async fn handle_incoming(
             .acquire_owned()
             .await
             .expect("semaphore should not be closed");
+        // Stop handling a request as soon as its client goes away.
+        //
+        // `handle_request` awaits the endpoint to completion BEFORE it touches
+        // the stream, so for a long-poll endpoint (`await_*`) the handler is
+        // parked in `wait_key_check`/`wait_key_exists` without any dependency on
+        // the connection. Losing the client therefore does not, by itself, stop
+        // that waiter: it stays alive (holding a task and a DB subscription)
+        // until the awaited key changes, which for a pending payment can be the
+        // full invoice lifetime. A client that reconnects while a wait is
+        // outstanding — a routine long-poll refresh, or a reconnect after a
+        // stalled request — would leave the previous waiter behind on every
+        // peer and accumulate them. Racing against `closed()` bounds an
+        // in-flight handler by the connection's lifetime.
+        //
+        // Cancelling here is safe for non-long-poll endpoints too: the response
+        // can no longer be delivered, and a dbtx that has not committed is
+        // dropped atomically. Where a write HAS committed, the client sees a
+        // failed request and retries; that is already the behaviour when a
+        // connection drops mid-response, so cancellation adds no new hazard —
+        // but note it is not literally idempotent everywhere. A retried
+        // `sign_api_announcement` bumps its nonce again, and a retried meta
+        // submit draws a fresh salt, so the second write is equivalent rather
+        // than identical.
+        let connection_closed = connection.clone();
+        let request_consensus_api = consensus_api.clone();
+        let request_core_api = core_api.clone();
+        let request_module_api = module_api.clone();
         task_group.spawn_cancellable_silent(
             "handle-iroh-request",
-            handle_request(
-                consensus_api.clone(),
-                core_api.clone(),
-                module_api.clone(),
-                send_stream,
-                recv_stream,
-                permit,
-            )
-            .then(|result| async {
-                if let Err(err) = result {
-                    warn!(target: LOG_NET_API, err = %err.fmt_compact_anyhow(), "Failed to handle iroh request");
+            async move {
+                tokio::select! {
+                    result = handle_request(
+                        request_consensus_api,
+                        request_core_api,
+                        request_module_api,
+                        send_stream,
+                        recv_stream,
+                        permit,
+                    ) => {
+                        if let Err(err) = result {
+                            warn!(target: LOG_NET_API, err = %err.fmt_compact_anyhow(), "Failed to handle iroh request");
+                        }
+                    }
+                    _ = connection_closed.closed() => {
+                        tracing::debug!(
+                            target: LOG_NET_API,
+                            "Client disconnected, abandoning in-flight iroh request"
+                        );
+                    }
                 }
-            }),
+            },
         );
     }
 }
@@ -626,7 +687,30 @@ async fn handle_request(
         .with_label_values(&[&method])
         .start_timer();
 
-    let response = await_response(consensus_api, core_api, module_api, request).await;
+    // Race the endpoint against the client abandoning *this request*, not just
+    // against losing the whole connection.
+    //
+    // A client that gives up on one request drops its `RecvStream`, which quinn
+    // turns into a STOP_SENDING and surfaces here as `stopped()`. Waiting only
+    // on `Connection::closed()` would miss that whenever the client keeps the
+    // connection for its other requests — it retires a stalled connection
+    // rather than closing it, precisely so unrelated in-flight requests are not
+    // torn down — and this waiter would then survive until the last of those
+    // drained, which for a consensus long-poll is up to an hour.
+    //
+    // `stopped()` cannot fire spuriously here: it yields `None` only after the
+    // local side finishes the stream, and nothing has been written yet.
+    let response = tokio::select! {
+        response = await_response(consensus_api, core_api, module_api, request) => response,
+        _ = send_stream.stopped() => {
+            tracing::debug!(
+                target: LOG_NET_API,
+                %method,
+                "Client abandoned the request, cancelling in-flight iroh request"
+            );
+            return Ok(());
+        }
+    };
 
     timer.observe_duration();
 

--- a/modules/fedimint-lnv2-common/src/endpoint_constants.rs
+++ b/modules/fedimint-lnv2-common/src/endpoint_constants.rs
@@ -1,4 +1,17 @@
 // Federation endpoints
+//
+// NOTE: the four payment-wait endpoints below (`await_incoming_contract`,
+// `await_preimage`, `await_incoming_contracts`, `decryption_key_share`) are
+// also listed by name in `IROH_LNV2_WAIT_METHODS` in
+// `fedimint-connectors/src/iroh.rs`, which gives them a shorter iroh request
+// budget than other long-polls. That crate cannot depend on this one, so the
+// names are duplicated there as literals, and renaming one here without
+// updating there silently changes its budget. The three `await_*` names would
+// still match that file's `await_`/`wait_` prefix heuristic and fall back to
+// the 1-hour tier; `decryption_key_share` matches neither and would fall all
+// the way back to the 60s prompt tier, which for a wait the gateway issues
+// before funding acceptance means closing the shared pooled connection once a
+// minute for the length of the wait.
 pub const ADD_GATEWAY_ENDPOINT: &str = "add_gateway";
 pub const AWAIT_INCOMING_CONTRACT_ENDPOINT: &str = "await_incoming_contract";
 pub const AWAIT_PREIMAGE_ENDPOINT: &str = "await_preimage";


### PR DESCRIPTION
Client-side half of the iroh long-poll work. The server-side half — cancelling in-flight API requests when the client goes away — is now **#8993**, and should land first (see Deployment ordering below).

## Problem — a degraded path pins a waiting client for up to an hour

The iroh connector gives every `await_*`/`wait_*` request a **3600s** budget (`IROH_REQUEST_TIMEOUT_LONG_POLL`), and a stalled connection is only closed + re-established when that request timeout fires (the close flips `is_connected()` false → the pool evicts it → the api-client retry loop reconnects).

QUIC keep-alive (30s) + `max_idle_timeout` (60s) recover a **fully dead** path in ~60s. A **degraded-but-not-dead** path — keep-alives still get through, so the idle timeout never fires, but request data no longer flows — is invisible to that. A client that mostly waits on lnv2 payment endpoints is then stuck for the full hour before it can get a fresh (working) connection.

Observed on a 24/7 client against a single-guardian `iroh://` federation: sustained receive/claim stalls, while the connection established after eviction worked fine. Reconnecting fixes it; the client just waits an hour to try.

## The changes

**`fix(iroh)`: retire pooled connections instead of closing them.** Closing was doing two jobs: evicting the pool entry *and* tearing down every unrelated request in flight on that connection. Not all of their callers retry (`gateways()` and others use `request_with_strategy`), so a routine long-poll refresh could fail a healthy one-shot call that merely overlapped it — and with a single guardian there is no second peer to absorb that, so the call just fails. A timed-out wait now retires the entry: `is_connected()` goes false so the pool stops handing it out and the retry loop gets a fresh connection, while in-flight requests run to completion and the connection closes as the last one finishes. One wrapper serves both the stable and `iroh_next` paths, which also removes the duplicated request body.

**`fix(iroh)`: shorter long-poll budget for the retry-safe lnv2 payment waits.** Add a second tier, `IROH_REQUEST_TIMEOUT_LNV2_WAIT = 5min`, applied by **exact method name** (before the generic prefix fallback) to `await_incoming_contract`, `await_incoming_contracts` (receive) and `await_preimage` (send proof-of-payment). A degraded path now recovers in ~5 min instead of ~1h, while a healthy idle subscription reconnects ~12×/hour — which #8993 makes cheap. Consensus long-polls (`await_transaction`, `await_block_height`, `await_signed_session_outcome`, …) keep the 1-hour bound so their healthy idle waits don't churn connections.

Also logs a long-poll timeout-close at `debug` rather than `warn`: reaching a long-poll budget with no data is expected steady state, whereas a *prompt* request exceeding the 60s default is genuinely unusual.

## Why re-issuing these waits is safe

They're pure server-side reads with no per-request state consumed:
- `await_incoming_contracts` is driven by the monotonic `IncomingContractStreamIndexKey` cursor, and the client persists `next_index` **only after** processing a batch — a re-issued request **replays but never skips**.
- A replayed incoming contract dedups on its stable `OperationId::from_encodable(&contract)` (the duplicate `manual_operation_start` is already tolerated).
- `await_incoming_contract` / `await_preimage` are read-only expiry-checked polls under the retry-forever threshold-consensus loop.

## Open questions / follow-ups

- ~~**Reconnect correlation.**~~ **Addressed.** Concurrent per-peer waits were expiring on the same tick, closing every pooled connection together and surfacing transient errors on non-retried fan-outs like `gateways()`. The short tier's budget is now spread over a 60s window by an offset keyed on the **remote's node id**. Only the short tier is spread; the 1-hour and prompt tiers keep their exact bounds.
  <br>Two earlier revisions of this got it wrong, so the choice of key is worth stating: an **issue-order counter** re-synchronizes the fleet (the order peers re-issue in *is* the order they last expired in, so a per-rank offset step cancels the per-rank stagger), and a **sub-second clock reading** is nanosecond-grained only on some targets — `fedimint_core::time::now()` is `js_sys::Date` on wasm (millisecond-quantised) and `FILETIME` on Windows (100ns, so `nanos % 60` cycles three values), so a fan-out issued inside one tick draws one offset for every peer and the spread is inert in exactly the case it exists for. A node id has neither problem: uniform, stable, known before the request, identical on every platform. It is folded through a splitmix64 finalizer rather than used raw so the spread does not depend on which bytes of the key happen to be well distributed.
- **Is 5 min the right value?** Still a judgement call, and I'd welcome a maintainer's view. An earlier revision of this description argued the value was bounded above by the incoming contract's lifetime — that the client could burn the contract's life and make funding permanently impossible. **That was wrong and I've removed it.** The awaiting client is an observer, not the funder (the gateway funds via `relay_incoming_htlc`/`relay_direct_swap` on the prompt tier, independent of this connection), claiming has no deadline (`process_input` for `Incoming` performs no expiration check and `IncomingContractOutpointKey` persists), and lnurl receives don't even carry a real expiration (`fee_encoded_expiration` is `u64::MAX - fee`). A stalled budget delays *learning and claiming* by up to its length; it does not turn a would-succeed receive into a permanent failure. The value rests on the original grounds only: bounded recovery from a degraded-but-not-dead path, and how long a receive is allowed to look stuck.
- **A liveness/progress watchdog** independent of the request (or a server-side long-poll timeout, so the client bound isn't load-bearing) would fix the degraded-path case without any reconnect churn, but is a larger design — happy to open a separate issue.
- ~~**Adjacent, pre-existing:** `decryption_key_share`…~~ **Now included.** It long-polls on `wait_key_exists` (its own server-side comment says it mirrors `AWAIT_INCOMING_CONTRACT` / `AWAIT_PREIMAGE`) but carries no `await_`/`wait_` prefix, so the heuristic dropped it to the 60s prompt tier — and the gateway deliberately issues it *before* the funding output is accepted, so blocking past 60s is the designed behaviour. On the old bound a legitimate wait closed the shared pooled connection once a minute for its whole duration. It is now matched by exact name alongside the other three. (`get_decrypted_preimage_status` in lnv1 has the same shape and is left alone — out of scope here.)

The open items above are genuinely open — happy to take any of them in this PR or split them out.

## Known limitations / minor effects

- **The spread bounds clustering, it does not eliminate it.** Distinct node ids give distinct cycle periods (`300s - offset`), so a fan-out re-issued together fans out immediately; but two periods share a common multiple, so a given pair re-coincides every `lcm` of them (300.0s and 280.0s → every 70min). That is a one-cycle coincidence rather than a sustained lock. Two ids that hash to the *same* slot share a period and stay together indefinitely — p≈1e-4 for 4 peers over 60_000 slots, and degrades to the no-spread baseline for that pair, never worse.
- **The node-id wiring is not unit-tested.** The classifier and the offset are covered, but a regression at either call site that passed `None` would silently disable the spread with every test still green; that path is only integration-testable. `None` now logs at `trace` so the degradation is at least observable.
- **Tier selection is by `Duration` equality**, so a future tier that happened to equal 5min would silently inherit the spread. Guarded today by the other-tier assertions in the test.
- **Draining connections.** Retiring rather than closing means a retired connection lives until its last in-flight request finishes. On a degraded-but-alive path where a new connection is minted every ~5 min and a consensus long-poll can hold one for up to an hour, the worst case is on the order of a dozen draining connections per peer. Bounded and transient, and strictly better than the previous behaviour of aborting everything on the connection — but it is a real change in resource profile.

## Deployment ordering

**#8993 should land first.** This PR alone cycles the lnv2 waits ~12x/hour instead of ~1x/hour. Against guardians without #8993, that accelerates the pre-existing server-side waiter leak by about the same factor — a client that reconnects while a wait is outstanding leaves the previous waiter behind on every peer, holding a task and a DB subscription until the awaited key changes. #8993 bounds an in-flight handler by its connection's lifetime, which is what makes this PR's reconnect rate cheap. Guardians first.