### PR TITLE
fix(lnv2): check both PaymentFee components against the fee limits

### DIFF
--- a/fedimint-recurringdv2/src/main.rs
+++ b/fedimint-recurringdv2/src/main.rs
@@ -209,7 +209,9 @@ async fn create_contract_and_fetch_invoice(
     let (routing_info, gateway) = select_gateway(gateways, federation_id, gateway_conn).await?;
 
     ensure!(
-        routing_info.receive_fee.le(&PaymentFee::RECEIVE_FEE_LIMIT),
+        routing_info
+            .receive_fee
+            .is_within(&PaymentFee::RECEIVE_FEE_LIMIT),
         "Payment fee exceeds limit"
     );
 

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -2285,7 +2285,7 @@ impl IAdminGateway for Gateway {
 
             // Check if the lightning fee + transaction fee is higher than the send limit
             let send_fees = lightning_fee + transaction_fee;
-            if contains_lnv2 && send_fees.gt(&PaymentFee::SEND_FEE_LIMIT) {
+            if contains_lnv2 && !send_fees.is_within(&PaymentFee::SEND_FEE_LIMIT) {
                 return Err(AdminGatewayError::GatewayConfigurationError(format!(
                     "Total Send fees exceeded {}",
                     PaymentFee::SEND_FEE_LIMIT
@@ -2293,7 +2293,7 @@ impl IAdminGateway for Gateway {
             }
 
             // Check if the transaction fee is higher than the receive limit
-            if contains_lnv2 && transaction_fee.gt(&PaymentFee::RECEIVE_FEE_LIMIT) {
+            if contains_lnv2 && !transaction_fee.is_within(&PaymentFee::RECEIVE_FEE_LIMIT) {
                 return Err(AdminGatewayError::GatewayConfigurationError(format!(
                     "Transaction fees exceeded RECEIVE LIMIT {}",
                     PaymentFee::RECEIVE_FEE_LIMIT

--- a/gateway/integration_tests/src/main.rs
+++ b/gateway/integration_tests/src/main.rs
@@ -185,7 +185,12 @@ async fn config_test(gw_type: LightningNodeType) -> anyhow::Result<()> {
 
                 // Change the routing fees for a specific federation
                 let fed_id = dev_fed.fed().await?.calculate_federation_id();
-                gw.client().set_federation_routing_fee(fed_id.clone(), 20, 20000)
+                // The gateway rejects a lightning fee whose sum with the transaction fee
+                // exceeds `PaymentFee::SEND_FEE_LIMIT` in either component. The default
+                // transaction fee contributes 3_000 parts per million, so the lightning
+                // fee has to stay at or below 12_000 to keep the total within the 15_000
+                // limit.
+                gw.client().set_federation_routing_fee(fed_id.clone(), 20, 10000)
                     .await?;
 
                 let lightning_fee = gw.client().get_lightning_fee(fed_id.clone()).await?;
@@ -194,8 +199,8 @@ async fn config_test(gw_type: LightningNodeType) -> anyhow::Result<()> {
                     "Federation base msat is not 20"
                 );
                 assert_eq!(
-                    lightning_fee.parts_per_million, 20000,
-                    "Federation proportional millionths is not 20000"
+                    lightning_fee.parts_per_million, 10000,
+                    "Federation proportional millionths is not 10000"
                 );
                 info!(target: LOG_TEST, "Verified per-federation routing fees changed");
 

--- a/modules/fedimint-lnv2-client/src/lib.rs
+++ b/modules/fedimint-lnv2-client/src/lib.rs
@@ -588,7 +588,7 @@ impl LightningClientModule {
 
         let (send_fee, expiration_delta) = routing_info.send_parameters(&invoice);
 
-        if !send_fee.le(&PaymentFee::SEND_FEE_LIMIT) {
+        if !send_fee.is_within(&PaymentFee::SEND_FEE_LIMIT) {
             return Err(SendPaymentError::GatewayFeeExceedsLimit);
         }
 
@@ -976,7 +976,7 @@ impl LightningClientModule {
         let send_fee = routing_info.send_fee_default;
 
         anyhow::ensure!(
-            send_fee.le(&PaymentFee::SEND_FEE_LIMIT),
+            send_fee.is_within(&PaymentFee::SEND_FEE_LIMIT),
             "Gateway's default send fee exceeds the limit"
         );
 
@@ -1026,7 +1026,10 @@ impl LightningClientModule {
                 .map_err(ReceiveError::SelectGateway)?,
         };
 
-        if !routing_info.receive_fee.le(&PaymentFee::RECEIVE_FEE_LIMIT) {
+        if !routing_info
+            .receive_fee
+            .is_within(&PaymentFee::RECEIVE_FEE_LIMIT)
+        {
             return Err(ReceiveError::GatewayFeeExceedsLimit);
         }
 

--- a/modules/fedimint-lnv2-common/src/gateway_api.rs
+++ b/modules/fedimint-lnv2-common/src/gateway_api.rs
@@ -184,19 +184,7 @@ impl RoutingInfo {
     }
 }
 
-#[derive(
-    Debug,
-    Clone,
-    Eq,
-    PartialEq,
-    PartialOrd,
-    Hash,
-    Serialize,
-    Deserialize,
-    Encodable,
-    Decodable,
-    Copy,
-)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Encodable, Decodable, Copy)]
 pub struct PaymentFee {
     pub base: Amount,
     pub parts_per_million: u64,
@@ -224,6 +212,17 @@ impl PaymentFee {
         base: Amount::from_sats(50),
         parts_per_million: 5_000,
     };
+
+    /// Returns `true` if this fee is within `limit` in both components.
+    ///
+    /// `absolute_fee` is monotonically increasing in `base` and in
+    /// `parts_per_million`, so a fee is bounded by the limit only when neither
+    /// component exceeds it. This is intentionally a named method rather than a
+    /// derived `PartialOrd`, which orders the fields lexicographically and
+    /// therefore stops at `base` whenever the two bases differ.
+    pub fn is_within(&self, limit: &PaymentFee) -> bool {
+        self.base <= limit.base && self.parts_per_million <= limit.parts_per_million
+    }
 
     pub fn add_to(&self, msats: u64) -> Amount {
         Amount::from_msats(msats.saturating_add(self.absolute_fee(msats)))
@@ -305,5 +304,54 @@ impl FromStr for PaymentFee {
             base,
             parts_per_million,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use fedimint_core::Amount;
+
+    use super::PaymentFee;
+
+    /// A lower `base` must not let an over-limit `parts_per_million` through,
+    /// which is what the lexicographic ordering used to allow.
+    #[test]
+    fn is_within_enforces_both_components() {
+        // base under the limit, ppm over it, on the send side.
+        let over_ppm = PaymentFee {
+            base: Amount::from_sats(0),
+            parts_per_million: 1_000_000,
+        };
+        assert!(!over_ppm.is_within(&PaymentFee::SEND_FEE_LIMIT));
+
+        let over_ppm = PaymentFee {
+            base: Amount::from_sats(0),
+            parts_per_million: 5_000_000,
+        };
+        assert!(!over_ppm.is_within(&PaymentFee::SEND_FEE_LIMIT));
+
+        // Same on the receive side, which has the lower cap of the two.
+        let over_ppm = PaymentFee {
+            base: Amount::from_sats(0),
+            parts_per_million: 500_000,
+        };
+        assert!(!over_ppm.is_within(&PaymentFee::RECEIVE_FEE_LIMIT));
+
+        // The reverse case, which the ordering already rejected.
+        let over_base = PaymentFee {
+            base: Amount::from_sats(101),
+            parts_per_million: 0,
+        };
+        assert!(!over_base.is_within(&PaymentFee::SEND_FEE_LIMIT));
+
+        // Exactly at the limit is accepted.
+        assert!(PaymentFee::SEND_FEE_LIMIT.is_within(&PaymentFee::SEND_FEE_LIMIT));
+
+        // Strictly within on both components is accepted.
+        let ok = PaymentFee {
+            base: Amount::from_sats(50),
+            parts_per_million: 10_000,
+        };
+        assert!(ok.is_within(&PaymentFee::SEND_FEE_LIMIT));
     }
 }


### PR DESCRIPTION
`PaymentFee` derives `PartialOrd`, so the comparisons against `SEND_FEE_LIMIT` and `RECEIVE_FEE_LIMIT` are lexicographic. They compare `base` and return as soon as the two bases differ, without looking at `parts_per_million`.

`absolute_fee` grows with both fields, so that is not the check these call sites want. A fee whose `base` is under the limit passes regardless of what its `parts_per_million` is.

This adds `PaymentFee::is_within`, which requires both components to be within the limit, and drops the `PartialOrd` derive so the ordering is not picked up again by accident. Six call sites compare a fee against a limit and are updated:

- `modules/fedimint-lnv2-client/src/lib.rs`, in `send`, `spendable_amount` and `create_contract_and_fetch_invoice`
- `fedimint-recurringdv2/src/main.rs`, in `create_contract_and_fetch_invoice`
- `gateway/fedimint-gateway-server/src/lib.rs`, in `handle_set_fees_msg` (x2)

### Testing

Added `is_within_enforces_both_components` in `gateway_api.rs`, covering an over-limit `parts_per_million` with an under-limit `base` on both the send and receive limits, the reverse case, and the boundary. Confirmed it fails when `is_within` is reverted to the lexicographic comparison and passes with the fix.

`cargo check --all-targets` is clean for `fedimint-lnv2-common`, `fedimint-lnv2-client`, `fedimint-recurringdv2` and `fedimint-gateway-server`, and `cargo +nightly fmt --check` is clean.

This touches the same struct as #8907, happy to rebase whichever lands second.
