### PR TITLE
fix(walletv2-client): claim outputs before extending the address index list

### DIFF
--- a/modules/fedimint-walletv2-client/src/lib.rs
+++ b/modules/fedimint-walletv2-client/src/lib.rs
@@ -807,6 +807,15 @@ impl WalletClientModule {
         for output in &outputs {
             if let Some(&address_index) = address_map.get(&output.script) {
                 matched_num += 1;
+
+                // Claim before extending the valid index list: the index search
+                // below is CPU-bound and can take longer than a short-lived
+                // client process (e.g. a cli invocation) lives. The claim is
+                // quick and the extension can be retried on the next scan.
+                if !output.spent && !self.process_unspent_output(output, address_index).await? {
+                    return Ok(false);
+                }
+
                 let next_address_index = valid_indices
                     .last()
                     .copied()
@@ -828,10 +837,6 @@ impl WalletClientModule {
                     valid_indices.push(index);
 
                     address_map.insert(self.derive_address(index).script_pubkey(), index);
-                }
-
-                if !output.spent && !self.process_unspent_output(output, address_index).await? {
-                    return Ok(false);
                 }
             }
 


### PR DESCRIPTION
### Summary

A walletv2 deposit made with a short-lived client process, e.g. a `fedimint-cli` invocation under devimint, can stay unclaimed forever. The output scanner runs a CPU-bound address-index search before claiming a matched output, and the process dies mid-search.

### Details

- in `check_outputs`, the per-output loop extends the valid address index list before processing an unspent output
- `next_valid_index` scans ~65k derivations on average, and a fresh deposit typically matches the highest valid index, so the search triggers on exactly the outputs that need claiming
- a short-lived client dies before the search finishes, the claim never runs, and the next short-lived invocation starts the search from scratch. Long-lived clients like gatewayd are unaffected, which makes the failure look like a client-specific hang rather than a scanner bug
- fix: claim first, then extend the index list. The claim is quick and the extension can be retried on any later scan

### Testing

- found while running a bridge test suite against a mintv2+walletv2-only devimint federation, where the internal client's peg-in hung roughly 1 in 3 runs. Federation-side inspection showed the client's deposit output registered and unspent while gatewayd's outputs were already claimed
- with this reorder applied to a v0.11.0-based branch, the same setup ran 8 for 8 without a hang
- `cargo check` and `just final-lint` pass on this branch

---

Generated by Claude Fable 5.
