### PR TITLE
feat(lnv2-client): expose the send status of an invoice

### DIFF
--- a/modules/fedimint-lnv2-client/src/lib.rs
+++ b/modules/fedimint-lnv2-client/src/lib.rs
@@ -679,6 +679,55 @@ impl LightningClientModule {
         Ok(operation_id)
     }
 
+    /// The status of a previous [`Self::send`] for this invoice.
+    ///
+    /// Callers deciding whether an invoice is safe to pay through another
+    /// mechanism must treat anything but [`InvoiceSendStatus::NotAttempted`]
+    /// as a potential double payment.
+    pub async fn get_invoice_send_status(
+        &self,
+        invoice: &Bolt11Invoice,
+    ) -> anyhow::Result<InvoiceSendStatus> {
+        // Send only creates attempt index 0 nowadays, but older clients
+        // allocated a fresh index per retry, so scan for the latest attempt.
+        // No new attempt was ever allocated after a success, so the latest
+        // attempt alone determines the status.
+        let mut last_op = None;
+
+        for attempt in 0_u64.. {
+            let operation_id = OperationId::from_encodable(&(invoice.clone(), attempt));
+
+            if !self.client_ctx.operation_exists(operation_id).await {
+                break;
+            }
+
+            last_op = Some(operation_id);
+        }
+
+        let Some(operation_id) = last_op else {
+            return Ok(InvoiceSendStatus::NotAttempted);
+        };
+
+        if self.client_ctx.has_active_states(operation_id).await {
+            return Ok(InvoiceSendStatus::InFlight(operation_id));
+        }
+
+        // The operation is finished; replaying its (already terminated) update
+        // stream yields the cached outcome without blocking.
+        let mut stream = self
+            .subscribe_send_operation_state_updates(operation_id)
+            .await?
+            .into_stream();
+
+        while let Some(state) = stream.next().await {
+            if let SendOperationState::Success(_) = state {
+                return Ok(InvoiceSendStatus::Succeeded(operation_id));
+            }
+        }
+
+        Ok(InvoiceSendStatus::Failed(operation_id))
+    }
+
     /// Subscribe to all state updates of the send operation.
     pub async fn subscribe_send_operation_state_updates(
         &self,
@@ -1287,6 +1336,21 @@ pub enum SelectGatewayError {
     NoGatewaysAvailable,
     #[error("All gateways failed to respond")]
     GatewaysUnresponsive,
+}
+
+/// The status of the latest send attempt for an invoice, derived from the
+/// operation log.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum InvoiceSendStatus {
+    /// No payment operation exists for this invoice.
+    NotAttempted,
+    /// A payment operation is still being driven to completion.
+    InFlight(OperationId),
+    /// The payment succeeded; paying the invoice again would be a double
+    /// payment.
+    Succeeded(OperationId),
+    /// The payment failed and any funds were refunded.
+    Failed(OperationId),
 }
 
 #[derive(Error, Debug, Clone, Eq, PartialEq)]

--- a/modules/fedimint-lnv2-tests/tests/tests.rs
+++ b/modules/fedimint-lnv2-tests/tests/tests.rs
@@ -18,8 +18,8 @@ use fedimint_lnv2_client::events::{
     ReceivePaymentEvent, SendPaymentEvent, SendPaymentStatus, SendPaymentUpdateEvent,
 };
 use fedimint_lnv2_client::{
-    LightningClientInit, LightningClientModule, LightningOperationMeta, ReceiveOperationState,
-    SendOperationState, SendPaymentError,
+    InvoiceSendStatus, LightningClientInit, LightningClientModule, LightningOperationMeta,
+    ReceiveOperationState, SendOperationState, SendPaymentError,
 };
 use fedimint_lnv2_common::{
     Bolt11InvoiceDescription, KIND, LightningInput, LightningInputV0, OutgoingWitness,
@@ -115,6 +115,14 @@ async fn can_pay_external_invoice_exactly_once() -> anyhow::Result<()> {
 
     let mut events = pin!(ln_event_stream(&client));
 
+    assert_eq!(
+        client
+            .get_first_module::<LightningClientModule>()?
+            .get_invoice_send_status(&invoice)
+            .await?,
+        InvoiceSendStatus::NotAttempted,
+    );
+
     let operation_id = client
         .get_first_module::<LightningClientModule>()?
         .send(invoice.clone(), Some(gateway_api.clone()), Value::Null)
@@ -158,9 +166,17 @@ async fn can_pay_external_invoice_exactly_once() -> anyhow::Result<()> {
     assert_eq!(
         client
             .get_first_module::<LightningClientModule>()?
-            .send(invoice, Some(gateway_api), Value::Null)
+            .send(invoice.clone(), Some(gateway_api), Value::Null)
             .await,
         Err(SendPaymentError::DuplicatePaymentAttempt(operation_id)),
+    );
+
+    assert_eq!(
+        client
+            .get_first_module::<LightningClientModule>()?
+            .get_invoice_send_status(&invoice)
+            .await?,
+        InvoiceSendStatus::Succeeded(operation_id),
     );
 
     Ok(())
@@ -180,13 +196,11 @@ async fn refund_failed_payment() -> anyhow::Result<()> {
 
     let mut events = pin!(ln_event_stream(&client));
 
+    let invoice = mock::unpayable_invoice();
+
     let operation_id = client
         .get_first_module::<LightningClientModule>()?
-        .send(
-            mock::unpayable_invoice(),
-            Some(mock::gateway()),
-            Value::Null,
-        )
+        .send(invoice.clone(), Some(mock::gateway()), Value::Null)
         .await?;
 
     let Some(LnEvent::Send(send)) = events.next().await else {
@@ -210,6 +224,14 @@ async fn refund_failed_payment() -> anyhow::Result<()> {
     };
     assert_eq!(update.operation_id, operation_id);
     assert_eq!(update.status, SendPaymentStatus::Refunded);
+
+    assert_eq!(
+        client
+            .get_first_module::<LightningClientModule>()?
+            .get_invoice_send_status(&invoice)
+            .await?,
+        InvoiceSendStatus::Failed(operation_id),
+    );
 
     Ok(())
 }
@@ -236,9 +258,11 @@ async fn unilateral_refund_of_outgoing_contracts() -> anyhow::Result<()> {
 
     let mut events = pin!(ln_event_stream(&client));
 
+    let invoice = mock::crash_invoice();
+
     let operation_id = client
         .get_first_module::<LightningClientModule>()?
-        .send(mock::crash_invoice(), Some(mock::gateway()), Value::Null)
+        .send(invoice.clone(), Some(mock::gateway()), Value::Null)
         .await?;
 
     let Some(LnEvent::Send(send)) = events.next().await else {
@@ -273,6 +297,13 @@ async fn unilateral_refund_of_outgoing_contracts() -> anyhow::Result<()> {
         .expect("Operation exists")
         .expect("Fee data is present for new operations");
     assert_eq!(operation_fees.get_bitcoin().msats, 2000);
+    assert_eq!(
+        client
+            .get_first_module::<LightningClientModule>()?
+            .get_invoice_send_status(&invoice)
+            .await?,
+        InvoiceSendStatus::Failed(operation_id),
+    );
 
     Ok(())
 }


### PR DESCRIPTION
Callers deciding whether paying an invoice through another mechanism is
safe (e.g. a client falling back to a different lightning module) had to
hand-roll the operation-id derivation and operation-log inspection. The
new get_invoice_send_status returns NotAttempted / InFlight / Succeeded
/ Failed for the latest send attempt, scanning legacy multi-attempt ids
so pre-single-attempt operation logs are still recognized.

Named InvoiceSendStatus because events::SendPaymentStatus already
exists in this crate.

Assisted-by: Claude (Fable 5)
