### PR TITLE
refactor(encoding): remove blanket SystemTime codecs

### DIFF
--- a/fedimint-client-module/src/oplog.rs
+++ b/fedimint-client-module/src/oplog.rs
@@ -4,7 +4,10 @@ use std::time::SystemTime;
 
 use fedimint_core::core::OperationId;
 use fedimint_core::db::DatabaseTransaction;
-use fedimint_core::encoding::{Decodable, DecodeError, Encodable};
+use fedimint_core::encoding::{
+    Decodable, DecodeError, Encodable, decode_field_from_finite_reader,
+    decode_legacy_system_time_from_finite_reader, encode_legacy_system_time, with_decoding_context,
+};
 use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_core::task::{MaybeSend, MaybeSync};
 use fedimint_core::util::BoxStream;
@@ -80,11 +83,37 @@ pub trait IOperationLog {
 
 /// Represents the outcome of an operation, combining both the outcome value and
 /// its timestamp
-#[derive(Debug, Clone, Serialize, Deserialize, Encodable, Decodable, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct OperationOutcome {
     pub time: SystemTime,
     pub outcome: JsonStringed,
+}
+
+impl Encodable for OperationOutcome {
+    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
+        encode_legacy_system_time(&self.time, writer)?;
+        self.outcome.consensus_encode(writer)
+    }
+}
+
+impl Decodable for OperationOutcome {
+    fn consensus_decode_partial_from_finite_reader<R: std::io::Read>(
+        reader: &mut R,
+        modules: &ModuleDecoderRegistry,
+    ) -> Result<Self, DecodeError> {
+        Ok(Self {
+            time: with_decoding_context(
+                decode_legacy_system_time_from_finite_reader(reader, modules),
+                "Decoding named block field: OperationOutcome{ ... time ... }",
+            )?,
+            outcome: decode_field_from_finite_reader(
+                reader,
+                modules,
+                "Decoding named block field: OperationOutcome{ ... outcome ... }",
+            )?,
+        })
+    }
 }
 
 /// Represents an operation triggered by a user, typically related to sending or

--- a/fedimint-client-module/src/sm/executor.rs
+++ b/fedimint-client-module/src/sm/executor.rs
@@ -4,7 +4,10 @@ use std::time::SystemTime;
 
 use fedimint_core::core::{ModuleInstanceId, OperationId};
 use fedimint_core::db::DatabaseTransaction;
-use fedimint_core::encoding::{Decodable, DecodeError, Encodable};
+use fedimint_core::encoding::{
+    Decodable, DecodeError, Encodable, decode_legacy_system_time_from_finite_reader,
+    encode_legacy_system_time, with_decoding_context,
+};
 use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_core::{apply, async_trait_maybe_send, maybe_add_send_sync};
 
@@ -55,9 +58,29 @@ impl Decodable for ActiveStateKey {
     }
 }
 
-#[derive(Debug, Copy, Clone, Encodable, Decodable)]
+#[derive(Debug, Copy, Clone)]
 pub struct ActiveStateMeta {
     pub created_at: SystemTime,
+}
+
+impl Encodable for ActiveStateMeta {
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<(), io::Error> {
+        encode_legacy_system_time(&self.created_at, writer)
+    }
+}
+
+impl Decodable for ActiveStateMeta {
+    fn consensus_decode_partial_from_finite_reader<R: Read>(
+        reader: &mut R,
+        modules: &ModuleDecoderRegistry,
+    ) -> Result<Self, DecodeError> {
+        Ok(Self {
+            created_at: with_decoding_context(
+                decode_legacy_system_time_from_finite_reader(reader, modules),
+                "Decoding named block field: ActiveStateMeta{ ... created_at ... }",
+            )?,
+        })
+    }
 }
 
 impl ActiveStateMeta {
@@ -117,10 +140,35 @@ impl Decodable for InactiveStateKey {
     }
 }
 
-#[derive(Debug, Copy, Clone, Decodable, Encodable)]
+#[derive(Debug, Copy, Clone)]
 pub struct InactiveStateMeta {
     pub created_at: SystemTime,
     pub exited_at: SystemTime,
+}
+
+impl Encodable for InactiveStateMeta {
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<(), io::Error> {
+        encode_legacy_system_time(&self.created_at, writer)?;
+        encode_legacy_system_time(&self.exited_at, writer)
+    }
+}
+
+impl Decodable for InactiveStateMeta {
+    fn consensus_decode_partial_from_finite_reader<R: Read>(
+        reader: &mut R,
+        modules: &ModuleDecoderRegistry,
+    ) -> Result<Self, DecodeError> {
+        Ok(Self {
+            created_at: with_decoding_context(
+                decode_legacy_system_time_from_finite_reader(reader, modules),
+                "Decoding named block field: InactiveStateMeta{ ... created_at ... }",
+            )?,
+            exited_at: with_decoding_context(
+                decode_legacy_system_time_from_finite_reader(reader, modules),
+                "Decoding named block field: InactiveStateMeta{ ... exited_at ... }",
+            )?,
+        })
+    }
 }
 
 #[apply(async_trait_maybe_send!)]

--- a/fedimint-client/src/db.rs
+++ b/fedimint-client/src/db.rs
@@ -15,8 +15,11 @@ use fedimint_core::db::{
     IDatabaseTransactionOpsCore, IDatabaseTransactionOpsCoreTyped, MODULE_GLOBAL_PREFIX,
     apply_migrations_dbtx, create_database_version_dbtx, get_current_database_version,
 };
-use fedimint_core::encoding::{Decodable, Encodable};
-use fedimint_core::module::registry::ModuleRegistry;
+use fedimint_core::encoding::{
+    Decodable, DecodeError, Encodable, decode_field_from_finite_reader,
+    decode_legacy_system_time_from_finite_reader, encode_legacy_system_time, with_decoding_context,
+};
+use fedimint_core::module::registry::{ModuleDecoderRegistry, ModuleRegistry};
 use fedimint_core::module::{Amounts, SupportedApiVersionsSummary};
 use fedimint_core::{ChainId, PeerId, TransactionId, impl_db_lookup, impl_db_record};
 use fedimint_eventlog::{
@@ -185,11 +188,37 @@ impl_db_record!(
 );
 
 /// Key used to lookup operation log entries in chronological order
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, Encodable, Decodable, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct ChronologicalOperationLogKey {
     pub creation_time: std::time::SystemTime,
     pub operation_id: OperationId,
+}
+
+impl Encodable for ChronologicalOperationLogKey {
+    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
+        encode_legacy_system_time(&self.creation_time, writer)?;
+        self.operation_id.consensus_encode(writer)
+    }
+}
+
+impl Decodable for ChronologicalOperationLogKey {
+    fn consensus_decode_partial_from_finite_reader<D: std::io::Read>(
+        decoder: &mut D,
+        modules: &ModuleDecoderRegistry,
+    ) -> Result<Self, DecodeError> {
+        Ok(Self {
+            creation_time: with_decoding_context(
+                decode_legacy_system_time_from_finite_reader(decoder, modules),
+                "Decoding named block field: ChronologicalOperationLogKey{ ... creation_time ... }",
+            )?,
+            operation_id: decode_field_from_finite_reader(
+                decoder,
+                modules,
+                "Decoding named block field: ChronologicalOperationLogKey{ ... operation_id ... }",
+            )?,
+        })
+    }
 }
 
 #[derive(Debug, Encodable)]
@@ -453,10 +482,36 @@ pub(crate) struct MetaFieldPrefix;
 #[derive(Encodable, Decodable, Debug)]
 pub struct MetaServiceInfoKey;
 
-#[derive(Encodable, Decodable, Debug)]
+#[derive(Debug)]
 pub struct MetaServiceInfo {
     pub last_updated: SystemTime,
     pub revision: u64,
+}
+
+impl Encodable for MetaServiceInfo {
+    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
+        encode_legacy_system_time(&self.last_updated, writer)?;
+        self.revision.consensus_encode(writer)
+    }
+}
+
+impl Decodable for MetaServiceInfo {
+    fn consensus_decode_partial_from_finite_reader<D: std::io::Read>(
+        decoder: &mut D,
+        modules: &ModuleDecoderRegistry,
+    ) -> Result<Self, DecodeError> {
+        Ok(Self {
+            last_updated: with_decoding_context(
+                decode_legacy_system_time_from_finite_reader(decoder, modules),
+                "Decoding named block field: MetaServiceInfo{ ... last_updated ... }",
+            )?,
+            revision: decode_field_from_finite_reader(
+                decoder,
+                modules,
+                "Decoding named block field: MetaServiceInfo{ ... revision ... }",
+            )?,
+        })
+    }
 }
 
 #[derive(

--- a/fedimint-core/src/backup.rs
+++ b/fedimint-core/src/backup.rs
@@ -4,7 +4,11 @@
 //! clients recover from a snapshot, instead of a blank slate.
 use std::time::SystemTime;
 
-use fedimint_core::encoding::{Decodable, Encodable};
+use fedimint_core::encoding::{
+    Decodable, DecodeError, Encodable, decode_field_from_finite_reader,
+    decode_legacy_system_time_from_finite_reader, encode_legacy_system_time, with_decoding_context,
+};
+use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_core::{impl_db_lookup, impl_db_record};
 use serde::{Deserialize, Serialize};
 
@@ -25,11 +29,37 @@ impl_db_record!(
 impl_db_lookup!(key = ClientBackupKey, query_prefix = ClientBackupKeyPrefix);
 
 /// User's backup, received at certain time, containing encrypted payload
-#[derive(Debug, Clone, PartialEq, Eq, Encodable, Decodable, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ClientBackupSnapshot {
     pub timestamp: SystemTime,
     #[serde(with = "fedimint_core::hex::serde")]
     pub data: Vec<u8>,
+}
+
+impl Encodable for ClientBackupSnapshot {
+    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
+        encode_legacy_system_time(&self.timestamp, writer)?;
+        self.data.consensus_encode(writer)
+    }
+}
+
+impl Decodable for ClientBackupSnapshot {
+    fn consensus_decode_partial_from_finite_reader<D: std::io::Read>(
+        decoder: &mut D,
+        modules: &ModuleDecoderRegistry,
+    ) -> Result<Self, DecodeError> {
+        Ok(Self {
+            timestamp: with_decoding_context(
+                decode_legacy_system_time_from_finite_reader(decoder, modules),
+                "Decoding named block field: ClientBackupSnapshot{ ... timestamp ... }",
+            )?,
+            data: decode_field_from_finite_reader(
+                decoder,
+                modules,
+                "Decoding named block field: ClientBackupSnapshot{ ... data ... }",
+            )?,
+        })
+    }
 }
 
 /// Statistics about backups stored in the federation

--- a/fedimint-core/src/core/backup.rs
+++ b/fedimint-core/src/core/backup.rs
@@ -1,7 +1,11 @@
 use std::fmt::{self, Debug};
 
 use bitcoin::hashes::{Hash, sha256};
-use fedimint_core::encoding::{Decodable, Encodable};
+use fedimint_core::encoding::{
+    Decodable, DecodeError, Encodable, decode_field_from_finite_reader,
+    decode_legacy_system_time_from_finite_reader, encode_legacy_system_time, with_decoding_context,
+};
+use fedimint_core::module::registry::ModuleDecoderRegistry;
 use secp256k1::{Keypair, Message, Secp256k1, Signing, Verification};
 use serde::{Deserialize, Serialize};
 
@@ -14,12 +18,44 @@ use serde::{Deserialize, Serialize};
 /// backup with 52 notes is around 5.1K.
 pub const BACKUP_REQUEST_MAX_PAYLOAD_SIZE_BYTES: usize = 128 * 1024;
 
-#[derive(Serialize, Deserialize, Encodable, Decodable)]
+#[derive(Serialize, Deserialize)]
 pub struct BackupRequest {
     pub id: secp256k1::PublicKey,
     #[serde(with = "fedimint_core::hex::serde")]
     pub payload: Vec<u8>,
     pub timestamp: std::time::SystemTime,
+}
+
+impl Encodable for BackupRequest {
+    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
+        self.id.consensus_encode(writer)?;
+        self.payload.consensus_encode(writer)?;
+        encode_legacy_system_time(&self.timestamp, writer)
+    }
+}
+
+impl Decodable for BackupRequest {
+    fn consensus_decode_partial_from_finite_reader<D: std::io::Read>(
+        decoder: &mut D,
+        modules: &ModuleDecoderRegistry,
+    ) -> Result<Self, DecodeError> {
+        Ok(Self {
+            id: decode_field_from_finite_reader(
+                decoder,
+                modules,
+                "Decoding named block field: BackupRequest{ ... id ... }",
+            )?,
+            payload: decode_field_from_finite_reader(
+                decoder,
+                modules,
+                "Decoding named block field: BackupRequest{ ... payload ... }",
+            )?,
+            timestamp: with_decoding_context(
+                decode_legacy_system_time_from_finite_reader(decoder, modules),
+                "Decoding named block field: BackupRequest{ ... timestamp ... }",
+            )?,
+        })
+    }
 }
 
 impl BackupRequest {

--- a/fedimint-core/src/encoding/mod.rs
+++ b/fedimint-core/src/encoding/mod.rs
@@ -281,6 +281,90 @@ pub trait Decodable: Sized {
     }
 }
 
+/// Encodes a timestamp as the legacy `(seconds, nanoseconds)` `SystemTime`
+/// representation.
+///
+/// Existing encoded types use this only to preserve their stored
+/// representation. It panics when `time` precedes the Unix epoch.
+pub fn encode_legacy_system_time<W: std::io::Write>(
+    time: &SystemTime,
+    writer: &mut W,
+) -> Result<(), std::io::Error> {
+    let duration = time
+        .duration_since(UNIX_EPOCH)
+        .expect("timestamps before the Unix epoch are unsupported");
+    duration.consensus_encode_dyn(writer)
+}
+
+/// Decodes a timestamp from the legacy `(seconds, nanoseconds)` representation.
+///
+/// Existing encoded types use this only to preserve their stored
+/// representation.
+pub fn decode_legacy_system_time_from_finite_reader<D: std::io::Read>(
+    decoder: &mut D,
+    modules: &ModuleDecoderRegistry,
+) -> Result<SystemTime, DecodeError> {
+    let duration = Duration::consensus_decode_partial_from_finite_reader(decoder, modules)?;
+    Ok(UNIX_EPOCH + duration)
+}
+
+/// Encodes an optional timestamp in the legacy `SystemTime` representation.
+///
+/// Existing encoded types use this only to preserve their stored
+/// representation.
+pub fn encode_legacy_option_system_time<W: std::io::Write>(
+    time: &Option<SystemTime>,
+    writer: &mut W,
+) -> Result<(), std::io::Error> {
+    match time {
+        Some(time) => {
+            1u8.consensus_encode(writer)?;
+            encode_legacy_system_time(time, writer)
+        }
+        None => 0u8.consensus_encode(writer),
+    }
+}
+
+/// Decodes an optional timestamp in the legacy `SystemTime` representation.
+///
+/// Existing encoded types use this only to preserve their stored
+/// representation.
+pub fn decode_legacy_option_system_time_from_finite_reader<D: std::io::Read>(
+    decoder: &mut D,
+    modules: &ModuleDecoderRegistry,
+) -> Result<Option<SystemTime>, DecodeError> {
+    match u8::consensus_decode_partial_from_finite_reader(decoder, modules)? {
+        0 => Ok(None),
+        1 => Ok(Some(decode_legacy_system_time_from_finite_reader(
+            decoder, modules,
+        )?)),
+        _ => Err(DecodeError::from_str(
+            "Invalid flag for option enum, expected 0 or 1",
+        )),
+    }
+}
+
+/// Decodes a field from a finite reader and annotates errors with its schema
+/// context.
+pub fn decode_field_from_finite_reader<T: Decodable, D: std::io::Read>(
+    decoder: &mut D,
+    modules: &ModuleDecoderRegistry,
+    context: &'static str,
+) -> Result<T, DecodeError> {
+    with_decoding_context(
+        T::consensus_decode_partial_from_finite_reader(decoder, modules),
+        context,
+    )
+}
+
+/// Adds schema context to an error returned while decoding a field.
+pub fn with_decoding_context<T>(
+    result: Result<T, DecodeError>,
+    context: &'static str,
+) -> Result<T, DecodeError> {
+    result.map_err(|error| DecodeError::new_custom(anyhow::Error::new(error).context(context)))
+}
+
 impl Encodable for SafeUrl {
     fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<(), Error> {
         self.to_string().consensus_encode(writer)
@@ -528,23 +612,6 @@ impl Decodable for String {
             d, modules,
         )?)
         .map_err(DecodeError::from_err)
-    }
-}
-
-impl Encodable for SystemTime {
-    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
-        let duration = self.duration_since(UNIX_EPOCH).expect("valid duration");
-        duration.consensus_encode_dyn(writer)
-    }
-}
-
-impl Decodable for SystemTime {
-    fn consensus_decode_partial<D: std::io::Read>(
-        d: &mut D,
-        modules: &ModuleDecoderRegistry,
-    ) -> Result<Self, DecodeError> {
-        let duration = Duration::consensus_decode_partial(d, modules)?;
-        Ok(UNIX_EPOCH + duration)
     }
 }
 
@@ -943,12 +1010,149 @@ mod tests {
     #[derive(Debug, Encodable, Decodable, Eq, PartialEq)]
     struct TestTupleStruct(Vec<u8>, u32);
 
+    #[derive(Debug)]
+    struct TestFiniteReader;
+
+    impl Decodable for TestFiniteReader {
+        fn consensus_decode_partial_from_finite_reader<R: std::io::Read>(
+            reader: &mut R,
+            modules: &ModuleDecoderRegistry,
+        ) -> Result<Self, DecodeError> {
+            let _: Vec<u8> = decode_field_from_finite_reader(
+                reader,
+                modules,
+                "Decoding tuple block TestFiniteReader field field_0",
+            )?;
+            let _: Vec<u8> = decode_field_from_finite_reader(
+                reader,
+                modules,
+                "Decoding tuple block TestFiniteReader field field_1",
+            )?;
+            Ok(Self)
+        }
+    }
+
     #[test_log::test]
     fn test_derive_tuple_struct() {
         let reference = TestTupleStruct(vec![1, 2, 3], 42);
         let bytes = [3, 1, 2, 3, 42];
 
         test_roundtrip_expected(&reference, &bytes);
+    }
+
+    #[test_log::test]
+    fn test_legacy_system_time_encoding() {
+        let time = UNIX_EPOCH + Duration::new(42, 100);
+        let expected = [42, 100];
+        let mut bytes = vec![];
+        encode_legacy_system_time(&time, &mut bytes).expect("encoding to a vector cannot fail");
+        assert_eq!(bytes, expected);
+
+        let mut cursor = Cursor::new(expected);
+        let decoded = decode_legacy_system_time_from_finite_reader(
+            &mut cursor,
+            &ModuleDecoderRegistry::default(),
+        )
+        .expect("valid encoding");
+        assert_eq!(decoded, time);
+    }
+
+    #[test_log::test]
+    fn test_client_backup_snapshot_uses_legacy_system_time_encoding() {
+        let reference = crate::backup::ClientBackupSnapshot {
+            timestamp: UNIX_EPOCH + Duration::new(42, 100),
+            data: vec![1, 2, 3],
+        };
+        let expected = [42, 100, 3, 1, 2, 3];
+
+        test_roundtrip_expected(&reference, &expected);
+    }
+
+    #[test_log::test]
+    fn test_legacy_optional_system_time_encoding() {
+        let time = Some(UNIX_EPOCH + Duration::new(42, 100));
+        let expected = [1, 42, 100];
+        let mut bytes = vec![];
+        encode_legacy_option_system_time(&time, &mut bytes)
+            .expect("encoding to a vector cannot fail");
+        assert_eq!(bytes, expected);
+
+        let mut cursor = Cursor::new(expected);
+        let decoded = decode_legacy_option_system_time_from_finite_reader(
+            &mut cursor,
+            &ModuleDecoderRegistry::default(),
+        )
+        .expect("valid encoding");
+        assert_eq!(decoded, time);
+    }
+
+    #[test_log::test]
+    fn test_legacy_optional_system_time_encoding_none() {
+        let mut bytes = vec![];
+        encode_legacy_option_system_time(&None, &mut bytes)
+            .expect("encoding to a vector cannot fail");
+        assert_eq!(bytes, [0]);
+
+        let mut cursor = Cursor::new(bytes);
+        let decoded = decode_legacy_option_system_time_from_finite_reader(
+            &mut cursor,
+            &ModuleDecoderRegistry::default(),
+        )
+        .expect("valid encoding");
+        assert_eq!(decoded, None);
+    }
+
+    #[test_log::test]
+    fn test_legacy_optional_system_time_encoding_rejects_invalid_flag() {
+        let error = decode_legacy_option_system_time_from_finite_reader(
+            &mut Cursor::new([2]),
+            &ModuleDecoderRegistry::default(),
+        )
+        .expect_err("invalid option flag must fail");
+        assert_eq!(
+            error.to_string(),
+            "Invalid flag for option enum, expected 0 or 1"
+        );
+    }
+
+    #[test_log::test]
+    fn test_legacy_system_time_field_decode_adds_context() {
+        let error = with_decoding_context(
+            decode_legacy_system_time_from_finite_reader(
+                &mut Cursor::new([42]),
+                &ModuleDecoderRegistry::default(),
+            ),
+            "Decoding named block field: Test{ ... timestamp ... }",
+        )
+        .expect_err("truncated timestamp must fail");
+        assert!(
+            error
+                .to_string()
+                .contains("Decoding named block field: Test{ ... timestamp ... }")
+        );
+    }
+
+    #[test_log::test]
+    fn test_finite_reader_shares_decode_limit_between_fields() {
+        let field = vec![0u8; MAX_DECODE_SIZE / 2];
+        let mut bytes = vec![];
+        field
+            .consensus_encode(&mut bytes)
+            .expect("encoding to a vector cannot fail");
+        field
+            .consensus_encode(&mut bytes)
+            .expect("encoding to a vector cannot fail");
+
+        let error = TestFiniteReader::consensus_decode_partial(
+            &mut Cursor::new(bytes),
+            &ModuleDecoderRegistry::default(),
+        )
+        .expect_err("both fields cannot exceed one decode limit");
+        assert!(
+            error
+                .to_string()
+                .contains("Decoding tuple block TestFiniteReader field field_1")
+        );
     }
 
     #[derive(Debug, Encodable, Decodable, Eq, PartialEq)]
@@ -973,11 +1177,6 @@ mod tests {
         for (reference, bytes) in test_cases {
             test_roundtrip_expected(&reference, &bytes);
         }
-    }
-
-    #[test_log::test]
-    fn test_systemtime() {
-        test_roundtrip(&fedimint_core::time::now());
     }
 
     #[test]

--- a/gateway/fedimint-gateway-server-db/src/lib.rs
+++ b/gateway/fedimint-gateway-server-db/src/lib.rs
@@ -10,7 +10,10 @@ use fedimint_core::db::{
     GeneralDbMigrationFnContext, IDatabaseTransactionOpsCore, IDatabaseTransactionOpsCoreTyped,
 };
 use fedimint_core::encoding::btc::NetworkLegacyEncodingWrapper;
-use fedimint_core::encoding::{Decodable, Encodable};
+use fedimint_core::encoding::{
+    Decodable, DecodeError, Encodable, decode_legacy_option_system_time_from_finite_reader,
+    encode_legacy_option_system_time, with_decoding_context,
+};
 use fedimint_core::invite_code::InviteCode;
 use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_core::{Amount, impl_db_lookup, impl_db_record, push_db_pair_items, secp256k1};
@@ -293,7 +296,9 @@ impl<Cap: Send> GatewayDbtxNcExt for DatabaseTransaction<'_, Cap> {
     async fn load_backup_records(&mut self) -> BTreeMap<FederationId, Option<SystemTime>> {
         self.find_by_prefix(&FederationBackupPrefix)
             .await
-            .map(|(key, time): (FederationBackupKey, Option<SystemTime>)| (key.federation_id, time))
+            .map(|(key, time): (FederationBackupKey, FederationBackupTime)| {
+                (key.federation_id, time.0)
+            })
             .collect::<BTreeMap<FederationId, Option<SystemTime>>>()
             .await
     }
@@ -302,7 +307,9 @@ impl<Cap: Send> GatewayDbtxNcExt for DatabaseTransaction<'_, Cap> {
         &mut self,
         federation_id: FederationId,
     ) -> Option<Option<SystemTime>> {
-        self.get_value(&FederationBackupKey { federation_id }).await
+        self.get_value(&FederationBackupKey { federation_id })
+            .await
+            .map(|time| time.0)
     }
 
     async fn save_federation_backup_record(
@@ -310,8 +317,11 @@ impl<Cap: Send> GatewayDbtxNcExt for DatabaseTransaction<'_, Cap> {
         federation_id: FederationId,
         backup_time: Option<SystemTime>,
     ) {
-        self.insert_entry(&FederationBackupKey { federation_id }, &backup_time)
-            .await;
+        self.insert_entry(
+            &FederationBackupKey { federation_id },
+            &FederationBackupTime(backup_time),
+        )
+        .await;
     }
 }
 
@@ -530,9 +540,31 @@ pub struct FederationBackupKey {
 #[derive(Debug, Encodable, Decodable)]
 pub struct FederationBackupPrefix;
 
+#[derive(Debug)]
+/// Gateway backup timestamp stored in the legacy timestamp representation.
+pub struct FederationBackupTime(Option<SystemTime>);
+
+impl Encodable for FederationBackupTime {
+    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
+        encode_legacy_option_system_time(&self.0, writer)
+    }
+}
+
+impl Decodable for FederationBackupTime {
+    fn consensus_decode_partial_from_finite_reader<D: std::io::Read>(
+        decoder: &mut D,
+        modules: &ModuleDecoderRegistry,
+    ) -> Result<Self, DecodeError> {
+        Ok(Self(with_decoding_context(
+            decode_legacy_option_system_time_from_finite_reader(decoder, modules),
+            "Decoding tuple block FederationBackupTime field field_0",
+        )?))
+    }
+}
+
 impl_db_record!(
     key = FederationBackupKey,
-    value = Option<SystemTime>,
+    value = FederationBackupTime,
     db_prefix = DbKeyPrefix::FederationBackup,
 );
 
@@ -760,7 +792,7 @@ async fn migrate_to_v6(mut ctx: GeneralDbMigrationFnContext<'_>) -> Result<(), a
             &FederationBackupKey {
                 federation_id: fed_id.id,
             },
-            &None,
+            &FederationBackupTime(None),
         )
         .await;
     }

--- a/modules/fedimint-ln-client/src/pay.rs
+++ b/modules/fedimint-ln-client/src/pay.rs
@@ -7,8 +7,12 @@ use fedimint_client_module::sm::{ClientSMDatabaseTransaction, State, StateTransi
 use fedimint_client_module::transaction::{ClientInput, ClientInputBundle};
 use fedimint_core::config::FederationId;
 use fedimint_core::core::OperationId;
-use fedimint_core::encoding::{Decodable, Encodable};
+use fedimint_core::encoding::{
+    Decodable, DecodeError, Encodable, decode_field_from_finite_reader,
+    decode_legacy_system_time_from_finite_reader, encode_legacy_system_time, with_decoding_context,
+};
 use fedimint_core::module::Amounts;
+use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_core::task::sleep;
 use fedimint_core::time::duration_since_epoch;
 use fedimint_core::util::FmtCompact as _;
@@ -228,12 +232,50 @@ impl LightningPayCreatedOutgoingLnContract {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct LightningPayFunded {
     pub payload: PayInvoicePayload,
     pub gateway: LightningGateway,
     pub timelock: u32,
     pub funding_time: SystemTime,
+}
+
+impl Encodable for LightningPayFunded {
+    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
+        self.payload.consensus_encode(writer)?;
+        self.gateway.consensus_encode(writer)?;
+        self.timelock.consensus_encode(writer)?;
+        encode_legacy_system_time(&self.funding_time, writer)
+    }
+}
+
+impl Decodable for LightningPayFunded {
+    fn consensus_decode_partial_from_finite_reader<D: std::io::Read>(
+        decoder: &mut D,
+        modules: &ModuleDecoderRegistry,
+    ) -> Result<Self, DecodeError> {
+        Ok(Self {
+            payload: decode_field_from_finite_reader(
+                decoder,
+                modules,
+                "Decoding named block field: LightningPayFunded{ ... payload ... }",
+            )?,
+            gateway: decode_field_from_finite_reader(
+                decoder,
+                modules,
+                "Decoding named block field: LightningPayFunded{ ... gateway ... }",
+            )?,
+            timelock: decode_field_from_finite_reader(
+                decoder,
+                modules,
+                "Decoding named block field: LightningPayFunded{ ... timelock ... }",
+            )?,
+            funding_time: with_decoding_context(
+                decode_legacy_system_time_from_finite_reader(decoder, modules),
+                "Decoding named block field: LightningPayFunded{ ... funding_time ... }",
+            )?,
+        })
+    }
 }
 
 #[derive(

--- a/modules/fedimint-ln-client/src/recurring/mod.rs
+++ b/modules/fedimint-ln-client/src/recurring/mod.rs
@@ -19,7 +19,11 @@ use fedimint_core::BitcoinHash;
 use fedimint_core::config::FederationId;
 use fedimint_core::core::ModuleKind;
 use fedimint_core::db::IDatabaseTransactionOpsCoreTyped;
-use fedimint_core::encoding::{Decodable, Encodable};
+use fedimint_core::encoding::{
+    Decodable, DecodeError, Encodable, decode_field_from_finite_reader,
+    decode_legacy_system_time_from_finite_reader, encode_legacy_system_time, with_decoding_context,
+};
+use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_core::secp256k1::{Keypair, PublicKey};
 use fedimint_core::task::sleep;
 use fedimint_core::util::{BoxFuture, FmtCompact, FmtCompactAnyhow, SafeUrl};
@@ -567,7 +571,7 @@ pub enum RecurringPaymentError {
     Other(#[from] anyhow::Error),
 }
 
-#[derive(Debug, Clone, Encodable, Decodable, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct RecurringPaymentCodeEntry {
     pub protocol: RecurringPaymentProtocol,
     pub root_keypair: Keypair,
@@ -576,6 +580,62 @@ pub struct RecurringPaymentCodeEntry {
     pub last_derivation_index: u64,
     pub creation_time: SystemTime,
     pub meta: String,
+}
+
+impl Encodable for RecurringPaymentCodeEntry {
+    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
+        self.protocol.consensus_encode(writer)?;
+        self.root_keypair.consensus_encode(writer)?;
+        self.code.consensus_encode(writer)?;
+        self.recurringd_api.consensus_encode(writer)?;
+        self.last_derivation_index.consensus_encode(writer)?;
+        encode_legacy_system_time(&self.creation_time, writer)?;
+        self.meta.consensus_encode(writer)
+    }
+}
+
+impl Decodable for RecurringPaymentCodeEntry {
+    fn consensus_decode_partial_from_finite_reader<D: std::io::Read>(
+        decoder: &mut D,
+        modules: &ModuleDecoderRegistry,
+    ) -> Result<Self, DecodeError> {
+        Ok(Self {
+            protocol: decode_field_from_finite_reader(
+                decoder,
+                modules,
+                "Decoding named block field: RecurringPaymentCodeEntry{ ... protocol ... }",
+            )?,
+            root_keypair: decode_field_from_finite_reader(
+                decoder,
+                modules,
+                "Decoding named block field: RecurringPaymentCodeEntry{ ... root_keypair ... }",
+            )?,
+            code: decode_field_from_finite_reader(
+                decoder,
+                modules,
+                "Decoding named block field: RecurringPaymentCodeEntry{ ... code ... }",
+            )?,
+            recurringd_api: decode_field_from_finite_reader(
+                decoder,
+                modules,
+                "Decoding named block field: RecurringPaymentCodeEntry{ ... recurringd_api ... }",
+            )?,
+            last_derivation_index: decode_field_from_finite_reader(
+                decoder,
+                modules,
+                "Decoding named block field: RecurringPaymentCodeEntry{ ... last_derivation_index ... }",
+            )?,
+            creation_time: with_decoding_context(
+                decode_legacy_system_time_from_finite_reader(decoder, modules),
+                "Decoding named block field: RecurringPaymentCodeEntry{ ... creation_time ... }",
+            )?,
+            meta: decode_field_from_finite_reader(
+                decoder,
+                modules,
+                "Decoding named block field: RecurringPaymentCodeEntry{ ... meta ... }",
+            )?,
+        })
+    }
 }
 
 /// Event that is fired when a recurring payment code (i.e. LNURL) had an

--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -1185,7 +1185,12 @@ impl Lightning {
     ) -> Option<sha256::Hash> {
         match dbtx.get_value(&LightningGatewayKey(gateway_id)).await {
             Some(gateway) => {
-                let mut valid_until_bytes = gateway.valid_until.to_bytes();
+                let mut valid_until_bytes = vec![];
+                fedimint_core::encoding::encode_legacy_system_time(
+                    &gateway.valid_until,
+                    &mut valid_until_bytes,
+                )
+                .expect("encoding to a vector cannot fail");
                 let mut challenge_bytes = gateway_id.to_bytes();
                 challenge_bytes.append(&mut valid_until_bytes);
                 Some(sha256::Hash::hash(&challenge_bytes))

--- a/modules/fedimint-mint-client/src/oob.rs
+++ b/modules/fedimint-mint-client/src/oob.rs
@@ -6,8 +6,12 @@ use fedimint_client_module::module::OutPointRange;
 use fedimint_client_module::sm::{ClientSMDatabaseTransaction, State, StateTransition};
 use fedimint_client_module::transaction::{ClientInput, ClientInputBundle, ClientInputSM};
 use fedimint_core::core::OperationId;
-use fedimint_core::encoding::{Decodable, Encodable};
+use fedimint_core::encoding::{
+    Decodable, DecodeError, Encodable, decode_field_from_finite_reader,
+    decode_legacy_system_time_from_finite_reader, encode_legacy_system_time, with_decoding_context,
+};
 use fedimint_core::module::Amounts;
+use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_core::{Amount, TransactionId, runtime};
 use fedimint_mint_common::MintInput;
 
@@ -72,17 +76,75 @@ pub struct MintOOBStateMachine {
     pub(crate) state: MintOOBStates,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct MintOOBStatesCreated {
     pub(crate) amount: Amount,
     pub(crate) spendable_note: SpendableNote,
     pub(crate) timeout: SystemTime,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
+impl Encodable for MintOOBStatesCreated {
+    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
+        self.amount.consensus_encode(writer)?;
+        self.spendable_note.consensus_encode(writer)?;
+        encode_legacy_system_time(&self.timeout, writer)
+    }
+}
+
+impl Decodable for MintOOBStatesCreated {
+    fn consensus_decode_partial_from_finite_reader<D: std::io::Read>(
+        decoder: &mut D,
+        modules: &ModuleDecoderRegistry,
+    ) -> Result<Self, DecodeError> {
+        Ok(Self {
+            amount: decode_field_from_finite_reader(
+                decoder,
+                modules,
+                "Decoding named block field: MintOOBStatesCreated{ ... amount ... }",
+            )?,
+            spendable_note: decode_field_from_finite_reader(
+                decoder,
+                modules,
+                "Decoding named block field: MintOOBStatesCreated{ ... spendable_note ... }",
+            )?,
+            timeout: with_decoding_context(
+                decode_legacy_system_time_from_finite_reader(decoder, modules),
+                "Decoding named block field: MintOOBStatesCreated{ ... timeout ... }",
+            )?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct MintOOBStatesCreatedMulti {
     pub(crate) spendable_notes: Vec<(Amount, SpendableNote)>,
     pub(crate) timeout: SystemTime,
+}
+
+impl Encodable for MintOOBStatesCreatedMulti {
+    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
+        self.spendable_notes.consensus_encode(writer)?;
+        encode_legacy_system_time(&self.timeout, writer)
+    }
+}
+
+impl Decodable for MintOOBStatesCreatedMulti {
+    fn consensus_decode_partial_from_finite_reader<D: std::io::Read>(
+        decoder: &mut D,
+        modules: &ModuleDecoderRegistry,
+    ) -> Result<Self, DecodeError> {
+        Ok(Self {
+            spendable_notes: decode_field_from_finite_reader(
+                decoder,
+                modules,
+                "Decoding named block field: MintOOBStatesCreatedMulti{ ... spendable_notes ... }",
+            )?,
+            timeout: with_decoding_context(
+                decode_legacy_system_time_from_finite_reader(decoder, modules),
+                "Decoding named block field: MintOOBStatesCreatedMulti{ ... timeout ... }",
+            )?,
+        })
+    }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]

--- a/modules/fedimint-mint-common/src/common.rs
+++ b/modules/fedimint-mint-common/src/common.rs
@@ -1,17 +1,53 @@
 use std::fmt::Debug;
 
 use bitcoin_hashes::{Hash, sha256};
-use fedimint_core::encoding::{Decodable, Encodable};
+use fedimint_core::encoding::{
+    Decodable, DecodeError, Encodable, decode_field_from_finite_reader,
+    decode_legacy_system_time_from_finite_reader, encode_legacy_system_time, with_decoding_context,
+};
+use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_core::secp256k1;
 use secp256k1::{Keypair, Message, PublicKey, SECP256K1, Secp256k1, Signing, Verification};
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize, Encodable, Decodable)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct BackupRequest {
     pub id: PublicKey,
     #[serde(with = "fedimint_core::hex::serde")]
     pub payload: Vec<u8>,
     pub timestamp: std::time::SystemTime,
+}
+
+impl Encodable for BackupRequest {
+    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
+        self.id.consensus_encode(writer)?;
+        self.payload.consensus_encode(writer)?;
+        encode_legacy_system_time(&self.timestamp, writer)
+    }
+}
+
+impl Decodable for BackupRequest {
+    fn consensus_decode_partial_from_finite_reader<D: std::io::Read>(
+        decoder: &mut D,
+        modules: &ModuleDecoderRegistry,
+    ) -> Result<Self, DecodeError> {
+        Ok(Self {
+            id: decode_field_from_finite_reader(
+                decoder,
+                modules,
+                "Decoding named block field: BackupRequest{ ... id ... }",
+            )?,
+            payload: decode_field_from_finite_reader(
+                decoder,
+                modules,
+                "Decoding named block field: BackupRequest{ ... payload ... }",
+            )?,
+            timestamp: with_decoding_context(
+                decode_legacy_system_time_from_finite_reader(decoder, modules),
+                "Decoding named block field: BackupRequest{ ... timestamp ... }",
+            )?,
+        })
+    }
 }
 
 impl BackupRequest {

--- a/modules/fedimint-wallet-client/src/client_db.rs
+++ b/modules/fedimint-wallet-client/src/client_db.rs
@@ -5,7 +5,13 @@ use std::time::SystemTime;
 
 use fedimint_client_module::module::init::recovery::RecoveryFromHistoryCommon;
 use fedimint_core::core::OperationId;
-use fedimint_core::encoding::{Decodable, Encodable};
+use fedimint_core::encoding::{
+    Decodable, DecodeError, Encodable, decode_field_from_finite_reader,
+    decode_legacy_option_system_time_from_finite_reader,
+    decode_legacy_system_time_from_finite_reader, encode_legacy_option_system_time,
+    encode_legacy_system_time, with_decoding_context,
+};
+use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_core::{TransactionId, impl_db_lookup, impl_db_record};
 use serde::{Deserialize, Serialize};
 use strum_macros::EnumIter;
@@ -119,7 +125,7 @@ pub struct PegInTweakIndexKey(pub TweakIdx);
 #[derive(Clone, Debug, Encodable, Decodable, Serialize)]
 pub struct PegInTweakIndexPrefix;
 
-#[derive(Clone, Debug, Encodable, Decodable, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 pub struct PegInTweakIndexData {
     /// [`OperationId`] corresponding to this peg-in address.
     pub operation_id: OperationId,
@@ -131,6 +137,48 @@ pub struct PegInTweakIndexData {
     pub next_check_time: Option<SystemTime>,
     /// All previous on chain outputs claimed for this peg-in address.
     pub claimed: Vec<bitcoin::OutPoint>,
+}
+
+impl Encodable for PegInTweakIndexData {
+    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
+        self.operation_id.consensus_encode(writer)?;
+        encode_legacy_system_time(&self.creation_time, writer)?;
+        encode_legacy_option_system_time(&self.last_check_time, writer)?;
+        encode_legacy_option_system_time(&self.next_check_time, writer)?;
+        self.claimed.consensus_encode(writer)
+    }
+}
+
+impl Decodable for PegInTweakIndexData {
+    fn consensus_decode_partial_from_finite_reader<D: std::io::Read>(
+        decoder: &mut D,
+        modules: &ModuleDecoderRegistry,
+    ) -> Result<Self, DecodeError> {
+        Ok(Self {
+            operation_id: decode_field_from_finite_reader(
+                decoder,
+                modules,
+                "Decoding named block field: PegInTweakIndexData{ ... operation_id ... }",
+            )?,
+            creation_time: with_decoding_context(
+                decode_legacy_system_time_from_finite_reader(decoder, modules),
+                "Decoding named block field: PegInTweakIndexData{ ... creation_time ... }",
+            )?,
+            last_check_time: with_decoding_context(
+                decode_legacy_option_system_time_from_finite_reader(decoder, modules),
+                "Decoding named block field: PegInTweakIndexData{ ... last_check_time ... }",
+            )?,
+            next_check_time: with_decoding_context(
+                decode_legacy_option_system_time_from_finite_reader(decoder, modules),
+                "Decoding named block field: PegInTweakIndexData{ ... next_check_time ... }",
+            )?,
+            claimed: decode_field_from_finite_reader(
+                decoder,
+                modules,
+                "Decoding named block field: PegInTweakIndexData{ ... claimed ... }",
+            )?,
+        })
+    }
 }
 
 impl_db_record!(

--- a/modules/fedimint-wallet-client/src/deposit.rs
+++ b/modules/fedimint-wallet-client/src/deposit.rs
@@ -6,7 +6,11 @@ use fedimint_client_module::DynGlobalClientContext;
 use fedimint_client_module::sm::{ClientSMDatabaseTransaction, State, StateTransition};
 use fedimint_client_module::transaction::{ClientInput, ClientInputBundle};
 use fedimint_core::core::OperationId;
-use fedimint_core::encoding::{Decodable, Encodable};
+use fedimint_core::encoding::{
+    Decodable, DecodeError, Encodable, decode_field_from_finite_reader,
+    decode_legacy_system_time_from_finite_reader, encode_legacy_system_time, with_decoding_context,
+};
+use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_core::module::{Amounts, ModuleConsensusVersion};
 use fedimint_core::secp256k1::Keypair;
 use fedimint_core::task::sleep;
@@ -327,10 +331,36 @@ pub enum DepositStates {
     TimedOut(TimedOutDepositState),
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct CreatedDepositState {
     pub(crate) tweak_key: Keypair,
     pub(crate) timeout_at: SystemTime,
+}
+
+impl Encodable for CreatedDepositState {
+    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
+        self.tweak_key.consensus_encode(writer)?;
+        encode_legacy_system_time(&self.timeout_at, writer)
+    }
+}
+
+impl Decodable for CreatedDepositState {
+    fn consensus_decode_partial_from_finite_reader<D: std::io::Read>(
+        decoder: &mut D,
+        modules: &ModuleDecoderRegistry,
+    ) -> Result<Self, DecodeError> {
+        Ok(Self {
+            tweak_key: decode_field_from_finite_reader(
+                decoder,
+                modules,
+                "Decoding named block field: CreatedDepositState{ ... tweak_key ... }",
+            )?,
+            timeout_at: with_decoding_context(
+                decode_legacy_system_time_from_finite_reader(decoder, modules),
+                "Decoding named block field: CreatedDepositState{ ... timeout_at ... }",
+            )?,
+        })
+    }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]


### PR DESCRIPTION
*Posted by Tau*

### Summary

Implement the first staged policy step proposed while reviewing [PR #8854](https://github.com/fedimint/fedimint/pull/8854): remove the blanket `SystemTime` consensus codecs while retaining legacy encodings for current persisted carriers. The policy and rationale appear in the [review comment](https://github.com/fedimint/fedimint/pull/8854#issuecomment-5138413919).

### Details

The previous blanket implementations allowed any derived encoded type to serialize the target-dependent `SystemTime` type. This change removes those implementations. Existing records now opt in to explicit, documented legacy `(seconds, nanoseconds)` codecs, preserving their wire and database bytes without expanding the staging scope to migrate or ban every timestamp field. The gateway backup record uses a dedicated wrapper for its direct optional timestamp value.

### Reviewing

Check that each manual record codec preserves its field order and uses a shared finite reader. The retained helpers intentionally exist only for legacy carrier compatibility; `Duration` encoding is unchanged.

### Testing

Run `just final-lint` and `cargo test -p fedimint-core --lib`.