### PR TITLE
fix(mintv2): return an error on duplicate ecash receive

### DIFF
--- a/modules/fedimint-mintv2-client/src/lib.rs
+++ b/modules/fedimint-mintv2-client/src/lib.rs
@@ -62,7 +62,7 @@ use fedimint_mintv2_common::config::{FeeConsensus, MintClientConfig, client_deno
 use fedimint_mintv2_common::{
     Denomination, KIND, MintCommonInit, MintInput, MintModuleTypes, MintOutput, Note, RecoveryItem,
 };
-use futures::{StreamExt, pin_mut};
+use futures::{StreamExt, TryFutureExt, pin_mut};
 use itertools::Itertools;
 use rand::seq::IteratorRandom;
 use serde::{Deserialize, Serialize};
@@ -905,8 +905,7 @@ impl MintClientModule {
         Ok(Some((operation_id, ecash)))
     }
 
-    /// Receive the `ECash` by reissuing the notes and return the total amount
-    /// of the ecash reissued. This method is idempotent.
+    /// Receive the `ECash` by reissuing the notes and return the operation ID.
     pub async fn receive(
         &self,
         ecash: ECash,
@@ -915,7 +914,7 @@ impl MintClientModule {
         let operation_id = OperationId::from_encodable(&ecash);
 
         if self.client_ctx.operation_exists(operation_id).await {
-            return Ok(operation_id);
+            return Err(ReceiveECashError::AlreadyReceived);
         }
 
         if ecash.mint() != Some(self.federation_id) {
@@ -946,8 +945,14 @@ impl MintClientModule {
                 },
                 TransactionBuilder::new().with_inputs(input),
             )
-            .await
-            .map_err(|_| ReceiveECashError::InsufficientFunds)?;
+            .or_else(|_| async {
+                if self.client_ctx.operation_exists(operation_id).await {
+                    Err(ReceiveECashError::AlreadyReceived)
+                } else {
+                    Err(ReceiveECashError::InsufficientFunds)
+                }
+            })
+            .await?;
 
         let mut dbtx = self.client_ctx.module_db().begin_transaction().await;
 
@@ -1237,6 +1242,8 @@ pub enum ReceiveECashError {
     UneconomicalDenomination,
     #[error("Receiving ecash requires additional funds")]
     InsufficientFunds,
+    #[error("The ECash was already received")]
+    AlreadyReceived,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
`receive()` returned `Ok` with the existing operation id when the notes had already been received, so callers cannot tell a duplicate from a fresh receive. Fedi's bridge hit this: it reported success and charged its receive fee again for notes that were already claimed (the v1 mint rejects the duplicate).

Return a new `ReceiveECashError::AlreadyReceived` instead. The early operation-log check is only a fast path since two concurrent receives of the same notes can both pass it. The atomic operation-id check inside `finalize_and_submit_transaction` is what reliably catches the duplicate, so its failure is mapped to `AlreadyReceived` as well (re-checking the operation log there is safe, it is append-only).

Verified with a Fedi bridge regression test against this rev: a second receive of the same notes errors and balance/fee accounting is unchanged.

Description: Generated by Claude Fable 5.
