### PR TITLE
fix(client): report a transaction submission that never resolves

### DIFF
--- a/fedimint-client-module/src/lib.rs
+++ b/fedimint-client-module/src/lib.rs
@@ -100,6 +100,40 @@ impl Event for TxRejectedEvent {
     const PERSISTENCE: EventPersistence = EventPersistence::Persistent;
 }
 
+/// Diagnostic signal that a transaction submission is being re-attempted
+/// indefinitely without reaching consensus.
+///
+/// Emitted only on the retry iterations where `submit_transaction` returns a
+/// decodable, non-rejection outcome — i.e. a peer accepted the submission but
+/// the transaction has still not been accepted into (or rejected from)
+/// consensus. Repeated transport, API, or decoding errors instead take the
+/// retry error path and do not emit this event, so its absence does not imply
+/// the submission has stopped.
+///
+/// Cadence: first emitted after roughly 30 minutes of continuous re-submission
+/// within a single client run, then repeated about every 30 minutes while the
+/// condition persists. Elapsed time is measured per client run, so a restart
+/// resets it.
+///
+/// It is [`EventPersistence::Transient`], so it is broadcast to live
+/// subscribers (and transits the unordered event staging table) but is never
+/// written to the ordered event log.
+#[derive(Serialize, Deserialize)]
+pub struct TxSubmissionStalledEvent {
+    pub txid: TransactionId,
+    pub operation_id: OperationId,
+    /// Submission attempts so far in this client run.
+    pub attempt: u64,
+    /// Seconds elapsed in this client run since submission started.
+    pub elapsed_s: u64,
+}
+
+impl Event for TxSubmissionStalledEvent {
+    const MODULE: Option<ModuleKind> = None;
+    const KIND: EventKind = EventKind::from_static("tx-submission-stalled");
+    const PERSISTENCE: EventPersistence = EventPersistence::Transient;
+}
+
 #[derive(Serialize, Deserialize)]
 pub struct ModuleRecoveryStarted {
     module_id: ModuleInstanceId,
@@ -231,6 +265,20 @@ pub trait IGlobalClientContext: Debug + MaybeSend + MaybeSync + 'static {
         persist: EventPersistence,
     );
 
+    /// Like [`Self::log_event_json`], but opens its own database transaction
+    /// instead of borrowing a [`ClientSMDatabaseTransaction`]. Meant for call
+    /// sites that run outside a state transition (e.g. the submission retry
+    /// loop) and therefore have no dbtx in scope. The implementation pairs the
+    /// event's `module` kind with its own module instance id, mirroring what
+    /// `log_event_json` derives from the transaction's `module_id()`.
+    async fn log_event_json_no_dbtx(
+        &self,
+        kind: EventKind,
+        module_kind: Option<ModuleKind>,
+        payload: serde_json::Value,
+        persist: EventPersistence,
+    );
+
     async fn transaction_update_stream(&self) -> BoxStream<TxSubmissionStatesSM>;
 
     /// Returns the core API version that the federation supports
@@ -284,6 +332,16 @@ impl IGlobalClientContext for () {
         _dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
         _kind: EventKind,
         _module: Option<(ModuleKind, ModuleInstanceId)>,
+        _payload: serde_json::Value,
+        _persist: EventPersistence,
+    ) {
+        unimplemented!("fake implementation, only for tests");
+    }
+
+    async fn log_event_json_no_dbtx(
+        &self,
+        _kind: EventKind,
+        _module_kind: Option<ModuleKind>,
         _payload: serde_json::Value,
         _persist: EventPersistence,
     ) {
@@ -383,6 +441,23 @@ impl DynGlobalClientContext {
             dbtx,
             E::KIND,
             E::MODULE.map(|m| (m, dbtx.module_id())),
+            serde_json::to_value(&event).expect("Payload serialization can't fail"),
+            <E as Event>::PERSISTENCE,
+        )
+        .await;
+    }
+
+    /// Log an event from outside a state transition, where no
+    /// [`ClientSMDatabaseTransaction`] is in scope. Opens its own database
+    /// transaction. Prefer [`Self::log_event`] whenever a dbtx is available so
+    /// the event commits atomically with the surrounding transition.
+    async fn log_event_no_dbtx<E>(&self, event: E)
+    where
+        E: Event + Send,
+    {
+        self.log_event_json_no_dbtx(
+            E::KIND,
+            E::MODULE,
             serde_json::to_value(&event).expect("Payload serialization can't fail"),
             <E as Event>::PERSISTENCE,
         )

--- a/fedimint-client-module/src/transaction/sm.rs
+++ b/fedimint-client-module/src/transaction/sm.rs
@@ -1,16 +1,18 @@
 //! State machine for submitting transactions
 
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use fedimint_core::TransactionId;
 use fedimint_core::core::{Decoder, IntoDynInstance, ModuleInstanceId, ModuleKind, OperationId};
 use fedimint_core::encoding::{Decodable, Encodable};
+use fedimint_core::time::duration_since_epoch;
 use fedimint_core::transaction::{Transaction, TransactionSubmissionOutcome};
 use fedimint_core::util::backoff_util::custom_backoff;
 use fedimint_core::util::retry;
 use fedimint_logging::LOG_CLIENT_NET_API;
 use tokio::sync::watch;
-use tracing::debug;
+use tracing::{debug, warn};
 
 use crate::sm::{Context, DynContext, State, StateTransition};
 use crate::{DynGlobalClientContext, DynState, TxAcceptedEvent, TxRejectedEvent};
@@ -18,6 +20,17 @@ use crate::{DynGlobalClientContext, DynState, TxAcceptedEvent, TxRejectedEvent};
 // TODO: how to prevent collisions? Generally reserve some range for custom IDs?
 /// Reserved module instance id used for client-internal state machines
 pub const TRANSACTION_SUBMISSION_MODULE_INSTANCE: ModuleInstanceId = 0xffff;
+
+/// How long a submission may keep being re-attempted within a single client
+/// run, without the transaction being accepted or rejected, before it is
+/// reported as stalled.
+///
+/// Comfortably above the submission backoff's own maximum delay, so a healthy
+/// but slow submission does not warn.
+const SUBMISSION_STALL_WARN_AFTER: Duration = Duration::from_mins(30);
+
+/// How often to repeat the stall report while the condition persists.
+const SUBMISSION_STALL_WARN_INTERVAL: Duration = Duration::from_mins(30);
 
 #[derive(Debug, Clone)]
 pub struct TxSubmissionContext;
@@ -97,6 +110,7 @@ impl State for TxSubmissionStatesSM {
                             transaction.clone(),
                             global_context.clone(),
                             tx_submitted_sender,
+                            operation_id,
                         ),
                         {
                             let global_context = global_context.clone();
@@ -198,13 +212,21 @@ impl TxSubmissionStates {
         transaction: Transaction,
         context: DynGlobalClientContext,
         tx_submitted: watch::Sender<bool>,
+        operation_id: OperationId,
     ) -> String {
         let txid = transaction.tx_hash();
         debug!(target: LOG_CLIENT_NET_API, %txid, "Submitting transaction");
+
+        let started_s = duration_since_epoch().as_secs();
+        let attempts = AtomicU64::new(0);
+        // Unix seconds of the last stall report; 0 means "not yet reported".
+        let reported_at_s = AtomicU64::new(0);
+
         retry(
             "tx-submit-sm",
             custom_backoff(Duration::from_secs(2), Duration::from_mins(10), None),
             || async {
+                let attempt = attempts.fetch_add(1, Ordering::Relaxed).saturating_add(1);
                 if let TransactionSubmissionOutcome(Err(transaction_error)) = context
                     .api()
                     .submit_transaction(transaction.clone())
@@ -219,6 +241,36 @@ impl TxSubmissionStates {
                         "Transaction submission accepted by peer, awaiting consensus",
                     );
                     tx_submitted.send_replace(true);
+
+                    // Re-submitting until the transaction is accepted or rejected is
+                    // intentional: submission does not guarantee the transaction reaches
+                    // consensus. But a submission stuck in this branch keeps its state
+                    // machine alive indefinitely, and at default log levels nothing
+                    // reports that it is happening, so surface it.
+                    //
+                    // Elapsed is measured per client run off a wall clock: a restart
+                    // resets it, and a large clock step can skew it. That is acceptable
+                    // for a diagnostic, which this is - it changes no behaviour.
+                    let now_s = duration_since_epoch().as_secs();
+                    let elapsed_s = now_s.saturating_sub(started_s);
+                    if SUBMISSION_STALL_WARN_AFTER.as_secs() <= elapsed_s {
+                        let last_s = reported_at_s.load(Ordering::Relaxed);
+                        if last_s == 0
+                            || SUBMISSION_STALL_WARN_INTERVAL.as_secs()
+                                <= now_s.saturating_sub(last_s)
+                        {
+                            reported_at_s.store(now_s, Ordering::Relaxed);
+                            warn!(
+                                target: LOG_CLIENT_NET_API,
+                                %txid,
+                                operation_id = %operation_id.fmt_short(),
+                                %attempt,
+                                %elapsed_s,
+                                "Transaction neither accepted nor rejected; still re-submitting",
+                            );
+                        }
+                    }
+
                     Err(anyhow::anyhow!("Transaction is still valid"))
                 }
             },

--- a/fedimint-client-module/src/transaction/sm.rs
+++ b/fedimint-client-module/src/transaction/sm.rs
@@ -15,7 +15,9 @@ use tokio::sync::watch;
 use tracing::{debug, warn};
 
 use crate::sm::{Context, DynContext, State, StateTransition};
-use crate::{DynGlobalClientContext, DynState, TxAcceptedEvent, TxRejectedEvent};
+use crate::{
+    DynGlobalClientContext, DynState, TxAcceptedEvent, TxRejectedEvent, TxSubmissionStalledEvent,
+};
 
 // TODO: how to prevent collisions? Generally reserve some range for custom IDs?
 /// Reserved module instance id used for client-internal state machines
@@ -219,8 +221,11 @@ impl TxSubmissionStates {
 
         let started_s = duration_since_epoch().as_secs();
         let attempts = AtomicU64::new(0);
-        // Unix seconds of the last stall report; 0 means "not yet reported".
-        let reported_at_s = AtomicU64::new(0);
+        // Unix second at which the next stall report is due. Starts one
+        // `SUBMISSION_STALL_WARN_AFTER` out and advances by
+        // `SUBMISSION_STALL_WARN_INTERVAL` after each report.
+        let next_alert_deadline_s =
+            AtomicU64::new(started_s + SUBMISSION_STALL_WARN_AFTER.as_secs());
 
         retry(
             "tx-submit-sm",
@@ -252,23 +257,31 @@ impl TxSubmissionStates {
                     // resets it, and a large clock step can skew it. That is acceptable
                     // for a diagnostic, which this is - it changes no behaviour.
                     let now_s = duration_since_epoch().as_secs();
-                    let elapsed_s = now_s.saturating_sub(started_s);
-                    if SUBMISSION_STALL_WARN_AFTER.as_secs() <= elapsed_s {
-                        let last_s = reported_at_s.load(Ordering::Relaxed);
-                        if last_s == 0
-                            || SUBMISSION_STALL_WARN_INTERVAL.as_secs()
-                                <= now_s.saturating_sub(last_s)
-                        {
-                            reported_at_s.store(now_s, Ordering::Relaxed);
-                            warn!(
-                                target: LOG_CLIENT_NET_API,
-                                %txid,
-                                operation_id = %operation_id.fmt_short(),
-                                %attempt,
-                                %elapsed_s,
-                                "Transaction neither accepted nor rejected; still re-submitting",
-                            );
-                        }
+                    if next_alert_deadline_s.load(Ordering::Relaxed) <= now_s {
+                        next_alert_deadline_s.store(
+                            now_s + SUBMISSION_STALL_WARN_INTERVAL.as_secs(),
+                            Ordering::Relaxed,
+                        );
+                        let elapsed_s = now_s.saturating_sub(started_s);
+                        warn!(
+                            target: LOG_CLIENT_NET_API,
+                            %txid,
+                            operation_id = %operation_id.fmt_short(),
+                            %attempt,
+                            %elapsed_s,
+                            "Transaction neither accepted nor rejected; still re-submitting",
+                        );
+                        // Surface the same condition to integrators as a transient
+                        // (non-persisted) event. No dbtx is in scope here, so this
+                        // opens its own.
+                        context
+                            .log_event_no_dbtx(TxSubmissionStalledEvent {
+                                txid,
+                                operation_id,
+                                attempt,
+                                elapsed_s,
+                            })
+                            .await;
                     }
 
                     Err(anyhow::anyhow!("Transaction is still valid"))

--- a/fedimint-client/src/client/global_ctx.rs
+++ b/fedimint-client/src/client/global_ctx.rs
@@ -115,6 +115,26 @@ impl IGlobalClientContext for ModuleGlobalClientContext {
             .await;
     }
 
+    async fn log_event_json_no_dbtx(
+        &self,
+        kind: EventKind,
+        module_kind: Option<ModuleKind>,
+        payload: serde_json::Value,
+        persist: EventPersistence,
+    ) {
+        let mut dbtx = self.client.db().begin_transaction().await;
+        self.client
+            .log_event_raw_dbtx(
+                &mut dbtx,
+                kind,
+                module_kind.map(|m| (m, self.module_instance_id)),
+                serde_json::to_vec(&payload).expect("Serialization can't fail"),
+                persist,
+            )
+            .await;
+        dbtx.commit_tx().await;
+    }
+
     async fn core_api_version(&self) -> fedimint_core::module::ApiVersion {
         self.client.core_api_version().await
     }


### PR DESCRIPTION
## Problem

`TxSubmissionStates::Created` leaves its state only on a **transaction-level
rejection**. `trigger_created_rejected` submits on an unbounded retry
(`custom_backoff(2s, 10min, None)` ⇒ `usize::MAX`, as its own
`.expect("Number of retries is has no limit")` says) and returns only when the
federation rejects; the sibling transition waits for consensus acceptance.

Re-submitting is intentional, and the in-code comment says why — submission does
not guarantee the transaction reaches consensus. But the consequence is that a
submission which is **neither accepted nor rejected** keeps its state machine
alive indefinitely, and at default log levels nothing reports it. The only
per-iteration signal is a `debug!`.

This is an observability gap in the loop as designed, not a claim that the
condition is common. I have no field measurement of how often it occurs.

## Change

Report the condition once a submission has gone 30 minutes without resolving,
and every 30 minutes thereafter:

```
WARN … Transaction neither accepted nor rejected; still re-submitting
       txid=… operation_id=… attempt=… elapsed_s=…
```

- **30 minutes** sits above the submission backoff's own 10-minute maximum, so a
  healthy but slow submission never warns.
- **`operation_id`** is included because grouping stalled submissions per
  operation is what makes the condition actionable; recovering that grouping
  otherwise means reading the client rocksdb directly.

## Behaviour is unchanged

The retry remains unbounded, no control flow is altered,
`tx_submitted.send_replace(true)` is untouched and still precedes the new code,
and the rejection path is untouched. The additions are a clock read, two
atomics, and a log call — no new `.await` and no new return path.

`AtomicU64` rather than `Cell` keeps the future `Send`; `Ordering::Relaxed` is
sufficient because the retry closure's futures run strictly sequentially.

## Notes / limitations

- Elapsed is measured **per client run** off `duration_since_epoch()`
  (wasm-safe; `Instant::now()` panics on `wasm32-unknown-unknown`). A restart
  resets it and a large clock step can skew it — stated in the code comment, and
  acceptable for a diagnostic.
- The report covers the awaiting-consensus branch only. A loop pinned in the `?`
  error path is deliberately not instrumented here.
- This is **observability, not a fix**, and it is not tied to a specific known
  defect. It makes a silent unbounded loop visible.
