### PR TITLE
fix(ci): mirror deleted Start9Labs/jsonpath dep for s9pk builds

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -839,10 +839,12 @@ jobs:
           if [ -z "$(command -v start-sdk)" ]; then
             export RUSTFLAGS=""
             export OS_ARCH=$(uname -m)
-            # Start9Labs/avahi-sys (a git dep pinned by start-os v0.3.5.1) was deleted
-            # upstream, breaking the s9pk build. Redirect it to a fedimint-controlled
-            # mirror of the same commit. See fedimint/fedimint#8810.
+            # Several git deps pinned by start-os v0.3.5.1 (Start9Labs/avahi-sys and
+            # Start9Labs/jsonpath) were deleted upstream, breaking the s9pk build.
+            # Redirect them to fedimint-controlled mirrors of the same commits.
+            # See fedimint/fedimint#8810.
             git config --global url."https://github.com/fedimint/avahi-sys".insteadOf "https://github.com/Start9Labs/avahi-sys"
+            git config --global url."https://github.com/fedimint/jsonpath".insteadOf "https://github.com/Start9Labs/jsonpath"
             export CARGO_NET_GIT_FETCH_WITH_CLI=true
             mkdir -p web/dist/static
             ./check-git-hash.sh
@@ -946,10 +948,12 @@ jobs:
           if [ -z "$(command -v start-sdk)" ]; then
             export RUSTFLAGS=""
             export OS_ARCH=$(uname -m)
-            # Start9Labs/avahi-sys (a git dep pinned by start-os v0.3.5.1) was deleted
-            # upstream, breaking the s9pk build. Redirect it to a fedimint-controlled
-            # mirror of the same commit. See fedimint/fedimint#8810.
+            # Several git deps pinned by start-os v0.3.5.1 (Start9Labs/avahi-sys and
+            # Start9Labs/jsonpath) were deleted upstream, breaking the s9pk build.
+            # Redirect them to fedimint-controlled mirrors of the same commits.
+            # See fedimint/fedimint#8810.
             git config --global url."https://github.com/fedimint/avahi-sys".insteadOf "https://github.com/Start9Labs/avahi-sys"
+            git config --global url."https://github.com/fedimint/jsonpath".insteadOf "https://github.com/Start9Labs/jsonpath"
             export CARGO_NET_GIT_FETCH_WITH_CLI=true
             mkdir -p web/dist/static
             ./check-git-hash.sh


### PR DESCRIPTION
Follow-up to the avahi-sys s9pk fix (#8881). The `v0.12.0-beta.1` release build got **past** avahi-sys (the mirror redirect worked) but hit a **second** deleted Start9 git dep:

```
error: failed to get `jsonpath_lib` as a dependency of package `start-os v0.3.5-rev.1`
  revision 1cacbd64afa2e1941a21fef06bad14317ba92f30 not found
```

`github.com/Start9Labs/jsonpath` was also deleted in Start9's org reorg. Same fix as avahi-sys: the pinned commit is recoverable (from `freestrings/jsonpath`, the crate's origin), so it's mirrored to **`github.com/fedimint/jsonpath`** (branch `master` @ `1cacbd64`), and this PR adds a second `insteadOf` redirect to both s9pk jobs in `ci-nix.yml`.

### Validated locally so beta.2 won't hit a third one

I audited **all 6** git deps in `start-os v0.3.5.1`'s lockfile and fetch-tested every pinned revision (with the two mirrors applied):

| dep | status |
|-----|--------|
| `Start9Labs/avahi-sys` | dead → mirror `fedimint/avahi-sys` ✅ |
| `Start9Labs/jsonpath` | dead → mirror `fedimint/jsonpath` ✅ (this PR) |
| `dr-bonez/tokio-tar`, `dr-bonez/yajrc`, `Start9Labs/emver-rs`, `Start9Labs/imbl-value` | live, revs fetchable ✅ |

All six resolve, so the next tag's s9pk build should complete. (s9pk jobs are tag-only, so this takes effect on the next tag — `v0.12.0-beta.1` shipped without s9pk.)

Part of #8810.