### PR TITLE
fix(connectors): don't reconnect pooled gateway HTTP connections each request

### DIFF
--- a/fedimint-connectors/src/http.rs
+++ b/fedimint-connectors/src/http.rs
@@ -51,15 +51,21 @@ pub(crate) struct HttpConnection {
 
 #[apply(async_trait_maybe_send!)]
 impl IConnection for HttpConnection {
-    async fn await_disconnection(&self) {}
+    async fn await_disconnection(&self) {
+        // `HttpConnection` is a stateless wrapper over a pooled `reqwest::Client`;
+        // it never actually disconnects. Returning immediately would make the
+        // `ConnectionPool` treat every request as a reconnection and impose its
+        // reconnect backoff (a 500ms floor) before each one, so we pend forever.
+        std::future::pending().await
+    }
 
     fn is_connected(&self) -> bool {
-        // `reqwest::Client` already implemented connection pooling. So instead of
-        // keeping this `HttpConnection` alive, we always return false here and
-        // force the `ConnectionRegistry` to re-create the connection. `HttpConnector`
-        // manages the `reqwest::Client` lifetime, so the same underlying TCP
-        // connection will be used for subsequent requests.
-        false
+        // `reqwest::Client` handles TCP/TLS connection pooling internally, so this
+        // wrapper is always "connected" and safe to cache. Reporting `false` here
+        // forced the `ConnectionPool` to reset the entry to a reconnecting state on
+        // every request, penalizing each one with a 500ms reconnect-backoff sleep
+        // even though the underlying connection was reused the whole time.
+        true
     }
 }
 


### PR DESCRIPTION
The HTTP gateway connection reported `is_connected() == false` with an instant `await_disconnection()`, so `ConnectionPool` reset the pool entry and slept its reconnect backoff (500ms floor) before *every* gateway request — even though the underlying `reqwest` connection was reused the whole time. This marks the pooled connection as connected and never-disconnecting, so healthy connections skip the backoff (reqwest still re-establishes a dropped connection transparently on the next request).

Measured against a live gateway:
- `routing_info` (one gateway call): ~735ms → ~19ms
- fetching an invoice (two gateway calls): ~1.5s → ~70ms
- a full internal lnv2 self-payment (same-federation direct swap — four gateway calls across `receive` + `send`, end-to-end incl. federation consensus): ~3.2s → ~2.4s

🤖 Generated with [Claude Code](https://claude.com/claude-code)