### PR TITLE
fix(client): report a failed module recovery instead of blocking forever

### DIFF
--- a/fedimint-client/src/client.rs
+++ b/fedimint-client/src/client.rs
@@ -103,6 +103,9 @@ pub(crate) mod event_log;
 pub(crate) mod global_ctx;
 pub(crate) mod handle;
 
+#[cfg(test)]
+mod tests;
+
 /// List of core api versions supported by the implementation.
 /// Notably `major` version is the one being supported, and corresponding
 /// `minor` version is the one required (for given `major` version).
@@ -129,6 +132,69 @@ pub(crate) struct PrimaryModuleCandidates {
 /// from the module (if it tracks one) once recovery completes.
 pub(crate) type ModuleRecoveryFuture =
     Pin<Box<maybe_add_send!(dyn Future<Output = anyhow::Result<Option<Amount>>>)>>;
+
+/// The state of a single module's recovery, as tracked by the client.
+///
+/// [`RecoveryProgress`] can only ever express how far a recovery got, never
+/// that it gave up, which makes a failed recovery indistinguishable from a
+/// merely slow one and blocks every waiter on the outcome forever. Carrying the
+/// failure as a state of the very thing the progress describes makes the
+/// contradictory "done and failed" unrepresentable for a module, so a recovery
+/// that terminally fails resolves the waiters it used to strand. Only a
+/// terminal failure does: a recovery that keeps retrying instead of giving up,
+/// as fetching the federation's history does, resolves nothing, and its waiters
+/// keep waiting.
+///
+/// Only the APIs returning a result observe the failure. The ones exposing the
+/// progress itself, like [`Client::has_pending_recoveries`] and
+/// [`Client::subscribe_to_recovery_progress`], keep reporting a failed recovery
+/// as not done, which it is.
+///
+/// Internal: the failure reaches callers as the error of the waiting API, not
+/// as this type, so it stays crate-private rather than committing an
+/// accessorless public type to the API surface.
+///
+/// The module this describes is the key of the map this is stored in, so it is
+/// deliberately not repeated here: a copy could contradict the key it is
+/// filed under.
+#[derive(Clone, Debug)]
+pub(crate) enum RecoveryStatus {
+    /// The latest progress of a recovery that has not failed.
+    ///
+    /// A successfully completed recovery is represented by a done progress.
+    InProgress(RecoveryProgress),
+    /// The recovery terminally failed at `last_progress`, which is kept so the
+    /// progress-reporting APIs can keep describing the module.
+    Failed {
+        last_progress: RecoveryProgress,
+        error: String,
+    },
+}
+
+impl RecoveryStatus {
+    /// Whether the module's recovery completed successfully.
+    ///
+    /// A failure is terminal but never done: the module recovered nothing
+    /// beyond the progress it got to.
+    pub(crate) fn is_successfully_done(&self) -> bool {
+        match self {
+            Self::InProgress(progress) => progress.is_done(),
+            Self::Failed { .. } => false,
+        }
+    }
+
+    /// The progress view of the status, which is all a progress-reporting API
+    /// can express.
+    pub(crate) fn progress(&self) -> RecoveryProgress {
+        match self {
+            Self::InProgress(progress)
+            | Self::Failed {
+                last_progress: progress,
+                ..
+            } => *progress,
+        }
+    }
+}
 
 /// Main client type
 ///
@@ -169,9 +235,19 @@ pub struct Client {
     /// federation prefix.
     client_span: Span,
 
-    /// Updates about client recovery progress
-    client_recovery_progress_receiver:
-        watch::Receiver<BTreeMap<ModuleInstanceId, RecoveryProgress>>,
+    /// Updates about the recovery status of every recovering module, keyed by
+    /// module instance
+    ///
+    /// Keyed rather than a single slot because a `watch` channel only keeps its
+    /// latest value: if one module's terminal state overwrote another's before
+    /// a waiter observed it, [`Self::wait_for_module_kind_recovery`] could miss
+    /// a failure of its own kind and block forever. Keeping a status per module
+    /// keeps the outcome determinate no matter how many modules fail.
+    ///
+    /// A [`RecoveryStatus::Failed`] is intentionally not persisted: on a
+    /// restart the recovery is simply attempted again, which is the right thing
+    /// to do for a transient cause.
+    client_recovery_status_receiver: watch::Receiver<BTreeMap<ModuleInstanceId, RecoveryStatus>>,
 
     /// Internal client sender to wake up log ordering task every time a
     /// (unuordered) log event is added.
@@ -1851,63 +1927,127 @@ impl Client {
 
     pub fn has_pending_recoveries(&self) -> bool {
         !self
-            .client_recovery_progress_receiver
+            .client_recovery_status_receiver
             .borrow()
-            .iter()
-            .all(|(_id, progress)| progress.is_done())
+            .values()
+            .all(RecoveryStatus::is_successfully_done)
     }
 
     /// Wait for all module recoveries to finish
     ///
-    /// This will block until the recovery task is done with recoveries.
-    /// Returns success if all recovery tasks are complete (success case),
-    /// or an error if some modules could not complete the recovery at the time.
+    /// Returns `Ok(())` once every module recovery completed, or an error as
+    /// soon as any one of them fails terminally.
+    ///
+    /// An error does not mean the recovery task is done: the failed module's
+    /// progress stays pending forever (so [`Self::has_pending_recoveries`]
+    /// keeps returning `true`) and the recovery task stays parked. The
+    /// failure is in-memory only and is not persisted, so reopening the
+    /// client retries the recovery from its last persisted, non-terminal
+    /// progress.
     ///
     /// A bit of a heavy approach.
     pub async fn wait_for_all_recoveries(&self) -> anyhow::Result<()> {
-        let mut recovery_receiver = self.client_recovery_progress_receiver.clone();
-        recovery_receiver
-            .wait_for(|in_progress| {
-                in_progress
-                    .iter()
-                    .all(|(_id, progress)| progress.is_done())
+        Self::wait_for_recoveries(
+            self.client_recovery_status_receiver.clone(),
+            |_module_instance_id| true,
+            "Recovery task completed and update receiver disconnected, but some modules failed to recover",
+        )
+        .await
+    }
+
+    /// Wait for the recovery of every module accepted by `module_filter` to
+    /// either complete or fail.
+    ///
+    /// Since [`RecoveryProgress`] can never express a failure, waiting on
+    /// progress alone would block forever on a module that gave up. A module
+    /// that gave up is recorded as [`RecoveryStatus::Failed`] by
+    /// [`Self::run_module_recoveries_task`] instead, so both outcomes are
+    /// observable on the same per-module status.
+    async fn wait_for_recoveries(
+        mut status_receiver: watch::Receiver<BTreeMap<ModuleInstanceId, RecoveryStatus>>,
+        module_filter: impl Fn(ModuleInstanceId) -> bool,
+        disconnected_context: &'static str,
+    ) -> anyhow::Result<()> {
+        let failure = status_receiver
+            .wait_for(|statuses| {
+                let matching = || {
+                    statuses
+                        .iter()
+                        .filter(|(module_instance_id, _status)| module_filter(**module_instance_id))
+                        .map(|(_module_instance_id, status)| status)
+                };
+
+                // A failure is terminal, so waiting for the modules that are
+                // still recovering would only delay an outcome that can no
+                // longer change.
+                matching().any(|status| matches!(status, RecoveryStatus::Failed { .. }))
+                    || matching().all(RecoveryStatus::is_successfully_done)
             })
             .await
-            .context("Recovery task completed and update receiver disconnected, but some modules failed to recover")?;
+            .context(disconnected_context)?
+            // Classified from the woken-up snapshot before anything else, so a
+            // failure of one module still wins over another one completing.
+            .iter()
+            .find_map(|(module_instance_id, status)| match status {
+                RecoveryStatus::Failed { error, .. } if module_filter(*module_instance_id) => {
+                    Some((*module_instance_id, error.clone()))
+                }
+                _ => None,
+            });
 
-        Ok(())
+        match failure {
+            Some((module_instance_id, error)) => Err(anyhow!(
+                "Module recovery failed: module_instance_id={module_instance_id}, error={error}"
+            )),
+            None => Ok(()),
+        }
     }
 
     /// Subscribe to recover progress for all the modules.
     ///
     /// This stream can contain duplicate progress for a module.
     /// Don't use this stream for detecting completion of recovery.
+    ///
+    /// It can't express a failure either: a module that failed to recover keeps
+    /// being reported with the last progress it made, which is never done. Use
+    /// [`Self::wait_for_all_recoveries`] or
+    /// [`Self::wait_for_module_kind_recovery`] to learn the outcome.
     pub fn subscribe_to_recovery_progress(
         &self,
     ) -> impl Stream<Item = (ModuleInstanceId, RecoveryProgress)> + use<> {
-        WatchStream::new(self.client_recovery_progress_receiver.clone())
-            .flat_map(futures::stream::iter)
+        WatchStream::new(self.client_recovery_status_receiver.clone()).flat_map(|statuses| {
+            futures::stream::iter(
+                statuses
+                    .into_iter()
+                    .map(|(module_instance_id, status)| (module_instance_id, status.progress())),
+            )
+        })
     }
 
+    /// Wait for the recoveries of all modules of `module_kind` to finish
+    ///
+    /// Returns `Ok(())` once every recovery of that kind completed, or an error
+    /// as soon as one of them fails terminally. Failures of other module kinds
+    /// are ignored.
+    ///
+    /// See [`Self::wait_for_all_recoveries`] for what an error does and does
+    /// not say about the state of the recovery.
     pub async fn wait_for_module_kind_recovery(
         &self,
         module_kind: ModuleKind,
     ) -> anyhow::Result<()> {
-        let mut recovery_receiver = self.client_recovery_progress_receiver.clone();
         let config = self.config().await;
-        recovery_receiver
-            .wait_for(|in_progress| {
-                !in_progress
-                    .iter()
-                    .filter(|(module_instance_id, _progress)| {
-                        config.modules[module_instance_id].kind == module_kind
-                    })
-                    .any(|(_id, progress)| !progress.is_done())
-            })
-            .await
-            .context("Recovery task completed and update receiver disconnected, but the desired modules are still unavailable or failed to recover")?;
-
-        Ok(())
+        Self::wait_for_recoveries(
+            self.client_recovery_status_receiver.clone(),
+            move |module_instance_id| {
+                config
+                    .modules
+                    .get(&module_instance_id)
+                    .is_some_and(|module| module.kind == module_kind)
+            },
+            "Recovery task completed and update receiver disconnected, but the desired modules are still unavailable or failed to recover",
+        )
+        .await
     }
 
     pub async fn wait_for_all_active_state_machines(&self) -> anyhow::Result<()> {
@@ -1927,7 +2067,7 @@ impl Client {
 
     fn spawn_module_recoveries_task(
         &self,
-        recovery_sender: watch::Sender<BTreeMap<ModuleInstanceId, RecoveryProgress>>,
+        recovery_sender: watch::Sender<BTreeMap<ModuleInstanceId, RecoveryStatus>>,
         module_recoveries: BTreeMap<ModuleInstanceId, ModuleRecoveryFuture>,
         module_recovery_progress_receivers: BTreeMap<
             ModuleInstanceId,
@@ -1939,6 +2079,10 @@ impl Client {
     ) {
         let db = self.db.clone();
         let log_ordering_wakeup_tx = self.log_ordering_wakeup_tx.clone();
+        // A module can finish its own final database commit before the client
+        // persists the corresponding completed progress below. Keep the
+        // coordinator alive across graceful shutdown so that gap cannot cause
+        // a non-idempotent module finalization to be replayed on reopen.
         self.spawn("module recoveries", |_task_handle| async {
             Self::run_module_recoveries_task(
                 db,
@@ -1955,7 +2099,7 @@ impl Client {
     async fn run_module_recoveries_task(
         db: Database,
         log_ordering_wakeup_tx: watch::Sender<()>,
-        recovery_sender: watch::Sender<BTreeMap<ModuleInstanceId, RecoveryProgress>>,
+        recovery_sender: watch::Sender<BTreeMap<ModuleInstanceId, RecoveryStatus>>,
         module_recoveries: BTreeMap<ModuleInstanceId, ModuleRecoveryFuture>,
         module_recovery_progress_receivers: BTreeMap<
             ModuleInstanceId,
@@ -1977,17 +2121,44 @@ impl Client {
         let progress_stream = futures::stream::FuturesUnordered::new();
 
         for (module_instance_id, f) in module_recoveries {
+            let recovery_sender = recovery_sender.clone();
             completed_stream.push(futures::stream::once(Box::pin(async move {
                 match f.await {
                     Ok(amount) => (module_instance_id, RecoveryUpdate::Completed(amount)),
                     Err(err) => {
+                        let error = err.fmt_compact_anyhow().to_string();
                         warn!(
                             target: LOG_CLIENT,
-                            err = %err.fmt_compact_anyhow(), module_instance_id, "Module recovery failed"
+                            err = %error.as_str(), module_instance_id, "Module recovery failed"
                         );
-                        // a module recovery that failed reports and error and
-                        // just never finishes, so we don't need a separate state
-                        // for it
+                        // since the progress a module reports can't express a
+                        // failure, record it as the terminal state of this
+                        // module's recovery for anyone waiting on the outcome.
+                        // Keyed by module instance so a later failure of
+                        // another module can't overwrite this one before a
+                        // waiter observes it.
+                        recovery_sender.send_modify(|statuses| {
+                            let last_progress = statuses
+                                .get(&module_instance_id)
+                                .expect("existing status must be present")
+                                .progress();
+                            statuses.insert(
+                                module_instance_id,
+                                RecoveryStatus::Failed {
+                                    last_progress,
+                                    error,
+                                },
+                            );
+                        });
+                        // The terminal failure is now published to the waiters,
+                        // and this branch stays pending on purpose so the
+                        // recovery coordinator and its single status sender
+                        // remain alive. The failed module's progress never
+                        // becomes done either, so observers that only see the
+                        // progress keep treating the recovery as pending, which
+                        // it effectively is. The failure is deliberately not
+                        // persisted, so reopening the client retries the
+                        // recovery.
                         futures::future::pending::<()>().await;
                         unreachable!()
                     }
@@ -2009,16 +2180,73 @@ impl Client {
         );
 
         while let Some((module_instance_id, update)) = futures.next().await {
-            let mut dbtx = db.begin_transaction().await;
-
-            let prev_progress = *recovery_sender
+            // Cloned so the `watch::Ref` is released right here: holding it
+            // across the awaits or the `send_modify` below would deadlock the
+            // channel it borrows from.
+            let prev_status = recovery_sender
                 .borrow()
                 .get(&module_instance_id)
-                .expect("existing progress must be present");
+                .expect("existing status must be present")
+                .clone();
+
+            // A failure is the terminal state of a module's recovery, but
+            // progress and completion are merged without any ordering between
+            // them, so a stale progress update of that module can still arrive
+            // after it. Applying it would overwrite the failure with an
+            // in-progress status, and a waiter subscribing afterwards would
+            // block forever again. Ignoring it entirely, without touching the
+            // channel, also keeps subscribers from seeing a snapshot that says
+            // nothing new. Mirrors the sticky "once done, stick with it"
+            // handling below.
+            if matches!(prev_status, RecoveryStatus::Failed { .. }) {
+                debug!(
+                    target: LOG_CLIENT_RECOVERY,
+                    module_instance_id,
+                    "Ignoring a recovery update of a module whose recovery already failed"
+                );
+                continue;
+            }
+
+            let prev_progress = prev_status.progress();
+
+            // A module reports its progress on a channel it owns, so the values
+            // arriving here are untrusted: `update_recovery_progress` filters
+            // them, but a module can send on `progress_tx` directly. Reject the
+            // values that would break the invariants downstream depends on
+            // before anything is persisted or broadcast.
+            if let RecoveryUpdate::Progress(progress) = &update {
+                if progress.is_done() {
+                    warn!(
+                        target: LOG_CLIENT_RECOVERY,
+                        module_instance_id,
+                        "Module bypassed the sanctioned recovery progress reporting API and reported a completed recovery progress. Ignoring"
+                    );
+                    continue;
+                }
+
+                // The module's channel starts at the progress the client seeded
+                // it with, so a "none" that doesn't regress anything is the
+                // normal start of a recovery, not a module misbehaving. Neither
+                // is one seen after the module already completed: progress and
+                // completion are merged without ordering between them, so a
+                // seeded value can arrive after the completion it preceded.
+                if progress.is_none() && !prev_progress.is_none() && !prev_progress.is_done() {
+                    warn!(
+                        target: LOG_CLIENT_RECOVERY,
+                        module_instance_id,
+                        "Module bypassed the sanctioned recovery progress reporting API and reported a none recovery progress, regressing its previous one. Ignoring"
+                    );
+                    continue;
+                }
+            }
+
+            let mut dbtx = db.begin_transaction().await;
 
             // The recovered amount is only known once the module's recovery
             // future resolves, which is also the only way progress transitions
-            // to "done" (modules can't report a completed `RecoveryProgress`).
+            // to "done": the guard above rejects a completed progress reported
+            // by a module, so `RecoveryUpdate::Completed` stays the only
+            // producer of a done progress, and done therefore implies success.
             let (progress, recovered_amount) = if prev_progress.is_done() {
                 // since updates might be out of order, once done, stick with it
                 (prev_progress, None)
@@ -2064,8 +2292,8 @@ impl Client {
             .await;
             dbtx.commit_tx().await;
 
-            recovery_sender.send_modify(|v| {
-                v.insert(module_instance_id, progress);
+            recovery_sender.send_modify(|statuses| {
+                statuses.insert(module_instance_id, RecoveryStatus::InProgress(progress));
             });
         }
         debug!(target: LOG_CLIENT_RECOVERY, "Recovery executor stopped");

--- a/fedimint-client/src/client/builder.rs
+++ b/fedimint-client/src/client/builder.rs
@@ -56,7 +56,7 @@ use crate::api_announcements::{
     run_api_announcement_refresh_task, store_api_announcements_updates_from_peers,
 };
 use crate::backup::{ClientBackup, Metadata};
-use crate::client::{ModuleRecoveryFuture, PrimaryModuleCandidates};
+use crate::client::{ModuleRecoveryFuture, PrimaryModuleCandidates, RecoveryStatus};
 use crate::db::{
     self, ApiSecretKey, ChainIdKey, ClientInitStateKey, ClientMetadataKey, ClientModuleRecovery,
     ClientModuleRecoveryState, ClientPreRootSecretHashKey, InitMode, InitState,
@@ -1014,9 +1014,14 @@ impl ClientBuilder {
 
         let recovery_receiver_init_val = module_recovery_progress_receivers
             .iter()
-            .map(|(module_instance_id, rx)| (*module_instance_id, *rx.borrow()))
+            .map(|(module_instance_id, rx)| {
+                (
+                    *module_instance_id,
+                    RecoveryStatus::InProgress(*rx.borrow()),
+                )
+            })
             .collect::<BTreeMap<_, _>>();
-        let (client_recovery_progress_sender, client_recovery_progress_receiver) =
+        let (client_recovery_status_sender, client_recovery_status_receiver) =
             watch::channel(recovery_receiver_init_val);
 
         let client_inner = Arc::new(Client {
@@ -1042,7 +1047,7 @@ impl ClientBuilder {
             task_group,
             client_span,
             operation_log: OperationLog::new(db.clone()),
-            client_recovery_progress_receiver,
+            client_recovery_status_receiver,
             meta_service: self.meta_service,
             iroh_enable_dht: self.iroh_enable_dht,
             iroh_enable_next,
@@ -1151,7 +1156,7 @@ impl ClientBuilder {
                 .map(|(id, module_config)| (*id, module_config.kind().clone()))
                 .collect();
             client_arc.spawn_module_recoveries_task(
-                client_recovery_progress_sender,
+                client_recovery_status_sender,
                 module_recoveries,
                 module_recovery_progress_receivers,
                 module_kinds,

--- a/fedimint-client/src/client/tests.rs
+++ b/fedimint-client/src/client/tests.rs
@@ -1,0 +1,829 @@
+use std::collections::BTreeMap;
+use std::future::{Future, pending};
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::anyhow;
+use bitcoin::key::Secp256k1;
+use fedimint_api_client::api::DynGlobalApi;
+use fedimint_api_client::api::global_api::with_request_hook::ApiRequestHook;
+use fedimint_client_module::meta::LegacyMetaSource;
+use fedimint_client_module::module::recovery::RecoveryProgress;
+use fedimint_client_module::module::{ClientModuleRegistry, FinalClientIface};
+use fedimint_connectors::ConnectorRegistry;
+use fedimint_core::config::{
+    ClientConfig, ClientModuleConfig, GlobalClientConfig, ModuleInitRegistry,
+};
+use fedimint_core::core::{ModuleInstanceId, ModuleKind};
+use fedimint_core::db::mem_impl::MemDatabase;
+use fedimint_core::db::{Database, IDatabaseTransactionOpsCoreTyped as _};
+use fedimint_core::encoding::DynRawFallback;
+use fedimint_core::module::registry::{ModuleDecoderRegistry, ModuleRegistry};
+use fedimint_core::module::{CoreConsensusVersion, ModuleConsensusVersion};
+use fedimint_core::runtime::timeout;
+use fedimint_core::task::TaskGroup;
+use fedimint_derive_secret::DerivableSecret;
+use futures::{StreamExt as _, poll};
+use tokio::select;
+use tokio::sync::{broadcast, oneshot, watch};
+use tokio::task::yield_now;
+
+use super::{Client, ModuleRecoveryFuture, RecoveryStatus};
+use crate::db::ClientModuleRecovery;
+use crate::meta::MetaService;
+use crate::oplog::OperationLog;
+use crate::sm::executor::Executor;
+use crate::sm::notifier::Notifier;
+
+const FAILING_MODULE_INSTANCE_ID: ModuleInstanceId = 1;
+const RECOVERING_MODULE_INSTANCE_ID: ModuleInstanceId = 2;
+const RECOVERY_ERROR: &str = "module recovery went wrong";
+const WAIT_TIMEOUT: Duration = Duration::from_secs(30);
+
+struct ModuleRecoveries {
+    task: Pin<Box<dyn Future<Output = ()>>>,
+    status_receiver: watch::Receiver<BTreeMap<ModuleInstanceId, RecoveryStatus>>,
+}
+
+fn run_module_recoveries() -> ModuleRecoveries {
+    let initial_progress = RecoveryProgress {
+        complete: 0,
+        total: 10,
+    };
+
+    let module_recoveries: BTreeMap<ModuleInstanceId, ModuleRecoveryFuture> = [
+        (
+            FAILING_MODULE_INSTANCE_ID,
+            Box::pin(async { Err(anyhow!(RECOVERY_ERROR)) }) as ModuleRecoveryFuture,
+        ),
+        (
+            RECOVERING_MODULE_INSTANCE_ID,
+            Box::pin(async { Ok(None) }) as ModuleRecoveryFuture,
+        ),
+    ]
+    .into_iter()
+    .collect();
+
+    let (progress_senders, module_recovery_progress_receivers): (Vec<_>, BTreeMap<_, _>) =
+        module_recoveries
+            .keys()
+            .map(|module_instance_id| {
+                let (progress_sender, progress_receiver) = watch::channel(initial_progress);
+                (progress_sender, (*module_instance_id, progress_receiver))
+            })
+            .unzip();
+
+    let module_kinds = module_recoveries
+        .keys()
+        .map(|module_instance_id| (*module_instance_id, ModuleKind::from_static_str("test")))
+        .collect();
+    let (recovery_sender, recovery_receiver) = watch::channel(
+        module_recoveries
+            .keys()
+            .map(|module_instance_id| {
+                (
+                    *module_instance_id,
+                    RecoveryStatus::InProgress(initial_progress),
+                )
+            })
+            .collect(),
+    );
+    let (log_ordering_wakeup_tx, _log_ordering_wakeup_rx) = watch::channel(());
+    let db = Database::new(MemDatabase::new(), ModuleRegistry::default());
+
+    let task = Box::pin(async move {
+        // Keep the progress streams open while the failed recovery is parked.
+        let _progress_senders = progress_senders;
+        Client::run_module_recoveries_task(
+            db,
+            log_ordering_wakeup_tx,
+            recovery_sender,
+            module_recoveries,
+            module_recovery_progress_receivers,
+            module_kinds,
+        )
+        .await;
+    });
+
+    ModuleRecoveries {
+        task,
+        status_receiver: recovery_receiver,
+    }
+}
+
+async fn client_for_recovery_test(
+    status_receiver: watch::Receiver<BTreeMap<ModuleInstanceId, RecoveryStatus>>,
+    module_kinds: BTreeMap<ModuleInstanceId, ModuleKind>,
+) -> Client {
+    let modules = module_kinds
+        .into_iter()
+        .map(|(module_instance_id, kind)| {
+            (
+                module_instance_id,
+                ClientModuleConfig {
+                    kind,
+                    version: ModuleConsensusVersion::new(0, 0),
+                    config: DynRawFallback::Raw {
+                        module_instance_id,
+                        raw: Vec::new(),
+                    },
+                },
+            )
+        })
+        .collect();
+    let config = ClientConfig {
+        global: GlobalClientConfig {
+            api_endpoints: BTreeMap::new(),
+            broadcast_public_keys: None,
+            consensus_version: CoreConsensusVersion::new(0, 0),
+            meta: BTreeMap::new(),
+        },
+        modules,
+    };
+    let federation_id = config.calculate_federation_id();
+    let connectors = ConnectorRegistry::build_from_testing_defaults()
+        .bind()
+        .await
+        .expect("Connector registry must build");
+    let db = Database::new(MemDatabase::new(), ModuleRegistry::default());
+    let task_group = TaskGroup::new();
+    let (log_ordering_wakeup_tx, _log_ordering_wakeup_rx) = watch::channel(());
+    let executor = Executor::builder().build(
+        db.clone(),
+        Notifier::new(),
+        task_group.clone(),
+        log_ordering_wakeup_tx.clone(),
+    );
+    let (_log_event_added_tx, log_event_added_rx) = watch::channel(());
+    let (log_event_added_transient_tx, _log_event_added_transient_rx) = broadcast::channel(1);
+    let request_hook: ApiRequestHook = Arc::new(|api| api);
+
+    Client {
+        final_client: FinalClientIface::default(),
+        config: tokio::sync::RwLock::new(config),
+        api_secret: None,
+        decoders: ModuleDecoderRegistry::default(),
+        connectors: connectors.clone(),
+        db: db.clone(),
+        federation_id,
+        federation_config_meta: BTreeMap::new(),
+        primary_modules: BTreeMap::new(),
+        modules: ClientModuleRegistry::default(),
+        module_inits: ModuleInitRegistry::new(),
+        executor,
+        api: DynGlobalApi::new(connectors, BTreeMap::new(), None).expect("Global API must build"),
+        root_secret: DerivableSecret::new_root(&[0; 32], &[0; 32]),
+        operation_log: OperationLog::new(db),
+        secp_ctx: Secp256k1::new(),
+        meta_service: MetaService::new(LegacyMetaSource::default()),
+        task_group,
+        client_span: Client::make_client_span(federation_id),
+        client_recovery_status_receiver: status_receiver,
+        log_ordering_wakeup_tx,
+        log_event_added_rx,
+        log_event_added_transient_tx,
+        request_hook,
+        iroh_enable_dht: false,
+        iroh_enable_next: false,
+        user_bitcoind_rpc: None,
+        user_bitcoind_rpc_no_chain_id: None,
+    }
+}
+
+fn recovery_module_kinds() -> BTreeMap<ModuleInstanceId, ModuleKind> {
+    [
+        (
+            FAILING_MODULE_INSTANCE_ID,
+            ModuleKind::from_static_str("failing"),
+        ),
+        (
+            RECOVERING_MODULE_INSTANCE_ID,
+            ModuleKind::from_static_str("recovering"),
+        ),
+    ]
+    .into_iter()
+    .collect()
+}
+
+/// The recovery of a single module, driven entirely by the test.
+///
+/// [`Self::module_progress_sender`] is the module's own progress channel, the
+/// one handed to a module as `ClientModuleRecoverArgs::progress_tx`. Sending on
+/// it directly is exactly what a module bypassing `update_recovery_progress`
+/// does, so it is how a test forges a progress the sanctioned API would drop.
+struct SingleModuleRecovery {
+    task: Pin<Box<dyn Future<Output = ()>>>,
+    db: Database,
+    module_progress_sender: watch::Sender<RecoveryProgress>,
+    status_receiver: watch::Receiver<BTreeMap<ModuleInstanceId, RecoveryStatus>>,
+}
+
+fn run_single_module_recovery(
+    initial_progress: RecoveryProgress,
+    recovery: ModuleRecoveryFuture,
+) -> SingleModuleRecovery {
+    let (module_progress_sender, module_progress_receiver) = watch::channel(initial_progress);
+    let (recovery_sender, status_receiver) = watch::channel(
+        [(
+            FAILING_MODULE_INSTANCE_ID,
+            RecoveryStatus::InProgress(initial_progress),
+        )]
+        .into_iter()
+        .collect(),
+    );
+    let (log_ordering_wakeup_tx, _log_ordering_wakeup_rx) = watch::channel(());
+    let db = Database::new(MemDatabase::new(), ModuleRegistry::default());
+
+    let task = Box::pin(Client::run_module_recoveries_task(
+        db.clone(),
+        log_ordering_wakeup_tx,
+        recovery_sender,
+        [(FAILING_MODULE_INSTANCE_ID, recovery)]
+            .into_iter()
+            .collect(),
+        [(FAILING_MODULE_INSTANCE_ID, module_progress_receiver)]
+            .into_iter()
+            .collect(),
+        [(
+            FAILING_MODULE_INSTANCE_ID,
+            ModuleKind::from_static_str("failing"),
+        )]
+        .into_iter()
+        .collect(),
+    ));
+
+    SingleModuleRecovery {
+        task,
+        db,
+        module_progress_sender,
+        status_receiver,
+    }
+}
+
+/// Poll the recovery task until it has consumed everything available to it.
+///
+/// The task is never spawned, so the test owns every interleaving: once the
+/// task has no more work it stays pending however often it is polled, which
+/// makes this a deterministic alternative to waiting for a while.
+async fn drive_recovery_task(task: &mut Pin<Box<dyn Future<Output = ()>>>) {
+    /// Comfortably above the handful of polls a single update needs to travel
+    /// through the merged streams, the database and back out on the status
+    /// channel. Polling a task with nothing left to do is free, so erring high
+    /// costs nothing.
+    const POLLS: usize = 16;
+
+    for _ in 0..POLLS {
+        assert!(
+            poll!(task.as_mut()).is_pending(),
+            "Recovery task must not finish"
+        );
+        yield_now().await;
+    }
+}
+
+/// [`RecoveryProgress`] isn't `PartialEq`, so compare it as a tuple.
+fn progress_tuple(progress: RecoveryProgress) -> (u32, u32) {
+    (progress.complete, progress.total)
+}
+
+/// The progress a module's status reports, whichever state it is in.
+fn status_progress_tuple(
+    statuses: &watch::Receiver<BTreeMap<ModuleInstanceId, RecoveryStatus>>,
+    module_instance_id: ModuleInstanceId,
+) -> (u32, u32) {
+    progress_tuple(statuses.borrow()[&module_instance_id].progress())
+}
+
+async fn persisted_recovery_progress(db: &Database) -> Option<RecoveryProgress> {
+    db.begin_transaction_nc()
+        .await
+        .get_value(&ClientModuleRecovery {
+            module_instance_id: FAILING_MODULE_INSTANCE_ID,
+        })
+        .await
+        .map(|state| state.progress)
+}
+
+#[tokio::test]
+async fn forged_done_recovery_progress_does_not_mask_a_later_failure() {
+    // `ClientModuleRecoverArgs::progress_tx` is public, so a module can report a
+    // "done" progress the sanctioned `update_recovery_progress` would drop. Such
+    // a progress must never be treated as a completed recovery: only the
+    // module's recovery future returning `Ok` completes one. Otherwise a failure
+    // arriving later could no longer retract the success already reported, and,
+    // worse, the persisted done state would make the next client startup skip
+    // the recovery altogether.
+    let (release_failure, failure_released) = oneshot::channel::<()>();
+    let SingleModuleRecovery {
+        mut task,
+        db,
+        module_progress_sender,
+        status_receiver,
+    } = run_single_module_recovery(
+        RecoveryProgress {
+            complete: 0,
+            total: 10,
+        },
+        Box::pin(async move {
+            // Keep the failure unobservable until the test releases it, so the
+            // forged progress is all the recovery task has to go on.
+            failure_released
+                .await
+                .expect("Release channel must stay open");
+            Err(anyhow!(RECOVERY_ERROR))
+        }) as ModuleRecoveryFuture,
+    );
+    let client = client_for_recovery_test(status_receiver.clone(), recovery_module_kinds()).await;
+
+    // Positive control: the seeded progress has to make it all the way through
+    // the task first, otherwise the assertions below would also hold for a
+    // forged progress that was simply never delivered.
+    drive_recovery_task(&mut task).await;
+    assert_eq!(
+        persisted_recovery_progress(&db).await.map(progress_tuple),
+        Some((0, 10)),
+        "The seeded progress must reach the recovery task"
+    );
+
+    module_progress_sender.send_replace(RecoveryProgress {
+        complete: 10,
+        total: 10,
+    });
+    drive_recovery_task(&mut task).await;
+
+    assert_eq!(
+        status_progress_tuple(&status_receiver, FAILING_MODULE_INSTANCE_ID),
+        (0, 10),
+        "A forged done progress must not be broadcast as a completed recovery"
+    );
+    assert_eq!(
+        persisted_recovery_progress(&db).await.map(progress_tuple),
+        Some((0, 10)),
+        "A forged done progress must not be persisted, or reopening the client would skip the recovery"
+    );
+    let mut wait_for_all_recoveries = Box::pin(client.wait_for_all_recoveries());
+    assert!(
+        poll!(wait_for_all_recoveries.as_mut()).is_pending(),
+        "A forged done progress must not complete the wait for all recoveries"
+    );
+
+    release_failure
+        .send(())
+        .expect("Recovery future must be waiting for the release");
+    let error = timeout(WAIT_TIMEOUT, async {
+        select! {
+            () = &mut task => panic!("Recovery task must not finish"),
+            result = wait_for_all_recoveries => result,
+        }
+    })
+    .await
+    .expect("Waiting on a failed module recovery must not block forever")
+    .expect_err("A failure after a forged done progress must still be reported as an error")
+    .to_string();
+
+    assert!(error.contains(RECOVERY_ERROR), "{error}");
+    assert!(
+        error.contains(&format!("module_instance_id={FAILING_MODULE_INSTANCE_ID}")),
+        "{error}"
+    );
+}
+
+#[tokio::test]
+async fn module_reported_none_recovery_progress_is_only_rejected_when_it_regresses() {
+    let SingleModuleRecovery {
+        mut task,
+        db,
+        module_progress_sender,
+        status_receiver,
+    } = run_single_module_recovery(
+        RecoveryProgress::none(),
+        Box::pin(pending()) as ModuleRecoveryFuture,
+    );
+
+    // A module's progress channel starts at the progress the client seeded it
+    // with, so the first update every recovery reports is that seeded value.
+    // Rejecting a "none" here would break normal startup.
+    drive_recovery_task(&mut task).await;
+
+    // Rejecting is inseparable from warning about a misbehaving module, so
+    // seeing the seeded progress persisted covers both.
+    assert_eq!(
+        persisted_recovery_progress(&db).await.map(progress_tuple),
+        Some(progress_tuple(RecoveryProgress::none())),
+        "The client-seeded initial none progress must be accepted"
+    );
+
+    module_progress_sender.send_replace(RecoveryProgress {
+        complete: 3,
+        total: 10,
+    });
+    drive_recovery_task(&mut task).await;
+
+    // Regressing back to "none" would throw away progress already made and
+    // persisted, so it is rejected however the module reported it.
+    module_progress_sender.send_replace(RecoveryProgress::none());
+    drive_recovery_task(&mut task).await;
+
+    assert_eq!(
+        status_progress_tuple(&status_receiver, FAILING_MODULE_INSTANCE_ID),
+        (3, 10)
+    );
+    assert_eq!(
+        persisted_recovery_progress(&db).await.map(progress_tuple),
+        Some((3, 10)),
+        "Progress must stay persisted"
+    );
+}
+
+#[tokio::test]
+async fn wait_for_all_recoveries_reports_success_once_every_module_completed() {
+    let complete_progress = RecoveryProgress {
+        complete: 10,
+        total: 10,
+    };
+    let module_kinds = recovery_module_kinds();
+    // Kept alive so the wait has to succeed on the statuses themselves, rather
+    // than because the channel is closed.
+    let (_status_sender, status_receiver) = watch::channel(
+        module_kinds
+            .keys()
+            .map(|module_instance_id| {
+                (
+                    *module_instance_id,
+                    RecoveryStatus::InProgress(complete_progress),
+                )
+            })
+            .collect(),
+    );
+    let client = client_for_recovery_test(status_receiver, module_kinds).await;
+
+    timeout(WAIT_TIMEOUT, client.wait_for_all_recoveries())
+        .await
+        .expect("Completed recoveries must not block the wait")
+        .expect("Completed recoveries must be reported as a success");
+}
+
+#[tokio::test]
+async fn wait_for_all_recoveries_reports_success_without_any_recovering_module() {
+    // Kept alive for the same reason as above: nothing is recovering, so the
+    // wait has to succeed right away instead of waiting for an update that is
+    // never coming.
+    let (_status_sender, status_receiver) = watch::channel(BTreeMap::new());
+    let client = client_for_recovery_test(status_receiver, recovery_module_kinds()).await;
+
+    timeout(WAIT_TIMEOUT, client.wait_for_all_recoveries())
+        .await
+        .expect("A client without recoveries must not block the wait")
+        .expect("A client without recoveries must be reported as a success");
+}
+
+#[tokio::test]
+async fn wait_for_all_recoveries_reports_failed_module_recovery() {
+    let ModuleRecoveries {
+        task,
+        status_receiver,
+    } = run_module_recoveries();
+    let client = client_for_recovery_test(status_receiver, recovery_module_kinds()).await;
+
+    let result = timeout(WAIT_TIMEOUT, async {
+        select! {
+            () = task => panic!("Recovery task must not finish"),
+            result = client.wait_for_all_recoveries() => result,
+        }
+    })
+    .await
+    .expect("Waiting on a failed module recovery must not block forever");
+    let error = result
+        .expect_err("Failed module recovery must be reported as an error")
+        .to_string();
+
+    assert!(error.contains(RECOVERY_ERROR), "{error}");
+    assert!(
+        error.contains(&format!("module_instance_id={FAILING_MODULE_INSTANCE_ID}")),
+        "{error}"
+    );
+    // Reporting the failure doesn't finish the recovery: the failed module's
+    // progress stays pending, which is what the progress-based observers keep
+    // reporting.
+    assert!(
+        client.has_pending_recoveries(),
+        "A failed module recovery must keep being reported as pending"
+    );
+
+    // A failed module must not silently vanish from the progress stream either:
+    // it keeps being reported with the last progress it made.
+    let (module_instance_id, progress) = Box::pin(client.subscribe_to_recovery_progress())
+        .next()
+        .await
+        .expect("The progress stream must yield the current progress of every module");
+    assert_eq!(module_instance_id, FAILING_MODULE_INSTANCE_ID);
+    assert_eq!(
+        progress_tuple(progress),
+        (0, 10),
+        "A failed module must keep being reported with its last progress"
+    );
+}
+
+#[tokio::test]
+async fn wait_for_all_recoveries_reports_a_recovery_task_that_went_away() {
+    // The sender lives in the recovery task, so dropping it is what a client
+    // shutting down mid-recovery looks like to a waiter. No outcome can be
+    // reported anymore, which has to surface as an error rather than a hang or a
+    // module failure nobody reported.
+    let in_progress = RecoveryProgress {
+        complete: 0,
+        total: 10,
+    };
+    let (status_sender, status_receiver) = watch::channel(
+        [(
+            FAILING_MODULE_INSTANCE_ID,
+            RecoveryStatus::InProgress(in_progress),
+        )]
+        .into_iter()
+        .collect(),
+    );
+    let client = client_for_recovery_test(status_receiver, recovery_module_kinds()).await;
+
+    drop(status_sender);
+
+    let error = timeout(WAIT_TIMEOUT, client.wait_for_all_recoveries())
+        .await
+        .expect("A recovery task that went away must not block the wait forever")
+        .expect_err("An unfinished recovery whose task went away must be reported as an error")
+        .to_string();
+
+    assert!(error.contains("disconnected"), "{error}");
+    assert!(
+        !error.contains("module_instance_id="),
+        "A closed status channel must not be reported as a module failure: {error}"
+    );
+}
+
+#[tokio::test]
+async fn wait_for_module_kind_recovery_reports_matching_failure() {
+    let ModuleRecoveries {
+        task,
+        status_receiver,
+    } = run_module_recoveries();
+    let module_kinds = recovery_module_kinds();
+    let failing_kind = module_kinds[&FAILING_MODULE_INSTANCE_ID].clone();
+    let client = client_for_recovery_test(status_receiver, module_kinds).await;
+
+    let result = timeout(WAIT_TIMEOUT, async {
+        select! {
+            () = task => panic!("Recovery task must not finish"),
+            result = client.wait_for_module_kind_recovery(failing_kind) => result,
+        }
+    })
+    .await
+    .expect("Waiting on a failed module recovery must not block forever");
+
+    result.expect_err("Failure of the requested module kind must be reported");
+}
+
+#[tokio::test]
+async fn wait_for_module_kind_recovery_ignores_unrelated_failure() {
+    let ModuleRecoveries {
+        task,
+        status_receiver,
+    } = run_module_recoveries();
+    let module_kinds = recovery_module_kinds();
+    let recovering_kind = module_kinds[&RECOVERING_MODULE_INSTANCE_ID].clone();
+    let client = client_for_recovery_test(status_receiver, module_kinds).await;
+
+    let result = timeout(WAIT_TIMEOUT, async {
+        select! {
+            () = task => panic!("Recovery task must not finish"),
+            result = client.wait_for_module_kind_recovery(recovering_kind) => result,
+        }
+    })
+    .await
+    .expect("Waiting on a completed module recovery must not block forever");
+
+    result.expect("Failure of an unrelated module kind must not fail the wait");
+}
+
+#[tokio::test]
+async fn recovery_failure_wins_if_completion_is_also_observable() {
+    // A single module can no longer be done and failed at the same time, but two
+    // modules still can, and a wait covering both has to report the failure
+    // rather than the completion it could just as well observe.
+    let (_status_sender, status_receiver) = watch::channel(
+        [
+            (
+                FAILING_MODULE_INSTANCE_ID,
+                RecoveryStatus::Failed {
+                    last_progress: RecoveryProgress {
+                        complete: 0,
+                        total: 10,
+                    },
+                    error: RECOVERY_ERROR.to_string(),
+                },
+            ),
+            (
+                RECOVERING_MODULE_INSTANCE_ID,
+                RecoveryStatus::InProgress(RecoveryProgress {
+                    complete: 10,
+                    total: 10,
+                }),
+            ),
+        ]
+        .into_iter()
+        .collect(),
+    );
+    let client = client_for_recovery_test(status_receiver, recovery_module_kinds()).await;
+
+    let error = timeout(WAIT_TIMEOUT, client.wait_for_all_recoveries())
+        .await
+        .expect("Recovery outcome must be determinate")
+        .expect_err("A recovery failure must take precedence over a completed recovery")
+        .to_string();
+
+    assert!(error.contains(RECOVERY_ERROR), "{error}");
+    assert!(
+        error.contains(&format!("module_instance_id={FAILING_MODULE_INSTANCE_ID}")),
+        "{error}"
+    );
+}
+
+#[tokio::test]
+async fn failed_status_is_not_overwritten_by_late_module_progress() {
+    // Progress and completion are merged without any ordering between them, so a
+    // module's progress update can still arrive after its recovery already
+    // failed. Applying it would replace the recorded failure with an in-progress
+    // status, and a waiter subscribing afterwards would block forever again,
+    // which is the very hang a determinate failure exists to prevent.
+    let initial_progress = RecoveryProgress {
+        complete: 0,
+        total: 10,
+    };
+    let (release_failure, failure_released) = oneshot::channel::<()>();
+    let SingleModuleRecovery {
+        mut task,
+        db,
+        module_progress_sender,
+        status_receiver,
+    } = run_single_module_recovery(
+        initial_progress,
+        Box::pin(async move {
+            // Held back so the seeded progress is processed first, which makes
+            // the update below the late one.
+            failure_released
+                .await
+                .expect("Release channel must stay open");
+            Err(anyhow!(RECOVERY_ERROR))
+        }) as ModuleRecoveryFuture,
+    );
+
+    // Positive control: an update of this module does reach the recovery task
+    // through this very channel, so the assertions below can't hold merely
+    // because the late update was never delivered.
+    drive_recovery_task(&mut task).await;
+    assert_eq!(
+        persisted_recovery_progress(&db).await.map(progress_tuple),
+        Some(progress_tuple(initial_progress)),
+        "The seeded progress must reach the recovery task"
+    );
+
+    release_failure
+        .send(())
+        .expect("Recovery future must be waiting for the release");
+    drive_recovery_task(&mut task).await;
+    assert!(
+        matches!(
+            status_receiver.borrow()[&FAILING_MODULE_INSTANCE_ID],
+            RecoveryStatus::Failed { .. }
+        ),
+        "The failed recovery must be recorded before the late update is delivered"
+    );
+
+    module_progress_sender.send_replace(RecoveryProgress {
+        complete: 5,
+        total: 10,
+    });
+    drive_recovery_task(&mut task).await;
+
+    match &status_receiver.borrow()[&FAILING_MODULE_INSTANCE_ID] {
+        RecoveryStatus::Failed {
+            last_progress,
+            error,
+        } => {
+            assert_eq!(
+                progress_tuple(*last_progress),
+                progress_tuple(initial_progress),
+                "A late progress update must not advance a failed recovery"
+            );
+            assert!(error.contains(RECOVERY_ERROR), "{error}");
+        }
+        RecoveryStatus::InProgress(_) => {
+            panic!("A late progress update must not erase a recorded recovery failure")
+        }
+    }
+    assert_eq!(
+        persisted_recovery_progress(&db).await.map(progress_tuple),
+        Some(progress_tuple(initial_progress)),
+        "A late progress update of a failed module must not be persisted"
+    );
+
+    // Subscribing only now is what makes this determinate: a waiter that missed
+    // the failure as it happened still has to learn about it from the status.
+    let client = client_for_recovery_test(status_receiver, recovery_module_kinds()).await;
+    let error = timeout(WAIT_TIMEOUT, async {
+        select! {
+            () = &mut task => panic!("Recovery task must not finish"),
+            result = client.wait_for_all_recoveries() => result,
+        }
+    })
+    .await
+    .expect("A late waiter on a failed module recovery must not block forever")
+    .expect_err("A late waiter must still be told about the failed module recovery")
+    .to_string();
+
+    assert!(error.contains(RECOVERY_ERROR), "{error}");
+    assert!(
+        error.contains(&format!("module_instance_id={FAILING_MODULE_INSTANCE_ID}")),
+        "{error}"
+    );
+}
+
+#[tokio::test]
+async fn wait_for_module_kind_recovery_reports_failure_despite_other_kind_failing() {
+    // Two modules of different kinds fail, one after the other. A single-slot
+    // signal would let the second failure overwrite the first, so a waiter
+    // asking about the first kind would neither observe a matching failure nor
+    // see its progress become done, and would block forever. Keeping a status
+    // per module keeps the per-kind wait determinate, even for a waiter that
+    // subscribes only after both updates happened.
+    const OTHER_FAILING_MODULE_INSTANCE_ID: ModuleInstanceId = 3;
+
+    let in_progress = RecoveryProgress {
+        complete: 0,
+        total: 10,
+    };
+    let (status_sender, _status_receiver) =
+        watch::channel::<BTreeMap<ModuleInstanceId, RecoveryStatus>>(
+            [
+                (
+                    FAILING_MODULE_INSTANCE_ID,
+                    RecoveryStatus::InProgress(in_progress),
+                ),
+                (
+                    OTHER_FAILING_MODULE_INSTANCE_ID,
+                    RecoveryStatus::InProgress(in_progress),
+                ),
+            ]
+            .into_iter()
+            .collect(),
+        );
+
+    status_sender.send_modify(|statuses| {
+        statuses.insert(
+            FAILING_MODULE_INSTANCE_ID,
+            RecoveryStatus::Failed {
+                last_progress: in_progress,
+                error: RECOVERY_ERROR.to_string(),
+            },
+        );
+    });
+    // The failure of the requested kind is now the value a waiter would have had
+    // to be listening for, and this update of an unrelated module is what
+    // replaces it as the latest one sent.
+    status_sender.send_modify(|statuses| {
+        statuses.insert(
+            OTHER_FAILING_MODULE_INSTANCE_ID,
+            RecoveryStatus::Failed {
+                last_progress: in_progress,
+                error: "other module recovery went wrong".to_string(),
+            },
+        );
+    });
+
+    let failing_kind = ModuleKind::from_static_str("failing");
+    let module_kinds = [
+        (FAILING_MODULE_INSTANCE_ID, failing_kind.clone()),
+        (
+            OTHER_FAILING_MODULE_INSTANCE_ID,
+            ModuleKind::from_static_str("other"),
+        ),
+    ]
+    .into_iter()
+    .collect();
+    // Subscribing only now: everything this waiter can go on is the shared map.
+    let client = client_for_recovery_test(status_sender.subscribe(), module_kinds).await;
+
+    let error = timeout(
+        WAIT_TIMEOUT,
+        client.wait_for_module_kind_recovery(failing_kind),
+    )
+    .await
+    .expect("Waiting on a failed module recovery must not block forever")
+    .expect_err("Failure of the requested kind must be reported despite an unrelated failure")
+    .to_string();
+
+    assert!(error.contains(RECOVERY_ERROR), "{error}");
+    assert!(
+        error.contains(&format!("module_instance_id={FAILING_MODULE_INSTANCE_ID}")),
+        "{error}"
+    );
+}


### PR DESCRIPTION
## Problem

When a module recovery future returns an error, `run_module_recoveries_task` logs it and then
parks on `futures::future::pending()` forever:

```rust
match f.await {
    Ok(amount) => (module_instance_id, RecoveryUpdate::Completed(amount)),
    Err(err) => {
        warn!(target: LOG_CLIENT, err = %err.fmt_compact_anyhow(), module_instance_id, "Module recovery failed");
        // a module recovery that failed reports and error and
        // just never finishes, so we don't need a separate state
        // for it
        futures::future::pending::<()>().await;
        unreachable!()
    }
}
```

The premise in that comment doesn't hold. `RecoveryProgress` can only ever express *how far* a
recovery got, never that it gave up — so a failed module is indistinguishable from a merely slow
one, and everything that waits on the outcome hangs forever:

- `Client::wait_for_all_recoveries()` waits for all progress to reach `is_done()`, which a failed
  module never will.
- `Client::wait_for_module_kind_recovery()` has the same hang for its kind.

The failure is fully determinate at `f.await` (the future returns `anyhow::Result<..>`); the
information simply isn't surfaced. A caller that must know whether recovery succeeded before using
the client has no way to find out, and blocks indefinitely on an error that already happened.

## Fix

Carry the terminal failure out-of-band on a `watch` channel, keyed by module instance, and have
both waiters race it against the progress updates with a biased `select!`. A failed recovery now
returns an error from the waiting API instead of hanging.

- **Keyed by module instance**, not a single slot: a `watch` channel only retains its latest
  value, so if one module's failure overwrote another's before a per-kind waiter observed it, that
  waiter could miss its own kind's failure and block forever. Keeping every failure keeps the
  outcome determinate regardless of how many modules fail.
- **Intentionally not persisted.** On restart the recovery is simply attempted again, which is the
  right behavior for a transient cause. `RecoveryProgress` (persisted in
  `ClientModuleRecoveryState`) is deliberately left untouched, so there is no on-disk schema
  change.
- The recovery task's own parking and its progress bookkeeping are unchanged; this only adds the
  side signal. `has_pending_recoveries()` still reports a failed recovery as "not done", which it
  is.

## Tests

Added coverage that a failure surfaces as an error rather than a hang (each bounded by a timeout so
a regression fails the test instead of blocking the suite): `wait_for_all_recoveries` reports a
failed module; a per-kind wait reports a matching-kind failure, ignores an unrelated-kind failure,
and still reports its own kind's failure when a different kind also fails; and a failure wins when
completion is simultaneously observable.