### PR TITLE
chore: change "experimental" to "legacy" in setup UI

### DIFF
--- a/fedimint-server-ui/src/setup.rs
+++ b/fedimint-server-ui/src/setup.rs
@@ -335,7 +335,7 @@ fn setup_form_content(
                                                 label class="form-check-label" for=(format!("module_{}", kind.as_str())) {
                                                     (kind.as_str())
                                                     @if !default_modules.contains(kind) {
-                                                        span class="badge bg-warning text-dark ms-2" { "experimental" }
+                                                        span class="badge bg-warning text-dark ms-2" { "legacy" }
                                                     }
                                                 }
                                             }


### PR DESCRIPTION
## Summary

Alternative to #8873: label the non-default modules in the setup UI `legacy` instead of `deprecated`.

## Details

Fixes: https://github.com/fedimint/fedimint/issues/8864

The badge is rendered for every module that is not enabled by default, which today is exactly the v1 `mint`, `wallet` and `ln` modules (see `is_enabled_by_default` in the respective `*-server` crates). Calling them "experimental" is plainly wrong — they are the modules that have been in production the longest.

"deprecated" as proposed in #8873 swings too far the other way: these modules are still supported, and a guardian setting up a federation shouldn't be led to believe they are about to be dropped. "legacy" says what they are — the older generation of modules, superseded by their v2 counterparts — without making a statement about ongoing support.

## Testing

Cosmetic single-string change in a `maud` template; covered by compilation. `just clippy`, the pre-commit lint hook and `just cargo-sort-check` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnZWyXz7ZNWgQZwcA96Dnd
