### PR TITLE
fix(iroh): point iroh 1.0 endpoints at Fedimint relays

### DIFF
--- a/fedimint-connectors/src/iroh.rs
+++ b/fedimint-connectors/src/iroh.rs
@@ -18,7 +18,9 @@ use fedimint_core::module::{
     ApiError, ApiMethod, ApiRequestErased, FEDIMINT_API_ALPN, FEDIMINT_GATEWAY_ALPN,
     IrohApiRequest, IrohGatewayRequest, IrohGatewayResponse,
 };
-use fedimint_core::net::iroh::{IROH_IDLE_TIMEOUT, IROH_KEEP_ALIVE_INTERVAL};
+use fedimint_core::net::iroh::{
+    DEFAULT_IROH_V1_RELAYS, IROH_IDLE_TIMEOUT, IROH_KEEP_ALIVE_INTERVAL,
+};
 
 /// The maximum number of bytes we are willing to buffer when reading an API
 /// response from an iroh QUIC stream. This must be large enough to accommodate
@@ -220,7 +222,7 @@ impl IrohConnector {
             // default (the iroh 1.0 publishers filter out direct addresses), so
             // the client must be able to dial via relays; `RelayMode::Disabled`
             // would disable dialing them, not just registration.
-            let mut builder = builder.relay_mode(iroh_next::RelayMode::Default);
+            let mut builder = builder.relay_mode(default_iroh_v1_relay_mode());
 
             #[cfg(not(target_family = "wasm"))]
             if iroh_enable_dht {
@@ -645,6 +647,24 @@ fn quic_transport_config_next() -> iroh_next::endpoint::QuicTransportConfig {
         ))
         .keep_alive_interval(IROH_KEEP_ALIVE_INTERVAL)
         .build()
+}
+
+/// Relay mode selecting the Fedimint-operated Iroh 1.0 relays.
+///
+/// `RelayMode::Default` would pick n0's public relays instead, so every
+/// `iroh_next` endpoint that has no operator-configured relay list uses this.
+/// Only the home-relay selection is constrained: iroh still dials peers via
+/// whatever relay URL their address record advertises, including relays absent
+/// from this map.
+pub fn default_iroh_v1_relay_mode() -> iroh_next::RelayMode {
+    iroh_next::RelayMode::Custom(
+        DEFAULT_IROH_V1_RELAYS
+            .into_iter()
+            .map(|url| {
+                iroh_next::RelayUrl::from_str(url).expect("default Iroh 1.0 relay URL is valid")
+            })
+            .collect(),
+    )
 }
 
 fn connectivity_from_iroh_conn_type(conn_type: &iroh::endpoint::ConnectionType) -> Connectivity {

--- a/fedimint-core/src/net/iroh.rs
+++ b/fedimint-core/src/net/iroh.rs
@@ -18,9 +18,22 @@ use crate::envs::{
     is_env_var_set_opt,
 };
 
+/// Fedimint-operated relays running the Iroh 0.35 relay protocol.
 const DEFAULT_IROH_RELAYS: [&str; 2] = [
     "https://euc1-1.relay.elsirion.fedimint.iroh.link/",
     "https://use1-1.relay.elsirion.fedimint.iroh.link/",
+];
+
+/// Fedimint-operated relays running the Iroh 1.0 relay protocol.
+///
+/// The relay wire protocol changed incompatibly between 0.35 and 1.0, so these
+/// are separate deployments from [`DEFAULT_IROH_RELAYS`] and the two lists must
+/// never be mixed. Kept here next to the 0.35 list so both are maintained in
+/// one place; the `RelayMode` is built by callers that have the `iroh_next`
+/// types in scope.
+pub const DEFAULT_IROH_V1_RELAYS: [&str; 2] = [
+    "https://euc1-2.relay.elsirion.fedimint.iroh.link/",
+    "https://use1-2.relay.elsirion.fedimint.iroh.link/",
 ];
 
 /// QUIC idle timeout used for iroh API endpoints.
@@ -183,8 +196,21 @@ mod tests {
 
     #[test]
     fn default_iroh_relays_are_valid_urls() {
-        for relay in DEFAULT_IROH_RELAYS {
+        for relay in DEFAULT_IROH_RELAYS
+            .into_iter()
+            .chain(DEFAULT_IROH_V1_RELAYS)
+        {
             Url::parse(relay).expect("default Iroh relay URL is valid");
+        }
+    }
+
+    #[test]
+    fn default_iroh_relay_lists_are_disjoint() {
+        for relay in DEFAULT_IROH_V1_RELAYS {
+            assert!(
+                !DEFAULT_IROH_RELAYS.contains(&relay),
+                "{relay} is listed as both an Iroh 0.35 and an Iroh 1.0 relay"
+            );
         }
     }
 }

--- a/fedimint-server/src/net/iroh.rs
+++ b/fedimint-server/src/net/iroh.rs
@@ -1,6 +1,7 @@
 use std::net::SocketAddr;
 
 use anyhow::Context as _;
+use fedimint_connectors::iroh::default_iroh_v1_relay_mode;
 use fedimint_core::envs::{
     FM_IROH_DHT_ENABLE_ENV, FM_IROH_N0_DISCOVERY_ENABLE_ENV, FM_IROH_PKARR_PUBLISHER_ENABLE_ENV,
     FM_IROH_PKARR_RESOLVER_ENABLE_ENV, FM_IROH_RELAYS_ENABLE_ENV, is_env_var_set,
@@ -35,7 +36,7 @@ pub(crate) async fn build_iroh_v1_endpoint(
     alpn: &[u8],
 ) -> anyhow::Result<Endpoint> {
     let relay_mode = if is_env_var_set_opt(FM_IROH_RELAYS_ENABLE_ENV).unwrap_or(true) {
-        RelayMode::Default
+        default_iroh_v1_relay_mode()
     } else {
         warn!(target: LOG_NET_IROH, "Iroh 1.0 relays are disabled");
         RelayMode::Disabled

--- a/fedimint-server/src/net/p2p_connector/iroh/endpoint.rs
+++ b/fedimint-server/src/net/p2p_connector/iroh/endpoint.rs
@@ -8,6 +8,7 @@ use std::borrow::Cow;
 use std::net::SocketAddr;
 
 use anyhow::Context as _;
+use fedimint_connectors::iroh::default_iroh_v1_relay_mode;
 use fedimint_core::envs::{
     FM_IROH_DHT_ENABLE_ENV, FM_IROH_N0_DISCOVERY_ENABLE_ENV, FM_IROH_PKARR_PUBLISHER_ENABLE_ENV,
     FM_IROH_PKARR_RESOLVER_ENABLE_ENV, FM_IROH_RELAYS_ENABLE_ENV, is_env_var_set,
@@ -34,7 +35,7 @@ pub(super) async fn build_iroh_endpoint(
         warn!(target: LOG_NET_IROH, "Iroh relays are disabled");
         RelayMode::Disabled
     } else if iroh_relays.is_empty() {
-        RelayMode::Default
+        default_iroh_v1_relay_mode()
     } else {
         RelayMode::Custom(
             iroh_relays


### PR DESCRIPTION
## Summary

Every iroh 1.0 (`iroh_next`) endpoint was built with `RelayMode::Default`, which resolves to n0's public relays rather than the Fedimint-operated ones. Only the iroh 0.35 builder had our relays hardcoded, so the Fedimint 1.0 relay deployment sat completely unused.

## Details

`fedimint-core/src/net/iroh.rs` hardcodes `DEFAULT_IROH_RELAYS` = `{euc1-1,use1-1}.relay.elsirion.fedimint.iroh.link`, and the 0.35 builder falls back to it whenever no relay list is configured. The three `iroh_next` endpoints had no equivalent and used `RelayMode::Default`, which is `iroh::defaults::prod::default_relay_map()` — `{use1-1,usw1-1,euc1-1,aps1-1}.relay.n0.iroh.link` (see `iroh-1.0.0/src/defaults.rs`):

| Site | Endpoint |
|---|---|
| `fedimint-server/src/net/iroh.rs` | guardian API v1 |
| `fedimint-server/src/net/p2p_connector/iroh/endpoint.rs` | guardian P2P (when no relay override configured) |
| `fedimint-connectors/src/iroh.rs` | client |

This adds `DEFAULT_IROH_V1_RELAYS` = `{euc1-2,use1-2}.relay.elsirion.fedimint.iroh.link` next to the existing 0.35 list, plus a `default_iroh_v1_relay_mode()` helper in `fedimint-connectors`, and uses it at all three sites.

Two design notes:

- **The relay lists are kept separate, not merged.** The relay wire protocol changed incompatibly between 0.35 and 1.0, and these are separate deployments (`-1` hosts run v0.35.0, `-2` hosts run v1.0.0). A test asserts the two lists stay disjoint so a future edit can't cross-contaminate them.
- **The const lives in `fedimint-core` but the `RelayMode` is built in `fedimint-connectors`.** `fedimint-core` deliberately stays on iroh 0.35 and has no `iroh-next` dependency, so it holds the URLs as plain `&str` and callers that already have the 1.0 types in scope construct the `RelayMode`.

Behavior that is unchanged: the guardian P2P site still honors an explicit `FM_IROH_RELAY` override, and `FM_IROH_RELAYS_ENABLE=0` still disables relays everywhere.

## Reviewing

The main thing worth a second opinion is whether constraining the **client's** relay map is safe. It is, but the reasoning is non-obvious: `RelayMode` only determines home-relay selection and net-report probing, not dialing. `start_active_relay` (`iroh-1.0.0/src/socket/transports/relay/actor.rs`) opens a connection to whatever relay URL a peer's address record advertises and consults the relay map only to look up an auth token. So a client on our relay map can still reach peers homed on n0 relays — which matters for interop with any federation still running default iroh.

Also worth a look: whether the guardian API v1 endpoint should accept an operator relay override the way guardian P2P does. I deliberately did not wire one up — `FM_IROH_RELAY` is a single list that today feeds the 0.35 endpoint, and pointing 0.35 relay URLs at a 1.0 endpoint would silently break it. Happy to add a separate flag if reviewers prefer that.

## Testing

- Extended `default_iroh_relays_are_valid_urls` to cover the new list; added `default_iroh_relay_lists_are_disjoint`.
- `just final-lint` and `just check-wasm` pass.
- Manually confirmed all four relay hostnames resolve and serve a live iroh relay over HTTPS.

The real verification is operational: after deploy, `euc1-2` / `use1-2` should start showing connected endpoints, which they currently do not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ER9MGhCfyB2E8wy83uxE5i