### PR TITLE
fix(server): reprocess consensus items on stale-snapshot commits

### DIFF
--- a/fedimint-core/src/db/mod.rs
+++ b/fedimint-core/src/db/mod.rs
@@ -2141,6 +2141,20 @@ pub enum DatabaseError {
     #[error("Write-write conflict detected")]
     WriteConflict,
 
+    /// The backend could not tell whether this transaction conflicted with
+    /// another one, because its snapshot is older than the write history the
+    /// backend still keeps around for conflict detection.
+    ///
+    /// This is *not* a conflict: it says nothing about whether any other
+    /// transaction touched the same keys, only that the transaction was open
+    /// for too many intervening writes to check. Nothing was written, and
+    /// rerunning the whole operation against a fresh transaction is the only
+    /// supported recovery — the failed transaction cannot be committed again.
+    ///
+    /// The usual cause is a transaction held open across something slow.
+    #[error("Transaction snapshot is older than the retained write history: {0}")]
+    SnapshotTooOld(Box<dyn Error + Send + Sync>),
+
     /// The transaction has already been consumed (committed or dropped).
     /// Operations cannot be performed on a consumed transaction.
     #[error("Transaction already consumed")]
@@ -2164,6 +2178,11 @@ impl DatabaseError {
     /// Create a DatabaseBackend error from any error type
     pub fn backend<E: Error + Send + Sync + 'static>(error: E) -> Self {
         Self::DatabaseBackend(Box::new(error))
+    }
+
+    /// Create a `SnapshotTooOld` error, preserving the backend's own error
+    pub fn snapshot_too_old<E: Error + Send + Sync + 'static>(error: E) -> Self {
+        Self::SnapshotTooOld(Box::new(error))
     }
 }
 

--- a/fedimint-rocksdb/src/lib.rs
+++ b/fedimint-rocksdb/src/lib.rs
@@ -418,15 +418,22 @@ impl IRawDatabaseTransaction for RocksDbTransaction<'_> {
             match self.0.commit() {
                 Ok(()) => Ok(()),
                 Err(err) => {
-                    // RocksDB's OptimisticTransactionDB can return Busy/TryAgain errors
-                    // when concurrent transactions conflict on the same keys.
-                    // These are retriable - return WriteConflict so autocommit retries.
+                    // `Busy` means another transaction wrote a key this one also wrote,
+                    // after our snapshot was taken. `TryAgain` means RocksDB could not
+                    // check for conflicts at all, because our snapshot is older than the
+                    // write history it retains — a different failure with a different
+                    // fix, so it gets its own variant.
+                    //
+                    // Anything else keeps its original kind and message: collapsing
+                    // unrelated failures into a conflict hides what actually went wrong.
+                    // Note that `Database::autocommit` retries on any commit error, so
+                    // nothing here changes which errors it recovers from.
+                    //
                     // See: https://github.com/fedimint/fedimint/issues/8077
+                    // See: https://github.com/fedimint/fedimint/issues/8872
                     match err.kind() {
-                        rocksdb::ErrorKind::Busy
-                        | rocksdb::ErrorKind::TryAgain
-                        | rocksdb::ErrorKind::MergeInProgress
-                        | rocksdb::ErrorKind::TimedOut => Err(DatabaseError::WriteConflict),
+                        rocksdb::ErrorKind::Busy => Err(DatabaseError::WriteConflict),
+                        rocksdb::ErrorKind::TryAgain => Err(DatabaseError::snapshot_too_old(err)),
                         _ => Err(DatabaseError::backend(err)),
                     }
                 }
@@ -869,9 +876,9 @@ mod fedimint_rocksdb_tests {
     /// commit with `TryAgain` even though no other transaction ever touched any
     /// of its keys.
     ///
-    /// This is not a write conflict, but we currently report it as one, so a
-    /// caller cannot tell a genuine race from a transaction that was simply
-    /// held open too long.
+    /// This is not a write conflict, and must not be reported as one: the
+    /// caller has to be able to tell a genuine race from a transaction that
+    /// was simply held open too long.
     ///
     /// See: <https://github.com/fedimint/fedimint/issues/8872>
     #[tokio::test(flavor = "multi_thread")]
@@ -911,8 +918,41 @@ mod fedimint_rocksdb_tests {
         let result = long_lived_dbtx.commit_tx_result().await;
 
         assert!(
+            matches!(result, Err(DatabaseError::SnapshotTooOld(_))),
+            "expected a stale snapshot, got {result:?}"
+        );
+    }
+
+    /// The counterpart to the test above: two transactions writing the *same*
+    /// key is a genuine conflict, and stays reported as one.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_same_key_write_is_a_conflict() {
+        let path = tempfile::Builder::new()
+            .prefix("fcb-rocksdb-test-same-key-write")
+            .tempdir()
+            .unwrap();
+
+        let db = Database::new(
+            RocksDb::build(path.as_ref()).open_blocking().unwrap(),
+            ModuleDecoderRegistry::default(),
+        );
+
+        let mut first_dbtx = db.begin_transaction().await;
+        first_dbtx
+            .insert_entry(&TestKey(vec![0]), &TestVal(vec![1]))
+            .await;
+
+        let mut second_dbtx = db.begin_transaction().await;
+        second_dbtx
+            .insert_entry(&TestKey(vec![0]), &TestVal(vec![2]))
+            .await;
+        second_dbtx.commit_tx().await;
+
+        let result = first_dbtx.commit_tx_result().await;
+
+        assert!(
             matches!(result, Err(DatabaseError::WriteConflict)),
-            "expected the stale snapshot to be reported as a write conflict, got {result:?}"
+            "expected a write conflict, got {result:?}"
         );
     }
 }

--- a/fedimint-rocksdb/src/lib.rs
+++ b/fedimint-rocksdb/src/lib.rs
@@ -859,4 +859,60 @@ mod fedimint_rocksdb_tests {
             ]
         );
     }
+
+    /// `RocksDB` validates an optimistic transaction at commit time against the
+    /// write history it still keeps in memory. That history is bounded by
+    /// `max_write_buffer_size_to_maintain`, which `OptimisticTransactionDB`
+    /// defaults to `max_write_buffer_number * write_buffer_size` — 4 MiB with
+    /// our options. Once a transaction's snapshot falls out of that window
+    /// `RocksDB` can no longer tell whether anything conflicted, and fails the
+    /// commit with `TryAgain` even though no other transaction ever touched any
+    /// of its keys.
+    ///
+    /// This is not a write conflict, but we currently report it as one, so a
+    /// caller cannot tell a genuine race from a transaction that was simply
+    /// held open too long.
+    ///
+    /// See: <https://github.com/fedimint/fedimint/issues/8872>
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_long_lived_transaction_fails_without_key_overlap() {
+        let path = tempfile::Builder::new()
+            .prefix("fcb-rocksdb-test-long-lived-transaction")
+            .tempdir()
+            .unwrap();
+
+        let db = Database::new(
+            RocksDb::build(path.as_ref()).open_blocking().unwrap(),
+            ModuleDecoderRegistry::default(),
+        );
+
+        // A transaction that writes a single key and then stays open, standing in
+        // for one that waits on something slow before committing.
+        let mut long_lived_dbtx = db.begin_transaction().await;
+        long_lived_dbtx
+            .insert_entry(&TestKey(vec![0]), &TestVal(vec![0]))
+            .await;
+
+        // Unrelated writers commit 8 MiB over keys that are disjoint from the
+        // above, which is enough to push the retained history past the snapshot.
+        // 6 MiB was the observed threshold, so this leaves some headroom.
+        let value = vec![0xab; 64 * 1024];
+
+        for index in 0u32..128 {
+            let mut dbtx = db.begin_transaction().await;
+            dbtx.insert_entry(
+                &TestKey2(index.to_be_bytes().to_vec()),
+                &TestVal2(value.clone()),
+            )
+            .await;
+            dbtx.commit_tx().await;
+        }
+
+        let result = long_lived_dbtx.commit_tx_result().await;
+
+        assert!(
+            matches!(result, Err(DatabaseError::WriteConflict)),
+            "expected the stale snapshot to be reported as a write conflict, got {result:?}"
+        );
+    }
 }

--- a/fedimint-server/src/consensus/engine.rs
+++ b/fedimint-server/src/consensus/engine.rs
@@ -11,7 +11,9 @@ use fedimint_api_client::api::{DynGlobalApi, FederationApiExt, ServerError};
 use fedimint_api_client::query::FilterMap;
 use fedimint_core::config::P2PMessage;
 use fedimint_core::core::{DynOutput, MODULE_INSTANCE_ID_GLOBAL};
-use fedimint_core::db::{Database, DatabaseTransaction, IDatabaseTransactionOpsCoreTyped};
+use fedimint_core::db::{
+    Database, DatabaseError, DatabaseResult, DatabaseTransaction, IDatabaseTransactionOpsCoreTyped,
+};
 use fedimint_core::encoding::Decodable;
 use fedimint_core::endpoint_constants::AWAIT_SIGNED_SESSION_OUTCOME_ENDPOINT;
 use fedimint_core::epoch::ConsensusItem;
@@ -57,6 +59,12 @@ use crate::metrics::{
 
 // The name of the directory where the database checkpoints are stored.
 const DB_CHECKPOINTS_DIR: &str = "db_checkpoints";
+
+/// How many times a single ordered consensus item is processed before we give
+/// up. Only a database transaction that could not be validated at commit time
+/// costs an attempt, and reprocessing takes a fresh snapshot, so needing more
+/// than a couple of these means something is wrong beyond a stale snapshot.
+const MAX_ITEM_PROCESSING_ATTEMPTS: usize = 10;
 
 /// Runs the main server consensus loop
 pub struct ConsensusEngine {
@@ -902,6 +910,62 @@ impl ConsensusEngine {
             ])
             .set(session_index as i64);
 
+        let mut attempt: usize = 1;
+
+        let outcome = loop {
+            match self
+                .process_consensus_item_attempt(item_index, &item, peer)
+                .await
+            {
+                Ok(outcome) => break outcome,
+                Err(err) => {
+                    // A snapshot that aged out of the backend's write history is the only
+                    // commit failure we can do anything about, and the only way to recover
+                    // is to rerun the whole operation against a fresh transaction. Nothing
+                    // was written, and reprocessing an ordered item is deterministic, so
+                    // the replay is equivalent to having processed it a moment later.
+                    assert!(
+                        matches!(err, DatabaseError::SnapshotTooOld(_)),
+                        "Committing consensus item failed: {err}"
+                    );
+
+                    assert!(
+                        attempt < MAX_ITEM_PROCESSING_ATTEMPTS,
+                        "Committing consensus item failed after {attempt} attempts: {err}"
+                    );
+
+                    warn!(
+                        target: LOG_CONSENSUS,
+                        %peer,
+                        item_index,
+                        attempt,
+                        err = %err.fmt_compact(),
+                        "Consensus item transaction could not be validated - reprocessing item"
+                    );
+
+                    attempt += 1;
+                }
+            }
+        };
+
+        outcome?;
+
+        timing_prom.observe_duration();
+
+        Ok(())
+    }
+
+    /// Process a single ordered consensus item in one database transaction.
+    ///
+    /// The outer `Err` means the transaction could not be committed and the
+    /// caller has to rerun the whole operation in a fresh one. The inner `Err`
+    /// means the item itself was rejected, which is a normal, final outcome.
+    async fn process_consensus_item_attempt(
+        &self,
+        item_index: u64,
+        item: &ConsensusItem,
+        peer: PeerId,
+    ) -> DatabaseResult<anyhow::Result<()>> {
         let mut dbtx = self.db.begin_transaction().await;
 
         dbtx.ignore_uncommitted();
@@ -909,32 +973,32 @@ impl ConsensusEngine {
         // When we recover from a mid-session crash aleph bft will replay the units that
         // were already processed before the crash. We therefore skip all consensus
         // items until we have seen every previously accepted items again.
-        if let Some(existing_item) = dbtx
-            .get_value(&AcceptedItemKey(item_index.to_owned()))
-            .await
-        {
-            if existing_item.item == item && existing_item.peer == peer {
-                return Ok(());
+        if let Some(existing_item) = dbtx.get_value(&AcceptedItemKey(item_index)).await {
+            if existing_item.item == *item && existing_item.peer == peer {
+                return Ok(Ok(()));
             }
 
-            bail!(
+            return Ok(Err(anyhow!(
                 "Item was discarded previously: existing: {existing_item:?} {}, current: {item:?}, {peer}",
                 existing_item.peer
-            );
+            )));
         }
 
-        self.process_consensus_item_with_db_transaction(&mut dbtx.to_ref_nc(), item.clone(), peer)
+        if let Err(err) = self
+            .process_consensus_item_with_db_transaction(&mut dbtx.to_ref_nc(), item.clone(), peer)
             .await
-            .inspect_err(|err| {
-                // Rejected items are very common, so only trace level
-                trace!(
-                    target: LOG_CONSENSUS,
-                    %peer,
-                    item = ?DebugConsensusItem(&item),
-                    err = %err.fmt_compact_anyhow(),
-                    "Rejected consensus item"
-                );
-            })?;
+        {
+            // Rejected items are very common, so only trace level
+            trace!(
+                target: LOG_CONSENSUS,
+                %peer,
+                item = ?DebugConsensusItem(item),
+                err = %err.fmt_compact_anyhow(),
+                "Rejected consensus item"
+            );
+
+            return Ok(Err(err));
+        }
 
         // After this point we have to commit the database transaction since the
         // item has been fully processed without errors
@@ -952,7 +1016,7 @@ impl ConsensusEngine {
         debug!(
             target: LOG_CONSENSUS,
             %peer,
-            item = ?DebugConsensusItem(&item),
+            item = ?DebugConsensusItem(item),
             "Processed consensus item"
         );
         let mut audit = Audit::default();
@@ -991,17 +1055,16 @@ impl ConsensusEngine {
             "Balance sheet of the fed has gone negative, this should never happen! {audit}"
         );
 
-        dbtx.commit_tx_result()
-            .await
-            .expect("Committing consensus epoch failed");
+        dbtx.commit_tx_result().await?;
 
+        // Counted here rather than in the caller so that only an attempt that actually
+        // committed is counted: the replay and rejection paths above return early, and
+        // a failed attempt loops back around to a fresh transaction.
         CONSENSUS_ITEMS_PROCESSED_TOTAL
             .with_label_values(&[&peer.to_usize().to_string()])
             .inc();
 
-        timing_prom.observe_duration();
-
-        Ok(())
+        Ok(Ok(()))
     }
 
     async fn process_consensus_item_with_db_transaction(


### PR DESCRIPTION
## Summary

A guardian can be killed by a RocksDB commit failure that is not a conflict. `process_consensus_item` commits with an `expect`, and the transaction it commits is held across everything the item's processing does — including, for a wallet block count vote, up to an hour of waiting for the Bitcoin backend. Once concurrent writers push RocksDB's retained write history past that transaction's snapshot, RocksDB can no longer validate it and fails the commit, even though nothing touched any of its keys. This gives that failure its own error variant and reprocesses the item in a fresh transaction instead of panicking.

Fixes #8872.

## Details

RocksDB validates an optimistic transaction at commit time by checking its tracked keys against write history it still holds in memory. That history is bounded by `max_write_buffer_size_to_maintain`, which `OptimisticTransactionDB::Open` defaults to `max_write_buffer_number * write_buffer_size` — **4 MiB** with our options (2 buffers × 2 MiB). If the transaction's snapshot is older than the earliest retained sequence, `CheckKey` gives up before it ever looks at whether a key changed and returns `TryAgain`.

So there are two very different failures behind what we currently call a write conflict:

- **`Busy`** — another transaction wrote a key we also wrote, after our snapshot. A real race.
- **`TryAgain`** — RocksDB could not check for conflicts at all. Says nothing about whether anything raced us; it only means the transaction was open across too many intervening writes.

The consensus path hits the second one. `process_consensus_item` opens one transaction, processes the item and audits every module in it, and only then commits. For a `WalletConsensusItem::BlockCount`, processing calls `sync_up_to_consensus_count`, which waits on `wait_for_finality_confs_or_shutdown` (`fibonacci_max_one_hour()`, i.e. up to an hour) and then fetches every block through retrying RPC loops — all with the transaction open. walletv2 does the same via `await_local_sync_to_block_count`. Meanwhile the AlephBFT backup writer commits once per unit at a 50 ms round delay, the client backup endpoint accepts payloads up to 128 KiB each, and the announcement and guardian-metadata writers add more. Nothing serializes those against the consensus transaction.

The `expect` then takes the process down: the panic unwinds the root `main` task, its `TaskPanicGuard` shuts down the task group, and `fedimintd` exits nonzero. A supervisor restart makes it look self-healing, because the failed transaction was atomic and AlephBFT replays the session — but without a supervisor the guardian just stays down.

Two changes:

1. **`DatabaseError::SnapshotTooOld`**, carrying the backend's own error so the original kind and message survive into logs. `MergeInProgress` and `TimedOut` stop being collapsed into `WriteConflict` too and keep their own kind — `Database::autocommit` retries on *any* commit error, so this does not change which errors it recovers from.

2. **The engine reprocesses the item** in a fresh transaction on `SnapshotTooOld`, up to `MAX_ITEM_PROCESSING_ATTEMPTS`. Per RocksDB's own contract the failed transaction cannot be committed again, so this reruns the whole operation rather than retrying the commit.

## Reviewing

**Is the replay safe?** This is the part worth being opinionated about. The failed attempt wrote nothing, ordered items are processed deterministically, and I checked every server module's `process_consensus_item` for effects outside the transaction — the only one is the wallet's `broadcast_pending.notify_one()`, which is already registered as an `on_commit` hook and so does not fire on a rolled-back attempt. The wallet's other work is Bitcoin RPC *reads*. If you know of a module doing something non-idempotent here, that invalidates the approach.

**Panicking on a genuine `WriteConflict`.** I kept it. On this path there is no other writer of `AcceptedItemKey` or the module keys, so a `Busy` would mean a real invariant violation rather than something to paper over. Happy to make it retry instead if you'd rather be lenient.

**`MAX_ITEM_PROCESSING_ATTEMPTS = 10`, no backoff.** The failure is history-driven, not contention-driven, and each attempt takes a fresh snapshot, so sleeping first would not help. Note the retry does not converge for free: a genuinely long block sync will re-run the sync each attempt. It is strictly better than today's single-attempt panic, but it is not a substitute for shortening the transaction — see below.

**Structure.** The body moved into `process_consensus_item_attempt`, returning `DatabaseResult<anyhow::Result<ProcessedItem>>`: outer `Err` means "rerun the operation", inner `Err` means "the item was rejected", which is a normal final outcome. The nested `Result` is a bit awkward; I did not find a cleaner shape that keeps the two outcomes distinct.

## Not addressed here

- **Shortening the consensus transaction** so it is not held across Bitcoin-backend synchronization (item 3 in the issue). That is the actual cause and a larger change; this PR makes the failure survivable.
- **`max_write_buffer_size_to_maintain`.** Worth knowing that the 4 MiB window is recent: 70c28aac6f0 (`chore(rocksdb): default to lower memory usage`, April) cut `write_buffer_size` from RocksDB's stock 64 MiB to 2 MiB, shrinking the window ~32×. Raising the maintained history back would reduce the frequency, at the cost of the memory that commit was reclaiming.
- **`consensus/api.rs`'s guardian-metadata endpoint** ends in a panicking `commit_tx()` while `GuardianMetadataKey` has several writers, so it is a plausible same-key `Busy` site. Different bug, left alone.

## Testing

Two tests in `fedimint-rocksdb`, both fast and deterministic:

- `test_long_lived_transaction_fails_without_key_overlap` — holds one transaction open across 8 MiB of writes to strictly disjoint keys, then commits it, and asserts `SnapshotTooOld`. The observed threshold on this configuration was ~6 MiB, so this leaves headroom. It is added in the first commit asserting today's `WriteConflict`, and the second commit changes that assertion — that flip *is* the fix, so it seemed clearer to show it than to write the test around it.
- `test_same_key_write_is_a_conflict` — the counterpart: two transactions writing the same key still report `WriteConflict`.

Same setup at RocksDB's stock 64 MiB write buffer (`FM_ROCKSDB_WRITE_BUFFER_SIZE=67108864`) commits fine at 16 MiB of churn, which is what identified the window as the variable.

Existing `fedimint-server`, `fedimint-core` and `fedimint-rocksdb` suites pass, as does `just final-lint`. The engine retry path itself has no automated coverage — I could not find a way to force a stale snapshot through a real federation without a test-only hook, and did not want to add one to production code without a steer from you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TWLVQtq5ew8zVaaQvWKi4a
