### PR TITLE
[Backport releases/v0.12] chore: change "experimental" to "legacy" in setup UI (#8886)

### DIFF
--- a/fedimint-server-ui/src/setup.rs
+++ b/fedimint-server-ui/src/setup.rs
@@ -335,7 +335,7 @@ fn setup_form_content(
                                                 label class="form-check-label" for=(format!("module_{}", kind.as_str())) {
                                                     (kind.as_str())
                                                     @if !default_modules.contains(kind) {
-                                                        span class="badge bg-warning text-dark ms-2" { "experimental" }
+                                                        span class="badge bg-warning text-dark ms-2" { "legacy" }
                                                     }
                                                 }
                                             }


### PR DESCRIPTION
Manual backport of #8886 to `releases/v0.12`.

The automated backport (`korthout/backport-action`) **failed** to create this PR — its `actions/checkout` step refused to run under `pull_request_target` because #8886 came from a fork ([failed run](https://github.com/fedimint/fedimint/actions/runs/30311636711)):

```
Refusing to check out fork pull request code from a 'pull_request_target' workflow.
... set 'allow-unsafe-pr-checkout: true' on the actions/checkout step.
```

So this backport was cherry-picked by hand (`git cherry-pick -x 3a897da0dbf`, clean, single-line change).

Needed on `releases/v0.12` before cutting `v0.12.0-beta.1`. Part of #8810.

> Note: `.github/workflows/backport.yml` will keep failing on fork-origin PRs until the checkout guard is addressed — tracked separately.