### PR TITLE
[Backport releases/v0.11] fix(tpe): correct lagrange multiplier for a single share (#8838)

### DIFF
--- a/crypto/tpe/src/lib.rs
+++ b/crypto/tpe/src/lib.rs
@@ -207,8 +207,7 @@ fn lagrange_multipliers(scalars: Vec<Scalar>) -> Vec<Scalar> {
                 .iter()
                 .filter(|j| *j != i)
                 .map(|j| j * (j - i).invert().expect("We filtered the case j == i"))
-                .reduce(|a, b| a * b)
-                .expect("We have at least one share")
+                .fold(Scalar::ONE, |a, b| a * b)
         })
         .collect()
 }

--- a/crypto/tpe/src/tests.rs
+++ b/crypto/tpe/src/tests.rs
@@ -73,3 +73,37 @@ fn test_roundtrip() {
 
     assert_eq!(preimage, decrypt_preimage(&ct, &agg_dk));
 }
+
+#[test]
+fn test_roundtrip_single_guardian() {
+    // A 1-of-1 federation: one peer, threshold 1.
+    const PEERS: u64 = 1;
+    const THRESHOLD: u64 = 1;
+
+    let encryption_seed = [7_u8; 32];
+    let preimage = [42_u8; 32];
+    let commitment = sha256::Hash::hash(&[0_u8; 32]);
+    let ct = encrypt_preimage(&dealer_agg_pk(), &encryption_seed, &preimage, &commitment);
+
+    assert!(verify_ciphertext(&ct, &commitment));
+
+    for peer in 0..PEERS {
+        assert!(verify_dk_share(
+            &dealer_pk(THRESHOLD, peer),
+            &create_dk_share(&dealer_sk(THRESHOLD, peer), &ct),
+            &ct,
+            &commitment
+        ));
+    }
+
+    let selected_shares = (0..THRESHOLD)
+        .map(|peer| (peer, create_dk_share(&dealer_sk(THRESHOLD, peer), &ct)))
+        .collect();
+
+    // regression: aggregating a single share used to panic in lagrange_multipliers
+    let agg_dk = aggregate_dk_shares(&selected_shares);
+
+    assert_eq!(agg_dk, derive_agg_dk(&dealer_agg_pk(), &encryption_seed));
+    assert!(verify_agg_dk(&dealer_agg_pk(), &agg_dk, &ct, &commitment));
+    assert_eq!(preimage, decrypt_preimage(&ct, &agg_dk));
+}


### PR DESCRIPTION
Backport of #8838 to `releases/v0.11`. Cherry-picks cleanly, no conflicts.

**Draft until #8838 merges on master** — opening it now so it is ready, not to
jump the queue.

## Why backport

Every 1-of-1 federation on v0.11.x panics on LNv2 decryption-share aggregation:

```
thread 'tokio-runtime-worker' panicked at crypto/tpe/src/lib.rs:211:18:
We have at least one share
```

The panic is inside a state machine transition, so it kills the client's
`sm-executor`. The client then keeps accepting work — intercepting HTLCs,
building funding transactions, writing `TxSubmission` state machines, logging
`Finalized and submitting transaction` — while nothing drives any of it. Nothing
is submitted and no error surfaces. Observed on a live v0.11.1 mainnet gateway:
11 state machines in `Created` spanning 26 hours, guardian received zero
`submit_transaction` calls. Full detail in #8837.

There is no workaround short of not using a 1-of-1 federation with LNv2.

## Verified on this branch

The repro fails on the `releases/v0.11` baseline and passes with the fix, with
the existing 3-of-4 roundtrip unaffected:

| | with this patch | v0.11 baseline |
|---|---|---|
| `test_roundtrip_single_guardian` | ok | **FAILED** — panics at `crypto/tpe/src/lib.rs:211:18` |
| `test_roundtrip` (3-of-4) | ok | ok |

## Scope

One combinator swap plus a test. `fold(Scalar::ONE, ..)` is bit-identical to
`reduce(..)` for every non-empty input, so behaviour changes only in the case
that previously panicked. No encoding, API, or consensus surface is touched, and
no dependency changes.
