### PR TITLE
fix(tbs): enforce error propagation on blinding key scalar inversion

### DIFF
--- a/crypto/tbs/benches/tbs.rs
+++ b/crypto/tbs/benches/tbs.rs
@@ -88,7 +88,7 @@ fn bench_unblind(c: &mut Criterion) {
     let bsig = aggregate_signature_shares(&shares);
 
     c.bench_function("signature unblinding", |b| {
-        b.iter(|| unblind_signature(bkey, bsig))
+        b.iter(|| unblind_signature(bkey, bsig).unwrap())
     });
 }
 
@@ -102,7 +102,7 @@ fn bench_verify(c: &mut Criterion) {
         .take(4)
         .collect();
     let bsig = aggregate_signature_shares(&shares);
-    let sig = unblind_signature(bkey, bsig);
+    let sig = unblind_signature(bkey, bsig).unwrap();
 
     c.bench_function("signature verification", |b| {
         b.iter(|| verify(msg, sig, pk))
@@ -119,7 +119,7 @@ fn bench_decode_signature(c: &mut Criterion) {
         .take(4)
         .collect();
     let bsig = aggregate_signature_shares(&shares);
-    let sig = unblind_signature(bkey, bsig);
+    let sig = unblind_signature(bkey, bsig).unwrap();
     let sig_bytes = sig.consensus_encode_to_vec();
 
     c.bench_function("signature decoding", |b| {

--- a/crypto/tbs/src/lib.rs
+++ b/crypto/tbs/src/lib.rs
@@ -254,9 +254,28 @@ pub fn verify_blinded_signature(
     pairing(&msg.0, &pk.0) == pairing(&sig.0, &G2Affine::generator())
 }
 
-pub fn unblind_signature(blinding_key: BlindingKey, blinded_sig: BlindedSignature) -> Signature {
-    let sig = blinded_sig.0 * blinding_key.0.invert().unwrap();
-    Signature(sig.to_affine())
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum Error {
+    InvalidBlindingKey,
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::InvalidBlindingKey => write!(f, "Invalid blinding key (zero scalar)"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+pub fn unblind_signature(
+    blinding_key: BlindingKey,
+    blinded_sig: BlindedSignature,
+) -> Result<Signature, Error> {
+    let inv = Option::from(blinding_key.0.invert()).ok_or(Error::InvalidBlindingKey)?;
+    let sig: G1Projective = blinded_sig.0 * inv;
+    Ok(Signature(sig.to_affine()))
 }
 
 pub fn verify(msg: Message, sig: Signature, pk: AggregatePublicKey) -> bool {

--- a/crypto/tbs/src/tests.rs
+++ b/crypto/tbs/src/tests.rs
@@ -67,7 +67,7 @@ fn test_roundtrip() {
 
     let signature = aggregate_signature_shares(&signature_shares);
 
-    let signature = unblind_signature(blinding_key, signature);
+    let signature = unblind_signature(blinding_key, signature).unwrap();
 
     assert!(verify(message, signature, dealer_agg_pk()));
 }

--- a/modules/fedimint-mint-client/src/output.rs
+++ b/modules/fedimint-mint-client/src/output.rs
@@ -397,7 +397,17 @@ impl MintOutputStatesCreated {
             };
         }
 
-        let spendable_note = created.issuance_request.finalize(agg_blind_signature);
+        let spendable_note = match created.issuance_request.finalize(agg_blind_signature) {
+            Ok(note) => note,
+            Err(e) => {
+                return MintOutputStateMachine {
+                    common: old_state.common,
+                    state: MintOutputStates::Failed(MintOutputStatesFailed {
+                        error: format!("Failed to finalize note: {e}"),
+                    }),
+                };
+            }
+        };
 
         assert!(spendable_note.note().verify(*amount_key));
 
@@ -770,7 +780,7 @@ impl MintOutputStatesCreatedMulti {
         let mut spendable_notes: Vec<(Amount, SpendableNote)> = vec![];
 
         // Note verification is relatively slow and CPU-bound, so parallelize them
-        blinded_signature_shares
+        let spendable_notes_result: Result<Vec<_>, String> = blinded_signature_shares
             .into_par_iter()
             .map(|(out_idx, blinded_signature_shares)| {
                 let agg_blind_signature = aggregate_signature_shares(
@@ -786,13 +796,24 @@ impl MintOutputStatesCreatedMulti {
 
                 let amount_key = tbs_pks.tier(amount).expect("Must have keys for any amount");
 
-                let spendable_note = issuance_request.finalize(agg_blind_signature);
+                let spendable_note = issuance_request.finalize(agg_blind_signature)
+                    .map_err(|e| format!("Failed to finalize note: {e}"))?;
 
                 assert!(spendable_note.note().verify(*amount_key), "We checked all signature shares in the trigger future, so the combined signature has to be valid");
 
-                (*amount, spendable_note)
+                Ok((*amount, spendable_note))
             })
-            .collect_into_vec(&mut spendable_notes);
+            .collect();
+
+        let spendable_notes = match spendable_notes_result {
+            Ok(notes) => notes,
+            Err(e) => {
+                return MintOutputStateMachine {
+                    common: old_state.common,
+                    state: MintOutputStates::Failed(MintOutputStatesFailed { error: e }),
+                };
+            }
+        };
 
         for (amount, spendable_note) in spendable_notes {
             debug!(target: LOG_CLIENT_MODULE_MINT, amount = %amount, note=%spendable_note, "Adding new note from transaction output");
@@ -939,11 +960,11 @@ impl NoteIssuanceRequest {
     }
 
     /// Use the blind signature to create spendable e-cash notes
-    pub fn finalize(&self, blinded_signature: BlindedSignature) -> SpendableNote {
-        SpendableNote {
-            signature: unblind_signature(self.blinding_key, blinded_signature),
+    pub fn finalize(&self, blinded_signature: BlindedSignature) -> Result<SpendableNote, tbs::Error> {
+        Ok(SpendableNote {
+            signature: unblind_signature(self.blinding_key, blinded_signature)?,
             spend_key: self.spend_key,
-        }
+        })
     }
 
     pub fn blinding_key(&self) -> &BlindingKey {

--- a/modules/fedimint-mint-client/src/output.rs
+++ b/modules/fedimint-mint-client/src/output.rs
@@ -777,8 +777,6 @@ impl MintOutputStatesCreatedMulti {
             panic!("Unexpected prior state")
         };
 
-        let mut spendable_notes: Vec<(Amount, SpendableNote)> = vec![];
-
         // Note verification is relatively slow and CPU-bound, so parallelize them
         let spendable_notes_result: Result<Vec<_>, String> = blinded_signature_shares
             .into_par_iter()

--- a/modules/fedimint-mint-server/src/test.rs
+++ b/modules/fedimint-mint-server/src/test.rs
@@ -86,7 +86,7 @@ fn issue_note(
         .collect();
 
     let blind_signature = tbs::aggregate_signature_shares(&bsig_shares);
-    let signature = tbs::unblind_signature(blinding_key, blind_signature);
+    let signature = tbs::unblind_signature(blinding_key, blind_signature).unwrap();
 
     (note_key, Note { nonce, signature })
 }

--- a/modules/fedimint-mintv2-client/src/issuance.rs
+++ b/modules/fedimint-mintv2-client/src/issuance.rs
@@ -32,12 +32,12 @@ impl NoteIssuanceRequest {
         MintOutput::new_v0(self.denomination, self.blinded_message(), self.tweak)
     }
 
-    pub fn finalize(&self, signature: BlindedSignature) -> SpendableNote {
-        SpendableNote {
+    pub fn finalize(&self, signature: BlindedSignature) -> Result<SpendableNote, tbs::Error> {
+        Ok(SpendableNote {
             denomination: self.denomination,
             keypair: self.keypair,
-            signature: unblind_signature(self.blinding_key, signature),
-        }
+            signature: unblind_signature(self.blinding_key, signature)?,
+        })
     }
 
     pub fn blinded_message(&self) -> BlindedMessage {

--- a/modules/fedimint-mintv2-client/src/output.rs
+++ b/modules/fedimint-mintv2-client/src/output.rs
@@ -129,6 +129,12 @@ impl MintOutputStateMachine {
             };
         };
 
+        // Finalize and verify ALL notes before writing any to the database.
+        // If we wrote to the database inside the loop and a later note failed,
+        // earlier notes would already be persisted while the state machine
+        // transitions to Failure, leaving the wallet balance partially updated.
+        let mut spendable_notes = Vec::with_capacity(old_state.common.issuance_requests.len());
+
         for (i, request) in old_state.common.issuance_requests.iter().enumerate() {
             let agg_blind_signature = aggregate_signature_shares(
                 &signature_shares
@@ -163,6 +169,11 @@ impl MintOutputStateMachine {
                 };
             }
 
+            spendable_notes.push(spendable_note);
+        }
+
+        // All notes finalized and verified — now write them all to the database.
+        for spendable_note in spendable_notes {
             dbtx.module_tx()
                 .insert_new_entry(&SpendableNoteKey(spendable_note), &())
                 .await;

--- a/modules/fedimint-mintv2-client/src/output.rs
+++ b/modules/fedimint-mintv2-client/src/output.rs
@@ -10,6 +10,7 @@ use fedimint_core::db::IDatabaseTransactionOpsCoreTyped;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_mintv2_common::{Denomination, verify_note};
 use tbs::{AggregatePublicKey, BlindedSignatureShare, PublicKeyShare, aggregate_signature_shares};
+use tracing::warn;
 
 use crate::api::MintV2ModuleApi;
 use crate::client_db::SpendableNoteKey;
@@ -136,7 +137,20 @@ impl MintOutputStateMachine {
                     .collect(),
             );
 
-            let spendable_note = request.finalize(agg_blind_signature);
+            let spendable_note = match request.finalize(agg_blind_signature) {
+                Ok(note) => note,
+                Err(e) => {
+                    warn!(
+                        error = %e,
+                        denomination = ?request.denomination,
+                        "Failed to unblind signature: invalid blinding key scalar"
+                    );
+                    return MintOutputStateMachine {
+                        common: old_state.common,
+                        state: OutputSMState::Failure,
+                    };
+                }
+            };
 
             let pk = *tbs_pks
                 .get(&request.denomination)


### PR DESCRIPTION
## Root Cause Analysis
Previously, `crypto/tbs` invoked `.unwrap()` on scalar inversion during
signature unblinding. If a blinding key scalar inversion failed (e.g.,
evaluating to zero due to invalid or malformed input), the thread would
trigger an unrecoverable panic, crashing the client or daemon process.
## Architectural Changes
- **Primitive Layer (`crypto/tbs`)**: Replaced `.unwrap()` with
  `Option::ok_or` returning a strongly typed `Error::InvalidBlindingKey`.
- **Client API Layer (`fedimint-mint-client` & `fedimint-mintv2-client`)**:
  Updated `NoteIssuanceRequest::finalize` to bubble up the `Result`.
- **State Machine Layer**: Updated the issuance state machines to transition
  gracefully to `MintOutputStates::Failed` upon encountering an invalid
  scalar, preserving client runtime stability.
## Testing & Validation
- Updated unit tests and benchmarks in `tbs` crate to handle `Result` variants.
- Verified parallel execution loops and state machine error paths compile
  cleanly with the new `Result` propagation.