### PR TITLE
fix(perf): start max spendable amount from near the top

### DIFF
--- a/fedimint-client-module/src/transaction/builder.rs
+++ b/fedimint-client-module/src/transaction/builder.rs
@@ -509,6 +509,12 @@ impl FeeQuote {
 /// never overestimates. A `fee_quote` error (e.g. the balance cannot fund a
 /// value that large) is treated as unaffordable.
 ///
+/// To keep those dry-runs cheap the search is *seeded near the top*: a first
+/// pass binary-searches `gross_up` alone (pure arithmetic, no quotes) for the
+/// largest fundable amount, peeling off the gateway fee for free, so the real
+/// fee quotes only probe the small window the federation fee leaves — a handful
+/// of dry-runs rather than one per bit of the balance.
+///
 /// The LNv2 and LNv1 send-all flows share this solver; they differ only in
 /// `gross_up` (the gateway fee model) and which `fee_quote` they pass.
 pub async fn max_affordable_send_amount<GrossUp, Quote, Fut>(
@@ -527,16 +533,75 @@ where
     let hi_bound = max_amount.msats.min(balance.msats);
     let lo_bound = min_amount.msats;
 
-    if lo_bound > hi_bound
-        || !send_amount_affordable(Amount::from_msats(lo_bound), balance, &gross_up, &fee_quote)
+    if lo_bound > hi_bound {
+        return None;
+    }
+
+    // The maximum is never near the bottom of `[lo_bound, hi_bound]`: it sits
+    // just below the largest amount the balance can *fund*, short by only the
+    // federation fee. `gross_up` is a pure, cheap function (no fee quote), so
+    // binary-search it for free to find that fundable ceiling and seed the real
+    // (fee-quoting) search there. This peels off the gateway fee — usually the
+    // larger of the two — for free, leaving the expensive quotes to probe only
+    // the small window the federation fee opens up, instead of the whole balance.
+    if gross_up(Amount::from_msats(lo_bound)).msats > balance.msats {
+        // The balance can't even fund the smallest amount's gross-up.
+        return None;
+    }
+    let fundable_max = {
+        let mut lo = lo_bound;
+        let mut hi = hi_bound;
+        while lo < hi {
+            let mid = lo + (hi - lo).div_ceil(2);
+            if gross_up(Amount::from_msats(mid)).msats <= balance.msats {
+                lo = mid;
+            } else {
+                hi = mid - 1;
+            }
+        }
+        lo
+    };
+
+    let mut lo = lo_bound;
+    let mut hi = fundable_max;
+    let mut lo_affordable = false;
+
+    // Probe the fee once at `fundable_max`. The send overhead (the gross-up plus
+    // the federation fee, less the amount) is monotone non-decreasing, so the
+    // overhead here is an upper bound on the overhead at the true maximum, and
+    // `balance - overhead` is therefore a proven-affordable, tight lower bound.
+    // If the quote errors — real note selection can't fund a value this large —
+    // the seed is skipped and the search falls back to the full bracket below.
+    let funded = gross_up(Amount::from_msats(fundable_max));
+    if let Ok(quote) = fee_quote(funded).await {
+        let total = funded
+            .msats
+            .saturating_add(quote.total().get_bitcoin().msats);
+        if total <= balance.msats {
+            // Even the largest fundable amount fits once the fee is included.
+            return Some(Amount::from_msats(fundable_max));
+        }
+        let overhead = total.saturating_sub(fundable_max);
+        let seed = balance
+            .msats
+            .saturating_sub(overhead)
+            .clamp(lo_bound, fundable_max);
+        if send_amount_affordable(Amount::from_msats(seed), balance, &gross_up, &fee_quote).await {
+            lo = seed;
+            lo_affordable = true;
+        }
+    }
+
+    // Without a usable seed the search must still start from a verified
+    // affordable lower bound, or give up if even `lo_bound` is unaffordable.
+    if !lo_affordable
+        && !send_amount_affordable(Amount::from_msats(lo_bound), balance, &gross_up, &fee_quote)
             .await
     {
         return None;
     }
 
-    let mut lo = lo_bound;
-    let mut hi = hi_bound;
-
+    // Exact maximum within the (now tight) `[lo, hi]` bracket.
     while lo < hi {
         // Bias the midpoint up so the search converges toward `hi`.
         let mid = lo + (hi - lo).div_ceil(2);

--- a/fedimint-client-module/src/transaction/builder/tests.rs
+++ b/fedimint-client-module/src/transaction/builder/tests.rs
@@ -1,5 +1,6 @@
 use core::fmt;
 use std::fmt::Write as _;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
 use bitcoin::key::Secp256k1;
@@ -338,4 +339,49 @@ async fn max_affordable_treats_quote_error_as_ceiling() {
     .await;
 
     assert_eq!(result, Some(Amount::from_msats(cap)));
+}
+
+#[tokio::test]
+async fn max_affordable_seeds_search_near_the_top() {
+    // A realistic split: a large proportional gateway fee, a tiny federation
+    // fee. Seeding off the free `gross_up`-only pass should peel the gateway fee
+    // off without a quote, leaving the (expensive) fee quotes to probe only the
+    // small window the federation fee opens up — so their count stays well below
+    // the ~log2(balance) a naive full-range search would need.
+    let balance = Amount::from_msats(100_000_000); // 100k sats
+    // 1000 msat base + 1% proportional gateway fee.
+    let gross_up = |invoice: Amount| Amount::from_msats(invoice.msats + 1000 + invoice.msats / 100);
+    // Tiny federation fee: 50 msat base + 0.001% of the contract.
+    let fed_fee = |contract: Amount| Amount::from_msats(50 + contract.msats / 100_000);
+    let quote_calls = AtomicUsize::new(0);
+
+    let x = max_affordable_send_amount(
+        balance,
+        Amount::from_msats(1),
+        balance,
+        gross_up,
+        |contract| {
+            quote_calls.fetch_add(1, Ordering::Relaxed);
+            async move { Ok(federation_fee(fed_fee(contract))) }
+        },
+    )
+    .await
+    .expect("balance covers a payment")
+    .msats;
+
+    // Still the exact maximum: `x` is payable, `x + 1` is not.
+    let cost = |v: u64| {
+        let contract = gross_up(Amount::from_msats(v));
+        contract.msats + fed_fee(contract).msats
+    };
+    assert!(cost(x) <= balance.msats);
+    assert!(cost(x + 1) > balance.msats);
+
+    // A naive binary search over the whole balance would need ~27 quotes here;
+    // seeding near the top keeps it to a handful.
+    let calls = quote_calls.load(Ordering::Relaxed);
+    assert!(
+        calls <= 16,
+        "expected a small number of fee quotes, used {calls}"
+    );
 }


### PR DESCRIPTION
Speeds up max_affordable_send_amount (the solver behind LNv1/LNv2 spendable_amount, added in #8840) by seeding its binary search near the answer instead of scanning the whole balance range.

 ## Why

  max_affordable_send_amount finds the largest amount payable in full out of the balance once the gateway fee and the on-federation send fee are covered. It
  did this with a binary search over [1 msat, balance], so it took ~log₂(balance-in-msats) ≈ 27–37 iterations — and every iteration is a fee_quote dry-run,
  which runs real note selection and lays out change notes (including blind-nonce generation / BLS blinding). Those dry-runs dominate the wall-clock, so the
  iteration count directly drives latency.

  In a wallet UI this is user-visible: computing the "send max" amount (e.g. a "Max" button when paying a Lightning Address / LNURL) took a couple of seconds,
  almost all of it in these repeated quotes.

  The observation: the maximum is never near the bottom of the range. It sits just below the largest amount the balance can fund — short by only the federation
  fee. The gateway fee (usually the larger of the two) is captured by gross_up, which is pure arithmetic with no quote.

 ## How

  1. Peel off the gateway fee for free. Binary-search gross_up alone (no fee_quote, no crypto) for fundable_max, the largest amount whose gross-up fits the
  balance. The answer is ≤ fundable_max.
  2. Seed the real search with one probe. Quote the fee once at fundable_max. The send overhead (gross-up + federation fee − amount) is monotone
  non-decreasing, so the overhead there is an upper bound on the overhead at the true maximum, making balance − overhead a proven-affordable, tight lower
  bound.
  3. Search only the small remaining window. The exact-maximum binary search is unchanged, but now spans just the federation-fee-sized gap between the seed and
  fundable_max — a handful of quotes instead of one per bit of the balance.
  
  Exactness is unchanged: the final binary search is identical, and the true maximum is provably within [seed, fundable_max]. Edge cases are preserved — if the
  top isn't quotable (e.g. note selection can't fund a value that large, the "quote error as ceiling" case) the seed is skipped and the search falls back to
  the full bracket.

 ## Impact

  Cuts the number of (expensive, crypto-heavy) fee_quote dry-runs roughly 3× for realistic fee splits — the gateway fee no longer costs any quotes, and only
  the small federation-fee window is probed.

 ## Tests

  All existing max_affordable_* tests pass unchanged. Adds max_affordable_seeds_search_near_the_top, which — for a realistic large-gateway-fee /
  tiny-federation-fee split over a 100k-sat balance — asserts the result is still the exact maximum and that the fee-quote count stays ≤ 16 (vs. ~27 for the
  old full-range search), locking in the speedup against regression.