### PR TITLE
refactor(api): classify public and admin endpoints

### DIFF
--- a/devimint/src/version_constants.rs
+++ b/devimint/src/version_constants.rs
@@ -8,3 +8,5 @@ pub static VERSION_0_11_0_ALPHA: LazyLock<Version> =
     LazyLock::new(|| Version::parse("0.11.0-alpha").expect("version is parsable"));
 pub static VERSION_0_12_0_ALPHA: LazyLock<Version> =
     LazyLock::new(|| Version::parse("0.12.0-alpha").expect("version is parsable"));
+pub static VERSION_0_13_0_ALPHA: LazyLock<Version> =
+    LazyLock::new(|| Version::parse("0.13.0-alpha").expect("version is parsable"));

--- a/docs/api.md
+++ b/docs/api.md
@@ -11,7 +11,10 @@ Backward compatibility of the DKG API (setup process) is currently not guarantee
 APIs of the other core server APIs and modules is internally versioned and
 backward compatible for the purpose of consumption by fedimint clients.
 
-Use [github search to find more details about every API](https://github.com/search?q=repo%3Afedimint%2Ffedimint+api_endpoint%21&type=code).
+Endpoints use `public_api_endpoint!` when guardian authentication is not
+required and `admin_api_endpoint!` when it is required.
+
+Use [GitHub search to find more details about every API](https://github.com/search?q=repo%3Afedimint%2Ffedimint+%2F%28public%7Cadmin%29_api_endpoint%2F&type=code).
 
 ## Core Server API Endpoints
 

--- a/fedimint-core/src/module/mod.rs
+++ b/fedimint-core/src/module/mod.rs
@@ -441,23 +441,12 @@ impl From<DatabaseError> for ApiError {
 pub struct ApiEndpointContext {
     db: Database,
     has_auth: bool,
-    request_auth: Option<ApiAuth>,
 }
 
 impl ApiEndpointContext {
     /// `db` should be isolated.
-    pub fn new(db: Database, has_auth: bool, request_auth: Option<ApiAuth>) -> Self {
-        Self {
-            db,
-            has_auth,
-            request_auth,
-        }
-    }
-
-    /// Returns the auth set on the request (regardless of whether it was
-    /// correct)
-    pub fn request_auth(&self) -> Option<ApiAuth> {
-        self.request_auth.clone()
+    pub fn new(db: Database, has_auth: bool) -> Self {
+        Self { db, has_auth }
     }
 
     /// Whether the request was authenticated as the guardian who controls this
@@ -514,14 +503,16 @@ pub trait TypedApiEndpoint {
 
 pub use serde_json;
 
+/// Declares an API endpoint that does not require guardian authentication.
+///
 /// # Example
 ///
 /// ```rust
 /// # use fedimint_core::module::ApiVersion;
-/// # use fedimint_core::module::{api_endpoint, ApiEndpoint, registry::ModuleInstanceId};
+/// # use fedimint_core::module::{public_api_endpoint, ApiEndpoint, registry::ModuleInstanceId};
 /// struct State;
 ///
-/// let _: ApiEndpoint<State> = api_endpoint! {
+/// let _: ApiEndpoint<State> = public_api_endpoint! {
 ///     "/foobar",
 ///     ApiVersion::new(0, 3),
 ///     async |state: &State, _dbtx, params: ()| -> i32 {
@@ -530,7 +521,7 @@ pub use serde_json;
 /// };
 /// ```
 #[macro_export]
-macro_rules! __api_endpoint {
+macro_rules! __public_api_endpoint {
     (
         $path:expr_2021,
         // API version this endpoint was introduced in, at the current consensus level.
@@ -561,7 +552,52 @@ macro_rules! __api_endpoint {
     }};
 }
 
-pub use __api_endpoint as api_endpoint;
+pub use __public_api_endpoint as public_api_endpoint;
+
+/// Declares an API endpoint that verifies guardian authentication before
+/// entering the handler body.
+///
+/// An optional token argument between the context and request binds the
+/// verified [`GuardianAuthToken`](crate::net::auth::GuardianAuthToken) for
+/// handlers that pass the proof of authentication to privileged inner
+/// functions.
+#[macro_export]
+macro_rules! __admin_api_endpoint {
+    (
+        $path:expr_2021,
+        $version_introduced:expr_2021,
+        async |$state:ident: &$state_ty:ty, $context:ident, $auth:ident, $param:ident: $param_ty:ty| -> $resp_ty:ty $body:block
+    ) => {{
+        $crate::module::public_api_endpoint! {
+            $path,
+            $version_introduced,
+            async |$state: &$state_ty, $context, $param: $param_ty| -> $resp_ty {
+                // Match normal function-parameter behavior: duplicate binder
+                // names must fail to compile instead of shadowing.
+                #[allow(unused_variables)]
+                let _ = |$state: (), $context: (), $auth: (), $param: ()| {};
+                let $auth = $crate::net::auth::check_auth($context)?;
+                $body
+            }
+        }
+    }};
+    (
+        $path:expr_2021,
+        $version_introduced:expr_2021,
+        async |$state:ident: &$state_ty:ty, $context:ident, $param:ident: $param_ty:ty| -> $resp_ty:ty $body:block
+    ) => {{
+        $crate::module::public_api_endpoint! {
+            $path,
+            $version_introduced,
+            async |$state: &$state_ty, $context, $param: $param_ty| -> $resp_ty {
+                $crate::net::auth::check_auth($context)?;
+                $body
+            }
+        }
+    }};
+}
+
+pub use __admin_api_endpoint as admin_api_endpoint;
 
 use self::registry::ModuleDecoderRegistry;
 

--- a/fedimint-server/src/config/setup.rs
+++ b/fedimint-server/src/config/setup.rs
@@ -22,9 +22,9 @@ use fedimint_core::envs::{
     FM_IROH_P2P_SECRET_KEY_OVERRIDE_ENV, is_env_var_set,
 };
 use fedimint_core::module::{
-    ApiAuth, ApiEndpoint, ApiEndpointContext, ApiError, ApiRequestErased, ApiVersion, api_endpoint,
+    ApiAuth, ApiEndpoint, ApiEndpointContext, ApiError, ApiRequestErased, ApiVersion,
+    admin_api_endpoint, public_api_endpoint,
 };
-use fedimint_core::net::auth::check_auth;
 use fedimint_core::setup_code::PeerEndpoints;
 use fedimint_core::{PeerId, base32, runtime};
 use fedimint_server_core::setup_ui::ISetupApi;
@@ -740,7 +740,7 @@ impl HasApiContext<SetupApi> for SetupApi {
             _ => false,
         };
 
-        let context = ApiEndpointContext::new(db, is_authenticated, request.auth.clone());
+        let context = ApiEndpointContext::new(db, is_authenticated);
 
         (self, context)
     }
@@ -748,60 +748,55 @@ impl HasApiContext<SetupApi> for SetupApi {
 
 pub fn server_endpoints() -> Vec<ApiEndpoint<SetupApi>> {
     vec![
-        api_endpoint! {
+        public_api_endpoint! {
             SETUP_STATUS_ENDPOINT,
             ApiVersion::new(0, 0),
             async |config: &SetupApi, _c, _v: ()| -> SetupStatus {
                 Ok(config.setup_status().await)
             }
         },
-        api_endpoint! {
+        admin_api_endpoint! {
             SET_LOCAL_PARAMS_ENDPOINT,
             ApiVersion::new(0, 0),
             async |config: &SetupApi, context, request: SetLocalParamsRequest| -> String {
-                check_auth(context)?;
 
                  config.set_local_parameters(request.name, request.federation_name, request.disable_base_fees, request.enabled_modules, request.federation_size)
                     .await
                     .map_err(|e| ApiError::bad_request(e.to_string()))
             }
         },
-        api_endpoint! {
+        admin_api_endpoint! {
             ADD_PEER_SETUP_CODE_ENDPOINT,
             ApiVersion::new(0, 0),
             async |config: &SetupApi, context, info: String| -> String {
-                check_auth(context)?;
 
                 config.add_peer_setup_code(info.clone())
                     .await
                     .map_err(|e|ApiError::bad_request(e.to_string()))
             }
         },
-        api_endpoint! {
+        admin_api_endpoint! {
             RESET_PEER_SETUP_CODES_ENDPOINT,
             ApiVersion::new(0, 0),
             async |config: &SetupApi, context, _v: ()| -> () {
-                check_auth(context)?;
 
                 config.reset_setup_codes().await;
 
                 Ok(())
             }
         },
-        api_endpoint! {
+        admin_api_endpoint! {
             GET_SETUP_CODE_ENDPOINT,
             ApiVersion::new(0, 0),
             async |config: &SetupApi, context, _request: ()| -> Option<String> {
-                check_auth(context)?;
 
                 Ok(config.setup_code().await)
             }
         },
-        api_endpoint! {
+        admin_api_endpoint! {
             START_DKG_ENDPOINT,
             ApiVersion::new(0, 0),
             async |config: &SetupApi, context, _v: ()| -> () {
-                check_auth(context)?;
 
                 config.start_dkg().await.map_err(|e| ApiError::server_error(e.to_string()))
             }

--- a/fedimint-server/src/consensus/api.rs
+++ b/fedimint-server/src/consensus/api.rs
@@ -40,12 +40,13 @@ use fedimint_core::invite_code::InviteCode;
 use fedimint_core::module::audit::{Audit, AuditSummary};
 use fedimint_core::module::{
     ApiAuth, ApiEndpoint, ApiEndpointContext, ApiError, ApiRequestErased, ApiResult, ApiVersion,
-    SerdeModuleEncoding, SerdeModuleEncodingBase64, SupportedApiVersionsSummary, api_endpoint,
+    SerdeModuleEncoding, SerdeModuleEncodingBase64, SupportedApiVersionsSummary,
+    admin_api_endpoint, public_api_endpoint,
 };
 use fedimint_core::net::api_announcement::{
     ApiAnnouncement, SignedApiAnnouncement, SignedApiAnnouncementSubmission,
 };
-use fedimint_core::net::auth::{GuardianAuthToken, check_auth};
+use fedimint_core::net::auth::GuardianAuthToken;
 use fedimint_core::secp256k1::{PublicKey, SECP256K1};
 use fedimint_core::session_outcome::{
     SessionOutcome, SessionStatus, SessionStatusV2, SignedSessionOutcome,
@@ -674,10 +675,7 @@ impl HasApiContext<ConsensusApi> for ConsensusApi {
             _ => false,
         };
 
-        (
-            self,
-            ApiEndpointContext::new(db, has_auth, request.auth.clone()),
-        )
+        (self, ApiEndpointContext::new(db, has_auth))
     }
 }
 
@@ -793,14 +791,14 @@ impl IDashboardApi for ConsensusApi {
 
 pub fn server_endpoints() -> Vec<ApiEndpoint<ConsensusApi>> {
     vec![
-        api_endpoint! {
+        public_api_endpoint! {
             VERSION_ENDPOINT,
             ApiVersion::new(0, 0),
             async |fedimint: &ConsensusApi, _context, _v: ()| -> SupportedApiVersionsSummary {
                 Ok(fedimint.api_versions_summary().to_owned())
             }
         },
-        api_endpoint! {
+        public_api_endpoint! {
             SUBMIT_TRANSACTION_ENDPOINT,
             ApiVersion::new(0, 0),
             async |fedimint: &ConsensusApi, _context, transaction: SerdeTransaction| -> SerdeModuleEncoding<TransactionSubmissionOutcome> {
@@ -813,7 +811,7 @@ pub fn server_endpoints() -> Vec<ApiEndpoint<ConsensusApi>> {
                 Ok((&TransactionSubmissionOutcome(fedimint.submit_transaction(transaction).await)).into())
             }
         },
-        api_endpoint! {
+        public_api_endpoint! {
             AWAIT_TRANSACTION_ENDPOINT,
             ApiVersion::new(0, 0),
             async |fedimint: &ConsensusApi, _context, tx_hash: TransactionId| -> TransactionId {
@@ -822,7 +820,7 @@ pub fn server_endpoints() -> Vec<ApiEndpoint<ConsensusApi>> {
                 Ok(tx_hash)
             }
         },
-        api_endpoint! {
+        public_api_endpoint! {
             AWAIT_OUTPUT_OUTCOME_ENDPOINT,
             ApiVersion::new(0, 0),
             async |fedimint: &ConsensusApi, _context, outpoint: OutPoint| -> SerdeModuleEncoding<DynOutputOutcome> {
@@ -834,7 +832,7 @@ pub fn server_endpoints() -> Vec<ApiEndpoint<ConsensusApi>> {
                 Ok(outcome)
             }
         },
-        api_endpoint! {
+        public_api_endpoint! {
             AWAIT_OUTPUTS_OUTCOMES_ENDPOINT,
             ApiVersion::new(0, 8),
             async |fedimint: &ConsensusApi, _context, outpoint_range: OutPointRange| -> Vec<Option<SerdeModuleEncoding<DynOutputOutcome>>> {
@@ -846,21 +844,21 @@ pub fn server_endpoints() -> Vec<ApiEndpoint<ConsensusApi>> {
                 Ok(outcomes)
             }
         },
-        api_endpoint! {
+        public_api_endpoint! {
             INVITE_CODE_ENDPOINT,
             ApiVersion::new(0, 0),
             async |fedimint: &ConsensusApi, _context,  _v: ()| -> String {
                 Ok(fedimint.get_invite_code(fedimint.get_active_api_secret()).await.to_string())
             }
         },
-        api_endpoint! {
+        public_api_endpoint! {
             FEDERATION_ID_ENDPOINT,
             ApiVersion::new(0, 2),
             async |fedimint: &ConsensusApi, _context,  _v: ()| -> String {
                 Ok(fedimint.cfg.calculate_federation_id().to_string())
             }
         },
-        api_endpoint! {
+        public_api_endpoint! {
             CLIENT_CONFIG_ENDPOINT,
             ApiVersion::new(0, 0),
             async |fedimint: &ConsensusApi, _context, _v: ()| -> ClientConfig {
@@ -868,21 +866,21 @@ pub fn server_endpoints() -> Vec<ApiEndpoint<ConsensusApi>> {
             }
         },
         // Helper endpoint for Admin UI that can't parse consensus encoding
-        api_endpoint! {
+        public_api_endpoint! {
             CLIENT_CONFIG_JSON_ENDPOINT,
             ApiVersion::new(0, 0),
             async |fedimint: &ConsensusApi, _context, _v: ()| -> JsonClientConfig {
                 Ok(fedimint.client_cfg.to_json())
             }
         },
-        api_endpoint! {
+        public_api_endpoint! {
             SERVER_CONFIG_CONSENSUS_HASH_ENDPOINT,
             ApiVersion::new(0, 0),
             async |fedimint: &ConsensusApi, _context, _v: ()| -> sha256::Hash {
                 Ok(legacy_consensus_config_hash(&fedimint.cfg.consensus))
             }
         },
-        api_endpoint! {
+        public_api_endpoint! {
             STATUS_ENDPOINT,
             ApiVersion::new(0, 0),
             async |fedimint: &ConsensusApi, _context, _v: ()| -> StatusResponse {
@@ -891,21 +889,21 @@ pub fn server_endpoints() -> Vec<ApiEndpoint<ConsensusApi>> {
                     federation: Some(fedimint.get_federation_status().await?)
                 })}
         },
-        api_endpoint! {
+        public_api_endpoint! {
             SETUP_STATUS_ENDPOINT,
             ApiVersion::new(0, 0),
             async |_f: &ConsensusApi, _c, _v: ()| -> SetupStatus {
                 Ok(SetupStatus::ConsensusIsRunning)
             }
         },
-        api_endpoint! {
+        public_api_endpoint! {
             CONSENSUS_ORD_LATENCY_ENDPOINT,
             ApiVersion::new(0, 0),
             async |fedimint: &ConsensusApi, _c, _v: ()| -> Option<Duration> {
                 Ok(*fedimint.ord_latency_receiver.borrow())
             }
         },
-        api_endpoint! {
+        public_api_endpoint! {
             P2P_CONNECTION_STATUS_ENDPOINT,
             ApiVersion::new(0, 0),
             async |fedimint: &ConsensusApi, _c, _v: ()| -> BTreeMap<PeerId, Option<P2PConnectionStatus>> {
@@ -915,67 +913,64 @@ pub fn server_endpoints() -> Vec<ApiEndpoint<ConsensusApi>> {
                     .collect())
             }
         },
-        api_endpoint! {
+        public_api_endpoint! {
             SESSION_COUNT_ENDPOINT,
             ApiVersion::new(0, 0),
             async |fedimint: &ConsensusApi, _context, _v: ()| -> u64 {
                 Ok(fedimint.session_count().await)
             }
         },
-        api_endpoint! {
+        public_api_endpoint! {
             AWAIT_SESSION_OUTCOME_ENDPOINT,
             ApiVersion::new(0, 0),
             async |fedimint: &ConsensusApi, _context, index: u64| -> SerdeModuleEncoding<SessionOutcome> {
                 Ok((&fedimint.await_signed_session_outcome(index).await.session_outcome).into())
             }
         },
-        api_endpoint! {
+        public_api_endpoint! {
             AWAIT_SIGNED_SESSION_OUTCOME_ENDPOINT,
             ApiVersion::new(0, 0),
             async |fedimint: &ConsensusApi, _context, index: u64| -> SerdeModuleEncoding<SignedSessionOutcome> {
                 Ok((&fedimint.await_signed_session_outcome(index).await).into())
             }
         },
-        api_endpoint! {
+        public_api_endpoint! {
             SESSION_STATUS_ENDPOINT,
             ApiVersion::new(0, 1),
             async |fedimint: &ConsensusApi, _context, index: u64| -> SerdeModuleEncoding<SessionStatus> {
                 Ok((&SessionStatus::from(fedimint.session_status(index).await)).into())
             }
         },
-        api_endpoint! {
+        public_api_endpoint! {
             SESSION_STATUS_V2_ENDPOINT,
             ApiVersion::new(0, 5),
             async |fedimint: &ConsensusApi, _context, index: u64| -> SerdeModuleEncodingBase64<SessionStatusV2> {
                 Ok((&fedimint.session_status(index).await).into())
             }
         },
-        api_endpoint! {
+        admin_api_endpoint! {
             SHUTDOWN_ENDPOINT,
             ApiVersion::new(0, 3),
             async |fedimint: &ConsensusApi, context, index: Option<u64>| -> () {
-                check_auth(context)?;
                 fedimint.shutdown(index);
                 Ok(())
             }
         },
-        api_endpoint! {
+        admin_api_endpoint! {
             AUDIT_ENDPOINT,
             ApiVersion::new(0, 0),
             async |fedimint: &ConsensusApi, context, _v: ()| -> AuditSummary {
-                check_auth(context)?;
                 Ok(fedimint.get_federation_audit().await?)
             }
         },
-        api_endpoint! {
+        admin_api_endpoint! {
             GUARDIAN_CONFIG_BACKUP_ENDPOINT,
             ApiVersion::new(0, 2),
-            async |fedimint: &ConsensusApi, context, _v: ()| -> GuardianConfigBackup {
-                let auth = check_auth(context)?;
+            async |fedimint: &ConsensusApi, context, auth, _v: ()| -> GuardianConfigBackup {
                 Ok(fedimint.get_guardian_config_backup(&auth))
             }
         },
-        api_endpoint! {
+        public_api_endpoint! {
             BACKUP_ENDPOINT,
             ApiVersion::new(0, 0),
             async |fedimint: &ConsensusApi, context, request: SignedBackupRequest| -> () {
@@ -988,7 +983,7 @@ pub fn server_endpoints() -> Vec<ApiEndpoint<ConsensusApi>> {
 
             }
         },
-        api_endpoint! {
+        public_api_endpoint! {
             RECOVER_ENDPOINT,
             ApiVersion::new(0, 0),
             async |fedimint: &ConsensusApi, context, id: PublicKey| -> Option<ClientBackupSnapshot> {
@@ -998,76 +993,72 @@ pub fn server_endpoints() -> Vec<ApiEndpoint<ConsensusApi>> {
                     .handle_recover_request(&mut dbtx, id).await)
             }
         },
-        api_endpoint! {
+        admin_api_endpoint! {
             AUTH_ENDPOINT,
             ApiVersion::new(0, 0),
             async |_fedimint: &ConsensusApi, context, _v: ()| -> () {
-                check_auth(context)?;
                 Ok(())
             }
         },
-        api_endpoint! {
+        public_api_endpoint! {
             API_ANNOUNCEMENTS_ENDPOINT,
             ApiVersion::new(0, 3),
             async |fedimint: &ConsensusApi, _context, _v: ()| -> BTreeMap<PeerId, SignedApiAnnouncement> {
                 Ok(fedimint.api_announcements().await)
             }
         },
-        api_endpoint! {
+        public_api_endpoint! {
             SUBMIT_API_ANNOUNCEMENT_ENDPOINT,
             ApiVersion::new(0, 3),
             async |fedimint: &ConsensusApi, _context, submission: SignedApiAnnouncementSubmission| -> () {
                 fedimint.submit_api_announcement(submission.peer_id, submission.signed_api_announcement).await
             }
         },
-        api_endpoint! {
+        admin_api_endpoint! {
             SIGN_API_ANNOUNCEMENT_ENDPOINT,
             ApiVersion::new(0, 3),
             async |fedimint: &ConsensusApi, context, new_url: SafeUrl| -> SignedApiAnnouncement {
-                check_auth(context)?;
                 Ok(fedimint.sign_api_announcement(new_url).await)
             }
         },
-        api_endpoint! {
+        public_api_endpoint! {
             GUARDIAN_METADATA_ENDPOINT,
             ApiVersion::new(0, 9),
             async |fedimint: &ConsensusApi, _context, _v: ()| -> BTreeMap<PeerId, fedimint_core::net::guardian_metadata::SignedGuardianMetadata> {
                 Ok(fedimint.guardian_metadata_list().await)
             }
         },
-        api_endpoint! {
+        public_api_endpoint! {
             SUBMIT_GUARDIAN_METADATA_ENDPOINT,
             ApiVersion::new(0, 9),
             async |fedimint: &ConsensusApi, _context, submission: fedimint_core::net::guardian_metadata::SignedGuardianMetadataSubmission| -> () {
                 fedimint.submit_guardian_metadata(submission.peer_id, submission.signed_guardian_metadata).await
             }
         },
-        api_endpoint! {
+        admin_api_endpoint! {
             SIGN_GUARDIAN_METADATA_ENDPOINT,
             ApiVersion::new(0, 9),
             async |fedimint: &ConsensusApi, context, metadata: fedimint_core::net::guardian_metadata::GuardianMetadata| -> fedimint_core::net::guardian_metadata::SignedGuardianMetadata {
-                check_auth(context)?;
                 Ok(fedimint.sign_guardian_metadata(metadata).await)
             }
         },
-        api_endpoint! {
+        public_api_endpoint! {
             FEDIMINTD_VERSION_ENDPOINT,
             ApiVersion::new(0, 4),
             async |fedimint: &ConsensusApi, _context, _v: ()| -> String {
                 Ok(fedimint.fedimintd_version())
             }
         },
-        api_endpoint! {
+        admin_api_endpoint! {
             BACKUP_STATISTICS_ENDPOINT,
             ApiVersion::new(0, 5),
             async |_fedimint: &ConsensusApi, context, _v: ()| -> BackupStatistics {
-                check_auth(context)?;
                 let db = context.db();
                 let mut dbtx = db.begin_transaction_nc().await;
                 Ok(backup_statistics_static(&mut dbtx).await)
             }
         },
-        api_endpoint! {
+        public_api_endpoint! {
             CHAIN_ID_ENDPOINT,
             ApiVersion::new(0, 9),
             async |fedimint: &ConsensusApi, _context, _v: ()| -> ChainId {

--- a/justfile.fedimint.just
+++ b/justfile.fedimint.just
@@ -357,7 +357,7 @@ ai-generate-api-docs:
   aider \
     --no-auto-commits --no-git \
     --message \
-      "Go through API endpoint functions (defined with Rust api_endpoint! macro) and create/update the api.md file documenting the name of the endpoint (resolve the name to value of the constant used), its arguments and return value and the purpose of the API call. When using non-primitive types defined by our project, make the name in the output link to our documentation page for it: 'https://docs.fedimint.org/?search=TypeNameHere'" \
+      "Go through API endpoint functions (defined with Rust public_api_endpoint! and admin_api_endpoint! macros) and create/update the api.md file documenting the public/admin macro convention, each endpoint's name (resolve the name to the value of the constant used), arguments, return value, and purpose. When using non-primitive types defined by our project, make the name in the output link to our documentation page for it: 'https://docs.fedimint.org/?search=TypeNameHere'" \
     ./fedimint-core/src/endpoint_constants.rs \
     ./fedimint-server/src/consensus/api.rs \
     ./modules/fedimint-meta-server/src/lib.rs \

--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -22,7 +22,7 @@ use fedimint_core::envs::{FM_ENABLE_MODULE_LNV1_ENV, is_env_var_set_opt};
 use fedimint_core::module::audit::Audit;
 use fedimint_core::module::{
     Amounts, ApiEndpoint, ApiEndpointContext, ApiVersion, CoreConsensusVersion, InputMeta,
-    ModuleConsensusVersion, ModuleInit, TransactionItemAmounts, api_endpoint,
+    ModuleConsensusVersion, ModuleInit, TransactionItemAmounts, public_api_endpoint,
 };
 use fedimint_core::secp256k1::{Message, PublicKey, SECP256K1};
 use fedimint_core::task::sleep;
@@ -832,7 +832,7 @@ impl ServerModule for Lightning {
 
     fn api_endpoints(&self) -> Vec<ApiEndpoint<Self>> {
         vec![
-            api_endpoint! {
+            public_api_endpoint! {
                 BLOCK_COUNT_ENDPOINT,
                 ApiVersion::new(0, 0),
                 async |module: &Lightning, context, _v: ()| -> Option<u64> {
@@ -841,7 +841,7 @@ impl ServerModule for Lightning {
                     Ok(Some(module.consensus_block_count(&mut dbtx).await))
                 }
             },
-            api_endpoint! {
+            public_api_endpoint! {
                 ACCOUNT_ENDPOINT,
                 ApiVersion::new(0, 0),
                 async |module: &Lightning, context, contract_id: ContractId| -> Option<ContractAccount> {
@@ -852,7 +852,7 @@ impl ServerModule for Lightning {
                         .await)
                 }
             },
-            api_endpoint! {
+            public_api_endpoint! {
                 AWAIT_ACCOUNT_ENDPOINT,
                 ApiVersion::new(0, 0),
                 async |module: &Lightning, context, contract_id: ContractId| -> ContractAccount {
@@ -861,7 +861,7 @@ impl ServerModule for Lightning {
                         .await)
                 }
             },
-            api_endpoint! {
+            public_api_endpoint! {
                 AWAIT_BLOCK_HEIGHT_ENDPOINT,
                 ApiVersion::new(0, 0),
                 async |module: &Lightning, context, block_height: u64| -> () {
@@ -871,28 +871,28 @@ impl ServerModule for Lightning {
                     Ok(())
                 }
             },
-            api_endpoint! {
+            public_api_endpoint! {
                 AWAIT_OUTGOING_CONTRACT_CANCELLED_ENDPOINT,
                 ApiVersion::new(0, 0),
                 async |module: &Lightning, context, contract_id: ContractId| -> ContractAccount {
                     Ok(module.wait_outgoing_contract_account_cancelled(context, contract_id).await)
                 }
             },
-            api_endpoint! {
+            public_api_endpoint! {
                 GET_DECRYPTED_PREIMAGE_STATUS,
                 ApiVersion::new(0, 0),
                 async |module: &Lightning, context, contract_id: ContractId| -> (IncomingContractAccount, DecryptedPreimageStatus) {
                     Ok(module.get_decrypted_preimage_status(context, contract_id).await)
                 }
             },
-            api_endpoint! {
+            public_api_endpoint! {
                 AWAIT_PREIMAGE_DECRYPTION,
                 ApiVersion::new(0, 0),
                 async |module: &Lightning, context, contract_id: ContractId| -> (IncomingContractAccount, Option<Preimage>) {
                     Ok(module.wait_preimage_decrypted(context, contract_id).await)
                 }
             },
-            api_endpoint! {
+            public_api_endpoint! {
                 OFFER_ENDPOINT,
                 ApiVersion::new(0, 0),
                 async |module: &Lightning, context, payment_hash: bitcoin_hashes::sha256::Hash| -> Option<IncomingContractOffer> {
@@ -903,7 +903,7 @@ impl ServerModule for Lightning {
                         .await)
                }
             },
-            api_endpoint! {
+            public_api_endpoint! {
                 AWAIT_OFFER_ENDPOINT,
                 ApiVersion::new(0, 0),
                 async |module: &Lightning, context, payment_hash: bitcoin_hashes::sha256::Hash| -> IncomingContractOffer {
@@ -912,7 +912,7 @@ impl ServerModule for Lightning {
                         .await)
                 }
             },
-            api_endpoint! {
+            public_api_endpoint! {
                 LIST_GATEWAYS_ENDPOINT,
                 ApiVersion::new(0, 0),
                 async |module: &Lightning, context, _v: ()| -> Vec<LightningGatewayAnnouncement> {
@@ -921,7 +921,7 @@ impl ServerModule for Lightning {
                     Ok(module.list_gateways(&mut dbtx).await)
                 }
             },
-            api_endpoint! {
+            public_api_endpoint! {
                 REGISTER_GATEWAY_ENDPOINT,
                 ApiVersion::new(0, 0),
                 async |module: &Lightning, context, gateway: LightningGatewayAnnouncement| -> () {
@@ -932,7 +932,7 @@ impl ServerModule for Lightning {
                     Ok(())
                 }
             },
-            api_endpoint! {
+            public_api_endpoint! {
                 REMOVE_GATEWAY_CHALLENGE_ENDPOINT,
                 ApiVersion::new(0, 1),
                 async |module: &Lightning, context, gateway_id: PublicKey| -> Option<sha256::Hash> {
@@ -941,7 +941,7 @@ impl ServerModule for Lightning {
                     Ok(module.get_gateway_remove_challenge(gateway_id, &mut dbtx).await)
                 }
             },
-            api_endpoint! {
+            public_api_endpoint! {
                 REMOVE_GATEWAY_ENDPOINT,
                 ApiVersion::new(0, 1),
                 async |module: &Lightning, context, remove_gateway_request: RemoveGatewayRequest| -> bool {

--- a/modules/fedimint-lnv2-server/src/lib.rs
+++ b/modules/fedimint-lnv2-server/src/lib.rs
@@ -25,9 +25,9 @@ use fedimint_core::envs::{FM_ENABLE_MODULE_LNV2_ENV, is_env_var_set_opt};
 use fedimint_core::module::audit::Audit;
 use fedimint_core::module::{
     Amounts, ApiEndpoint, ApiError, ApiVersion, CoreConsensusVersion, InputMeta,
-    ModuleConsensusVersion, ModuleInit, TransactionItemAmounts, api_endpoint,
+    ModuleConsensusVersion, ModuleInit, TransactionItemAmounts, admin_api_endpoint,
+    public_api_endpoint,
 };
-use fedimint_core::net::auth::check_auth;
 use fedimint_core::task::timeout;
 use fedimint_core::time::duration_since_epoch;
 use fedimint_core::util::SafeUrl;
@@ -627,7 +627,7 @@ impl ServerModule for Lightning {
 
     fn api_endpoints(&self) -> Vec<ApiEndpoint<Self>> {
         vec![
-            api_endpoint! {
+            public_api_endpoint! {
                 CONSENSUS_BLOCK_COUNT_ENDPOINT,
                 ApiVersion::new(0, 0),
                 async |module: &Lightning, context, _params : () | -> u64 {
@@ -637,7 +637,7 @@ impl ServerModule for Lightning {
                     Ok(module.consensus_block_count(&mut dbtx).await)
                 }
             },
-            api_endpoint! {
+            public_api_endpoint! {
                 AWAIT_INCOMING_CONTRACT_ENDPOINT,
                 ApiVersion::new(0, 0),
                 async |module: &Lightning, context, params: (ContractId, u64) | -> Option<OutPoint> {
@@ -646,7 +646,7 @@ impl ServerModule for Lightning {
                     Ok(module.await_incoming_contract(db, params.0, params.1).await)
                 }
             },
-            api_endpoint! {
+            public_api_endpoint! {
                 AWAIT_PREIMAGE_ENDPOINT,
                 ApiVersion::new(0, 0),
                 async |module: &Lightning, context, params: (OutPoint, u64)| -> Option<[u8; 32]> {
@@ -655,7 +655,7 @@ impl ServerModule for Lightning {
                     Ok(module.await_preimage(db, params.0, params.1).await)
                 }
             },
-            api_endpoint! {
+            public_api_endpoint! {
                 DECRYPTION_KEY_SHARE_ENDPOINT,
                 ApiVersion::new(0, 0),
                 async |_module: &Lightning, context, params: OutPoint| -> DecryptionKeyShare {
@@ -670,7 +670,7 @@ impl ServerModule for Lightning {
                         .await)
                 }
             },
-            api_endpoint! {
+            public_api_endpoint! {
                 OUTGOING_CONTRACT_EXPIRATION_ENDPOINT,
                 ApiVersion::new(0, 0),
                 async |module: &Lightning, context, outpoint: OutPoint| -> Option<(ContractId, u64)> {
@@ -679,7 +679,7 @@ impl ServerModule for Lightning {
                     Ok(module.outgoing_contract_expiration(db, outpoint).await)
                 }
             },
-            api_endpoint! {
+            public_api_endpoint! {
                 AWAIT_INCOMING_CONTRACTS_ENDPOINT,
                 ApiVersion::new(0, 0),
                 async |module: &Lightning, context, params: (u64, usize)| -> (Vec<IncomingContract>, u64) {
@@ -692,29 +692,27 @@ impl ServerModule for Lightning {
                     Ok(module.await_incoming_contracts(db, params.0, params.1).await)
                 }
             },
-            api_endpoint! {
+            admin_api_endpoint! {
                 ADD_GATEWAY_ENDPOINT,
                 ApiVersion::new(0, 0),
                 async |_module: &Lightning, context, gateway: SafeUrl| -> bool {
-                    check_auth(context)?;
 
                     let db = context.db();
 
                     Ok(Lightning::add_gateway(db, gateway).await)
                 }
             },
-            api_endpoint! {
+            admin_api_endpoint! {
                 REMOVE_GATEWAY_ENDPOINT,
                 ApiVersion::new(0, 0),
                 async |_module: &Lightning, context, gateway: SafeUrl| -> bool {
-                    check_auth(context)?;
 
                     let db = context.db();
 
                     Ok(Lightning::remove_gateway(db, gateway).await)
                 }
             },
-            api_endpoint! {
+            public_api_endpoint! {
                 GATEWAYS_ENDPOINT,
                 ApiVersion::new(0, 0),
                 async |_module: &Lightning, context, _params : () | -> Vec<SafeUrl> {

--- a/modules/fedimint-meta-server/src/lib.rs
+++ b/modules/fedimint-meta-server/src/lib.rs
@@ -28,9 +28,8 @@ use fedimint_core::module::audit::Audit;
 use fedimint_core::module::serde_json::Value;
 use fedimint_core::module::{
     ApiEndpoint, ApiError, ApiVersion, CoreConsensusVersion, InputMeta, ModuleConsensusVersion,
-    ModuleInit, TransactionItemAmounts, api_endpoint, serde_json,
+    ModuleInit, TransactionItemAmounts, admin_api_endpoint, public_api_endpoint, serde_json,
 };
-use fedimint_core::net::auth::check_auth;
 use fedimint_core::{InPoint, NumPeers, OutPoint, PeerId, push_db_pair_items};
 use fedimint_logging::LOG_MODULE_META;
 use fedimint_meta_common::config::{
@@ -414,11 +413,10 @@ impl ServerModule for Meta {
 
     fn api_endpoints(&self) -> Vec<ApiEndpoint<Self>> {
         vec![
-            api_endpoint! {
+            admin_api_endpoint! {
                 SUBMIT_ENDPOINT,
                 ApiVersion::new(0, 0),
                 async |module: &Meta, context, request: SubmitRequest| -> () {
-                    check_auth(context)?;
 
                     let db = context.db();
                     let mut dbtx = db.begin_transaction().await;
@@ -428,7 +426,7 @@ impl ServerModule for Meta {
                     Ok(())
                 }
             },
-            api_endpoint! {
+            public_api_endpoint! {
                 GET_CONSENSUS_ENDPOINT,
                 ApiVersion::new(0, 0),
                 async |module: &Meta, context, request: GetConsensusRequest| -> Option<MetaConsensusValue> {
@@ -437,7 +435,7 @@ impl ServerModule for Meta {
                     module.handle_get_consensus_request(&mut dbtx, &request).await
                 }
             },
-            api_endpoint! {
+            public_api_endpoint! {
                 GET_CONSENSUS_REV_ENDPOINT,
                 ApiVersion::new(0, 0),
                 async |module: &Meta, context, request: GetConsensusRequest| -> Option<u64> {
@@ -446,11 +444,10 @@ impl ServerModule for Meta {
                     module.handle_get_consensus_revision_request(&mut dbtx, &request).await
                 }
             },
-            api_endpoint! {
+            admin_api_endpoint! {
                 GET_SUBMISSIONS_ENDPOINT,
                 ApiVersion::new(0, 0),
                 async |module: &Meta, context, request: GetSubmissionsRequest| -> GetSubmissionResponse {
-                    check_auth(context)?;
 
                     let db = context.db();
                     let mut dbtx = db.begin_transaction_nc().await;
@@ -525,7 +522,8 @@ impl Meta {
 // UI Methods for Meta Module
 
 impl Meta {
-    /// UI helper to submit a value change with default auth
+    /// Submits a value after the server UI's `UserAuth` boundary authenticates
+    /// the caller.
     pub async fn handle_submit_request_ui(&self, value: Value) -> Result<(), ApiError> {
         let mut dbtx = self.db.begin_transaction().await;
 
@@ -567,7 +565,8 @@ impl Meta {
         .map(|r| r.unwrap_or(0))
     }
 
-    /// Get the submissions for UI display,
+    /// Gets submissions after the server UI's `UserAuth` boundary authenticates
+    /// the caller.
     pub async fn handle_get_submissions_request_ui(
         &self,
     ) -> Result<BTreeMap<PeerId, Value>, ApiError> {

--- a/modules/fedimint-meta-tests/src/bin/meta-module-tests.rs
+++ b/modules/fedimint-meta-tests/src/bin/meta-module-tests.rs
@@ -4,7 +4,8 @@ use anyhow::{Result, bail};
 use clap::Parser;
 use devimint::cmd;
 use devimint::federation::Client;
-use devimint::util::poll_simple;
+use devimint::util::{FedimintdCmd, poll_simple};
+use devimint::version_constants::VERSION_0_13_0_ALPHA;
 use fedimint_core::PeerId;
 use serde_json::json;
 use tracing::{info, warn};
@@ -34,6 +35,37 @@ async fn sanity_tests() -> anyhow::Result<()> {
 
             async fn get_consensus(client: &Client) -> anyhow::Result<serde_json::Value> {
                 cmd!(client, "module", "meta", "get").out_json().await
+            }
+
+            // Older fedimintd versions do not enforce authentication for these
+            // endpoints, so only assert the new behavior when testing a current server.
+            if *VERSION_0_13_0_ALPHA <= FedimintdCmd::version_or_default().await {
+                cmd!(
+                    client,
+                    "--our-id",
+                    "0",
+                    "--password",
+                    "incorrect",
+                    "module",
+                    "meta",
+                    "get-submissions"
+                )
+                .assert_error_contains("Invalid authorization")
+                .await?;
+
+                cmd!(
+                    client,
+                    "--our-id",
+                    "0",
+                    "--password",
+                    "incorrect",
+                    "module",
+                    "meta",
+                    "submit",
+                    "\"unauthorized\""
+                )
+                .assert_error_contains("Invalid authorization")
+                .await?;
             }
 
             async fn get_submissions(

--- a/modules/fedimint-mint-server/src/lib.rs
+++ b/modules/fedimint-mint-server/src/lib.rs
@@ -26,7 +26,7 @@ use fedimint_core::module::audit::Audit;
 use fedimint_core::module::{
     Amounts, ApiEndpoint, ApiError, ApiVersion, CoreConsensusVersion, InputMeta,
     ModuleConsensusVersion, ModuleInit, SerdeModuleEncodingBase64, TransactionItemAmounts,
-    api_endpoint,
+    public_api_endpoint,
 };
 use fedimint_core::{
     Amount, InPoint, NumPeersExt, OutPoint, PeerId, Tiered, TieredMulti, apply,
@@ -771,7 +771,7 @@ impl ServerModule for Mint {
 
     fn api_endpoints(&self) -> Vec<ApiEndpoint<Self>> {
         vec![
-            api_endpoint! {
+            public_api_endpoint! {
                 NOTE_SPENT_ENDPOINT,
                 ApiVersion::new(0, 1),
                 async |_module: &Mint, context, nonce: Nonce| -> bool {
@@ -780,7 +780,7 @@ impl ServerModule for Mint {
                     Ok(dbtx.get_value(&NonceKey(nonce)).await.is_some())
                 }
             },
-            api_endpoint! {
+            public_api_endpoint! {
                 BLIND_NONCE_USED_ENDPOINT,
                 ApiVersion::new(0, 1),
                 async |_module: &Mint, context, blind_nonce: BlindNonce| -> bool {
@@ -789,7 +789,7 @@ impl ServerModule for Mint {
                     Ok(dbtx.get_value(&BlindNonceKey(blind_nonce)).await.is_some())
                 }
             },
-            api_endpoint! {
+            public_api_endpoint! {
                 RECOVERY_COUNT_ENDPOINT,
                 ApiVersion::new(0, 1),
                 async |_module: &Mint, context, _params: ()| -> u64 {
@@ -798,7 +798,7 @@ impl ServerModule for Mint {
                     Ok(get_recovery_count(&mut dbtx).await)
                 }
             },
-            api_endpoint! {
+            public_api_endpoint! {
                 RECOVERY_SLICE_ENDPOINT,
                 ApiVersion::new(0, 1),
                 async |_module: &Mint, context, range: (u64, u64)| -> SerdeModuleEncodingBase64<Vec<RecoveryItem>> {
@@ -807,7 +807,7 @@ impl ServerModule for Mint {
                     Ok((&get_recovery_slice(&mut dbtx, range).await).into())
                 }
             },
-            api_endpoint! {
+            public_api_endpoint! {
                 RECOVERY_SLICE_HASH_ENDPOINT,
                 ApiVersion::new(0, 1),
                 async |_module: &Mint, context, range: (u64, u64)| -> sha256::Hash {
@@ -816,7 +816,7 @@ impl ServerModule for Mint {
                     Ok(get_recovery_slice(&mut dbtx, range).await.consensus_hash())
                 }
             },
-            api_endpoint! {
+            public_api_endpoint! {
                 RECOVERY_BLIND_NONCE_OUTPOINTS_ENDPOINT,
                 ApiVersion::new(0, 1),
                 async |_module: &Mint, context, blind_nonces: Vec<BlindNonce>| -> Vec<OutPoint> {

--- a/modules/fedimint-mintv2-server/src/lib.rs
+++ b/modules/fedimint-mintv2-server/src/lib.rs
@@ -23,7 +23,7 @@ use fedimint_core::envs::{FM_ENABLE_MODULE_MINTV2_ENV, is_env_var_set_opt};
 use fedimint_core::module::audit::Audit;
 use fedimint_core::module::{
     AmountUnit, Amounts, ApiEndpoint, ApiError, ApiVersion, CoreConsensusVersion, InputMeta,
-    ModuleConsensusVersion, ModuleInit, TransactionItemAmounts, api_endpoint,
+    ModuleConsensusVersion, ModuleInit, TransactionItemAmounts, public_api_endpoint,
 };
 use fedimint_core::{
     Amount, BitcoinHash, InPoint, NumPeers, NumPeersExt, OutPoint, PeerId, apply,
@@ -504,7 +504,7 @@ impl ServerModule for Mint {
 
     fn api_endpoints(&self) -> Vec<ApiEndpoint<Self>> {
         vec![
-            api_endpoint! {
+            public_api_endpoint! {
                 SIGNATURE_SHARES_ENDPOINT,
                 ApiVersion::new(0, 1),
                 async |_module: &Mint, context, range: fedimint_core::OutPointRange| -> Vec<BlindedSignatureShare> {
@@ -513,7 +513,7 @@ impl ServerModule for Mint {
                     Ok(get_signature_shares(&mut dbtx, range).await)
                 }
             },
-            api_endpoint! {
+            public_api_endpoint! {
                 SIGNATURE_SHARES_RECOVERY_ENDPOINT,
                 ApiVersion::new(0, 1),
                 async |_module: &Mint, context, messages: Vec<tbs::BlindedMessage>| -> Vec<BlindedSignatureShare> {
@@ -522,7 +522,7 @@ impl ServerModule for Mint {
                     get_signature_shares_recovery(&mut dbtx, messages).await
                 }
             },
-            api_endpoint! {
+            public_api_endpoint! {
                 RECOVERY_SLICE_ENDPOINT,
                 ApiVersion::new(0, 1),
                 async |_module: &Mint, context, range: (u64, u64)| -> Vec<RecoveryItem> {
@@ -531,7 +531,7 @@ impl ServerModule for Mint {
                     Ok(get_recovery_slice(&mut dbtx, range).await)
                 }
             },
-            api_endpoint! {
+            public_api_endpoint! {
                 RECOVERY_SLICE_HASH_ENDPOINT,
                 ApiVersion::new(0, 1),
                 async |_module: &Mint, context, range: (u64, u64)| -> bitcoin::hashes::sha256::Hash {
@@ -540,7 +540,7 @@ impl ServerModule for Mint {
                     Ok(get_recovery_slice(&mut dbtx, range).await.consensus_hash())
                 }
             },
-            api_endpoint! {
+            public_api_endpoint! {
                 RECOVERY_COUNT_ENDPOINT,
                 ApiVersion::new(0, 1),
                 async |_module: &Mint, context, _params: ()| -> u64 {

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -61,9 +61,9 @@ use fedimint_core::envs::{
 use fedimint_core::module::audit::Audit;
 use fedimint_core::module::{
     Amounts, ApiEndpoint, ApiError, ApiRequestErased, ApiVersion, CoreConsensusVersion, InputMeta,
-    ModuleConsensusVersion, ModuleInit, TransactionItemAmounts, api_endpoint,
+    ModuleConsensusVersion, ModuleInit, TransactionItemAmounts, admin_api_endpoint,
+    public_api_endpoint,
 };
-use fedimint_core::net::auth::check_auth;
 use fedimint_core::task::TaskGroup;
 #[cfg(not(target_family = "wasm"))]
 use fedimint_core::task::sleep;
@@ -960,7 +960,7 @@ impl ServerModule for Wallet {
 
     fn api_endpoints(&self) -> Vec<ApiEndpoint<Self>> {
         vec![
-            api_endpoint! {
+            public_api_endpoint! {
                 BLOCK_COUNT_ENDPOINT,
                 ApiVersion::new(0, 0),
                 async |module: &Wallet, context, _params: ()| -> u32 {
@@ -969,14 +969,14 @@ impl ServerModule for Wallet {
                     Ok(module.consensus_block_count(&mut dbtx).await)
                 }
             },
-            api_endpoint! {
+            public_api_endpoint! {
                 BLOCK_COUNT_LOCAL_ENDPOINT,
                 ApiVersion::new(0, 0),
                 async |module: &Wallet, _context, _params: ()| -> Option<u32> {
                     Ok(module.get_block_count().ok())
                 }
             },
-            api_endpoint! {
+            public_api_endpoint! {
                 PEG_OUT_FEES_ENDPOINT,
                 ApiVersion::new(0, 0),
                 async |module: &Wallet, context, params: (Address<NetworkUnchecked>, u64)| -> Option<PegOutFees> {
@@ -1011,19 +1011,18 @@ impl ServerModule for Wallet {
                     }
                 }
             },
-            api_endpoint! {
+            public_api_endpoint! {
                 BITCOIN_KIND_ENDPOINT,
                 ApiVersion::new(0, 1),
                 async |module: &Wallet, _context, _params: ()| -> String {
                     Ok(module.btc_rpc.get_bitcoin_rpc_config().kind)
                 }
             },
-            api_endpoint! {
+            admin_api_endpoint! {
                 BITCOIN_RPC_CONFIG_ENDPOINT,
                 ApiVersion::new(0, 1),
                 async |module: &Wallet, context, _params: ()| -> BitcoinRpcConfig {
-                    check_auth(context)?;
-                    let config = module.btc_rpc.get_bitcoin_rpc_config();
+                        let config = module.btc_rpc.get_bitcoin_rpc_config();
 
                     // we need to remove auth, otherwise we'll send over the wire
                     let without_auth = config.url.clone().without_auth().map_err(|()| {
@@ -1036,7 +1035,7 @@ impl ServerModule for Wallet {
                     })
                 }
             },
-            api_endpoint! {
+            public_api_endpoint! {
                 WALLET_SUMMARY_ENDPOINT,
                 ApiVersion::new(0, 1),
                 async |module: &Wallet, context, _params: ()| -> WalletSummary {
@@ -1045,7 +1044,7 @@ impl ServerModule for Wallet {
                     Ok(module.get_wallet_summary(&mut dbtx).await)
                 }
             },
-            api_endpoint! {
+            public_api_endpoint! {
                 MODULE_CONSENSUS_VERSION_ENDPOINT,
                 ApiVersion::new(0, 2),
                 async |module: &Wallet, context, _params: ()| -> ModuleConsensusVersion {
@@ -1054,18 +1053,17 @@ impl ServerModule for Wallet {
                     Ok(module.consensus_module_consensus_version(&mut dbtx).await)
                 }
             },
-            api_endpoint! {
+            public_api_endpoint! {
                 SUPPORTED_MODULE_CONSENSUS_VERSION_ENDPOINT,
                 ApiVersion::new(0, 2),
                 async |_module: &Wallet, _context, _params: ()| -> ModuleConsensusVersion {
                     Ok(MODULE_CONSENSUS_VERSION)
                 }
             },
-            api_endpoint! {
+            admin_api_endpoint! {
                 ACTIVATE_CONSENSUS_VERSION_VOTING_ENDPOINT,
                 ApiVersion::new(0, 2),
                 async |_module: &Wallet, context, _params: ()| -> () {
-                    check_auth(context)?;
 
                     let db = context.db();
                     let mut dbtx = db.begin_transaction().await;
@@ -1074,7 +1072,7 @@ impl ServerModule for Wallet {
                     Ok(())
                 }
             },
-            api_endpoint! {
+            public_api_endpoint! {
                 UTXO_CONFIRMED_ENDPOINT,
                 ApiVersion::new(0, 2),
                 async |module: &Wallet, context, outpoint: bitcoin::OutPoint| -> bool {
@@ -1083,7 +1081,7 @@ impl ServerModule for Wallet {
                     Ok(module.is_utxo_confirmed(&mut dbtx, outpoint).await)
                 }
             },
-            api_endpoint! {
+            public_api_endpoint! {
                 RECOVERY_COUNT_ENDPOINT,
                 ApiVersion::new(0, 1),
                 async |_module: &Wallet, context, _params: ()| -> u64 {
@@ -1092,7 +1090,7 @@ impl ServerModule for Wallet {
                     Ok(get_recovery_count(&mut dbtx).await)
                 }
             },
-            api_endpoint! {
+            public_api_endpoint! {
                 RECOVERY_SLICE_ENDPOINT,
                 ApiVersion::new(0, 1),
                 async |_module: &Wallet, context, range: (u64, u64)| -> Vec<RecoveryItem> {

--- a/modules/fedimint-walletv2-server/src/lib.rs
+++ b/modules/fedimint-walletv2-server/src/lib.rs
@@ -46,7 +46,7 @@ use fedimint_core::envs::{
 use fedimint_core::module::audit::Audit;
 use fedimint_core::module::{
     Amounts, ApiEndpoint, ApiVersion, CoreConsensusVersion, InputMeta, ModuleConsensusVersion,
-    ModuleInit, MultiApiVersion, TransactionItemAmounts, api_endpoint,
+    ModuleInit, MultiApiVersion, TransactionItemAmounts, public_api_endpoint,
 };
 #[cfg(not(target_family = "wasm"))]
 use fedimint_core::task::TaskGroup;
@@ -795,7 +795,7 @@ impl ServerModule for Wallet {
 
     fn api_endpoints(&self) -> Vec<ApiEndpoint<Self>> {
         vec![
-            api_endpoint! {
+            public_api_endpoint! {
                 CONSENSUS_BLOCK_COUNT_ENDPOINT,
                 ApiVersion::new(0, 0),
                 async |module: &Wallet, context, _params: ()| -> u64 {
@@ -804,7 +804,7 @@ impl ServerModule for Wallet {
                     Ok(module.consensus_block_count(&mut dbtx).await)
                 }
             },
-            api_endpoint! {
+            public_api_endpoint! {
                 CONSENSUS_FEERATE_ENDPOINT,
                 ApiVersion::new(0, 0),
                 async |module: &Wallet, context, _params: ()| -> Option<u64> {
@@ -813,7 +813,7 @@ impl ServerModule for Wallet {
                     Ok(module.consensus_feerate(&mut dbtx).await)
                 }
             },
-            api_endpoint! {
+            public_api_endpoint! {
                 FEDERATION_WALLET_ENDPOINT,
                 ApiVersion::new(0, 0),
                 async |_module: &Wallet, context, _params: ()| -> Option<FederationWallet> {
@@ -822,7 +822,7 @@ impl ServerModule for Wallet {
                     Ok(dbtx.get_value(&FederationWalletKey).await)
                 }
             },
-            api_endpoint! {
+            public_api_endpoint! {
                 SEND_FEE_ENDPOINT,
                 ApiVersion::new(0, 0),
                 async |module: &Wallet, context, _params: ()| -> Option<Amount> {
@@ -831,7 +831,7 @@ impl ServerModule for Wallet {
                     Ok(module.send_fee(&mut dbtx).await)
                 }
             },
-            api_endpoint! {
+            public_api_endpoint! {
                 RECEIVE_FEE_ENDPOINT,
                 ApiVersion::new(0, 0),
                 async |module: &Wallet, context, _params: ()| -> Option<Amount> {
@@ -840,7 +840,7 @@ impl ServerModule for Wallet {
                     Ok(module.receive_fee(&mut dbtx).await)
                 }
             },
-            api_endpoint! {
+            public_api_endpoint! {
                 TRANSACTION_ID_ENDPOINT,
                 ApiVersion::new(0, 0),
                 async |module: &Wallet, context, params: OutPoint| -> Option<Txid> {
@@ -849,7 +849,7 @@ impl ServerModule for Wallet {
                     Ok(module.tx_id(&mut dbtx, params).await)
                 }
             },
-            api_endpoint! {
+            public_api_endpoint! {
                 OUTPUT_INFO_SLICE_ENDPOINT,
                 ApiVersion::new(0, 0),
                 async |module: &Wallet, context, params: (u64, u64)| -> Vec<OutputInfo> {
@@ -858,7 +858,7 @@ impl ServerModule for Wallet {
                     Ok(module.get_outputs(&mut dbtx, params.0, params.1).await)
                 }
             },
-            api_endpoint! {
+            public_api_endpoint! {
                 PENDING_TRANSACTION_CHAIN_ENDPOINT,
                 ApiVersion::new(0, 0),
                 async |module: &Wallet, context, _params: ()| -> Vec<TxInfo> {
@@ -867,7 +867,7 @@ impl ServerModule for Wallet {
                     Ok(module.pending_tx_chain(&mut dbtx).await)
                 }
             },
-            api_endpoint! {
+            public_api_endpoint! {
                 TRANSACTION_CHAIN_ENDPOINT,
                 ApiVersion::new(0, 0),
                 async |module: &Wallet, context, _params: ()| -> Vec<TxInfo> {


### PR DESCRIPTION
*Posted by Tau*

## Summary

Split the auth-neutral `api_endpoint!` declaration into explicit `public_api_endpoint!` and `admin_api_endpoint!` declarations so every endpoint advertises its access policy and admin handlers cannot silently omit guardian authentication.

Fixes #8903.

## Details

The previous macro left authentication as an optional line inside each handler. The new admin macro runs `check_auth` before entering the handler body, while the public macro makes the lack of a guardian check explicit at the declaration site.

This migrates every core and module endpoint to one of the two classifications. An additional admin form binds the verified `GuardianAuthToken`, preserving the guardian-config backup endpoint's proof-carrying inner API. The change also removes the now-unused raw `ApiEndpointContext::request_auth` escape hatch.

The meta `submit` and `get-submissions` endpoints now rely on macro-provided verified authentication. Their unused raw-auth parameters are gone, and the UI helpers document their separate `UserAuth` boundary.

## Reviewing

Please check the public/admin classifications, especially endpoints whose policy is less obvious from their names. The guardian-config backup declaration demonstrates the token-binding admin form.

## Testing

The meta integration test now verifies that both privileged endpoints reject an incorrect guardian password with `Invalid authorization`, then exercises their successful authenticated paths.
