### PR TITLE
[Backport releases/v0.11] fix(client): waiting for wrong txid (#8426)

### DIFF
--- a/modules/fedimint-mint-client/src/input.rs
+++ b/modules/fedimint-mint-client/src/input.rs
@@ -88,8 +88,8 @@ impl State for MintInputStateMachine {
             MintInputStates::CreatedBundle(_) => {
                 MintInputStateCreatedBundle::transitions(self.common, global_context)
             }
-            MintInputStates::RefundedBundle(_) => {
-                MintInputStateRefundedBundle::transitions(self.common, global_context)
+            MintInputStates::RefundedBundle(state) => {
+                MintInputStateRefundedBundle::transitions(state, global_context)
             }
             MintInputStates::Refund(refund) => refund.transitions(global_context),
             MintInputStates::Success(_)
@@ -315,12 +315,12 @@ pub struct MintInputStateRefundedBundle {
 
 impl MintInputStateRefundedBundle {
     fn transitions(
-        common: MintInputCommon,
+        state: &MintInputStateRefundedBundle,
         global_context: &DynGlobalClientContext,
     ) -> Vec<StateTransition<MintInputStateMachine>> {
         let global_context = global_context.clone();
         vec![StateTransition::new(
-            Self::await_success(common, global_context.clone()),
+            Self::await_success(state.refund_txid, global_context.clone()),
             move |dbtx, result, old_state| {
                 Box::pin(Self::transition_success(
                     result,
@@ -333,12 +333,10 @@ impl MintInputStateRefundedBundle {
     }
 
     async fn await_success(
-        common: MintInputCommon,
+        txid: TransactionId,
         global_context: DynGlobalClientContext,
     ) -> Result<(), String> {
-        global_context
-            .await_tx_accepted(common.out_point_range.txid())
-            .await
+        global_context.await_tx_accepted(txid).await
     }
 
     async fn transition_success(


### PR DESCRIPTION
Backport of the first commit of #8426 (`a62036d`, "fix(client): waiting for wrong
txid") to `releases/v0.11`. Cherry-picks cleanly; the result is content-identical
to master for the function it touches.

**Deliberately not backporting #8426's second commit** (`c9f7cdc`, "reminting a
single note might fail due to fees") — reasoning at the end.

## Why this is worth backporting

The bug reproduces on a live v0.11.1 gateway and is completely silent. Detail and
evidence in #8834; in short:

`MintInputStateRefundedBundle::await_success` awaits
`common.out_point_range.txid()` — the original funding txid, which was already
rejected, since a rejection is the only reason that state exists. It therefore
resolves `Err` on the first poll and falls through to the per-note refund path
even when the bundled refund it just created was **accepted**.

One rejected N-note funding bundle produces N+2 transactions over the same notes.
All but one are rejected `The note is already spent`, and because
`submit_transaction` outcomes are not surfaced to the operation (#5238), nothing
is logged.

Decoded from the gateway's client DB, matching all 10 terminal
`Accepted`/`Rejected` txids back to the transactions they refer to:

| operation | funding bundle | funding tx | bundled refund | per-note refunds spawned |
|---|---|---|---|---|
| `0dfb1e94` | 3 notes | rejected | **accepted** | **3, still active** |
| `7e80b3a1` | 4 notes | rejected | still in flight | 3 active + a 17-in re-bundle |
| `34bc5080` | 1 note | rejected | accepted | none |
| `687d157c` | 1 note | rejected | accepted | none |

The one-note branch in `refund()` skips `RefundedBundle` entirely, so single-note
bundles cannot hit this — and none did. Every multi-note bundle did. Note count
predicts both whether the cascade happens and how wide it is.

`0dfb1e94` is the clearest case: its bundled refund was accepted and it spawned
three per-note refunds over those same three notes anyway, which can only ever be
rejected.

## Scope

No encoding, variant ordering, or persisted-state interpretation change —
`RefundedBundle` already carries `refund_txid`; this only starts reading it. An
already-persisted row decodes identically and begins awaiting its own refund
transaction instead of the rejected funding one, so a client upgrading mid-flight
is fine. Rows that already cascaded to `RefundedPerNote` are terminal and
untouched. The other producer of `RefundedBundle`
(`modules/fedimint-mint-client/src/oob.rs:339-347`) sets `refund_txid` equal to
`common.out_point_range.txid()`, so this is a provable no-op for the OOB cancel
path.

## Why only the first commit

Short version: I am taking the minimal fix and leaving #8426's second commit for
maintainers to decide, because both of its options are bad in different ways and
I do not think the choice is mine to make on a release branch.

That commit replaces `.expect("Cannot claim input, additional funding needed")`
with a `warn!` in `MintInputStateRefundedBundle::refund`. The two failure modes:

**Keeping the `expect` is not benign.** A panic inside a state-machine transition
kills the client's `sm-executor` task. After that the client keeps running and
keeps accepting work — it builds transactions and writes `TxSubmission` state
machines — while nothing drives any of them, so nothing is ever submitted and no
error surfaces. I hit exactly this failure mode from a different panic and wrote
it up with a repro in #8837; the observed signature there was 11 state machines
sitting in `Created` across 26 hours with the guardian receiving zero
`submit_transaction` calls. Because the state is persisted, a restart re-runs the
same transition and re-panics. So "it crashes loudly and retries" is wrong — it
wedges the whole client silently.

**Swallowing the error loses funds.** `claim_inputs` is not transactional; it
mutates the caller's dbtx with no savepoint. `consolidate_notes` deletes notes
(`modules/fedimint-mint-client/src/lib.rs:1538`) and can still fail afterwards,
and `create_final_inputs_and_outputs` calls it before `create_sufficient_input`
(`lib.rs:1021`, then `lib.rs:1038` — the exact fee failure that commit targets).
The executor runs transitions inside
`db.autocommit::<'_, '_, _, _, Infallible>` (`fedimint-client/src/sm/executor.rs:709`),
so the closure cannot return `Err` and the dbtx is always committed; unwinding
from the `expect` was the only thing rolling those deletions back. Swallowing it
commits note deletions with no transaction spending them, and `RefundedPerNote`
is terminal (`input.rs:101`), so nothing retries.

Neither is right. The actual fix is to make that failure retryable — leave the
machine in a non-terminal state, or give `claim_inputs` a savepoint — and neither
commit does that. I would rather not smuggle that decision into a backport.

Worth noting the `.expect` is still the convention: 15 such sites remain
tree-wide, including `input.rs:196` and `input.rs:291`. `input.rs:291`
(`MintInputStateCreatedBundle::refund`) runs first on every cascade and still
panics, so the second commit does not close the class in any case.

This commit on its own also reduces exposure to that fee failure by a large
factor, since it stops the spurious cascade from firing on every bundle refund.

Say the word and I will add the second commit, or a variant that keeps the state
retryable instead. The underlying `claim_inputs` dbtx-pollution hazard is present
on master too and probably deserves its own issue.

## Verification

`cargo check` and `cargo test -p fedimint-mint-client` pass on this branch against
`releases/v0.11`. `git range-diff` against the master original shows the patch is
content-identical; the only delta is the `(cherry picked from ...)` trailer.

The `Audit` check fails with 13 pre-existing advisories (`RUSTSEC-2026-0186`,
`RUSTSEC-2026-0097` and others in transitive deps). The job force-updates
`advisory-db` to current before running, so any PR against this branch fails it
today; this change touches one source file and no dependencies.

