### PR TITLE
fix(uniffi): run subscribe_* callback loops on a multi-threaded runtime

### DIFF
--- a/fedimint-core/src/runtime.rs
+++ b/fedimint-core/src/runtime.rs
@@ -49,3 +49,84 @@ pub fn block_on<F: Future>(future: F) -> F::Output {
     // nosemgrep: ban-raw-block-on
     tokio::runtime::Handle::current().block_on(future)
 }
+
+/// The single, process-wide multi-threaded Tokio runtime that backs every
+/// Fedimint UniFFI entry point.
+///
+/// UniFFI's `#[uniffi::export(async_runtime = "tokio")]` async methods are
+/// polled by `async_compat::Compat` on whatever host thread (a Kotlin
+/// coroutine dispatcher, a Swift `Task`, ...) drives the call. That thread
+/// usually has no ambient Tokio runtime, so `async_compat` enters its own
+/// global *current-thread* runtime. Any work *spawned* from that context
+/// therefore runs on a current-thread runtime, and Fedimint's rocksdb access
+/// uses [`block_in_place`], which aborts the process with "can call blocking
+/// only when running on the multi-threaded runtime" when run inside such a
+/// task.
+///
+/// Routing all spawned FFI work onto this dedicated multi-threaded runtime
+/// keeps [`block_in_place`] valid regardless of which host thread drove the
+/// poll. It is created once, lazily, and reused for the life of the process,
+/// so this is a fixed worker pool — not a thread per call.
+#[cfg(all(feature = "uniffi", not(target_family = "wasm")))]
+pub fn ffi_runtime() -> &'static tokio::runtime::Runtime {
+    use std::sync::OnceLock;
+    static RUNTIME: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
+    RUNTIME.get_or_init(|| {
+        tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .thread_name("fedimint-ffi")
+            .build()
+            .expect("failed to build fedimint FFI runtime")
+    })
+}
+
+/// Run `fut` to completion on the shared multi-threaded [`ffi_runtime`],
+/// regardless of which (possibly current-thread) runtime is ambient on the
+/// thread driving the FFI poll.
+///
+/// Wrap the body of a `#[uniffi::export(async_runtime = "tokio")]` async
+/// method in this whenever its work — or anything it transitively spawns,
+/// such as a client's state-machine executor — must run on genuine
+/// multi-threaded workers.
+#[cfg(all(feature = "uniffi", not(target_family = "wasm")))]
+pub async fn ffi_spawn<F, T>(fut: F) -> T
+where
+    F: Future<Output = T> + Send + 'static,
+    T: Send + 'static,
+{
+    ffi_runtime()
+        .spawn(fut)
+        .await
+        .expect("fedimint FFI task panicked")
+}
+
+/// Spawn a detached background task that drives a UniFFI `subscribe_*`
+/// callback loop on the shared multi-threaded [`ffi_runtime`].
+///
+/// This is only meant for the fire-and-forget background loops behind
+/// `subscribe_*` FFI methods; the spawned task is detached. See
+/// [`ffi_runtime`] for why a multi-threaded runtime is required here.
+#[cfg(all(feature = "uniffi", not(target_family = "wasm")))]
+pub fn ffi_spawn_subscription<F>(name: &str, future: F)
+where
+    F: Future<Output = ()> + Send + 'static,
+{
+    let span = tracing::debug_span!(target: LOG_RUNTIME, parent: None, "spawn", task = name);
+    ffi_runtime().spawn(future.instrument(span));
+}
+
+/// wasm has no multi-threaded runtime and no [`block_in_place`] (rocksdb is
+/// not used there), so the ambient-runtime hazard does not exist: just run
+/// the future on the ambient executor like [`spawn`] does.
+#[cfg(all(feature = "uniffi", target_family = "wasm"))]
+pub async fn ffi_spawn<F: Future>(fut: F) -> F::Output {
+    fut.await
+}
+
+#[cfg(all(feature = "uniffi", target_family = "wasm"))]
+pub fn ffi_spawn_subscription<F>(name: &str, future: F)
+where
+    F: Future<Output = ()> + 'static,
+{
+    spawn(name, future);
+}

--- a/modules/fedimint-ln-client/src/ffi.rs
+++ b/modules/fedimint-ln-client/src/ffi.rs
@@ -2,9 +2,10 @@ use std::str::FromStr;
 
 use anyhow::anyhow;
 use bitcoin::secp256k1::SecretKey;
+use fedimint_core::Amount;
+use fedimint_core::runtime::ffi_spawn_subscription;
 use fedimint_core::secp256k1::PublicKey;
 use fedimint_core::util::ffi::UniffiError;
-use fedimint_core::{Amount, runtime};
 use fedimint_ln_common::{LightningGateway, LightningGatewayAnnouncement};
 use futures::StreamExt;
 use lightning_invoice::{Bolt11Invoice, Bolt11InvoiceDescription};
@@ -92,7 +93,7 @@ impl LightningClientModule {
         let client_ctx = self.client_ctx.clone();
         let ln = client_ctx.self_ref();
         let updates = ln.subscribe_ln_pay(operation_id).await?;
-        runtime::spawn("uniffi-subscribe-ln-pay", async move {
+        ffi_spawn_subscription("uniffi-subscribe-ln-pay", async move {
             let mut stream = updates.into_stream();
             while let Some(state) = stream.next().await {
                 callback.on_state(operation_id, state);
@@ -110,7 +111,7 @@ impl LightningClientModule {
         let client_ctx = self.client_ctx.clone();
         let ln = client_ctx.self_ref();
         let updates = ln.subscribe_internal_pay(operation_id).await?;
-        runtime::spawn("uniffi-subscribe-internal-pay", async move {
+        ffi_spawn_subscription("uniffi-subscribe-internal-pay", async move {
             let mut stream = updates.into_stream();
             while let Some(state) = stream.next().await {
                 callback.on_state(operation_id, state);
@@ -128,7 +129,7 @@ impl LightningClientModule {
         let client_ctx = self.client_ctx.clone();
         let ln = client_ctx.self_ref();
         let updates = ln.subscribe_ln_receive(operation_id).await?;
-        runtime::spawn("uniffi-subscribe-ln-receive", async move {
+        ffi_spawn_subscription("uniffi-subscribe-ln-receive", async move {
             let mut stream = updates.into_stream();
             while let Some(state) = stream.next().await {
                 callback.on_state(operation_id, state);

--- a/modules/fedimint-mint-client/src/ffi.rs
+++ b/modules/fedimint-mint-client/src/ffi.rs
@@ -1,8 +1,9 @@
 use std::time::Duration;
 
 use fedimint_client::OperationId;
+use fedimint_core::Amount;
+use fedimint_core::runtime::ffi_spawn_subscription;
 use fedimint_core::util::ffi::UniffiError;
-use fedimint_core::{Amount, runtime};
 use futures::StreamExt;
 
 use crate::{
@@ -51,7 +52,7 @@ impl MintClientModule {
         let client_ctx = self.client_ctx.clone();
         let mint = client_ctx.self_ref();
         let updates = mint.subscribe_reissue_external_notes(operation_id).await?;
-        runtime::spawn("uniffi-subscribe-reissue-external-notes", async move {
+        ffi_spawn_subscription("uniffi-subscribe-reissue-external-notes", async move {
             let mut stream = updates.into_stream();
             while let Some(state) = stream.next().await {
                 callback.on_state(operation_id, state);
@@ -120,7 +121,7 @@ impl MintClientModule {
         let client_ctx = self.client_ctx.clone();
         let mint = client_ctx.self_ref();
         let updates = mint.subscribe_spend_notes(operation_id).await?;
-        runtime::spawn("uniffi-subscribe-spend-notes", async move {
+        ffi_spawn_subscription("uniffi-subscribe-spend-notes", async move {
             let mut stream = updates.into_stream();
             while let Some(state) = stream.next().await {
                 callback.on_state(operation_id, state);

--- a/modules/fedimint-wallet-client/src/ffi.rs
+++ b/modules/fedimint-wallet-client/src/ffi.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 use bitcoin::address::NetworkUnchecked;
 use bitcoin::{Address, Amount, OutPoint, Txid};
 use fedimint_core::core::OperationId;
-use fedimint_core::runtime;
+use fedimint_core::runtime::ffi_spawn_subscription;
 use fedimint_core::util::ffi::UniffiError;
 use fedimint_wallet_common::WalletSummary;
 use futures::StreamExt as _;
@@ -77,7 +77,7 @@ impl WalletClientModule {
         let client_ctx = self.client_ctx.clone();
         let wallet = client_ctx.self_ref();
         let updates = wallet.subscribe_deposit(operation_id).await?;
-        runtime::spawn("uniffi-subscribe-deposit", async move {
+        ffi_spawn_subscription("uniffi-subscribe-deposit", async move {
             let mut stream = updates.into_stream();
             while let Some(state) = stream.next().await {
                 callback.on_state(operation_id, state);
@@ -96,7 +96,7 @@ impl WalletClientModule {
         let client_ctx = self.client_ctx.clone();
         let wallet = client_ctx.self_ref();
         let updates = wallet.subscribe_withdraw_updates(operation_id).await?;
-        runtime::spawn("uniffi-subscribe-withdraw", async move {
+        ffi_spawn_subscription("uniffi-subscribe-withdraw", async move {
             let mut stream = updates.into_stream();
             while let Some(state) = stream.next().await {
                 callback.on_state(operation_id, state);


### PR DESCRIPTION

### Summary

The UniFFI `subscribe_*` methods on the client modules abort the host process (e.g. an Android/iOS app) the first time a subscription state is processed — most visibly right after generating a Lightning invoice and subscribing to its receive updates. This routes those background loops onto a shared multi-threaded runtime so their blocking DB access is valid.

### Details

Why this happens, exactly:

1. The module `subscribe_*_uniffi` methods are exported with `#[uniffi::export(async_runtime = "tokio")]`. UniFFI drives those futures through `async_compat::Compat`.
2. `async_compat` uses `Handle::try_current()` and, when the host poll thread has **no ambient Tokio runtime** — the normal case, since UniFFI polls on a Kotlin coroutine dispatcher / Swift `Task` thread — falls back to its own hardcoded **current-thread** runtime.
3. Each `subscribe_*_uniffi` method spawned its callback loop with `fedimint_core::runtime::spawn`, i.e. `tokio::spawn` on the **ambient** runtime. Under UniFFI that ambient runtime is async_compat's current-thread runtime, so the loop runs *as a task on a current-thread runtime*.
4. Processing subscription states touches the DB, and Fedimint's rocksdb access uses `tokio::task::block_in_place`. `block_in_place` **panics/aborts** when invoked from a task running on a current-thread runtime: `"can call blocking only when running on the multi-threaded runtime"`. With `panic = "abort"` in the mobile profile, that takes down the whole app.

Why inline methods (e.g. `create_bolt11_invoice`) does **not** crash: they `.await` their work directly inside the UniFFI-polled future rather than spawning. `block_in_place` only aborts when it runs *inside a runtime task*; called from outside a runtime task (async_compat only enters a handle during poll, it doesn't `block_on`), it just runs the closure. So only the **spawned** loops were affected.

The fix adds `fedimint_core::util::ffi::ffi_spawn_subscription`, backed by a single process-wide multi-threaded runtime (`ffi_runtime`), and routes every module `subscribe_*` loop through it. The loops then always run on genuine multi-threaded workers, so their `block_in_place` DB calls are valid no matter which host thread drove the FFI poll. It's a fixed worker pool created once — not a thread per call. On `wasm` (no `block_in_place`, no multi-thread runtime) the helper just spawns on the ambient executor as before.

PS: Description generated through Claude.