### PR TITLE
fix(gateway): Gateway UI Auth issues

### DIFF
--- a/fedimint-ui-common/src/auth.rs
+++ b/fedimint-ui-common/src/auth.rs
@@ -1,6 +1,8 @@
-use axum::extract::FromRequestParts;
+use axum::extract::{FromRequestParts, Request};
 use axum::http::request::Parts;
-use axum::response::Redirect;
+use axum::http::{Method, StatusCode, header};
+use axum::middleware::Next;
+use axum::response::{Redirect, Response};
 use axum_extra::extract::CookieJar;
 use fedimint_core::net::auth::GuardianAuthToken;
 
@@ -21,6 +23,77 @@ impl UserAuth {
             guardian_auth_token: GuardianAuthToken::new_unchecked(),
         }
     }
+}
+
+/// Middleware that rejects state-changing cross-origin browser requests,
+/// protecting cookie-authenticated UI routes against CSRF.
+///
+/// The auth cookie is `HttpOnly` + `SameSite=Lax`, which already keeps
+/// browsers from attaching it to cross-site POSTs. This adds an independent
+/// layer based on metadata browsers attach automatically:
+///
+/// - `Sec-Fetch-Site` (all modern browsers): only same-origin and
+///   user-initiated (`none`) requests are allowed. Unlike `SameSite=Lax`, this
+///   also rejects requests from sibling subdomains (`same-site`).
+/// - `Origin` (legacy browsers send it on all cross-site POSTs): its authority
+///   must match the request's `Host`.
+///
+/// Requests carrying neither header (curl and other non-browser clients)
+/// pass through; they don't attach cookies ambiently, so CSRF does not
+/// apply to them.
+pub async fn csrf_protection_middleware(
+    request: Request,
+    next: Next,
+) -> Result<Response, StatusCode> {
+    if is_request_origin_allowed(&request) {
+        Ok(next.run(request).await)
+    } else {
+        Err(StatusCode::FORBIDDEN)
+    }
+}
+
+fn is_request_origin_allowed(request: &Request) -> bool {
+    let method = request.method();
+    if method == Method::GET || method == Method::HEAD || method == Method::OPTIONS {
+        return true;
+    }
+
+    let headers = request.headers();
+
+    if let Some(site) = headers.get("sec-fetch-site") {
+        return site
+            .to_str()
+            .is_ok_and(|site| site == "same-origin" || site == "none");
+    }
+
+    if let Some(origin) = headers.get(header::ORIGIN) {
+        // An opaque origin ("null") or a non-http(s) scheme is never
+        // acceptable for a state-changing request
+        let Some(origin_authority) = origin.to_str().ok().and_then(|origin| {
+            origin
+                .strip_prefix("http://")
+                .or_else(|| origin.strip_prefix("https://"))
+        }) else {
+            return false;
+        };
+
+        let Some(host) = headers
+            .get(header::HOST)
+            .and_then(|host| host.to_str().ok())
+            .or_else(|| {
+                request
+                    .uri()
+                    .authority()
+                    .map(|authority| authority.as_str())
+            })
+        else {
+            return false;
+        };
+
+        return origin_authority.eq_ignore_ascii_case(host);
+    }
+
+    true
 }
 
 impl<Api> FromRequestParts<UiState<Api>> for UserAuth

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -2877,8 +2877,14 @@ impl IAdminGateway for Gateway {
     /// Set the gateway's root mnemonic by generating a new one or using the
     /// words provided in `SetMnemonicPayload`.
     async fn handle_set_mnemonic_msg(&self, payload: SetMnemonicPayload) -> AdminResult<()> {
+        // The state lock must be held from the `NotConfigured` check until the
+        // transition to `Disconnected`, otherwise a concurrent call could pass
+        // the check, lose the race for the seed write, and leave the gateway
+        // stuck in `NotConfigured` with a seed already stored
+        let mut state_guard = self.state.write().await;
+
         // Verify the state is NotConfigured
-        let GatewayState::NotConfigured { mnemonic_sender } = self.get_state().await else {
+        let GatewayState::NotConfigured { mnemonic_sender } = state_guard.clone() else {
             return Err(AdminGatewayError::MnemonicError(anyhow!(
                 "Gateway is not is NotConfigured state"
             )));
@@ -2900,7 +2906,8 @@ impl IAdminGateway for Gateway {
             .await
             .map_err(AdminGatewayError::MnemonicError)?;
 
-        self.set_gateway_state(GatewayState::Disconnected).await;
+        *state_guard = GatewayState::Disconnected;
+        drop(state_guard);
 
         // Alert the gateway background threads that the mnemonic has been set
         let _ = mnemonic_sender.send(());

--- a/gateway/fedimint-gateway-server/src/rpc_server.rs
+++ b/gateway/fedimint-gateway-server/src/rpc_server.rs
@@ -87,7 +87,14 @@ pub async fn run_webserver(
     let mut handlers = Handlers::new();
 
     let routes = routes(gateway.clone(), task_group.clone(), &mut handlers);
-    let ui_routes = fedimint_gateway_ui::router(gateway.clone());
+    // The UI router is merged separately from `routes` below and merged
+    // routers keep their own layers, so it needs its own
+    // `not_configured_middleware` layer. Without it, only the API routes are
+    // restricted to `is_allowed_setup_route` while the gateway is
+    // `NotConfigured`
+    let ui_routes = fedimint_gateway_ui::router(gateway.clone())
+        .layer(middleware::from_fn(not_configured_middleware))
+        .layer(Extension(gateway.clone()));
     let api_v1 = Router::new()
         .nest(&format!("/{V1_API_ENDPOINT}"), routes.clone())
         // Backwards compatibility: Continue supporting gateway APIs without versioning

--- a/gateway/fedimint-gateway-ui/src/lib.rs
+++ b/gateway/fedimint-gateway-ui/src/lib.rs
@@ -18,7 +18,7 @@ use axum::extract::{Query, State};
 use axum::http::header;
 use axum::response::{Html, IntoResponse, Redirect, Response};
 use axum::routing::{get, post};
-use axum::{Form, Router};
+use axum::{Form, Router, middleware};
 use axum_extra::extract::CookieJar;
 use axum_extra::extract::cookie::{Cookie, SameSite};
 use fedimint_core::bitcoin::Network;
@@ -41,7 +41,7 @@ use fedimint_gateway_common::{
 use fedimint_ln_common::contracts::Preimage;
 use fedimint_logging::LOG_GATEWAY_UI;
 use fedimint_ui_common::assets::WithStaticRoutesExt;
-use fedimint_ui_common::auth::UserAuth;
+use fedimint_ui_common::auth::{UserAuth, csrf_protection_middleware};
 use fedimint_ui_common::{
     LOGIN_ROUTE, LoginInput, ROOT_ROUTE, UiState, dashboard_layout,
     login_form as render_login_form, single_card_layout,
@@ -524,7 +524,8 @@ pub fn router<E: Display + Send + Sync + std::fmt::Debug + 'static>(
             MNEMONIC_IFRAME_ROUTE,
             get(mnemonic_iframe_handler).post(mnemonic_reveal_handler),
         )
-        .with_static_routes();
+        .with_static_routes()
+        .layer(middleware::from_fn(csrf_protection_middleware));
 
     app.with_state(UiState::new(api, true))
 }

--- a/gateway/fedimint-gateway-ui/src/lib.rs
+++ b/gateway/fedimint-gateway-ui/src/lib.rs
@@ -298,7 +298,7 @@ async fn login_submit<E>(
 
 async fn dashboard_view<E>(
     State(state): State<UiState<DynGatewayApi<E>>>,
-    _auth: UserAuth,
+    auth: UserAuth,
     Query(msg): Query<DashboardQuery>,
 ) -> impl IntoResponse
 where
@@ -306,7 +306,7 @@ where
 {
     // If gateway is not configured, show setup view instead of dashboard
     if !state.api.is_configured().await {
-        return setup::setup_view(State(state), Query(msg))
+        return setup::setup_view(State(state), auth, Query(msg))
             .await
             .into_response();
     }

--- a/gateway/fedimint-gateway-ui/src/setup.rs
+++ b/gateway/fedimint-gateway-ui/src/setup.rs
@@ -3,6 +3,7 @@ use axum::extract::{Query, State};
 use axum::response::{Html, IntoResponse, Redirect};
 use bip39::Language;
 use fedimint_gateway_common::SetMnemonicPayload;
+use fedimint_ui_common::auth::UserAuth;
 use fedimint_ui_common::{ROOT_ROUTE, UiState, single_card_layout};
 use maud::{PreEscaped, html};
 use serde::Deserialize;
@@ -32,6 +33,7 @@ pub struct RecoverWalletForm {
 /// - Recover Wallet
 pub async fn setup_view<E>(
     State(_state): State<UiState<DynGatewayApi<E>>>,
+    _auth: UserAuth,
     Query(msg): Query<DashboardQuery>,
 ) -> impl IntoResponse
 where
@@ -77,6 +79,7 @@ where
 /// Handler for creating a new wallet (generates new mnemonic)
 pub async fn create_wallet_handler<E>(
     State(state): State<UiState<DynGatewayApi<E>>>,
+    _auth: UserAuth,
 ) -> impl IntoResponse
 where
     E: std::fmt::Display,
@@ -94,6 +97,7 @@ where
 /// Renders the recovery form where user can enter their 12 words
 pub async fn recover_wallet_form<E>(
     State(_state): State<UiState<DynGatewayApi<E>>>,
+    _auth: UserAuth,
     Query(msg): Query<DashboardQuery>,
 ) -> impl IntoResponse
 where
@@ -176,6 +180,7 @@ where
 /// Handler for recovering a wallet with provided mnemonic words
 pub async fn recover_wallet_handler<E>(
     State(state): State<UiState<DynGatewayApi<E>>>,
+    _auth: UserAuth,
     Form(form): Form<RecoverWalletForm>,
 ) -> impl IntoResponse
 where


### PR DESCRIPTION
Fixes: https://github.com/fedimint/fedimint/issues/8852

The gateway UI currently has 2 issues that allow an un-authorized user to set the seed phrase of the gateway. This is difficult to exploit, since most of the time the UI is deployed locally.

 - Adds `UserAuth` to the create wallet and recover wallet UI endpoints.
 - Adds CRSF protection and atomic state transition when setting the mnemonic
 - Properly sets up the allow list for the endpoints allowed during the `NotConfigured` state.