### PR TITLE
build(deps): drop the unused reqwest stream feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -307,7 +307,6 @@ reqwest = { version = "0.12.28", features = [
     "rustls-tls",
     "charset",
     "http2",
-    "stream",
 ], default-features = false }
 rexie = "0.6.2"
 ring = "0.17.14"


### PR DESCRIPTION
iroh 1.0 hard-depends on reqwest 0.13 with its own stream feature, so
keeping stream on our reqwest 0.12 puts two wasm-streams versions into
any downstream wasm graph. Both export the same unmangled wasm-bindgen
symbols and the downstream cdylib fails to link with duplicate-symbol
errors. Nothing in-tree uses the streaming API (no bytes_stream
callers), so the feature can simply go.

Assisted-by: Claude (Fable 5)
