### PR TITLE
fix(ci): check out base branch in backport workflow so fork PRs backport

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -29,6 +29,9 @@ jobs:
       was_successful: ${{ steps.create-pr.outputs.was_successful }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # check out the base branch (no fork code) so the fork-PR guard under pull_request_target passes
+          ref: ${{ github.base_ref }}
       - id: create-pr
         name: Create backport pull requests
         uses: korthout/backport-action@66065406958f46e82238fd59546f5a99e69e22aa # v4.5.2
@@ -45,6 +48,9 @@ jobs:
     if: ${{ needs.backport.outputs.was_successful == 'false' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # check out the base branch (no fork code) so the fork-PR guard under pull_request_target passes
+          ref: ${{ github.base_ref }}
       - name: Set SHORT_PR_TITLE env
         run: |
           # logic to truncate titles needs to be run in a previous step


### PR DESCRIPTION
Fork-origin backports currently fail. The backport workflow runs on `pull_request_target`, and its `actions/checkout` steps have no explicit `ref`, so checkout defaults to the PR merge ref (`refs/pull/N/merge`), which contains fork code. Since `actions/checkout` was bumped v6 -> v7 (commit 9a80cd642), checkout enforces a fork-PR guard and now refuses:

> Refusing to check out fork pull request code from a 'pull_request_target' workflow.

This breaks every fork-origin backport (e.g. #8886, #8875, both manually backported), while upstream-branch PRs still work.

`korthout/backport-action` does not need the fork code — it cherry-picks the merge commit itself using its token. The safe fix is to check out the base branch (`ref: ${{ github.base_ref }}`) in both checkout steps (the `backport` job and the `open-issue` job). This contains no fork code, so the guard passes. It avoids the insecure `allow-unsafe-pr-checkout: true` opt-in and keeps checkout on v7.

Part of #8810.