### PR TITLE
fix(ci): mirror deleted Start9Labs/avahi-sys dep for s9pk builds

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -839,6 +839,11 @@ jobs:
           if [ -z "$(command -v start-sdk)" ]; then
             export RUSTFLAGS=""
             export OS_ARCH=$(uname -m)
+            # Start9Labs/avahi-sys (a git dep pinned by start-os v0.3.5.1) was deleted
+            # upstream, breaking the s9pk build. Redirect it to a fedimint-controlled
+            # mirror of the same commit. See fedimint/fedimint#8810.
+            git config --global url."https://github.com/fedimint/avahi-sys".insteadOf "https://github.com/Start9Labs/avahi-sys"
+            export CARGO_NET_GIT_FETCH_WITH_CLI=true
             mkdir -p web/dist/static
             ./check-git-hash.sh
             cargo update -p time --manifest-path=core/Cargo.toml
@@ -941,6 +946,11 @@ jobs:
           if [ -z "$(command -v start-sdk)" ]; then
             export RUSTFLAGS=""
             export OS_ARCH=$(uname -m)
+            # Start9Labs/avahi-sys (a git dep pinned by start-os v0.3.5.1) was deleted
+            # upstream, breaking the s9pk build. Redirect it to a fedimint-controlled
+            # mirror of the same commit. See fedimint/fedimint#8810.
+            git config --global url."https://github.com/fedimint/avahi-sys".insteadOf "https://github.com/Start9Labs/avahi-sys"
+            export CARGO_NET_GIT_FETCH_WITH_CLI=true
             mkdir -p web/dist/static
             ./check-git-hash.sh
             cargo update -p time --manifest-path=core/Cargo.toml


### PR DESCRIPTION
## Problem

The `Build fedimintd.s9pk` and `Build fedimint-gatewayd.s9pk` jobs fail (e.g. on the `v0.12.0-beta.0` tag build). The s9pk jobs check out Start9's `start-os @ v0.3.5.1` and build its SDK, whose `Cargo.lock` pins a transitive git dependency:

```
git+https://github.com/Start9Labs/avahi-sys?branch=feature/dynamic-linking#12bef9e435cfb0d36cb229b9d08e2114c176ea7a
```

`github.com/Start9Labs/avahi-sys` now returns **404** — Start9 reorganized their org (`start-os` kept a rename-redirect, but `avahi-sys` was deleted with none). cargo interprets the 404 as a private repo and tries to authenticate, producing:

```
failed to load source for dependency `avahi-sys`
revision 12bef9e...435 not found
failed to authenticate when downloading repository
```

Our s9pk CI is byte-identical to the working v0.11.0 release build, so this is pure upstream breakage.

## Fix

The pinned commit is still recoverable (via the `tari/avahi-sys` fork network), so it has been mirrored to a fedimint-controlled repo:

- **`github.com/fedimint/avahi-sys`**, branch `feature/dynamic-linking` @ `12bef9e...435` (same commit).

This PR adds, to both s9pk jobs' "Build start-sdk" step (before the cargo invocations), a git `insteadOf` rewrite pointing at that mirror, with `CARGO_NET_GIT_FETCH_WITH_CLI=true` so cargo honors it:

```
git config --global url."https://github.com/fedimint/avahi-sys".insteadOf "https://github.com/Start9Labs/avahi-sys"
export CARGO_NET_GIT_FETCH_WITH_CLI=true
```

No change to the `start-os` pin (`v0.3.5.1`).

## Notes

- s9pk jobs are tag-only, so this takes effect on the **next** v0.12 tag (labeled for backport to `releases/v0.12`). `v0.12.0-beta.0` won't retroactively get s9pk packages without a re-tag.
- Longer-term, the real fix is Start9 restoring the public `avahi-sys` repo (or its redirect); until then the mirror keeps our builds green.

Part of #8810.