### PR TITLE
fix(ci): grant s9pk jobs contents:write so they can attach to the release

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -774,6 +774,8 @@ jobs:
   start9:
     if: github.repository == 'fedimint/fedimint' && github.ref_type == 'tag'
     name: "Build fedimintd.s9pk"
+    permissions:
+      contents: write # softprops/action-gh-release attaches the .s9pk to the release
     needs: manifest
     runs-on: ubuntu-24.04
     timeout-minutes: 180
@@ -885,6 +887,8 @@ jobs:
   start9-gatewayd:
     if: github.repository == 'fedimint/fedimint' && github.ref_type == 'tag'
     name: "Build fedimint-gatewayd.s9pk"
+    permissions:
+      contents: write # softprops/action-gh-release attaches the .s9pk to the release
     needs: manifest
     runs-on: ubuntu-24.04
     timeout-minutes: 180


### PR DESCRIPTION
With the dependency fixes (#8881 avahi-sys, #8895 jsonpath) in place, the s9pk jobs now **build and upload successfully** — but the final "Attach to release" step fails:

```
Found release v0.12.0-beta.2 (id=…)
##[error]Resource not accessible by integration — update-a-release
```

The workflow sets top-level `permissions: contents: read`. The sibling **"Release packages"** job overrides this with `contents: write` (that's why binaries/deb/rpm attach), but the two `start9*` s9pk jobs had no such override, so their `softprops/action-gh-release` step can't write to the release. This only surfaced now because s9pk never got past the *build* step before.

Fix: give both s9pk jobs `permissions: contents: write`, matching the "Release packages" job.

Validated: the built `.s9pk` artifacts from the beta.2 run are intact (fedimintd 708 MB, gatewayd 604 MB) — the build is fine; only the attach was blocked.

Part of #8810.