### PR TITLE
fix(tpe): correct lagrange multiplier for a single share

### DIFF
--- a/crypto/tpe/src/lib.rs
+++ b/crypto/tpe/src/lib.rs
@@ -207,8 +207,7 @@ fn lagrange_multipliers(scalars: Vec<Scalar>) -> Vec<Scalar> {
                 .iter()
                 .filter(|j| *j != i)
                 .map(|j| j * (j - i).invert().expect("We filtered the case j == i"))
-                .reduce(|a, b| a * b)
-                .expect("We have at least one share")
+                .fold(Scalar::ONE, |a, b| a * b)
         })
         .collect()
 }

--- a/crypto/tpe/src/tests.rs
+++ b/crypto/tpe/src/tests.rs
@@ -73,3 +73,37 @@ fn test_roundtrip() {
 
     assert_eq!(preimage, decrypt_preimage(&ct, &agg_dk));
 }
+
+#[test]
+fn test_roundtrip_single_guardian() {
+    // A 1-of-1 federation: one peer, threshold 1.
+    const PEERS: u64 = 1;
+    const THRESHOLD: u64 = 1;
+
+    let encryption_seed = [7_u8; 32];
+    let preimage = [42_u8; 32];
+    let commitment = sha256::Hash::hash(&[0_u8; 32]);
+    let ct = encrypt_preimage(&dealer_agg_pk(), &encryption_seed, &preimage, &commitment);
+
+    assert!(verify_ciphertext(&ct, &commitment));
+
+    for peer in 0..PEERS {
+        assert!(verify_dk_share(
+            &dealer_pk(THRESHOLD, peer),
+            &create_dk_share(&dealer_sk(THRESHOLD, peer), &ct),
+            &ct,
+            &commitment
+        ));
+    }
+
+    let selected_shares = (0..THRESHOLD)
+        .map(|peer| (peer, create_dk_share(&dealer_sk(THRESHOLD, peer), &ct)))
+        .collect();
+
+    // regression: aggregating a single share used to panic in lagrange_multipliers
+    let agg_dk = aggregate_dk_shares(&selected_shares);
+
+    assert_eq!(agg_dk, derive_agg_dk(&dealer_agg_pk(), &encryption_seed));
+    assert!(verify_agg_dk(&dealer_agg_pk(), &agg_dk, &ct, &commitment));
+    assert_eq!(preimage, decrypt_preimage(&ct, &agg_dk));
+}


### PR DESCRIPTION
Fixes #8837.

`lagrange_multipliers` filters out the scalar it is computing the multiplier
for, so with exactly one share the inner iterator is empty, `reduce` returns
`None`, and the `expect` fires:

```
thread 'tokio-runtime-worker' panicked at crypto/tpe/src/lib.rs:211:18:
We have at least one share
```

Every 1-of-1 federation hits this on LNv2 decryption-share aggregation. Because
the panic happens inside a state machine transition, it takes down the client's
`sm-executor` task — after which the client keeps accepting work and writing
`TxSubmission` state machines while nothing drives them, so nothing is submitted
and no error surfaces. Field detail in #8837.

## The change

The Lagrange coefficient for a single share is the empty product, `1`:

```diff
-                .reduce(|a, b| a * b)
-                .expect("We have at least one share")
+                .fold(Scalar::ONE, |a, b| a * b)
```

`L_i(0) = prod_{j != i} (0 - x_j)/(x_i - x_j) = prod_{j != i} x_j/(x_j - x_i)` —
the two `-1` factors cancel per factor, so there is no dependence on how many
terms there are, and the degree-0 case is the empty product. Results are
bit-identical for every non-empty input, since `Scalar::ONE` is the
multiplicative identity and multiplication is associative.

The outer `expect` in `aggregate_dk_shares` is left alone deliberately: its share
map comes from `FilterMapThreshold`, which only returns once `len() == threshold`,
and `threshold >= 1` for every `n >= 1`, so non-empty is a real precondition
there.

## Test

`test_roundtrip_single_guardian` is the existing `test_roundtrip` with
`PEERS`/`THRESHOLD` set to 1. It fails on master with the panic above and passes
with the fix. Note it asserts `agg_dk == derive_agg_dk(...)` — an exact
group-element equality against an independently computed key — so it pins the
coefficient rather than merely checking that a roundtrip completes.

The existing 3-of-4 `test_roundtrip` is unchanged and still passes.

## Related

The same bug exists verbatim in `tbs::lagrange_multipliers`
(`crypto/tbs/src/lib.rs:235-247`), where it is unreachable only because both
callers short-circuit with `if shares.len() == 1` first
(`crypto/tbs/src/lib.rs:174-175`, `:207-208`, commented "this is a special case
for one-of-one federations"). `tpe`, added later for LNv2, never got that
workaround.

I have left `tbs` alone to keep this minimal, but the same `fold` change would
let those two short-circuits go away — happy to include it if preferred.
