### PR TITLE
feat(mint): add `dev check-nonce` and `dev check-blind-nonce` CLI commands

### DIFF
--- a/modules/fedimint-mint-client/src/api.rs
+++ b/modules/fedimint-mint-client/src/api.rs
@@ -16,6 +16,28 @@ pub trait MintFederationApi {
 
     async fn check_note_spent(&self, nonce: Nonce) -> FederationResult<bool>;
 
+    /// Asks a single peer if e-cash has already been issued for `blind_nonce`.
+    ///
+    /// Unlike [`MintFederationApi::check_blind_nonce_used`] this does not wait
+    /// for a threshold of peers to agree, which makes it possible to observe
+    /// disagreement between peers.
+    async fn check_blind_nonce_used_single_peer(
+        &self,
+        peer: PeerId,
+        blind_nonce: BlindNonce,
+    ) -> anyhow::Result<bool>;
+
+    /// Asks a single peer if the note identified by `nonce` was already spent.
+    ///
+    /// Unlike [`MintFederationApi::check_note_spent`] this does not wait for a
+    /// threshold of peers to agree, which makes it possible to observe
+    /// disagreement between peers.
+    async fn check_note_spent_single_peer(
+        &self,
+        peer: PeerId,
+        nonce: Nonce,
+    ) -> anyhow::Result<bool>;
+
     /// Returns the total number of recovery items stored on the federation.
     async fn fetch_recovery_count(&self) -> anyhow::Result<u64>;
 
@@ -57,6 +79,34 @@ where
             ApiRequestErased::new(nonce),
         )
         .await
+    }
+
+    async fn check_blind_nonce_used_single_peer(
+        &self,
+        peer: PeerId,
+        blind_nonce: BlindNonce,
+    ) -> anyhow::Result<bool> {
+        Ok(self
+            .request_single_peer::<bool>(
+                BLIND_NONCE_USED_ENDPOINT.to_string(),
+                ApiRequestErased::new(blind_nonce),
+                peer,
+            )
+            .await?)
+    }
+
+    async fn check_note_spent_single_peer(
+        &self,
+        peer: PeerId,
+        nonce: Nonce,
+    ) -> anyhow::Result<bool> {
+        Ok(self
+            .request_single_peer::<bool>(
+                NOTE_SPENT_ENDPOINT.to_string(),
+                ApiRequestErased::new(nonce),
+                peer,
+            )
+            .await?)
     }
 
     async fn fetch_recovery_count(&self) -> anyhow::Result<u64> {

--- a/modules/fedimint-mint-client/src/cli.rs
+++ b/modules/fedimint-mint-client/src/cli.rs
@@ -1,18 +1,23 @@
 use std::collections::BTreeMap;
+use std::str::FromStr;
 use std::time::Duration;
 use std::{ffi, iter};
 
-use anyhow::bail;
-use clap::Parser;
-use fedimint_core::{Amount, TieredMulti};
+use anyhow::{Context, bail};
+use clap::{Parser, Subcommand};
+use fedimint_core::encoding::{Decodable, Encodable};
+use fedimint_core::module::registry::ModuleDecoderRegistry;
+use fedimint_core::{Amount, PeerId, TieredMulti};
 use futures::StreamExt;
+use futures::future::join_all;
 use serde::Serialize;
 use serde_json::json;
 use tracing::{info, warn};
 
+use crate::api::MintFederationApi;
 use crate::{
-    MintClientModule, OOBNotes, ReissueExternalNotesState, SelectNotesWithAtleastAmount,
-    SelectNotesWithExactAmount,
+    BlindNonce, MintClientModule, Nonce, OOBNotes, ReissueExternalNotesState,
+    SelectNotesWithAtleastAmount, SelectNotesWithExactAmount,
 };
 
 #[derive(Parser, Serialize)]
@@ -54,6 +59,129 @@ enum Opts {
         /// E-Cash note to validate
         oob_notes: OOBNotes,
     },
+    /// Debugging commands querying the federation directly
+    Dev {
+        #[clap(subcommand)]
+        command: DevOpts,
+    },
+}
+
+#[derive(Subcommand, Serialize)]
+enum DevOpts {
+    /// Ask every guardian if a note's nonce has already been spent
+    ///
+    /// Accepts either a hex-encoded nonce (33 byte compressed secp256k1 public
+    /// key) or an out-of-band e-cash notes string, in which case every nonce it
+    /// contains is checked.
+    CheckNonce {
+        /// Hex-encoded nonce or e-cash notes string
+        nonce: String,
+    },
+    /// Ask every guardian if e-cash has already been issued for a blind nonce
+    ///
+    /// Accepts a hex-encoded blind nonce (48 byte compressed BLS12-381 G1
+    /// point). Note that the human-readable form logged for a blind nonce is a
+    /// SHA256 digest of it and can not be used here.
+    CheckBlindNonce {
+        /// Hex-encoded blind nonce
+        blind_nonce: String,
+    },
+}
+
+/// A single guardian's answer to a nonce or blind nonce query
+#[derive(Serialize)]
+#[serde(untagged)]
+enum PeerCheckResult {
+    Answer(bool),
+    Error(String),
+}
+
+/// Asks every guardian if `nonce` was already spent.
+///
+/// Peers that fail to answer are reported as errors instead of failing the
+/// whole query, since seeing the remaining guardians' answers is the point.
+async fn check_nonce_spent(
+    mint: &MintClientModule,
+    nonce: Nonce,
+) -> BTreeMap<PeerId, PeerCheckResult> {
+    let api = mint.client_ctx.module_api();
+
+    join_all(api.all_peers().iter().map(|&peer| {
+        let api = &api;
+        async move {
+            let result = match api.check_note_spent_single_peer(peer, nonce).await {
+                Ok(spent) => PeerCheckResult::Answer(spent),
+                Err(e) => PeerCheckResult::Error(format!("error: {e}")),
+            };
+            (peer, result)
+        }
+    }))
+    .await
+    .into_iter()
+    .collect()
+}
+
+/// Asks every guardian if e-cash was already issued for `blind_nonce`.
+async fn check_blind_nonce_used(
+    mint: &MintClientModule,
+    blind_nonce: BlindNonce,
+) -> BTreeMap<PeerId, PeerCheckResult> {
+    let api = mint.client_ctx.module_api();
+
+    join_all(api.all_peers().iter().map(|&peer| {
+        let api = &api;
+        async move {
+            let result = match api
+                .check_blind_nonce_used_single_peer(peer, blind_nonce)
+                .await
+            {
+                Ok(used) => PeerCheckResult::Answer(used),
+                Err(e) => PeerCheckResult::Error(format!("error: {e}")),
+            };
+            (peer, result)
+        }
+    }))
+    .await
+    .into_iter()
+    .collect()
+}
+
+async fn check_nonce(mint: &MintClientModule, nonce: &str) -> anyhow::Result<serde_json::Value> {
+    if let Ok(nonce) = Nonce::consensus_decode_hex(nonce, &ModuleDecoderRegistry::default()) {
+        return Ok(json!({
+            "nonce": nonce.consensus_encode_to_hex(),
+            "spent": check_nonce_spent(mint, nonce).await,
+        }));
+    }
+
+    let oob_notes = OOBNotes::from_str(nonce)
+        .context("Argument is neither a hex-encoded nonce nor an e-cash notes string")?;
+
+    let mut nonces = Vec::new();
+    for (amount, note) in oob_notes.notes().iter_items() {
+        let nonce = note.nonce();
+        nonces.push(json!({
+            "nonce": nonce.consensus_encode_to_hex(),
+            "amount_msat": amount.msats,
+            "spent": check_nonce_spent(mint, nonce).await,
+        }));
+    }
+
+    Ok(json!({ "nonces": nonces }))
+}
+
+async fn check_blind_nonce(
+    mint: &MintClientModule,
+    blind_nonce: &str,
+) -> anyhow::Result<serde_json::Value> {
+    let blind_nonce =
+        BlindNonce::consensus_decode_hex(blind_nonce, &ModuleDecoderRegistry::default())
+            .context("Argument is not a hex-encoded blind nonce")?;
+
+    Ok(json!({
+        "blind_nonce": blind_nonce.consensus_encode_to_hex(),
+        "issued": check_blind_nonce_used(mint, blind_nonce).await,
+    }))
 }
 
 async fn spend(
@@ -194,5 +322,42 @@ pub(crate) async fn handle_cli_command(
                 Ok(json!({ "amount_msat": amount }))
             }
         }
+        Opts::Dev { command } => match command {
+            DevOpts::CheckNonce { nonce } => check_nonce(mint, &nonce).await,
+            DevOpts::CheckBlindNonce { blind_nonce } => check_blind_nonce(mint, &blind_nonce).await,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bls12_381::G1Affine;
+    use tbs::BlindedMessage;
+
+    use super::*;
+
+    /// The hex `dev check-nonce` accepts is the plain compressed public key, so
+    /// it matches what the JSON representation of a nonce shows.
+    #[test]
+    fn nonce_hex_round_trip() {
+        let nonce_hex = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+        let nonce = Nonce::consensus_decode_hex(nonce_hex, &ModuleDecoderRegistry::default())
+            .expect("Valid compressed public key");
+
+        assert_eq!(nonce.consensus_encode_to_hex(), nonce_hex);
+    }
+
+    /// Same for `dev check-blind-nonce` and the compressed G1 point.
+    #[test]
+    fn blind_nonce_hex_round_trip() {
+        let blind_nonce = BlindNonce(BlindedMessage(G1Affine::generator()));
+        let blind_nonce_hex = blind_nonce.consensus_encode_to_hex();
+
+        assert_eq!(blind_nonce_hex.len(), 96);
+        assert_eq!(
+            BlindNonce::consensus_decode_hex(&blind_nonce_hex, &ModuleDecoderRegistry::default())
+                .expect("Valid compressed G1 point"),
+            blind_nonce
+        );
     }
 }

--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use anyhow::ensure;
 use assert_matches::assert_matches;
 use bls12_381::G1Affine;
 use fedimint_client::ClientHandleArc;
@@ -10,7 +11,8 @@ use fedimint_core::core::OperationId;
 use fedimint_core::db::IDatabaseTransactionOpsCoreTyped;
 use fedimint_core::module::{AmountUnit, Amounts};
 use fedimint_core::task::sleep_in_test;
-use fedimint_core::util::NextOrPending;
+use fedimint_core::util::backoff_util::aggressive_backoff;
+use fedimint_core::util::{NextOrPending, retry};
 use fedimint_core::{Amount, TieredMulti, sats, secp256k1};
 use fedimint_dummy_client::{DummyClientInit, DummyClientModule};
 use fedimint_dummy_server::DummyInit;
@@ -353,6 +355,134 @@ async fn blind_nonce_index() -> anyhow::Result<()> {
         client_mint.api.check_blind_nonce_used(blind_nonce).await?,
         "Blind nonce should be used now"
     );
+
+    Ok(())
+}
+
+/// The single-peer nonce checks backing `mint dev check-nonce` and `mint dev
+/// check-blind-nonce` have to agree with the threshold API, both before and
+/// after the nonces are used.
+#[tokio::test(flavor = "multi_thread")]
+async fn single_peer_nonce_checks() -> anyhow::Result<()> {
+    // Every peer has to be online, otherwise there is no answer to compare
+    // against for the offline one.
+    let fed = fixtures().new_fed_not_degraded().await;
+    let (client1, client2) = fed.two_clients().await;
+    issue_ecash(&client1, sats(1000)).await?;
+
+    let client1_mint = client1.get_first_module::<MintClientModule>()?;
+    let client2_mint = client2.get_first_module::<MintClientModule>()?;
+    let peers = client1_mint.api.all_peers().clone();
+
+    let (_op, notes) = client1_mint
+        .spend_notes_with_selector(
+            &SelectNotesWithAtleastAmount,
+            sats(750),
+            Some(TIMEOUT),
+            false,
+            (),
+        )
+        .await?;
+    let nonces = notes
+        .notes()
+        .iter_items()
+        .map(|(_, note)| note.nonce())
+        .collect::<Vec<_>>();
+
+    for &peer in &peers {
+        for &nonce in &nonces {
+            assert!(
+                !client1_mint
+                    .api
+                    .check_note_spent_single_peer(peer, nonce)
+                    .await?,
+                "Peer {peer} should not consider the nonce spent yet"
+            );
+        }
+    }
+
+    let op = client2_mint.reissue_external_notes(notes, ()).await?;
+    let mut sub = client2_mint
+        .subscribe_reissue_external_notes(op)
+        .await?
+        .into_stream();
+    assert_eq!(sub.ok().await?, ReissueExternalNotesState::Created);
+    assert_eq!(sub.ok().await?, ReissueExternalNotesState::Issuing);
+    assert_eq!(sub.ok().await?, ReissueExternalNotesState::Done);
+
+    // A single peer can lag behind the threshold of peers that accepted the
+    // transaction, so give each one a chance to catch up.
+    for &peer in &peers {
+        for &nonce in &nonces {
+            retry(
+                format!("waiting for peer {peer} to see the nonce as spent"),
+                aggressive_backoff(),
+                || async {
+                    ensure!(
+                        client1_mint
+                            .api
+                            .check_note_spent_single_peer(peer, nonce)
+                            .await?,
+                        "Peer {peer} does not consider the nonce spent yet"
+                    );
+                    Ok(())
+                },
+            )
+            .await?;
+        }
+    }
+
+    // Same for a blind nonce, which goes from unused to used once the output
+    // creating it is accepted.
+    let mut dbtx = client1_mint.db.begin_transaction().await;
+    let operation_id = OperationId::new_random();
+    let issuance_req = client1_mint
+        .create_output(&mut dbtx.to_ref_nc(), operation_id, 1, Amount::from_sats(1))
+        .await;
+    dbtx.commit_tx().await;
+
+    let blind_nonce = issuance_req
+        .outputs()
+        .first()
+        .expect("There should be at least one note in here")
+        .output
+        .ensure_v0_ref()?
+        .blind_nonce;
+
+    for &peer in &peers {
+        assert!(
+            !client1_mint
+                .api
+                .check_blind_nonce_used_single_peer(peer, blind_nonce)
+                .await?,
+            "Peer {peer} should not consider the blind nonce used yet"
+        );
+    }
+
+    let tx = TransactionBuilder::new().with_outputs(client1_mint.client_ctx.make_dyn(issuance_req));
+    let change_range = client1_mint
+        .client_ctx
+        .finalize_and_submit_transaction(operation_id, "mint", |_| (), tx)
+        .await?;
+    client1.api().await_transaction(change_range.txid()).await;
+
+    for &peer in &peers {
+        retry(
+            format!("waiting for peer {peer} to see the blind nonce as used"),
+            aggressive_backoff(),
+            || async {
+                ensure!(
+                    client1_mint
+                        .api
+                        .check_blind_nonce_used_single_peer(peer, blind_nonce)
+                        .await?,
+                    "Peer {peer} does not consider the blind nonce used yet"
+                );
+                Ok(())
+            },
+        )
+        .await?;
+    }
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Adds two debugging commands to the mint client CLI, `fedimint-cli module mint dev check-nonce <NONCE_HEX | OOB_NOTES>` and `fedimint-cli module mint dev check-blind-nonce <BLIND_NONCE_HEX>`, which ask the federation whether a note nonce has already been spent, respectively whether e-cash has already been issued for a blind nonce.

## Details

The `NOTE_SPENT_ENDPOINT` and `BLIND_NONCE_USED_ENDPOINT` endpoints and their client-side wrappers already existed, so this is mostly CLI plumbing. There are no server-side changes.

The commands query **every guardian individually** via `request_single_peer` instead of using the existing threshold calls. When debugging a mint the interesting case is precisely the one the threshold API hides: guardians disagreeing about whether a nonce was spent. A guardian that fails to answer is reported as an error next to the answers of the ones that did, rather than failing the whole query:

```
$ fedimint-cli module mint dev check-nonce 02ab..
{
  "nonce": "02ab..",
  "spent": { "0": true, "1": true, "2": false, "3": "error: ..." }
}
```

Both commands take the hex of the consensus encoding, which is the plain compressed point in either case — a 33 byte secp256k1 public key for a nonce and a 48 byte BLS12-381 G1 point for a blind nonce. That is what the JSON/serde representations of these types show, so a value copied out of a DB dump or a decoded transaction can be pasted in directly. Note that this is *not* what `BlindNonce`'s `Display` prints: that is a SHA256 digest of the point and is one-way, so it cannot be used as input. The help text says so.

As a convenience `check-nonce` also accepts an out-of-band e-cash notes string and then checks every nonce it contains, reporting each one separately. This overlaps with `mint validate --online`, which only answers "did any of these get spent" as a single boolean.

## Reviewing

The two things worth being opinionated about:

- **Per-peer only.** There is no `--per-peer` flag or threshold mode; per-peer is the only behaviour. It seemed like the right default for a `dev` command, but it does mean a peer that is slow to answer will hold up the output.
- **Input encoding.** Accepting the consensus-encoding hex is a choice; the alternative would have been to accept the base64 serde form used elsewhere for module types.

## Testing

- `single_peer_nonce_checks` in `fedimint-mint-tests` runs against a 4/4 online federation and asserts that every peer individually agrees with the threshold API, both before and after a nonce is spent and a blind nonce is used. It uses `new_fed_not_degraded()` on purpose, since an offline peer has no answer to compare against.
- Two unit tests in `cli.rs` pin the hex round-trip for both types, so the documented input format can't silently drift.
- `just final-lint` equivalent (pre-commit hook, `cargo clippy --all-targets -D warnings`, `cargo-sort-check`) passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PGKpyd2jtsCekAiKmSjjSu