### PR TITLE
chore(nix): update nixpkgs to nixos-26.05

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -21,6 +21,9 @@ tpe = "tpe"
 # appears in bitcoin test addresses
 nd = "nd"
 
+# trait name from the `lightning` crate
+Writeable = "Writeable"
+
 [files]
 extend-exclude = [
   "db/**",

--- a/devimint/src/cfg/lnd.conf
+++ b/devimint/src/cfg/lnd.conf
@@ -4,6 +4,10 @@ listen=0.0.0.0:{listen_port}
 rpclisten=0.0.0.0:{rpc_port}
 restlisten=0.0.0.0:{rest_port}
 noseedbackup=1
+# lnd 0.20 stopped disabling peer bootstrapping on regtest, and bootstrapping
+# into our own tiny network makes lnd dial a peer it is already connected to,
+# tearing down the live channel link and failing payments in flight
+nobootstrap=1
 wtclient.active=false
 sync-freelist=true
 max-commit-fee-rate-anchors=5

--- a/fedimint-client/src/backup.rs
+++ b/fedimint-client/src/backup.rs
@@ -138,7 +138,7 @@ impl ClientBackup {
     /// the backup, temporarily going over the limit is not a big problem.
     pub const PER_MODULE_SIZE_LIMIT_BYTES: usize = 32 * 1024;
 
-    /// Align an ecoded message size up for better privacy
+    /// Align an encoded message size up for better privacy
     fn get_alignment_size(len: usize) -> usize {
         let padding_alignment = Self::PADDING_ALIGNMENT;
         ((len.saturating_sub(1) / padding_alignment) + 1) * padding_alignment

--- a/fedimint-client/src/db.rs
+++ b/fedimint-client/src/db.rs
@@ -695,7 +695,7 @@ pub fn get_core_client_database_migrations()
                         module_instance_id: module_id,
                     };
                     let Some(value) = dbtx.get_value(&old_key).await else {
-                        debug!(target: LOG_CLIENT_DB, %module_id, "No more ClientModuleRecovery keys found for migartion");
+                        debug!(target: LOG_CLIENT_DB, %module_id, "No more ClientModuleRecovery keys found for migration");
                         break;
                     };
 

--- a/flake.lock
+++ b/flake.lock
@@ -520,16 +520,16 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1782651437,
-        "narHash": "sha256-10srBgrJz7JOWzS1KG5BhrwHCUPTcPqZgwNKo5N9YE4=",
+        "lastModified": 1785133411,
+        "narHash": "sha256-Yjv0WEg39KRYS0rBdTbu6Fc/or/ihAKk13W9sQ6VWd0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0a47451dbe2082a660b88a79a83efdc8d85de445",
+        "rev": "2f5a153c270b70cb0f8c11f46d96d6d3bc39f4e3",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   inputs = {
     nixpkgs = {
-      url = "github:nixos/nixpkgs/nixos-25.11";
+      url = "github:nixos/nixpkgs/nixos-26.05";
     };
     nixpkgs-unstable = {
       url = "github:nixos/nixpkgs/nixos-unstable";
@@ -55,6 +55,7 @@
         (import ./nix/overlays/darwin-compile-fixes.nix)
         (import ./nix/overlays/cargo-honggfuzz.nix)
         (import ./nix/overlays/trustedcoin.nix)
+        (import ./nix/overlays/sqlcipher-static.nix)
       ];
     in
     {
@@ -321,7 +322,7 @@
                     pkgs.cargo-deny
                     pkgs.cargo-sort
                     pkgs.parallel
-                    pkgs.nixfmt-rfc-style
+                    pkgs.nixfmt
                     pkgs.just
                     pkgs.time
                     pkgs.gawk
@@ -338,11 +339,11 @@
                     pkgs.git
 
                     # Nix
-                    pkgs.nixfmt-rfc-style
+                    pkgs.nixfmt
                     pkgs.shellcheck
                     pkgs.nil
                     pkgs.convco
-                    pkgs.nodePackages.bash-language-server
+                    pkgs.bash-language-server
                   ]
                   ++ lib.optionals (!stdenv.isAarch64 && !stdenv.isDarwin) [ pkgs.semgrep ]
                   ++ lib.optionals (!stdenv.isDarwin) [

--- a/nix/flakebox.nix
+++ b/nix/flakebox.nix
@@ -439,7 +439,8 @@ in
         // (lib.optionalAttrs (pname != null) { inherit pname; })
         // {
           cargoArtifacts = deps;
-          meta = { inherit mainProgram; };
+          # `mkDerivation` rejects a null `meta.mainProgram`, so only set it when we have one
+          meta = lib.optionalAttrs (mainProgram != null) { inherit mainProgram; };
           cargoBuildCommand = "runLowPrio bash ${./bin/cargo-with-memlimit.sh} build --profile $CARGO_PROFILE";
           cargoExtraArgs = "${extraArgs}";
 

--- a/nix/overlays/sqlcipher-static.nix
+++ b/nix/overlays/sqlcipher-static.nix
@@ -1,0 +1,30 @@
+final: prev: {
+  # `pkgsStatic.sqlcipher` does not build since sqlcipher moved to sqlite's
+  # autosetup build (4.6.1 -> 4.14.0): the TCL extension links against the
+  # shared library, so `make` builds `libsqlite3.so` even though `configure`
+  # was told not to, and linking a shared object fails in a static musl
+  # environment.
+  #
+  # Drop TCL, and with it the shared library fixups in the upstream
+  # `postInstall`, which have nothing left to operate on.
+  sqlcipher = prev.sqlcipher.overrideAttrs (
+    prevAttrs:
+    prev.lib.optionalAttrs prev.stdenv.hostPlatform.isStatic {
+      configureFlags = prevAttrs.configureFlags ++ [ "--disable-tcl" ];
+
+      postInstall = ''
+        mv $out/bin/{sqlite3,sqlcipher}
+        mkdir $out/include/sqlcipher
+        mv $out/include/sqlite3.h $out/include/sqlcipher/sqlite3.h
+        mv $out/include/sqlite3ext.h $out/include/sqlcipher/sqlite3ext.h
+        mv $out/lib/lib{sqlite3,sqlcipher}.a
+        mv $out/lib/pkgconfig/{sqlite3,sqlcipher}.pc
+        mv $out/share/man/man1/{sqlite3,sqlcipher}.1
+        substituteInPlace $out/lib/pkgconfig/sqlcipher.pc \
+          --replace-fail "-lsqlite3" "-lsqlcipher" \
+          --replace-fail "-lz" "-lz -lcrypto" \
+          --replace-fail "includedir}" "includedir}/sqlcipher"
+      '';
+    }
+  );
+}


### PR DESCRIPTION
## Summary

The flake self-check has started failing on PRs — ``ERROR: the `nixpkgs` input is 31 days old (the max allowed is 30)``. The `nixos-25.11` branch has not moved since 2026-06-30, so re-locking within 25.11 would put us at 29 days and fail again within a day or two. This moves the input to `nixos-26.05`, whose tip is 2026-07-27.

## What the new nixpkgs needed

**lnd 0.19.3 → 0.20.1 breaks the LN tests.** From lnd's own 0.20 release notes:

> Previously, automatic peer bootstrapping was disabled for simnet, signet and regtest networks even if the `--nobootstrap` flag was not set. This automatic disabling has now been removed meaning that any test network scripts that rely on bootstrapping being disabled will need to explicitly define the `--nobootstrap` flag.

devimint is exactly such a test network. The only address lnd can bootstrap to is a peer it already has a channel with, so it dials it, and the duplicate connection tears down the live channel link mid-test:

```
DISC: Obtained 1 addrs to bootstrap network with
SRVR: Established outbound connection to: 02d3c8f0…@127.0.0.1:10021
PEER: disconnecting 02d3c8f0…, reason: server: disconnecting peer
HSWC: Removing channel link with ChannelID(38b17220…)
PEER: disconnecting 02d3c8f0…, reason: unable to start peer: unable to send init msg: … broken pipe
```

After that the gateway cannot route and payments fail — `latency_ln_receive` died on `RouteNotFound` from the LDK gateway, `lnv2_module_payments` panicked with `unexpected send state: Refunded`. It is a race, so it does not fail every time; CI lost it twice. `nobootstrap=1` in `devimint/src/cfg/lnd.conf` is the documented migration.

**`pkgsStatic.sqlcipher` no longer builds.** sqlcipher 4.6.1 → 4.14.0 switched to sqlite's autosetup build, where the TCL extension links against the shared library:

```
tclsqlite3.deps.0 = $(libsqlite3.DLL)
```

So `make` builds `libsqlite3.so` even though `configure` reports `Build shared library? no`, and linking a shared object fails under static musl (`relocation R_X86_64_32 against hidden symbol __TMC_END__`). `nixos-unstable` (sqlcipher 4.17.0) is broken the same way, so this is not something waiting for us on a newer channel.

`nix/overlays/sqlcipher-static.nix` passes `--disable-tcl` for static builds, and replaces the upstream `postInstall` with one that drops the shared-library fixups — with no `.so` around, `rename libsqlite3 libsqlcipher $out/lib/libsqlite3*` matches nothing and fails. The output ends up with the same contents as the 4.6.1 build we were getting from 25.11: `bin/sqlcipher`, `lib/libsqlcipher.a`, `lib/pkgconfig`, and the headers under `include/sqlcipher`, which is what `SQLCIPHER_*_LIB_DIR` / `SQLCIPHER_*_STATIC` in `nix/flakebox.nix` point at.

Two smaller ones:

- **`nodePackages` was removed.** `pkgs.nodePackages.bash-language-server` → `pkgs.bash-language-server`. This one aborts dev shell evaluation outright.
- **`mkDerivation` rejects a null `meta.mainProgram`.** `rawBuildPackageGroup` did `meta = { inherit mainProgram; }` unconditionally and `mainProgram` defaults to `null`, so `fedimint-pkgs-group` failed with ``The `env` attribute set can only contain derivation, string, boolean or integer attributes. The `NIX_MAIN_PROGRAM` attribute is of type null.`` Now only set when non-null.

Also dropped the `nixfmt-rfc-style` alias in favour of `nixfmt` — 26.05 warns on it, and it fired on every dev shell evaluation.

The first commit is separate fallout: the newer `typos` in the lint shell flags two real typos (`ecoded`, `migartion`, in a comment and a log message) and the `lightning` crate's `Writeable` trait, which is now allowed in `.typos.toml`. It comes first so that neither commit is red on its own.

## Not addressed here

clightning also jumps 25.09.2 → 26.04.1 with this bump. Nothing in CI has complained about it, but it is the other large version move in here.

## Testing

- `lnv2-module-test.sh payments` locally, before and after the lnd change. Before: `Obtained 1 addrs to bootstrap network with` followed by the link teardown above, mid-test. After: `Auto peer bootstrapping is disabled`, and the only `Removing channel link` lines are at shutdown.
- `nix develop` builds and works: cargo 1.93.0, bash-language-server 5.6.0, nixfmt 1.4.0. This is what exercises the sqlcipher fix — rocksdb, esplora and the static libs all built.
- `nix develop --ignore-environment .#lint --command ./misc/git-hooks/pre-commit` — the CI "Commit check" step — passes. It is what surfaced the `typos` fallout.
- `nix flake check --no-build` passes: every package and all eight dev shells evaluate. On master, before this, it fails on the first package.
- The two remaining eval warnings — a nested list in `nativeBuildInputs`, and `rust.toRustTarget` — come from crane/flakebox upstream, not from this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196iFikUTnbwtwpsveTN6Sz