### PR TITLE
chore: bump master to v0.13.0-alpha

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2534,7 +2534,7 @@ dependencies = [
 
 [[package]]
 name = "devimint"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -3099,7 +3099,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fedimint-aead"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "argon2",
@@ -3131,7 +3131,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-api-client"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3158,7 +3158,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-bip39"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "bip39",
  "fedimint-client",
@@ -3169,7 +3169,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-bitcoind"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3184,14 +3184,14 @@ dependencies = [
 
 [[package]]
 name = "fedimint-build"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "fedimint-cli"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3235,7 +3235,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3270,7 +3270,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client-module"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3302,7 +3302,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client-rpc"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3330,7 +3330,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client-wasm"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3348,7 +3348,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-connectors"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "arti-client",
@@ -3383,7 +3383,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-core"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3450,7 +3450,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-cursed-redb"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3470,7 +3470,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-db-locked"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3482,7 +3482,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dbtool"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3518,7 +3518,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-derive"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
@@ -3528,7 +3528,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-derive-secret"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",
@@ -3540,11 +3540,11 @@ dependencies = [
 
 [[package]]
 name = "fedimint-docs"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 
 [[package]]
 name = "fedimint-dummy-client"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3566,7 +3566,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dummy-common"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -3576,7 +3576,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dummy-server"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3592,7 +3592,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-empty-client"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3609,7 +3609,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-empty-common"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -3619,7 +3619,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-empty-server"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3635,7 +3635,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-eventlog"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3654,7 +3654,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-fountain"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3666,7 +3666,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-fuzz"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "fedimint-core",
  "fedimint-ln-common",
@@ -3679,7 +3679,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-client"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "bcrypt",
@@ -3704,7 +3704,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-common"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -3722,7 +3722,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-server"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3803,7 +3803,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-server-db"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -3831,7 +3831,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-ui"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -3863,7 +3863,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gw-client"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3894,7 +3894,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gwv2-client"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3921,7 +3921,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-hkdf"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "bitcoin_hashes",
 ]
@@ -3969,7 +3969,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lightning"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3996,7 +3996,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-client"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -4031,7 +4031,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-common"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4055,7 +4055,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-server"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4080,7 +4080,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-tests"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4109,7 +4109,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnurl"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "bech32",
  "lightning-invoice",
@@ -4121,7 +4121,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-client"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -4153,7 +4153,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-common"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4173,7 +4173,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-server"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4197,7 +4197,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-tests"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4234,7 +4234,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-load-test-tool"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "clap",
@@ -4262,7 +4262,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-logging"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "console-subscriber",
@@ -4275,7 +4275,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-client"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4298,7 +4298,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-common"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -4313,7 +4313,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-server"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4332,7 +4332,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-tests"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "clap",
@@ -4346,7 +4346,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-metrics"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -4358,7 +4358,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-client"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -4401,7 +4401,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-common"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",
@@ -4414,7 +4414,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-server"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4441,7 +4441,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-tests"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4477,7 +4477,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mintv2-client"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -4516,7 +4516,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mintv2-common"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",
@@ -4529,7 +4529,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mintv2-server"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4554,7 +4554,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mintv2-tests"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4587,7 +4587,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-portalloc"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "dirs",
@@ -4601,7 +4601,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-recoverytool"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -4624,7 +4624,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-recurringd"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -4655,7 +4655,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-recurringd-tests"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "devimint",
@@ -4669,7 +4669,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-recurringdv2"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -4690,7 +4690,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-rocksdb"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4707,7 +4707,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -4765,7 +4765,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server-bitcoin-rpc"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4781,7 +4781,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server-core"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4799,7 +4799,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server-tests"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "bitcoin",
  "fedimint-api-client",
@@ -4819,7 +4819,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server-ui"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4846,7 +4846,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-tbs"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "bls12_381",
  "criterion 0.5.1",
@@ -4861,7 +4861,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-testing"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4901,7 +4901,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-testing-core"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -4962,7 +4962,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-tpe"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "bitcoin_hashes",
  "bls12_381",
@@ -4976,7 +4976,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ui-common"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "axum 0.8.9",
  "axum-extra",
@@ -4988,7 +4988,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-unknown-common"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -4998,7 +4998,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-unknown-server"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5012,14 +5012,14 @@ dependencies = [
 
 [[package]]
 name = "fedimint-util-error"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "fedimint-wallet-client"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -5051,7 +5051,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-common"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -5068,7 +5068,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-server"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5095,7 +5095,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-tests"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -5128,7 +5128,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-walletv2-client"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -5156,7 +5156,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-walletv2-common"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -5169,7 +5169,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-walletv2-server"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5191,7 +5191,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-walletv2-tests"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -5221,7 +5221,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wasm-tests"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "fedimint-client",
@@ -5242,7 +5242,7 @@ dependencies = [
 
 [[package]]
 name = "fedimintd"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -5279,7 +5279,7 @@ dependencies = [
 
 [[package]]
 name = "fedimintd-envs"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 
 [[package]]
 name = "ff"
@@ -5601,7 +5601,7 @@ dependencies = [
 
 [[package]]
 name = "gateway-tests"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ keywords = ["bitcoin", "lightning", "chaumian", "e-cash", "federated"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/fedimint/fedimint"
-version = "0.12.0-alpha"
+version = "0.13.0-alpha"
 
 [workspace.metadata]
 authors = ["The Fedimint Developers"]
@@ -167,7 +167,7 @@ criterion = "0.5.1"
 # We need to pin this arti's `curve25519-dalek` dependency, due to `https://rustsec.org/advisories/RUSTSEC-2024-0344` vulnerability
 # It's been updated by https://gitlab.torproject.org/tpo/core/arti/-/merge_requests/2211, should be removed in next release.
 curve25519-dalek = ">=4.1.3"
-devimint = { path = "./devimint", version = "=0.12.0-alpha" }
+devimint = { path = "./devimint", version = "=0.13.0-alpha" }
 dirs = "6.0.0"
 erased-serde = "0.4"
 esplora-client = { version = "0.12.3", default-features = false, features = [
@@ -176,70 +176,70 @@ esplora-client = { version = "0.12.3", default-features = false, features = [
     "tokio",
 ] }
 
-fedimint-aead = { path = "./crypto/aead", version = "=0.12.0-alpha" }
-fedimint-api-client = { path = "./fedimint-api-client", version = "=0.12.0-alpha" }
-fedimint-bip39 = { path = "./fedimint-bip39", version = "=0.12.0-alpha" }
-fedimint-bitcoind = { path = "./fedimint-bitcoind", version = "=0.12.0-alpha" }
-fedimint-build = { path = "./fedimint-build", version = "=0.12.0-alpha" }
-fedimint-client = { path = "./fedimint-client", version = "=0.12.0-alpha" }
-fedimint-client-module = { path = "./fedimint-client-module", version = "=0.12.0-alpha" }
-fedimint-client-rpc = { path = "./fedimint-client-rpc", version = "=0.12.0-alpha" }
-fedimint-connectors = { path = "./fedimint-connectors", version = "=0.12.0-alpha" }
-fedimint-core = { path = "./fedimint-core", version = "=0.12.0-alpha" }
-fedimint-cursed-redb = { path = "./fedimint-cursed-redb", version = "=0.12.0-alpha" }
-fedimint-db-locked = { path = "./fedimint-db-locked", version = "=0.12.0-alpha" }
-fedimint-derive = { path = "./fedimint-derive", version = "=0.12.0-alpha" }
-fedimint-derive-secret = { path = "./crypto/derive-secret", version = "=0.12.0-alpha" }
-fedimint-dummy-client = { path = "./modules/fedimint-dummy-client", version = "=0.12.0-alpha" }
-fedimint-dummy-common = { path = "./modules/fedimint-dummy-common", version = "=0.12.0-alpha" }
-fedimint-dummy-server = { path = "./modules/fedimint-dummy-server", version = "=0.12.0-alpha" }
-fedimint-empty-common = { path = "./modules/fedimint-empty-common", version = "=0.12.0-alpha" }
-fedimint-eventlog = { path = "./fedimint-eventlog", version = "=0.12.0-alpha" }
-fedimint-gateway-common = { package = "fedimint-gateway-common", path = "./gateway/fedimint-gateway-common", version = "=0.12.0-alpha" }
-fedimint-gateway-server = { package = "fedimint-gateway-server", path = "./gateway/fedimint-gateway-server", version = "=0.12.0-alpha" }
-fedimint-gateway-server-db = { package = "fedimint-gateway-server-db", path = "./gateway/fedimint-gateway-server-db", version = "=0.12.0-alpha" }
-fedimint-gateway-ui = { package = "fedimint-gateway-ui", path = "./gateway/fedimint-gateway-ui", version = "=0.12.0-alpha" }
-fedimint-gw-client = { path = "./modules/fedimint-gw-client", version = "=0.12.0-alpha" }
-fedimint-gwv2-client = { path = "./modules/fedimint-gwv2-client", version = "=0.12.0-alpha" }
-fedimint-lightning = { package = "fedimint-lightning", path = "./gateway/fedimint-lightning", version = "=0.12.0-alpha" }
-fedimint-ln-client = { path = "./modules/fedimint-ln-client", version = "=0.12.0-alpha" }
-fedimint-ln-common = { path = "./modules/fedimint-ln-common", version = "=0.12.0-alpha" }
-fedimint-ln-server = { path = "./modules/fedimint-ln-server", version = "=0.12.0-alpha" }
-fedimint-lnurl = { path = "./fedimint-lnurl", version = "=0.12.0-alpha" }
-fedimint-lnv2-client = { path = "./modules/fedimint-lnv2-client", version = "=0.12.0-alpha" }
-fedimint-lnv2-common = { path = "./modules/fedimint-lnv2-common", version = "=0.12.0-alpha" }
-fedimint-lnv2-server = { path = "./modules/fedimint-lnv2-server", version = "=0.12.0-alpha" }
-fedimint-logging = { path = "./fedimint-logging", version = "=0.12.0-alpha" }
-fedimint-meta-client = { path = "./modules/fedimint-meta-client", version = "=0.12.0-alpha" }
-fedimint-meta-common = { path = "./modules/fedimint-meta-common", version = "=0.12.0-alpha" }
-fedimint-meta-server = { path = "./modules/fedimint-meta-server", version = "=0.12.0-alpha" }
-fedimint-metrics = { path = "./fedimint-metrics", version = "=0.12.0-alpha" }
-fedimint-mint-client = { path = "./modules/fedimint-mint-client", version = "=0.12.0-alpha" }
-fedimint-mint-common = { path = "./modules/fedimint-mint-common", version = "=0.12.0-alpha" }
-fedimint-mint-server = { path = "./modules/fedimint-mint-server", version = "=0.12.0-alpha" }
-fedimint-mintv2-client = { path = "./modules/fedimint-mintv2-client", version = "=0.12.0-alpha" }
-fedimint-mintv2-common = { path = "./modules/fedimint-mintv2-common", version = "=0.12.0-alpha" }
-fedimint-mintv2-server = { path = "./modules/fedimint-mintv2-server", version = "=0.12.0-alpha" }
-fedimint-portalloc = { path = "utils/portalloc", version = "=0.12.0-alpha" }
-fedimint-rocksdb = { path = "./fedimint-rocksdb", version = "=0.12.0-alpha" }
-fedimint-server = { path = "./fedimint-server", version = "=0.12.0-alpha" }
-fedimint-server-bitcoin-rpc = { path = "./fedimint-server-bitcoin-rpc", version = "=0.12.0-alpha" }
-fedimint-server-core = { path = "./fedimint-server-core", version = "=0.12.0-alpha" }
-fedimint-server-ui = { path = "./fedimint-server-ui", version = "=0.12.0-alpha" }
-fedimint-testing = { path = "./fedimint-testing", version = "=0.12.0-alpha" }
-fedimint-testing-core = { path = "./fedimint-testing-core", version = "=0.12.0-alpha" }
-fedimint-ui-common = { path = "./fedimint-ui-common", version = "=0.12.0-alpha" }
-fedimint-unknown-common = { path = "./modules/fedimint-unknown-common", version = "=0.12.0-alpha" }
-fedimint-unknown-server = { path = "./modules/fedimint-unknown-server", version = "=0.12.0-alpha" }
-fedimint-util-error = { path = "./fedimint-util-error", version = "=0.12.0-alpha" }
-fedimint-wallet-client = { path = "./modules/fedimint-wallet-client", version = "=0.12.0-alpha" }
-fedimint-wallet-common = { path = "./modules/fedimint-wallet-common", version = "=0.12.0-alpha" }
-fedimint-wallet-server = { path = "./modules/fedimint-wallet-server", version = "=0.12.0-alpha" }
-fedimint-walletv2-client = { path = "./modules/fedimint-walletv2-client", version = "=0.12.0-alpha" }
-fedimint-walletv2-common = { path = "./modules/fedimint-walletv2-common", version = "=0.12.0-alpha" }
-fedimint-walletv2-server = { path = "./modules/fedimint-walletv2-server", version = "=0.12.0-alpha" }
-fedimintd = { path = "./fedimintd", version = "=0.12.0-alpha" }
-fedimintd-envs = { path = "./fedimintd-envs", version = "=0.12.0-alpha" }
+fedimint-aead = { path = "./crypto/aead", version = "=0.13.0-alpha" }
+fedimint-api-client = { path = "./fedimint-api-client", version = "=0.13.0-alpha" }
+fedimint-bip39 = { path = "./fedimint-bip39", version = "=0.13.0-alpha" }
+fedimint-bitcoind = { path = "./fedimint-bitcoind", version = "=0.13.0-alpha" }
+fedimint-build = { path = "./fedimint-build", version = "=0.13.0-alpha" }
+fedimint-client = { path = "./fedimint-client", version = "=0.13.0-alpha" }
+fedimint-client-module = { path = "./fedimint-client-module", version = "=0.13.0-alpha" }
+fedimint-client-rpc = { path = "./fedimint-client-rpc", version = "=0.13.0-alpha" }
+fedimint-connectors = { path = "./fedimint-connectors", version = "=0.13.0-alpha" }
+fedimint-core = { path = "./fedimint-core", version = "=0.13.0-alpha" }
+fedimint-cursed-redb = { path = "./fedimint-cursed-redb", version = "=0.13.0-alpha" }
+fedimint-db-locked = { path = "./fedimint-db-locked", version = "=0.13.0-alpha" }
+fedimint-derive = { path = "./fedimint-derive", version = "=0.13.0-alpha" }
+fedimint-derive-secret = { path = "./crypto/derive-secret", version = "=0.13.0-alpha" }
+fedimint-dummy-client = { path = "./modules/fedimint-dummy-client", version = "=0.13.0-alpha" }
+fedimint-dummy-common = { path = "./modules/fedimint-dummy-common", version = "=0.13.0-alpha" }
+fedimint-dummy-server = { path = "./modules/fedimint-dummy-server", version = "=0.13.0-alpha" }
+fedimint-empty-common = { path = "./modules/fedimint-empty-common", version = "=0.13.0-alpha" }
+fedimint-eventlog = { path = "./fedimint-eventlog", version = "=0.13.0-alpha" }
+fedimint-gateway-common = { package = "fedimint-gateway-common", path = "./gateway/fedimint-gateway-common", version = "=0.13.0-alpha" }
+fedimint-gateway-server = { package = "fedimint-gateway-server", path = "./gateway/fedimint-gateway-server", version = "=0.13.0-alpha" }
+fedimint-gateway-server-db = { package = "fedimint-gateway-server-db", path = "./gateway/fedimint-gateway-server-db", version = "=0.13.0-alpha" }
+fedimint-gateway-ui = { package = "fedimint-gateway-ui", path = "./gateway/fedimint-gateway-ui", version = "=0.13.0-alpha" }
+fedimint-gw-client = { path = "./modules/fedimint-gw-client", version = "=0.13.0-alpha" }
+fedimint-gwv2-client = { path = "./modules/fedimint-gwv2-client", version = "=0.13.0-alpha" }
+fedimint-lightning = { package = "fedimint-lightning", path = "./gateway/fedimint-lightning", version = "=0.13.0-alpha" }
+fedimint-ln-client = { path = "./modules/fedimint-ln-client", version = "=0.13.0-alpha" }
+fedimint-ln-common = { path = "./modules/fedimint-ln-common", version = "=0.13.0-alpha" }
+fedimint-ln-server = { path = "./modules/fedimint-ln-server", version = "=0.13.0-alpha" }
+fedimint-lnurl = { path = "./fedimint-lnurl", version = "=0.13.0-alpha" }
+fedimint-lnv2-client = { path = "./modules/fedimint-lnv2-client", version = "=0.13.0-alpha" }
+fedimint-lnv2-common = { path = "./modules/fedimint-lnv2-common", version = "=0.13.0-alpha" }
+fedimint-lnv2-server = { path = "./modules/fedimint-lnv2-server", version = "=0.13.0-alpha" }
+fedimint-logging = { path = "./fedimint-logging", version = "=0.13.0-alpha" }
+fedimint-meta-client = { path = "./modules/fedimint-meta-client", version = "=0.13.0-alpha" }
+fedimint-meta-common = { path = "./modules/fedimint-meta-common", version = "=0.13.0-alpha" }
+fedimint-meta-server = { path = "./modules/fedimint-meta-server", version = "=0.13.0-alpha" }
+fedimint-metrics = { path = "./fedimint-metrics", version = "=0.13.0-alpha" }
+fedimint-mint-client = { path = "./modules/fedimint-mint-client", version = "=0.13.0-alpha" }
+fedimint-mint-common = { path = "./modules/fedimint-mint-common", version = "=0.13.0-alpha" }
+fedimint-mint-server = { path = "./modules/fedimint-mint-server", version = "=0.13.0-alpha" }
+fedimint-mintv2-client = { path = "./modules/fedimint-mintv2-client", version = "=0.13.0-alpha" }
+fedimint-mintv2-common = { path = "./modules/fedimint-mintv2-common", version = "=0.13.0-alpha" }
+fedimint-mintv2-server = { path = "./modules/fedimint-mintv2-server", version = "=0.13.0-alpha" }
+fedimint-portalloc = { path = "utils/portalloc", version = "=0.13.0-alpha" }
+fedimint-rocksdb = { path = "./fedimint-rocksdb", version = "=0.13.0-alpha" }
+fedimint-server = { path = "./fedimint-server", version = "=0.13.0-alpha" }
+fedimint-server-bitcoin-rpc = { path = "./fedimint-server-bitcoin-rpc", version = "=0.13.0-alpha" }
+fedimint-server-core = { path = "./fedimint-server-core", version = "=0.13.0-alpha" }
+fedimint-server-ui = { path = "./fedimint-server-ui", version = "=0.13.0-alpha" }
+fedimint-testing = { path = "./fedimint-testing", version = "=0.13.0-alpha" }
+fedimint-testing-core = { path = "./fedimint-testing-core", version = "=0.13.0-alpha" }
+fedimint-ui-common = { path = "./fedimint-ui-common", version = "=0.13.0-alpha" }
+fedimint-unknown-common = { path = "./modules/fedimint-unknown-common", version = "=0.13.0-alpha" }
+fedimint-unknown-server = { path = "./modules/fedimint-unknown-server", version = "=0.13.0-alpha" }
+fedimint-util-error = { path = "./fedimint-util-error", version = "=0.13.0-alpha" }
+fedimint-wallet-client = { path = "./modules/fedimint-wallet-client", version = "=0.13.0-alpha" }
+fedimint-wallet-common = { path = "./modules/fedimint-wallet-common", version = "=0.13.0-alpha" }
+fedimint-wallet-server = { path = "./modules/fedimint-wallet-server", version = "=0.13.0-alpha" }
+fedimint-walletv2-client = { path = "./modules/fedimint-walletv2-client", version = "=0.13.0-alpha" }
+fedimint-walletv2-common = { path = "./modules/fedimint-walletv2-common", version = "=0.13.0-alpha" }
+fedimint-walletv2-server = { path = "./modules/fedimint-walletv2-server", version = "=0.13.0-alpha" }
+fedimintd = { path = "./fedimintd", version = "=0.13.0-alpha" }
+fedimintd-envs = { path = "./fedimintd-envs", version = "=0.13.0-alpha" }
 ff = "0.13.1"
 fs-lock = "=0.1.10"
 fs2 = "0.4.3"
@@ -251,7 +251,7 @@ gloo-timers = "0.3.0"
 group = "0.13.0"
 hex = "0.4.3"
 hex-conservative = "1.0.0"
-hkdf = { package = "fedimint-hkdf", path = "./crypto/hkdf", version = "=0.12.0-alpha" }
+hkdf = { package = "fedimint-hkdf", path = "./crypto/hkdf", version = "=0.13.0-alpha" }
 honggfuzz = { version = "=0.5.60", default-features = false } # needs to be pinned to the same version `cargo-fuzz` binary uses
 hyper = "1.9"
 imbl = "5.0.0"
@@ -331,7 +331,7 @@ substring = "1.4.5"
 subtle = "2.6.1"
 syn = "2.0"
 tar = "0.4.46"
-tbs = { package = "fedimint-tbs", path = "./crypto/tbs", version = "=0.12.0-alpha" }
+tbs = { package = "fedimint-tbs", path = "./crypto/tbs", version = "=0.13.0-alpha" }
 tempfile = "3.20.0"
 test-log = { version = "0.2", features = ["trace"], default-features = false }
 thiserror = "2.0.18"
@@ -351,7 +351,7 @@ tonic_lnd = { version = "0.4.0", package = "fedimint-tonic-lnd", features = [
 tor-rtcompat = { version = "0.38.0", features = ["tokio", "rustls"] }
 tower = { version = "0.4.13", default-features = false }
 tower-http = { version = "0.6.8", features = ["cors"] }
-tpe = { package = "fedimint-tpe", path = "./crypto/tpe", version = "=0.12.0-alpha" }
+tpe = { package = "fedimint-tpe", path = "./crypto/tpe", version = "=0.13.0-alpha" }
 tracing = "0.1.44"
 tracing-opentelemetry = "0.29.0"
 tracing-subscriber = "0.3.22"


### PR DESCRIPTION
Bumps the workspace version on `master` from `0.12.0-alpha` to `0.13.0-alpha`, following the [release process](https://github.com/fedimint/fedimint/blob/master/docs/release-process.md) now that the `releases/v0.12` branch has been cut and `v0.12.0-beta.0` tagged.

Part of #8810.