### PR TITLE
fix(nixos): default custom nginx vhost settings

### DIFF
--- a/nix/modules/fedimintd.nix
+++ b/nix/modules/fedimintd.nix
@@ -13,7 +13,6 @@ let
     mkEnableOption
     mkIf
     mkOption
-    mkOverride
     mkPackageOption
     nameValuePair
     recursiveUpdate
@@ -390,13 +389,11 @@ in
         fedimintdName: cfg:
         (nameValuePair cfg.nginx.fqdn (
           lib.mkMerge [
-            cfg.nginx.config
+            (lib.mapAttrsRecursive (_: lib.mkDefault) cfg.nginx.config)
 
             {
-              # Note: we want by default to enable OpenSSL, but it seems anything 100 and above is
-              # overridden by default value from vhost-options.nix
-              enableACME = mkOverride 99 true;
-              forceSSL = mkOverride 99 true;
+              enableACME = true;
+              forceSSL = true;
               locations.${cfg.nginx.path_ws} = {
                 proxyPass = "http://127.0.0.1:${builtins.toString cfg.api_ws.port}/";
                 proxyWebsockets = true;


### PR DESCRIPTION
*Posted by Tau*

## Summary

Treat the internal NixOS module's materialized nginx vhost configuration as defaults before merging module-owned settings.

## Details

Map `services.fedimintd.<name>.nginx.config` recursively through `lib.mkDefault`. This lets the module set `enableACME` and `forceSSL` normally instead of using the `mkOverride 99` workaround for defaults inherited from nginx's vhost submodule, while higher-priority user configuration remains effective.

This mirrors the fix for the nixpkgs Fedimint module in [NixOS/nixpkgs#544352](https://github.com/NixOS/nixpkgs/pull/544352).
