### PR TITLE
fix(lnv2): saturate PaymentFee addition instead of overflowing

### DIFF
--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -2284,7 +2284,11 @@ impl IAdminGateway for Gateway {
                 .any(|m| fedimint_lnv2_common::LightningCommonInit::KIND == m.kind);
 
             // Check if the lightning fee + transaction fee is higher than the send limit
-            let send_fees = lightning_fee + transaction_fee;
+            let send_fees = lightning_fee.checked_add(transaction_fee).ok_or_else(|| {
+                AdminGatewayError::GatewayConfigurationError(
+                    "Lightning fee and transaction fee sum overflows".to_string(),
+                )
+            })?;
             if contains_lnv2 && !send_fees.is_within(&PaymentFee::SEND_FEE_LIMIT) {
                 return Err(AdminGatewayError::GatewayConfigurationError(format!(
                     "Total Send fees exceeded {}",
@@ -3029,6 +3033,12 @@ impl Gateway {
         let lightning_fee = fed_config.lightning_fee;
         let transaction_fee = fed_config.transaction_fee;
 
+        // These are gateway-configured fees, but reject rather than wrap if a
+        // misconfiguration makes their sum overflow.
+        let send_fee_default = lightning_fee.checked_add(transaction_fee).ok_or_else(|| {
+            anyhow::anyhow!("Configured lightning fee and transaction fee sum overflows")
+        })?;
+
         Ok(self
             .public_key_v2(federation_id)
             .await
@@ -3036,7 +3046,7 @@ impl Gateway {
                 lightning_public_key: context.lightning_public_key,
                 lightning_alias: Some(context.lightning_alias.clone()),
                 module_public_key,
-                send_fee_default: lightning_fee + transaction_fee,
+                send_fee_default,
                 // The base fee ensures that the gateway does not loose sats sending the payment due
                 // to fees paid on the transaction claiming the outgoing contract or
                 // subsequent transactions spending the newly issued ecash

--- a/modules/fedimint-lnv2-common/src/gateway_api.rs
+++ b/modules/fedimint-lnv2-common/src/gateway_api.rs
@@ -1,4 +1,3 @@
-use std::ops::Add;
 use std::str::FromStr;
 
 use bitcoin::secp256k1::PublicKey;
@@ -243,15 +242,19 @@ impl PaymentFee {
             .checked_add(self.base.msats)
             .expect("The division creates sufficient headroom to add the base fee")
     }
-}
 
-impl Add for PaymentFee {
-    type Output = PaymentFee;
-    fn add(self, rhs: Self) -> Self::Output {
-        PaymentFee {
-            base: Amount::from_msats(self.base.msats.saturating_add(rhs.base.msats)),
-            parts_per_million: self.parts_per_million.saturating_add(rhs.parts_per_million),
-        }
+    /// Adds two fees component-wise, returning `None` if either the base or the
+    /// proportional part would overflow `u64`.
+    ///
+    /// There is deliberately no `Add` impl: the caller must choose how to
+    /// handle overflow for its context (a client can `expect`, a server
+    /// rejects the request), and a silent wrap or saturation here could let
+    /// a crafted fee slip past `SEND_FEE_LIMIT`.
+    pub fn checked_add(self, rhs: PaymentFee) -> Option<PaymentFee> {
+        Some(PaymentFee {
+            base: Amount::from_msats(self.base.msats.checked_add(rhs.base.msats)?),
+            parts_per_million: self.parts_per_million.checked_add(rhs.parts_per_million)?,
+        })
     }
 }
 
@@ -356,7 +359,7 @@ mod tests {
     }
 
     #[test]
-    fn payment_fee_add_saturates_instead_of_wrapping() {
+    fn payment_fee_checked_add_detects_overflow() {
         let huge = PaymentFee {
             base: Amount::from_msats(u64::MAX),
             parts_per_million: u64::MAX,
@@ -365,10 +368,23 @@ mod tests {
             base: Amount::from_msats(1),
             parts_per_million: 1,
         };
-        let sum = huge + one;
-        // must saturate, not wrap to 0 (a wrap would silently bypass SEND_FEE_LIMIT)
-        assert_eq!(sum.base.msats, u64::MAX);
-        assert_eq!(sum.parts_per_million, u64::MAX);
-        assert!(!sum.is_within(&PaymentFee::SEND_FEE_LIMIT));
+        // Overflow in either component yields `None` rather than wrapping past
+        // `SEND_FEE_LIMIT`; the caller decides whether that is a panic or a
+        // rejection.
+        assert!(huge.checked_add(one).is_none());
+        assert!(one.checked_add(huge).is_none());
+
+        // A non-overflowing add sums both components.
+        let a = PaymentFee {
+            base: Amount::from_msats(10),
+            parts_per_million: 20,
+        };
+        let b = PaymentFee {
+            base: Amount::from_msats(3),
+            parts_per_million: 4,
+        };
+        let sum = a.checked_add(b).expect("does not overflow");
+        assert_eq!(sum.base.msats, 13);
+        assert_eq!(sum.parts_per_million, 24);
     }
 }

--- a/modules/fedimint-lnv2-common/src/gateway_api.rs
+++ b/modules/fedimint-lnv2-common/src/gateway_api.rs
@@ -249,8 +249,8 @@ impl Add for PaymentFee {
     type Output = PaymentFee;
     fn add(self, rhs: Self) -> Self::Output {
         PaymentFee {
-            base: self.base + rhs.base,
-            parts_per_million: self.parts_per_million + rhs.parts_per_million,
+            base: Amount::from_msats(self.base.msats.saturating_add(rhs.base.msats)),
+            parts_per_million: self.parts_per_million.saturating_add(rhs.parts_per_million),
         }
     }
 }
@@ -353,5 +353,22 @@ mod tests {
             parts_per_million: 10_000,
         };
         assert!(ok.is_within(&PaymentFee::SEND_FEE_LIMIT));
+    }
+
+    #[test]
+    fn payment_fee_add_saturates_instead_of_wrapping() {
+        let huge = PaymentFee {
+            base: Amount::from_msats(u64::MAX),
+            parts_per_million: u64::MAX,
+        };
+        let one = PaymentFee {
+            base: Amount::from_msats(1),
+            parts_per_million: 1,
+        };
+        let sum = huge + one;
+        // must saturate, not wrap to 0 (a wrap would silently bypass SEND_FEE_LIMIT)
+        assert_eq!(sum.base.msats, u64::MAX);
+        assert_eq!(sum.parts_per_million, u64::MAX);
+        assert!(!sum.is_within(&PaymentFee::SEND_FEE_LIMIT));
     }
 }


### PR DESCRIPTION
### Problem

`impl Add for PaymentFee` (`gateway_api.rs:249`) adds `base` and `parts_per_million` unchecked. The gateway checks `(lightning_fee + transaction_fee).gt(&SEND_FEE_LIMIT)`; in a release build (`overflow-checks` off) a large fee wraps `base` to a small value, so the limit check passes and the oversized fee is persisted — and in a debug/CI build the add panics.

`PaymentFee::absolute_fee` right above already uses saturating/checked arithmetic; `Add` was the outlier.

### Change

`saturating_add` on both fields, so the `gt(SEND_FEE_LIMIT)` comparison rejects the oversized fee instead of being bypassed.

### Testing

`payment_fee_add_saturates_instead_of_wrapping`: `{base: u64::MAX} + {base: 1}` saturates to `u64::MAX` (not `0`) and is `> SEND_FEE_LIMIT`. Passes; without the fix a debug build panics on the add. `cargo build -p fedimint-lnv2-common` clean.