### PR TITLE
fix(gateway): use the remote peer's policy when building LND route hints

### DIFF
--- a/gateway/fedimint-lightning/src/lnd.rs
+++ b/gateway/fedimint-lightning/src/lnd.rs
@@ -899,7 +899,17 @@ impl ILnRpcClient for GatewayLndClient {
                 })?
                 .into_inner();
 
-            let Some(policy) = info.node1_policy else {
+            // The route hint hop describes the remote peer forwarding a payment
+            // *into* the gateway, so it must carry that peer's advertised channel
+            // policy. `node1`/`node2` are ordered by pubkey (BOLT 7), not by which
+            // side is the gateway, so select the policy belonging to the remote
+            // peer rather than always taking node1's.
+            let policy = if info.node1_pub == chan.remote_pubkey {
+                info.node1_policy
+            } else {
+                info.node2_policy
+            };
+            let Some(policy) = policy else {
                 continue;
             };
             let src_node_id =


### PR DESCRIPTION
The LND route-hint builder in `fedimint-lightning` always reads `node1_policy`, but per BOLT 7 `node1`/`node2` are ordered by pubkey, not by which side is the gateway. When the gateway's pubkey sorts below a peer's, `node1_policy` is the gateway's *own* policy rather than the forwarding peer's — so the route hint advertises the wrong fees/CLTV/HTLC bounds — and when `node1_policy` is absent the hint is dropped entirely even though `node2_policy` is valid.

With `DEFAULT_NUM_ROUTE_HINTS = 1`, the single hint offered on a receive invoice rotates by channel balance, so depending on which channel is picked and how its pubkeys sort, the hint is sometimes correct and sometimes wrong-sided or missing. The result is intermittent `RouteNotFound` failures when paying LNv1 gateway invoices that clear on retry. This selects the policy belonging to the remote (forwarding) peer instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)