### PR TITLE
feat(lnv2): recover direct receives via the incoming contract scan

### DIFF
--- a/modules/fedimint-lnv2-client/src/cli.rs
+++ b/modules/fedimint-lnv2-client/src/cli.rs
@@ -35,6 +35,11 @@ enum Opts {
     /// Retry claiming a receive operation whose claim transaction was
     /// rejected. Returns the new operation id to await.
     ReclaimReceive { operation_id: OperationId },
+    /// Recover direct receives missed because the incoming contract scan
+    /// cursor had already advanced past them, for example on a wallet
+    /// restored from seed before direct receives were recovered
+    /// automatically. Returns the operation ids of the recovered receives.
+    RescanIncomingContracts,
     /// Lnurl subcommands
     #[command(subcommand)]
     Lnurl(LnurlOpts),
@@ -108,6 +113,9 @@ pub(crate) async fn handle_cli_command(
         ),
         Opts::ReclaimReceive { operation_id } => {
             json(lightning.reclaim_receive(operation_id).await?)
+        }
+        Opts::RescanIncomingContracts => {
+            json(lightning.rescan_incoming_contracts(Value::Null).await?)
         }
         Opts::Lnurl(lnurl_opts) => match lnurl_opts {
             LnurlOpts::Generate {

--- a/modules/fedimint-lnv2-client/src/events.rs
+++ b/modules/fedimint-lnv2-client/src/events.rs
@@ -48,7 +48,9 @@ pub struct ReceivePaymentEvent {
     pub operation_id: OperationId,
     pub amount: Amount,
     /// Absolute fee paid to the gateway. Defaults to zero for events recorded
-    /// before this field was added.
+    /// before this field was added, and is zero for recovered receives, whose
+    /// invoice - and with it the gateway fee - was lost with the original
+    /// database.
     #[serde(default)]
     pub fee: Amount,
 }

--- a/modules/fedimint-lnv2-client/src/lib.rs
+++ b/modules/fedimint-lnv2-client/src/lib.rs
@@ -42,7 +42,7 @@ use fedimint_core::module::{
 use fedimint_core::secp256k1::SECP256K1;
 use fedimint_core::task::TaskGroup;
 use fedimint_core::time::duration_since_epoch;
-use fedimint_core::util::SafeUrl;
+use fedimint_core::util::{FmtCompactAnyhow as _, SafeUrl};
 use fedimint_core::{Amount, PeerId, apply, async_trait_maybe_send};
 use fedimint_derive_secret::{ChildId, DerivableSecret};
 use fedimint_lnv2_common::config::LightningClientConfig;
@@ -63,7 +63,7 @@ use serde_json::Value;
 use strum::IntoEnumIterator as _;
 use thiserror::Error;
 use tpe::{AggregateDecryptionKey, derive_agg_dk};
-use tracing::warn;
+use tracing::{debug, warn};
 
 use crate::api::LightningFederationApi;
 use crate::events::SendPaymentEvent;
@@ -83,6 +83,7 @@ pub enum LightningOperationMeta {
     Send(SendOperationMeta),
     Receive(ReceiveOperationMeta),
     LnurlReceive(LnurlReceiveOperationMeta),
+    RecoveredReceive(RecoveredReceiveOperationMeta),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -127,6 +128,19 @@ impl ReceiveOperationMeta {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LnurlReceiveOperationMeta {
+    pub contract: IncomingContract,
+    pub custom_meta: Value,
+}
+
+/// Operation meta of a direct receive rediscovered by the incoming contract
+/// scan rather than driven by a locally created invoice, e.g. after a restore
+/// from seed where the original operation was lost with the database.
+///
+/// The invoice is unavailable on this client, so the gateway fee cannot be
+/// recovered; the receive payment event reports the contract amount with a
+/// zero fee.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RecoveredReceiveOperationMeta {
     pub contract: IncomingContract,
     pub custom_meta: Value,
 }
@@ -190,6 +204,7 @@ pub type SendResult = Result<OperationId, SendPaymentError>;
 ///     Pending -- invoice expires --> Expired
 ///     Claiming -- ecash is minted --> Claimed
 ///     Claiming -- the claim is rejected or minting ecash fails --> Failure
+///     Pending -- the claim cannot be funded --> Uneconomical
 /// ```
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub enum ReceiveOperationState {
@@ -206,8 +221,9 @@ pub enum ReceiveOperationState {
     /// remains claimable and the operation can be re-driven with
     /// [`LightningClientModule::reclaim_receive`].
     Failure,
-    /// The contract is worth less than the federation charges to claim it, so
-    /// it was left unclaimed. Reachable without any payment request of ours:
+    /// The claim could not be funded: it costs more than the contract is worth
+    /// and the wallet held too little to cover the difference, so the contract
+    /// was left unclaimed. Reachable without any payment request of ours:
     /// anyone can address an incoming contract to a published lnurl key.
     Uneconomical,
 }
@@ -224,8 +240,9 @@ pub enum FinalReceiveOperationState {
     /// remains claimable and the operation can be re-driven with
     /// [`LightningClientModule::reclaim_receive`].
     Failure,
-    /// The contract is worth less than the federation charges to claim it, so
-    /// it was left unclaimed.
+    /// The claim could not be funded: it costs more than the contract is worth
+    /// and the wallet held too little to cover the difference, so the contract
+    /// was left unclaimed.
     Uneconomical,
 }
 
@@ -915,14 +932,31 @@ impl LightningClientModule {
     /// actual claim - the lightning input fee at this federation's fee
     /// consensus, the change the primary module has to mint, and the
     /// sub-denomination remainder that cannot be minted at all - rather than
-    /// assuming a floor. A quote that fails outright is the same verdict: the
-    /// claim spends the contract as the transaction's only input, so a fee
-    /// larger than the contract leaves a transaction that cannot be balanced.
-    async fn is_worth_claiming(&self, amount: Amount) -> bool {
-        match self.receive_fee_quote(amount).await {
-            Ok(quote) => quote.total().get_bitcoin() < amount,
-            Err(_) => false,
+    /// assuming a floor.
+    ///
+    /// `Err` is a quote that could not be taken at all, which is not the same
+    /// answer as `Ok(false)`. Refusing to create an invoice on either is safe,
+    /// so the creation path folds them together; a scan must not, because it
+    /// skips the contract and advances a cursor that never goes back - which
+    /// abandons claimable funds whenever quoting is temporarily impossible,
+    /// as it is while the primary module is absent from the registry during a
+    /// recovery.
+    ///
+    /// Which is why the definitive case is answered before the quote is taken.
+    /// The lightning input fee is the one component known locally, and it is
+    /// only ever a lower bound on the quote's total, so an amount that does
+    /// not even cover it is uneconomical whatever the quote would have added
+    /// on top. Deciding it here keeps that answer independent of the primary
+    /// module: an unsolicited dust contract to a wallet that cannot fund a
+    /// quote would otherwise be an unpriceable `Err` forever, holding the scan
+    /// cursor and wedging the scan on exactly the contracts this check exists
+    /// to discard.
+    async fn claim_verdict(&self, amount: Amount) -> anyhow::Result<bool> {
+        if self.cfg.fee_consensus.fee(amount) >= amount {
+            return Ok(false);
         }
+
+        Ok(self.receive_fee_quote(amount).await?.total().get_bitcoin() < amount)
     }
 
     /// Computes the federation fee a `send` funding an outgoing contract worth
@@ -1071,8 +1105,9 @@ impl LightningClientModule {
 
         // Quoting the claim against this federation's fee consensus is exact, where a
         // fixed floor is either too permissive or too strict depending on how the
-        // federation is configured.
-        if !self.is_worth_claiming(contract_amount).await {
+        // federation is configured. Refusing on an unavailable quote is safe here -
+        // nothing has been created yet - so both answers fold into one refusal.
+        if !self.claim_verdict(contract_amount).await.unwrap_or(false) {
             return Err(ReceiveError::AmountTooSmall);
         }
 
@@ -1131,7 +1166,7 @@ impl LightningClientModule {
         contract: IncomingContract,
         operation_meta: LightningOperationMeta,
     ) -> Option<OperationId> {
-        let operation_id = OperationId::from_encodable(&contract.clone());
+        let operation_id = OperationId::from_encodable(&contract);
 
         let (claim_keypair, agg_decryption_key) = self.recover_contract_keys(sk, &contract)?;
 
@@ -1145,8 +1180,10 @@ impl LightningClientModule {
             state: ReceiveSMState::Pending,
         });
 
-        // this may only fail if the operation id is already in use, in which case we
-        // ignore the error such that the method is idempotent
+        // Ignore operation-start errors to keep the method idempotent. Callers
+        // that advance persistent progress after this call must verify that the
+        // operation exists, since a failed database commit is also reported as
+        // an operation-start error.
         self.client_ctx
             .manual_operation_start(
                 operation_id,
@@ -1334,8 +1371,9 @@ impl LightningClientModule {
     /// Returns an error if the original operation is not a lightning receive,
     /// if its receive state machine is still active, if it did not fail with a
     /// rejected claim transaction, if its state-machine history is
-    /// unavailable, or if the recorded claim transaction cannot be verified
-    /// because it created no change outputs. When the recorded claim is still
+    /// unavailable, if the recorded claim transaction cannot be verified
+    /// because it created no change outputs, or if the contract's amount no
+    /// longer covers the claim fee. When the recorded claim is still
     /// undecided - the federation is unreachable, say - this waits for the
     /// decision rather than erroring.
     pub async fn reclaim_receive(
@@ -1420,6 +1458,21 @@ impl LightningClientModule {
                 "The recorded claim transaction was accepted; there is nothing to reclaim"
             );
         }
+
+        // Re-quote before resubmitting: the fee consensus can have risen since
+        // the claim was rejected, and the contract is the transaction's only
+        // input, so the primary module would top the shortfall up out of the
+        // existing balance rather than the claim failing. `Uneconomical` only
+        // catches a wallet too empty to cover the difference, so without this
+        // the reclaim silently costs more than it returns.
+        anyhow::ensure!(
+            self.claim_verdict(receive_sm.common.contract.commitment.amount)
+                .await
+                .map_err(|e| anyhow::anyhow!(
+                    "Cannot price the claim of the recorded contract: {e}"
+                ))?,
+            "The contract's amount no longer covers the claim fee; there is nothing worth reclaiming"
+        );
 
         // The original operation meta is reused such that the fee reported by
         // the receive payment event stays correct for the reclaimed contract.
@@ -1508,6 +1561,229 @@ impl LightningClientModule {
         );
     }
 
+    /// Rescans the incoming contract stream below the persisted scan cursor
+    /// for direct receives locked to the static module key. Returns recovery
+    /// operation ids that became recorded while the call ran, so callers can
+    /// subscribe to them.
+    ///
+    /// This is only needed by a wallet that restored from seed before direct
+    /// receives were recovered by the scan: its cursor has already advanced
+    /// past its historical contracts and the tail scan, which only ever moves
+    /// forward, never revisits them.
+    ///
+    /// This checks only the static module key. An lnurl contract left behind
+    /// the cursor by an older client is not covered.
+    ///
+    /// The rescan keeps no state of its own and does not move the scan
+    /// cursor. It is idempotent - recoveries are recorded under
+    /// contract-derived operation ids - so an interrupted run is simply
+    /// re-run.
+    ///
+    /// The stream endpoint returns the first remaining entries at or after
+    /// the queried index, and claimed contracts are removed from the stream,
+    /// so on a sparse stream the final batch may also include contracts at
+    /// or above the captured cursor. That overlap with the tail scan is
+    /// harmless: whichever caller records the operation first wins and the
+    /// other skips it.
+    ///
+    /// If a run errors or is cancelled, ids collected before the interruption
+    /// are not returned; those operations remain in the operation log and
+    /// their state machines keep claiming. A re-run reports only recoveries
+    /// that were still missing.
+    ///
+    /// A recovered receive whose claim transaction is rejected fails
+    /// terminally, as any other receive does, and is re-driven manually with
+    /// [`LightningClientModule::reclaim_receive`]; rerunning the rescan does
+    /// not retry it, since its operation is already recorded.
+    ///
+    /// Contracts whose amount no longer covers the claim fee are skipped and
+    /// not reported, as they are by the tail scan. Claiming one is not merely
+    /// pointless: the contract is the transaction's only input, so the primary
+    /// module tops the shortfall up out of the existing balance whenever the
+    /// wallet can afford it, and the recovery costs more than it returns.
+    pub async fn rescan_incoming_contracts(
+        &self,
+        custom_meta: Value,
+    ) -> anyhow::Result<Vec<OperationId>> {
+        let cursor = self
+            .client_ctx
+            .module_db()
+            .begin_transaction_nc()
+            .await
+            .get_value(&IncomingContractStreamIndexKey)
+            .await
+            .unwrap_or(0);
+
+        let mut operation_ids = Vec::new();
+        let mut failed_contracts = 0_usize;
+        let mut index = 0;
+
+        // Every queried index lies below the cursor and therefore below the
+        // federation's stream tip, so the long-polling endpoint returns
+        // immediately. The batch size is capped to the size of the remaining
+        // range, but since the endpoint returns the first remaining entries
+        // at or after the queried index and claimed contracts are removed
+        // from the stream, a batch on a sparse stream may still include
+        // contracts at or above the cursor. Recovering those overlaps with
+        // the tail scan and is harmless: recording is idempotent and
+        // whichever caller records the operation first wins.
+        while index < cursor {
+            let batch_size =
+                usize::try_from((cursor - index).min(128)).expect("Bounded by the batch size");
+
+            let (contracts, next_index) = self
+                .module_api
+                .await_incoming_contracts(index, batch_size)
+                .await;
+
+            for contract in &contracts {
+                match self
+                    .try_recover_direct_receive(contract, custom_meta.clone())
+                    .await
+                {
+                    DirectReceiveRecovery::Recorded(operation_id) => {
+                        operation_ids.push(operation_id);
+                    }
+                    DirectReceiveRecovery::NotNeeded => {}
+                    DirectReceiveRecovery::Failed => failed_contracts += 1,
+                }
+            }
+
+            index = next_index;
+        }
+
+        // Erroring out instead of skipping keeps the caller from mistaking an
+        // incomplete rescan for a complete one. The whole range is processed
+        // first so one failing contract does not hide later recoverable ones:
+        // the recoveries recorded by this run are already durable, and
+        // re-running the rescan retries only the failed contracts.
+        anyhow::ensure!(
+            failed_contracts == 0,
+            "Recorded {} recoveries but failed to record {failed_contracts}; rerun the rescan",
+            operation_ids.len(),
+        );
+
+        Ok(operation_ids)
+    }
+
+    /// Whether this id belongs to a recorded lnv2 operation. The module-kind
+    /// check avoids treating a cross-module operation-id collision as a
+    /// successfully recorded recovery.
+    async fn operation_recorded(&self, operation_id: OperationId) -> bool {
+        self.client_ctx.get_operation(operation_id).await.is_ok()
+    }
+
+    /// Rediscovers a direct receive for a contract locked to the static
+    /// module key, e.g. after a restore from seed, unless the operation is
+    /// already known to this client.
+    ///
+    /// Seed recovery cannot distinguish a restored replacement device from a
+    /// second live client on the same seed, so - as for lnurl receives - a
+    /// concurrent same-seed client now races the invoice creator for the
+    /// claim; the loser's operation fails even though the payment settled on
+    /// the other device. Concurrent same-seed clients are unsupported.
+    async fn try_recover_direct_receive(
+        &self,
+        contract: &IncomingContract,
+        custom_meta: Value,
+    ) -> DirectReceiveRecovery {
+        // Ownership first, and it is the cheapest of the three checks for the
+        // case that dominates: the stream carries every incoming contract the
+        // federation funded, so almost all of them are other clients', and a
+        // foreign one fails the claim key comparison after purely local
+        // arithmetic. The operation-log read below is a database transaction
+        // and the quote reads the wallet - paying either for every payment the
+        // federation makes would cost every client a lookup per payment.
+        if self
+            .recover_contract_keys(self.keypair.secret_key(), contract)
+            .is_none()
+        {
+            return DirectReceiveRecovery::NotNeeded;
+        }
+
+        // Matches the operation id derivation in `receive_incoming_contract`,
+        // so contracts of receives this client already tracks are skipped
+        // before it is asked to start a second state machine for them.
+        let operation_id = OperationId::from_encodable(contract);
+
+        if self.operation_recorded(operation_id).await {
+            return DirectReceiveRecovery::NotNeeded;
+        }
+
+        match self.claim_verdict(contract.commitment.amount).await {
+            Ok(true) => {}
+            // Nobody else can address a contract to the static key - only the
+            // tweaked claim key leaves this client - so this is not the lnurl
+            // branch's unsolicited-dust case but our own invoice repriced by a
+            // fee consensus that rose after it was created. Claim it anyway and
+            // the primary module tops the shortfall up out of the existing
+            // balance, costing more than the contract returns.
+            Ok(false) => {
+                warn!(
+                    target: LOG_CLIENT_MODULE_LNV2,
+                    contract_id = ?contract.contract_id(),
+                    amount = %contract.commitment.amount,
+                    "Not recovering incoming contract, its amount does not cover the claim fee"
+                );
+
+                return DirectReceiveRecovery::NotNeeded;
+            }
+            // An unavailable quote is not a verdict. Reporting `NotNeeded` here
+            // would let the caller advance its cursor past a contract that was
+            // never priced, and the scan never comes back.
+            Err(err) => {
+                warn!(
+                    target: LOG_CLIENT_MODULE_LNV2,
+                    err = %err.fmt_compact_anyhow(),
+                    contract_id = ?contract.contract_id(),
+                    "Cannot price the claim of an incoming contract, not advancing past it"
+                );
+
+                return DirectReceiveRecovery::Failed;
+            }
+        }
+
+        if self
+            .receive_incoming_contract(
+                self.keypair.secret_key(),
+                contract.clone(),
+                LightningOperationMeta::RecoveredReceive(RecoveredReceiveOperationMeta {
+                    contract: contract.clone(),
+                    custom_meta,
+                }),
+            )
+            .await
+            .is_none()
+        {
+            // The contract is not locked to the static module key; there is
+            // nothing to recover.
+            return DirectReceiveRecovery::NotNeeded;
+        }
+
+        // `receive_incoming_contract` swallows every `manual_operation_start`
+        // error for idempotency, including a failed commit, so whether the
+        // recovery was actually recorded has to be verified before the tail
+        // scan advances past the contract: the scan only ever moves forward
+        // and never revisits it.
+        if self.operation_recorded(operation_id).await {
+            debug!(
+                target: LOG_CLIENT_MODULE_LNV2,
+                contract_id = ?contract.contract_id(),
+                "Discovered incoming contract locked to the static module key"
+            );
+
+            DirectReceiveRecovery::Recorded(operation_id)
+        } else {
+            warn!(
+                target: LOG_CLIENT_MODULE_LNV2,
+                contract_id = ?contract.contract_id(),
+                "Failed to record the recovery of an incoming contract"
+            );
+
+            DirectReceiveRecovery::Failed
+        }
+    }
+
     async fn receive_lnurl(&self, custom_meta: Value) {
         // Read the stream cursor with a short-lived transaction. It must NOT stay open
         // across the long-poll below: RocksDB's optimistic transactions validate a
@@ -1533,27 +1809,76 @@ impl LightningClientModule {
             .await_incoming_contracts(stream_index, 128)
             .await;
 
+        let mut batch_handled = true;
+
         for contract in &contracts {
             // The stream carries every incoming contract the federation funded, and
             // anyone can address one to a published lnurl key. Check that it is ours
             // before quoting - recovering the keys is local arithmetic, the quote
-            // reads the wallet - and skip the contracts the claim fee would swallow,
-            // so that unsolicited dust never becomes an operation in the first place.
-            if self
+            // reads the wallet. Both of this module's keys are checked: the lnurl
+            // key an lnurl receive is addressed to, and the static module key a
+            // direct receive uses, which the recovery branch below claims under.
+            // Checking only the lnurl key here would skip every contract the
+            // recovery branch exists to find.
+            let is_lnurl = self
                 .recover_contract_keys(self.lnurl_keypair.secret_key(), contract)
-                .is_none()
-            {
-                continue;
-            }
+                .is_some();
 
-            if !self.is_worth_claiming(contract.commitment.amount).await {
-                warn!(
-                    target: LOG_CLIENT_MODULE_LNV2,
-                    amount = %contract.commitment.amount,
-                    "Ignoring incoming contract, its amount does not cover the claim fee"
+            if !is_lnurl {
+                // Not addressed to the lnurl key, so it is only ours if it is
+                // locked to the static module key used by direct (invoice)
+                // receives. On a client whose database still holds the original
+                // operation this is a no-op; on a client restored from seed it
+                // rediscovers a funded contract whose operation was lost with
+                // the database and claims it.
+                //
+                // That path owns its own already-recorded and dust checks, in
+                // that order, so quoting here would price every contract this
+                // client already tracks - the common case on a client that
+                // never lost its database.
+                //
+                // Unlike the lnurl branch below, the final state is not awaited
+                // inline: the recovery is driven by its own persisted state
+                // machine, so the scan need not block on the claim reaching
+                // consensus before moving on.
+                batch_handled &= !matches!(
+                    self.try_recover_direct_receive(contract, custom_meta.clone())
+                        .await,
+                    DirectReceiveRecovery::Failed
                 );
 
                 continue;
+            }
+
+            // Skip the contracts the claim fee would swallow, so that unsolicited
+            // dust never becomes an operation in the first place. Anyone can
+            // address one to a published lnurl key, which is why this gate exists
+            // on this branch.
+            match self.claim_verdict(contract.commitment.amount).await {
+                Ok(true) => {}
+                Ok(false) => {
+                    warn!(
+                        target: LOG_CLIENT_MODULE_LNV2,
+                        amount = %contract.commitment.amount,
+                        "Ignoring incoming contract, its amount does not cover the claim fee"
+                    );
+
+                    continue;
+                }
+                // Hold the cursor rather than skip: an unavailable quote is not
+                // a verdict, and the scan only ever moves forward.
+                Err(err) => {
+                    warn!(
+                        target: LOG_CLIENT_MODULE_LNV2,
+                        err = %err.fmt_compact_anyhow(),
+                        contract_id = ?contract.contract_id(),
+                        "Cannot price the claim of an incoming contract, not advancing past it"
+                    );
+
+                    batch_handled = false;
+
+                    continue;
+                }
             }
 
             if let Some(operation_id) = self
@@ -1567,10 +1892,31 @@ impl LightningClientModule {
                 )
                 .await
             {
-                self.await_final_receive_operation_state(operation_id)
-                    .await
-                    .ok();
+                if self.operation_recorded(operation_id).await {
+                    self.await_final_receive_operation_state(operation_id)
+                        .await
+                        .ok();
+                } else {
+                    warn!(
+                        target: LOG_CLIENT_MODULE_LNV2,
+                        contract_id = ?contract.contract_id(),
+                        "Failed to record an lnurl receive operation"
+                    );
+
+                    batch_handled = false;
+                }
             }
+        }
+
+        // A receive that failed to commit must not be skipped: the scan only
+        // ever moves forward, so nothing revisits a contract once the cursor
+        // is past it. Leaving the cursor in place re-fetches and re-processes
+        // the batch - idempotently, thanks to the contract-derived operation
+        // ids - on the next iteration.
+        if !batch_handled {
+            fedimint_core::runtime::sleep(std::time::Duration::from_secs(10)).await;
+
+            return;
         }
 
         // Advance the cursor in its own short transaction. This is the only writer of
@@ -1588,6 +1934,22 @@ impl LightningClientModule {
 
         dbtx.commit_tx().await;
     }
+}
+
+/// The outcome of attempting to recover a direct receive from a single
+/// incoming contract.
+#[derive(Debug)]
+enum DirectReceiveRecovery {
+    /// A recovery operation was recorded for the contract and verified to
+    /// exist.
+    Recorded(OperationId),
+    /// There is nothing to recover: the contract is not locked to the static
+    /// module key, the operation already exists, or the claim fee would
+    /// swallow the contract's amount.
+    NotNeeded,
+    /// The recovery failed to be recorded, so a scan must not advance past
+    /// the contract.
+    Failed,
 }
 
 #[derive(Error, Debug, Clone, Eq, PartialEq)]

--- a/modules/fedimint-lnv2-client/src/lib.rs
+++ b/modules/fedimint-lnv2-client/src/lib.rs
@@ -55,6 +55,7 @@ use fedimint_lnv2_common::{
     LightningModuleTypes, LightningOutput, LightningOutputV0, MINIMUM_INCOMING_CONTRACT_AMOUNT,
     lnurl, tweak,
 };
+use fedimint_logging::LOG_CLIENT_MODULE_LNV2;
 use futures::StreamExt;
 use lightning_invoice::{Bolt11Invoice, Currency};
 use secp256k1::{Keypair, PublicKey, Scalar, SecretKey, ecdh};
@@ -63,7 +64,7 @@ use serde_json::Value;
 use strum::IntoEnumIterator as _;
 use thiserror::Error;
 use tpe::{AggregateDecryptionKey, derive_agg_dk};
-use tracing::warn;
+use tracing::{debug, warn};
 
 use crate::api::LightningFederationApi;
 use crate::events::SendPaymentEvent;
@@ -83,6 +84,7 @@ pub enum LightningOperationMeta {
     Send(SendOperationMeta),
     Receive(ReceiveOperationMeta),
     LnurlReceive(LnurlReceiveOperationMeta),
+    RecoveredReceive(RecoveredReceiveOperationMeta),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -127,6 +129,19 @@ impl ReceiveOperationMeta {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LnurlReceiveOperationMeta {
+    pub contract: IncomingContract,
+    pub custom_meta: Value,
+}
+
+/// Operation meta of a direct receive rediscovered by the incoming contract
+/// scan rather than driven by a locally created invoice, e.g. after a restore
+/// from seed where the original operation was lost with the database.
+///
+/// The invoice is unavailable on this client, so the gateway fee cannot be
+/// recovered; the receive payment event reports the contract amount with a
+/// zero fee.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RecoveredReceiveOperationMeta {
     pub contract: IncomingContract,
     pub custom_meta: Value,
 }
@@ -1100,7 +1115,7 @@ impl LightningClientModule {
         contract: IncomingContract,
         operation_meta: LightningOperationMeta,
     ) -> Option<OperationId> {
-        let operation_id = OperationId::from_encodable(&contract.clone());
+        let operation_id = OperationId::from_encodable(&contract);
 
         let (claim_keypair, agg_decryption_key) = self.recover_contract_keys(sk, &contract)?;
 
@@ -1114,8 +1129,10 @@ impl LightningClientModule {
             state: ReceiveSMState::Pending,
         });
 
-        // this may only fail if the operation id is already in use, in which case we
-        // ignore the error such that the method is idempotent
+        // Ignore operation-start errors to keep the method idempotent. Callers
+        // that advance persistent progress after this call must verify that the
+        // operation exists, since a failed database commit is also reported as
+        // an operation-start error.
         self.client_ctx
             .manual_operation_start(
                 operation_id,
@@ -1469,6 +1486,176 @@ impl LightningClientModule {
         );
     }
 
+    /// Rescans the incoming contract stream below the persisted scan cursor
+    /// for direct receives locked to the static module key. Returns recovery
+    /// operation ids that became recorded while the call ran, so callers can
+    /// subscribe to them.
+    ///
+    /// This is only needed by a wallet that restored from seed before direct
+    /// receives were recovered by the scan: its cursor has already advanced
+    /// past its historical contracts and the tail scan, which only ever moves
+    /// forward, never revisits them.
+    ///
+    /// This checks only the static module key. An lnurl contract left behind
+    /// the cursor by an older client is not covered.
+    ///
+    /// The rescan keeps no state of its own and does not move the scan
+    /// cursor. It is idempotent - recoveries are recorded under
+    /// contract-derived operation ids - so an interrupted run is simply
+    /// re-run.
+    ///
+    /// The stream endpoint returns the first remaining entries at or after
+    /// the queried index, and claimed contracts are removed from the stream,
+    /// so on a sparse stream the final batch may also include contracts at
+    /// or above the captured cursor. That overlap with the tail scan is
+    /// harmless: whichever caller records the operation first wins and the
+    /// other skips it.
+    ///
+    /// If a run errors or is cancelled, ids collected before the interruption
+    /// are not returned; those operations remain in the operation log and
+    /// their state machines keep claiming. A re-run reports only recoveries
+    /// that were still missing.
+    ///
+    /// A recovered receive whose claim transaction is rejected fails
+    /// terminally, as any other receive does, and is re-driven manually with
+    /// [`LightningClientModule::reclaim_receive`]; rerunning the rescan does
+    /// not retry it, since its operation is already recorded.
+    pub async fn rescan_incoming_contracts(
+        &self,
+        custom_meta: Value,
+    ) -> anyhow::Result<Vec<OperationId>> {
+        let cursor = self
+            .client_ctx
+            .module_db()
+            .begin_transaction_nc()
+            .await
+            .get_value(&IncomingContractStreamIndexKey)
+            .await
+            .unwrap_or(0);
+
+        let mut operation_ids = Vec::new();
+        let mut failed_contracts = 0_usize;
+        let mut index = 0;
+
+        // Every queried index lies below the cursor and therefore below the
+        // federation's stream tip, so the long-polling endpoint returns
+        // immediately. The batch size is capped to the size of the remaining
+        // range, but since the endpoint returns the first remaining entries
+        // at or after the queried index and claimed contracts are removed
+        // from the stream, a batch on a sparse stream may still include
+        // contracts at or above the cursor. Recovering those overlaps with
+        // the tail scan and is harmless: recording is idempotent and
+        // whichever caller records the operation first wins.
+        while index < cursor {
+            let batch_size =
+                usize::try_from((cursor - index).min(128)).expect("Bounded by the batch size");
+
+            let (contracts, next_index) = self
+                .module_api
+                .await_incoming_contracts(index, batch_size)
+                .await;
+
+            for contract in &contracts {
+                match self
+                    .try_recover_direct_receive(contract, custom_meta.clone())
+                    .await
+                {
+                    DirectReceiveRecovery::Recorded(operation_id) => {
+                        operation_ids.push(operation_id);
+                    }
+                    DirectReceiveRecovery::NotNeeded => {}
+                    DirectReceiveRecovery::Failed => failed_contracts += 1,
+                }
+            }
+
+            index = next_index;
+        }
+
+        // Erroring out instead of skipping keeps the caller from mistaking an
+        // incomplete rescan for a complete one. The whole range is processed
+        // first so one failing contract does not hide later recoverable ones:
+        // the recoveries recorded by this run are already durable, and
+        // re-running the rescan retries only the failed contracts.
+        anyhow::ensure!(
+            failed_contracts == 0,
+            "Recorded {} recoveries but failed to record {failed_contracts}; rerun the rescan",
+            operation_ids.len(),
+        );
+
+        Ok(operation_ids)
+    }
+
+    /// Whether this id belongs to a recorded lnv2 operation. The module-kind
+    /// check avoids treating a cross-module operation-id collision as a
+    /// successfully recorded recovery.
+    async fn operation_recorded(&self, operation_id: OperationId) -> bool {
+        self.client_ctx.get_operation(operation_id).await.is_ok()
+    }
+
+    /// Rediscovers a direct receive for a contract locked to the static
+    /// module key, e.g. after a restore from seed, unless the operation is
+    /// already known to this client.
+    ///
+    /// Seed recovery cannot distinguish a restored replacement device from a
+    /// second live client on the same seed, so - as for lnurl receives - a
+    /// concurrent same-seed client now races the invoice creator for the
+    /// claim; the loser's operation fails even though the payment settled on
+    /// the other device. Concurrent same-seed clients are unsupported.
+    async fn try_recover_direct_receive(
+        &self,
+        contract: &IncomingContract,
+        custom_meta: Value,
+    ) -> DirectReceiveRecovery {
+        // Matches the operation id derivation in `receive_incoming_contract`,
+        // so contracts of receives this client already tracks are skipped
+        // without deriving any keys.
+        let operation_id = OperationId::from_encodable(contract);
+
+        if self.operation_recorded(operation_id).await {
+            return DirectReceiveRecovery::NotNeeded;
+        }
+
+        if self
+            .receive_incoming_contract(
+                self.keypair.secret_key(),
+                contract.clone(),
+                LightningOperationMeta::RecoveredReceive(RecoveredReceiveOperationMeta {
+                    contract: contract.clone(),
+                    custom_meta,
+                }),
+            )
+            .await
+            .is_none()
+        {
+            // The contract is not locked to the static module key; there is
+            // nothing to recover.
+            return DirectReceiveRecovery::NotNeeded;
+        }
+
+        // `receive_incoming_contract` swallows every `manual_operation_start`
+        // error for idempotency, including a failed commit, so whether the
+        // recovery was actually recorded has to be verified before the tail
+        // scan advances past the contract: the scan only ever moves forward
+        // and never revisits it.
+        if self.operation_recorded(operation_id).await {
+            debug!(
+                target: LOG_CLIENT_MODULE_LNV2,
+                contract_id = ?contract.contract_id(),
+                "Discovered incoming contract locked to the static module key"
+            );
+
+            DirectReceiveRecovery::Recorded(operation_id)
+        } else {
+            warn!(
+                target: LOG_CLIENT_MODULE_LNV2,
+                contract_id = ?contract.contract_id(),
+                "Failed to record the recovery of an incoming contract"
+            );
+
+            DirectReceiveRecovery::Failed
+        }
+    }
+
     async fn receive_lnurl(&self, custom_meta: Value) {
         // Read the stream cursor with a short-lived transaction. It must NOT stay open
         // across the long-poll below: RocksDB's optimistic transactions validate a
@@ -1492,6 +1679,8 @@ impl LightningClientModule {
             .await_incoming_contracts(stream_index, 128)
             .await;
 
+        let mut batch_handled = true;
+
         for contract in &contracts {
             if let Some(operation_id) = self
                 .receive_incoming_contract(
@@ -1504,10 +1693,48 @@ impl LightningClientModule {
                 )
                 .await
             {
-                self.await_final_receive_operation_state(operation_id)
-                    .await
-                    .ok();
+                if self.operation_recorded(operation_id).await {
+                    self.await_final_receive_operation_state(operation_id)
+                        .await
+                        .ok();
+                } else {
+                    warn!(
+                        target: LOG_CLIENT_MODULE_LNV2,
+                        contract_id = ?contract.contract_id(),
+                        "Failed to record an lnurl receive operation"
+                    );
+
+                    batch_handled = false;
+                }
+            } else {
+                // The contract is not locked to the lnurl key, so check the
+                // static module key used by direct (invoice) receives. On a
+                // client whose database contains the original operation this
+                // is skipped; on a client restored from seed it rediscovers a
+                // funded contract whose operation was lost with the database
+                // and claims it.
+                //
+                // Unlike the lnurl branch above, the final state is not
+                // awaited inline: the recovery is driven by its own
+                // persisted state machine, so the scan need not block on
+                // the claim reaching consensus before moving on.
+                batch_handled &= !matches!(
+                    self.try_recover_direct_receive(contract, custom_meta.clone())
+                        .await,
+                    DirectReceiveRecovery::Failed
+                );
             }
+        }
+
+        // A receive that failed to commit must not be skipped: the scan only
+        // ever moves forward, so nothing revisits a contract once the cursor
+        // is past it. Leaving the cursor in place re-fetches and re-processes
+        // the batch - idempotently, thanks to the contract-derived operation
+        // ids - on the next iteration.
+        if !batch_handled {
+            fedimint_core::runtime::sleep(std::time::Duration::from_secs(10)).await;
+
+            return;
         }
 
         // Advance the cursor in its own short transaction. This is the only writer of
@@ -1525,6 +1752,21 @@ impl LightningClientModule {
 
         dbtx.commit_tx().await;
     }
+}
+
+/// The outcome of attempting to recover a direct receive from a single
+/// incoming contract.
+#[derive(Debug)]
+enum DirectReceiveRecovery {
+    /// A recovery operation was recorded for the contract and verified to
+    /// exist.
+    Recorded(OperationId),
+    /// There is nothing to recover: the operation already exists or the
+    /// contract is not locked to the static module key.
+    NotNeeded,
+    /// The recovery failed to be recorded, so a scan must not advance past
+    /// the contract.
+    Failed,
 }
 
 #[derive(Error, Debug, Clone, Eq, PartialEq)]

--- a/modules/fedimint-lnv2-client/src/receive_sm.rs
+++ b/modules/fedimint-lnv2-client/src/receive_sm.rs
@@ -52,10 +52,12 @@ pub enum ReceiveSMState {
     /// [`crate::LightningClientModule::reclaim_receive`].
     ClaimingLegacy(Vec<OutPoint>),
     Expired,
-    /// Claiming the contract costs more in federation fees than the contract is
-    /// worth, so there is nothing to recover. Terminal: the verdict follows
-    /// from the contract amount and the federation's fee consensus, so waiting
-    /// does not change it.
+    /// The claim could not be funded, so there is nothing to recover. The
+    /// contract is the transaction's only input, so the primary module has to
+    /// cover the shortfall whenever the federation's fees exceed the contract;
+    /// this state is the case where it holds too little to do so. Terminal:
+    /// the state machine does not poll for the balance or the fee consensus to
+    /// change.
     Uneconomical,
     Claiming {
         change: OutPointRange,
@@ -80,7 +82,7 @@ pub enum ReceiveSMState {
 ///
 ///     Pending -- incoming contract is confirmed --> Claiming
 ///     Pending -- decryption contract expires --> Expired
-///     Pending -- claim fee exceeds the contract --> Uneconomical
+///     Pending -- the claim cannot be funded --> Uneconomical
 ///     Claiming -- claim transaction is accepted --> Claimed
 ///     Claiming -- claim transaction is rejected --> Failed
 /// ```
@@ -255,6 +257,10 @@ impl ReceiveStateMachine {
             // manually created invoices; lnurl receives have no invoice on the
             // client, so the fee is recovered from the fee-encoded expiration.
             Ok(LightningOperationMeta::Receive(meta)) => meta.gateway_fee(),
+            // A recovered receive lost its invoice with the original database
+            // and its expiration is a real timestamp rather than a fee
+            // encoding, so the gateway fee is unknown and reported as zero.
+            Ok(LightningOperationMeta::RecoveredReceive(..)) => Amount::ZERO,
             _ => Amount::from_msats(fee_from_expiration(
                 old_state.common.contract.commitment.expiration_or_fee,
             )),

--- a/modules/fedimint-lnv2-client/src/receive_sm.rs
+++ b/modules/fedimint-lnv2-client/src/receive_sm.rs
@@ -228,6 +228,10 @@ impl ReceiveStateMachine {
             // manually created invoices; lnurl receives have no invoice on the
             // client, so the fee is recovered from the fee-encoded expiration.
             Ok(LightningOperationMeta::Receive(meta)) => meta.gateway_fee(),
+            // A recovered receive lost its invoice with the original database
+            // and its expiration is a real timestamp rather than a fee
+            // encoding, so the gateway fee is unknown and reported as zero.
+            Ok(LightningOperationMeta::RecoveredReceive(..)) => Amount::ZERO,
             _ => Amount::from_msats(fee_from_expiration(
                 old_state.common.contract.commitment.expiration_or_fee,
             )),

--- a/modules/fedimint-lnv2-tests/tests/tests.rs
+++ b/modules/fedimint-lnv2-tests/tests/tests.rs
@@ -2,25 +2,30 @@ mod mock;
 
 use std::pin::pin;
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::Context as _;
 use async_stream::stream;
 use bitcoin::hashes::sha256;
-use fedimint_client::ClientHandleArc;
+use fedimint_client::db::CachedApiVersionSetKey;
+use fedimint_client::secret::{PlainRootSecretStrategy, RootSecretStrategy};
 use fedimint_client::sm::executor::InactiveStateKeyDb;
 use fedimint_client::transaction::{
     ClientInput, ClientInputBundle, ClientOutput, ClientOutputBundle, TransactionBuilder,
 };
+use fedimint_client::{Client, ClientHandleArc, RootSecret};
 use fedimint_client_module::module::ClientModule;
 use fedimint_client_module::sm::InactiveStateMeta;
 use fedimint_client_module::sm::executor::InactiveStateKey;
 use fedimint_core::base32::{FEDIMINT_PREFIX, decode_prefixed};
 use fedimint_core::core::{IntoDynInstance, OperationId};
-use fedimint_core::db::IDatabaseTransactionOpsCoreTyped;
+use fedimint_core::db::mem_impl::MemDatabase;
+use fedimint_core::db::{Database, IDatabaseTransactionOpsCoreTyped};
 use fedimint_core::encoding::Encodable;
 use fedimint_core::module::{AmountUnit, Amounts};
 use fedimint_core::secp256k1::rand::rngs::OsRng;
 use fedimint_core::secp256k1::{Keypair, PublicKey, SECP256K1, Scalar, SecretKey};
+use fedimint_core::task::sleep_in_test;
 use fedimint_core::time::duration_since_epoch;
 use fedimint_core::util::{NextOrPending as _, SafeUrl, backoff_util, retry};
 use fedimint_core::{Amount, BitcoinHash, OutPoint, TransactionId, msats, sats, secp256k1};
@@ -28,13 +33,15 @@ use fedimint_dummy_client::{DummyClientInit, DummyClientModule};
 use fedimint_dummy_server::DummyInit;
 use fedimint_eventlog::{Event, EventLogEntry, EventLogId};
 use fedimint_lnurl::parse_lnurl;
+use fedimint_lnv2_client::db::IncomingContractStreamIndexKey;
 use fedimint_lnv2_client::events::{
     ReceivePaymentEvent, SendPaymentEvent, SendPaymentStatus, SendPaymentUpdateEvent,
 };
 use fedimint_lnv2_client::{
     FinalReceiveOperationState, InvoiceSendStatus, LightningClientInit, LightningClientModule,
     LightningOperationMeta, LnurlReceiveOperationMeta, ReceiveOperationState, ReceiveSMCommon,
-    ReceiveSMState, ReceiveStateMachine, SendOperationState, SendPaymentError,
+    ReceiveSMState, ReceiveStateMachine, RecoveredReceiveOperationMeta, SendOperationState,
+    SendPaymentError,
 };
 use fedimint_lnv2_common::config::LightningClientConfig;
 use fedimint_lnv2_common::contracts::{IncomingContract, PaymentImage};
@@ -45,6 +52,7 @@ use fedimint_lnv2_common::{
 };
 use fedimint_lnv2_server::LightningInit;
 use fedimint_logging::LOG_TEST;
+use fedimint_testing::federation::FederationTest;
 use fedimint_testing::fixtures::Fixtures;
 use futures::StreamExt;
 use serde_json::Value;
@@ -102,20 +110,21 @@ fn try_parse_ln_event(entry: &EventLogEntry) -> Option<LnEvent> {
     None
 }
 
+fn lightning_client_init() -> LightningClientInit {
+    LightningClientInit {
+        gateway_conn: Some(Arc::new(MockGatewayConnection::default())),
+        custom_meta_fn: Arc::new(|| {
+            serde_json::json!({
+                "timestamp": chrono::Utc::now().timestamp(),
+            })
+        }),
+    }
+}
+
 fn fixtures() -> Fixtures {
     let fixtures = Fixtures::new_primary(DummyClientInit, DummyInit);
 
-    fixtures.with_module(
-        LightningClientInit {
-            gateway_conn: Some(Arc::new(MockGatewayConnection::default())),
-            custom_meta_fn: Arc::new(|| {
-                serde_json::json!({
-                    "timestamp": chrono::Utc::now().timestamp(),
-                })
-            }),
-        },
-        LightningInit,
-    )
+    fixtures.with_module(lightning_client_init(), LightningInit)
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -372,6 +381,9 @@ async fn claiming_outgoing_contract_triggers_success() -> anyhow::Result<()> {
         LightningOperationMeta::Receive(..) => panic!("Operation Meta is a Receive variant"),
         LightningOperationMeta::LnurlReceive(..) => {
             panic!("Operation Meta is a LnurlReceive variant")
+        }
+        LightningOperationMeta::RecoveredReceive(..) => {
+            panic!("Operation Meta is a RecoveredReceive variant")
         }
     };
 
@@ -666,6 +678,446 @@ async fn funded_receive_is_claimed() -> anyhow::Result<()> {
         panic!("Expected Receive event");
     };
     assert_eq!(receive.operation_id, operation_id);
+
+    Ok(())
+}
+
+fn root_secret(bytes: &[u8; 64]) -> RootSecret {
+    RootSecret::StandardDoubleDerive(PlainRootSecretStrategy::to_root_secret(bytes))
+}
+
+/// Creates a direct receive on a client derived from `root_secret`, then
+/// shuts the client down, simulating a database lost before the payment was
+/// claimed. Returns the incoming contract and the contract-derived operation
+/// id a rediscovering client will record it under.
+async fn receive_and_lose_db(
+    fed: &FederationTest,
+    root_secret: RootSecret,
+) -> anyhow::Result<(IncomingContract, OperationId)> {
+    let original = fed
+        .join_client_with_db(MemDatabase::new().into(), root_secret)
+        .await;
+
+    let operation_id = original
+        .get_first_module::<LightningClientModule>()?
+        .receive(
+            Amount::from_sats(1000),
+            3600,
+            Bolt11InvoiceDescription::Direct(String::new()),
+            Some(mock::gateway()),
+            Value::Null,
+        )
+        .await?
+        .1;
+
+    let operation = original
+        .operation_log()
+        .get_operation(operation_id)
+        .await
+        .ok_or(anyhow::anyhow!("Operation not found"))?;
+
+    let contract = match operation.meta::<LightningOperationMeta>() {
+        LightningOperationMeta::Receive(meta) => meta.contract,
+        _ => panic!("Operation meta is not a receive variant"),
+    };
+
+    Arc::into_inner(original)
+        .expect("The test holds the only handle")
+        .shutdown()
+        .await;
+
+    Ok((contract, operation_id))
+}
+
+/// Waits until the recovered receive credits the client's balance and
+/// asserts the operation was recorded with a recovered receive meta.
+async fn await_recovered_receive(
+    client: &ClientHandleArc,
+    operation_id: OperationId,
+) -> anyhow::Result<RecoveredReceiveOperationMeta> {
+    let mut balance = Amount::ZERO;
+
+    for _ in 0..300 {
+        balance = client.get_balance_for_btc().await?;
+
+        if balance != Amount::ZERO {
+            break;
+        }
+
+        sleep_in_test(
+            "Waiting for the contract scan to claim the recovered receive",
+            Duration::from_millis(200),
+        )
+        .await;
+    }
+
+    // The claim credits the contract amount minus the lnv2 input fee.
+    assert!(
+        balance >= Amount::from_msats(900_000),
+        "Expected the recovered contract to be claimed, balance is {balance}"
+    );
+
+    // The rediscovered operation is recorded under the contract-derived
+    // operation id with a recovered receive meta.
+    let recovered_operation = client
+        .operation_log()
+        .get_operation(operation_id)
+        .await
+        .ok_or(anyhow::anyhow!("Recovered operation not found"))?;
+
+    let recovered_meta = match recovered_operation.meta::<LightningOperationMeta>() {
+        LightningOperationMeta::RecoveredReceive(meta) => meta,
+        meta => panic!("Operation meta is not a recovered receive variant: {meta:?}"),
+    };
+
+    // The invoice was lost with the original database, so the receive event
+    // reports the contract amount with a zero gateway fee rather than
+    // decoding the contract expiration as a fee.
+    let mut events = pin!(ln_event_stream(client));
+
+    let Some(LnEvent::Receive(receive)) = events.next().await else {
+        panic!("Expected Receive event");
+    };
+
+    assert_eq!(receive.operation_id, operation_id);
+    assert_eq!(receive.fee, Amount::ZERO);
+    assert_eq!(receive.amount, recovered_meta.contract.commitment.amount);
+
+    Ok(recovered_meta)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn scan_recovers_direct_receive_after_restore_from_seed() -> anyhow::Result<()> {
+    const RESTORE_SK: [u8; 64] = [0x21; 64];
+
+    let fixtures = fixtures();
+    let fed = fixtures.new_fed_degraded().await;
+
+    // The original client creates an invoice, then loses its database before
+    // the payment arrives.
+    let (contract, operation_id) = receive_and_lose_db(&fed, root_secret(&RESTORE_SK)).await?;
+
+    // A gateway funds the contract while the original client is gone.
+    let funder = fed.new_client().await;
+
+    funder
+        .get_first_module::<DummyClientModule>()?
+        .mock_receive(sats(10_000), AmountUnit::BITCOIN)
+        .await?;
+
+    fund_incoming_contract(&funder, contract.clone()).await?;
+
+    // The restored client has the seed but a fresh database. The incoming
+    // contract scan rediscovers the funded contract via the static module
+    // key and claims it without any local operation history.
+    let restored = fed
+        .join_client_with_db(MemDatabase::new().into(), root_secret(&RESTORE_SK))
+        .await;
+
+    let recovered_meta = await_recovered_receive(&restored, operation_id).await?;
+
+    // The automatic scan attaches the client's configured custom metadata,
+    // exactly like the lnurl branch of the same loop.
+    assert!(
+        recovered_meta.custom_meta.get("timestamp").is_some(),
+        "Expected the configured custom meta, got {:?}",
+        recovered_meta.custom_meta
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn rescan_recovers_direct_receive_missed_by_earlier_scan() -> anyhow::Result<()> {
+    const RESTORE_SK: [u8; 64] = [0x22; 64];
+
+    let fixtures = fixtures();
+    let fed = fixtures.new_fed_degraded().await;
+
+    let (contract, operation_id) = receive_and_lose_db(&fed, root_secret(&RESTORE_SK)).await?;
+
+    let funder = fed.new_client().await;
+
+    funder
+        .get_first_module::<DummyClientModule>()?
+        .mock_receive(sats(10_000), AmountUnit::BITCOIN)
+        .await?;
+
+    fund_incoming_contract(&funder, contract.clone()).await?;
+
+    // Simulate a database restored from seed by a client from before direct
+    // receives were recovered by the scan: its persisted cursor has already
+    // advanced past the funded contract, so the tail scan alone never
+    // revisits it and only a manual rescan can rediscover it.
+    let lnv2_module_id = funder
+        .get_first_instance(&LightningClientModule::kind())
+        .expect("lnv2 module is registered");
+
+    let db: Database = MemDatabase::new().into();
+
+    {
+        let (module_db, _) = db.with_prefix_module_id(lnv2_module_id);
+
+        let mut dbtx = module_db.begin_transaction().await;
+
+        // The module's own scan cursor, under the client's module instance
+        // prefix: already at the stream tip of one funded contract.
+        dbtx.insert_entry(&IncomingContractStreamIndexKey, &1).await;
+
+        dbtx.commit_tx().await;
+    }
+
+    let restored = fed.join_client_with_db(db, root_secret(&RESTORE_SK)).await;
+
+    // The tail scan starts at the cursor, which is already past the funded
+    // contract, so it never records the recovery on its own.
+    assert!(
+        restored
+            .operation_log()
+            .get_operation(operation_id)
+            .await
+            .is_none(),
+        "The tail scan must not recover a contract behind the persisted cursor"
+    );
+
+    let operation_ids = restored
+        .get_first_module::<LightningClientModule>()?
+        .rescan_incoming_contracts(Value::Null)
+        .await?;
+
+    assert!(
+        operation_ids.contains(&operation_id),
+        "Expected the rescan to record the recovery of the funded contract, got {operation_ids:?}"
+    );
+
+    let recovered_meta = await_recovered_receive(&restored, operation_id).await?;
+
+    // A manual rescan uses the metadata passed by its caller.
+    assert_eq!(recovered_meta.custom_meta, Value::Null);
+
+    Ok(())
+}
+
+/// Reads the incoming contract scan cursor out of a client's database.
+///
+/// The cursor is the module's own `IncomingContractStreamIndexKey`, read under
+/// the client's module instance prefix the way
+/// `rescan_recovers_direct_receive_missed_by_earlier_scan` writes it. `None`
+/// means the scan has never committed a cursor, i.e. it never got past its
+/// first batch.
+async fn scan_cursor(client: &Client) -> Option<u64> {
+    let lnv2_module_id = client
+        .get_first_instance(&LightningClientModule::kind())
+        .expect("lnv2 module is registered");
+
+    let (module_db, _) = client.db().with_prefix_module_id(lnv2_module_id);
+
+    module_db
+        .begin_transaction_nc()
+        .await
+        .get_value(&IncomingContractStreamIndexKey)
+        .await
+}
+
+/// A batch of nothing but dust must not hold the scan cursor.
+///
+/// Skipping a contract the claim fee would swallow is the point of the dust
+/// check, but pricing one through a fee quote asks the primary module to
+/// balance a claim the contract cannot fund, which fails outright on a wallet
+/// with no balance to top the shortfall up from. Reading that failure as
+/// "cannot price this yet" holds the cursor, and the cursor only ever moves
+/// forward: the scan re-fetches the same batch every ten seconds forever, and
+/// once 128 dust contracts fill a batch no later contract is ever seen again —
+/// a wallet bricked for the price of a few sats, by a different route.
+///
+/// `unsolicited_dust_contract_does_not_wedge_the_client` cannot see this: it
+/// funds a claimable contract in the same batch, which the victim claims
+/// whether or not the cursor ever moved.
+#[tokio::test(flavor = "multi_thread")]
+async fn dust_alone_does_not_hold_the_scan_cursor() -> anyhow::Result<()> {
+    let fixtures = fixtures();
+    let fed = fixtures.new_fed_degraded().await;
+    let victim = fed.new_client().await;
+    let attacker = fed.new_client().await;
+
+    attacker
+        .get_first_module::<DummyClientModule>()?
+        .mock_receive(sats(10_000), AmountUnit::BITCOIN)
+        .await?;
+
+    // Everything the attacker needs is in what the victim publishes.
+    let lnurl = victim
+        .get_first_module::<LightningClientModule>()?
+        .generate_lnurl(
+            SafeUrl::parse("https://recurring.xyz/").expect("Valid Url"),
+            Some(mock::gateway()),
+        )
+        .await?;
+    let url = parse_lnurl(&lnurl).expect("Generated lnurl decodes");
+    let payload = url.rsplit("pay/").next().expect("Url carries a payload");
+    let request = decode_prefixed::<LnurlRequest>(FEDIMINT_PREFIX, payload)?;
+
+    // The stream holds nothing but the dust, and the victim holds no balance
+    // at all — the state a fresh wallet publishing an address is in, and the
+    // one in which no quote for the claim can be taken.
+    let dust = incoming_contract_for(request.recipient_pk, request.aggregate_pk, msats(1));
+    fund_incoming_contract(&attacker, dust.clone()).await?;
+
+    let cursor = retry(
+        "waiting for the scan cursor to advance past the dust contract",
+        backoff_util::aggressive_backoff(),
+        || async {
+            scan_cursor(&victim)
+                .await
+                .context("The scan cursor never advanced past the dust contract")
+        },
+    )
+    .await;
+
+    assert!(
+        matches!(cursor, Ok(1)),
+        "The scan cursor must advance past the only dust contract in the stream, got {cursor:?}"
+    );
+
+    // Advancing past the dust is skipping it, not claiming it.
+    assert!(
+        victim
+            .operation_log()
+            .get_operation(OperationId::from_encodable(&dust))
+            .await
+            .is_none(),
+        "Dust contract should have been ignored"
+    );
+
+    Ok(())
+}
+
+/// A claim that genuinely cannot be priced must hold the scan cursor, and the
+/// contract must still be recovered once pricing works again.
+///
+/// This is the case the dust check must not swallow. The contract is worth
+/// claiming; the client is simply in no position to price it, because a fee
+/// quote is balanced by the primary module and no primary module is in the
+/// registry. That is the real shape of a restore from seed: a module whose
+/// recovery is still running stays out of the module registry until the client
+/// is reopened with that recovery complete (the `initialize_module` branch in
+/// `fedimint-client/src/client/builder.rs`). Advancing the cursor there would
+/// abandon the contract, since the scan only ever moves forward.
+///
+/// The registry is emptied of everything but the lightning module to reach
+/// that state, which is what
+/// `scan_recovers_direct_receive_after_restore_from_seed` cannot do: it joins
+/// with the fixture's registry, primary module included.
+#[tokio::test(flavor = "multi_thread")]
+async fn scan_holds_the_cursor_until_the_claim_can_be_priced() -> anyhow::Result<()> {
+    const RESTORE_SK: [u8; 64] = [0x23; 64];
+    const FILLER_SK: [u8; 64] = [0x24; 64];
+
+    let fixtures = fixtures();
+    let fed = fixtures.new_fed_degraded().await;
+
+    // `receive_and_lose_db` asks for a thousand satoshis, three orders of
+    // magnitude clear of the one the lightning input fee costs, so the verdict
+    // genuinely depends on the quote rather than being settled by the local
+    // dust check ahead of it. Were that amount ever dropped into dust range,
+    // the cursor assertion below is what fails: the dust check would skip the
+    // contract and let the cursor advance.
+    let (contract, operation_id) = receive_and_lose_db(&fed, root_secret(&RESTORE_SK)).await?;
+
+    let funder = fed.new_client().await;
+
+    funder
+        .get_first_module::<DummyClientModule>()?
+        .mock_receive(sats(10_000), AmountUnit::BITCOIN)
+        .await?;
+
+    // Consume stream index zero, then claim the contract so the stream is
+    // sparse. This lets the rescan below start before the persisted cursor and
+    // still reach the target exactly at that cursor, proving the unpriceable
+    // recovery path ran without moving the cursor past the target first.
+    let (filler, filler_operation_id) = receive_and_lose_db(&fed, root_secret(&FILLER_SK)).await?;
+
+    fund_incoming_contract(&funder, filler).await?;
+
+    let filler_recipient = fed
+        .join_client_with_db(MemDatabase::new().into(), root_secret(&FILLER_SK))
+        .await;
+
+    await_recovered_receive(&filler_recipient, filler_operation_id).await?;
+
+    fund_incoming_contract(&funder, contract.clone()).await?;
+
+    let db: Database = MemDatabase::new().into();
+
+    {
+        let lnv2_module_id = funder
+            .get_first_instance(&LightningClientModule::kind())
+            .expect("lnv2 module is registered");
+        let (module_db, _) = db.with_prefix_module_id(lnv2_module_id);
+        let mut dbtx = module_db.begin_transaction().await;
+
+        // The module's own scan cursor: index zero was claimed above, and the
+        // target is at index one.
+        dbtx.insert_entry(&IncomingContractStreamIndexKey, &1).await;
+
+        dbtx.commit_tx().await;
+    }
+
+    // A client that runs the lightning module and nothing else, because
+    // nothing else is in its registry. Its scan runs, and every fee quote it
+    // takes fails for want of a primary module to balance against.
+    let unpriceable = {
+        let mut builder = Client::builder().await?;
+
+        builder.with_module(lightning_client_init());
+
+        builder
+            .preview_with_existing_config(funder.endpoints().clone(), funder.config().await, None)
+            .await?
+            .join(db.clone(), root_secret(&RESTORE_SK))
+            .await?
+    };
+
+    // The sparse rescan begins at index zero and reaches the target at index
+    // one. The failed quote returns before `receive_incoming_contract` can
+    // attempt to record the recovery, so the resulting rescan error proves the
+    // direct-recovery verdict was attempted and could not be priced.
+    unpriceable
+        .get_first_module::<LightningClientModule>()?
+        .rescan_incoming_contracts(Value::Null)
+        .await
+        .expect_err("The rescan must report an unpriceable recovery");
+
+    // The rescan itself never writes the cursor, so this catches only the tail
+    // scan advancing it. That the hold actually preserved the claim is what
+    // the recovery after the reopen below proves.
+    assert_eq!(
+        scan_cursor(&unpriceable).await,
+        Some(1),
+        "The scan must not advance past a contract whose claim it could not price"
+    );
+
+    unpriceable.shutdown().await;
+
+    // Joining with a registry short of the primary module also cached an API
+    // version set short of it, and a cached set is reused on the next open —
+    // which would drop the module from the reopened client too. That is an
+    // artifact of how this test takes the module away, not of the state it
+    // stands in for: a restore from seed negotiates against its whole
+    // registry both times, and the module is missing only for as long as its
+    // recovery runs. Dropping the cache lets the reopen negotiate afresh.
+    let mut dbtx = db.begin_transaction().await;
+
+    dbtx.remove_entry(&CachedApiVersionSetKey).await;
+
+    dbtx.commit_tx().await;
+
+    // Reopening the same database with a primary module present is the other
+    // half of a restore from seed: the recovery is complete, the module is
+    // back in the registry, and the scan resumes from the cursor it held.
+    let restored = fed.open_client_with_db(db, root_secret(&RESTORE_SK)).await;
+
+    await_recovered_receive(&restored, operation_id).await?;
 
     Ok(())
 }

--- a/modules/fedimint-lnv2-tests/tests/tests.rs
+++ b/modules/fedimint-lnv2-tests/tests/tests.rs
@@ -2,23 +2,27 @@ mod mock;
 
 use std::pin::pin;
 use std::sync::Arc;
+use std::time::Duration;
 
 use async_stream::stream;
 use bitcoin::hashes::sha256;
-use fedimint_client::ClientHandleArc;
+use fedimint_client::secret::{PlainRootSecretStrategy, RootSecretStrategy};
 use fedimint_client::sm::executor::InactiveStateKeyDb;
 use fedimint_client::transaction::{
     ClientInput, ClientInputBundle, ClientOutput, ClientOutputBundle, TransactionBuilder,
 };
+use fedimint_client::{ClientHandleArc, RootSecret};
 use fedimint_client_module::module::ClientModule;
 use fedimint_client_module::sm::InactiveStateMeta;
 use fedimint_client_module::sm::executor::InactiveStateKey;
 use fedimint_core::core::{IntoDynInstance, OperationId};
-use fedimint_core::db::IDatabaseTransactionOpsCoreTyped;
+use fedimint_core::db::mem_impl::MemDatabase;
+use fedimint_core::db::{Database, IDatabaseTransactionOpsCore, IDatabaseTransactionOpsCoreTyped};
 use fedimint_core::encoding::Encodable;
 use fedimint_core::module::{AmountUnit, Amounts};
 use fedimint_core::secp256k1::rand::rngs::OsRng;
 use fedimint_core::secp256k1::{Keypair, SECP256K1, SecretKey};
+use fedimint_core::task::sleep_in_test;
 use fedimint_core::util::NextOrPending as _;
 use fedimint_core::{Amount, BitcoinHash, OutPoint, TransactionId, sats};
 use fedimint_dummy_client::{DummyClientInit, DummyClientModule};
@@ -30,7 +34,8 @@ use fedimint_lnv2_client::events::{
 use fedimint_lnv2_client::{
     FinalReceiveOperationState, InvoiceSendStatus, LightningClientInit, LightningClientModule,
     LightningOperationMeta, LnurlReceiveOperationMeta, ReceiveOperationState, ReceiveSMCommon,
-    ReceiveSMState, ReceiveStateMachine, SendOperationState, SendPaymentError,
+    ReceiveSMState, ReceiveStateMachine, RecoveredReceiveOperationMeta, SendOperationState,
+    SendPaymentError,
 };
 use fedimint_lnv2_common::config::LightningClientConfig;
 use fedimint_lnv2_common::contracts::{IncomingContract, PaymentImage};
@@ -40,6 +45,7 @@ use fedimint_lnv2_common::{
 };
 use fedimint_lnv2_server::LightningInit;
 use fedimint_logging::LOG_TEST;
+use fedimint_testing::federation::FederationTest;
 use fedimint_testing::fixtures::Fixtures;
 use futures::StreamExt;
 use serde_json::Value;
@@ -367,6 +373,9 @@ async fn claiming_outgoing_contract_triggers_success() -> anyhow::Result<()> {
         LightningOperationMeta::LnurlReceive(..) => {
             panic!("Operation Meta is a LnurlReceive variant")
         }
+        LightningOperationMeta::RecoveredReceive(..) => {
+            panic!("Operation Meta is a RecoveredReceive variant")
+        }
     };
 
     let client_input = ClientInput::<LightningInput> {
@@ -537,6 +546,224 @@ async fn funded_receive_is_claimed() -> anyhow::Result<()> {
         panic!("Expected Receive event");
     };
     assert_eq!(receive.operation_id, operation_id);
+
+    Ok(())
+}
+
+fn root_secret(bytes: &[u8; 64]) -> RootSecret {
+    RootSecret::StandardDoubleDerive(PlainRootSecretStrategy::to_root_secret(bytes))
+}
+
+/// Creates a direct receive on a client derived from `root_secret`, then
+/// shuts the client down, simulating a database lost before the payment was
+/// claimed. Returns the incoming contract and the contract-derived operation
+/// id a rediscovering client will record it under.
+async fn receive_and_lose_db(
+    fed: &FederationTest,
+    root_secret: RootSecret,
+) -> anyhow::Result<(IncomingContract, OperationId)> {
+    let original = fed
+        .join_client_with_db(MemDatabase::new().into(), root_secret)
+        .await;
+
+    let operation_id = original
+        .get_first_module::<LightningClientModule>()?
+        .receive(
+            Amount::from_sats(1000),
+            3600,
+            Bolt11InvoiceDescription::Direct(String::new()),
+            Some(mock::gateway()),
+            Value::Null,
+        )
+        .await?
+        .1;
+
+    let operation = original
+        .operation_log()
+        .get_operation(operation_id)
+        .await
+        .ok_or(anyhow::anyhow!("Operation not found"))?;
+
+    let contract = match operation.meta::<LightningOperationMeta>() {
+        LightningOperationMeta::Receive(meta) => meta.contract,
+        _ => panic!("Operation meta is not a receive variant"),
+    };
+
+    Arc::into_inner(original)
+        .expect("The test holds the only handle")
+        .shutdown()
+        .await;
+
+    Ok((contract, operation_id))
+}
+
+/// Waits until the recovered receive credits the client's balance and
+/// asserts the operation was recorded with a recovered receive meta.
+async fn await_recovered_receive(
+    client: &ClientHandleArc,
+    operation_id: OperationId,
+) -> anyhow::Result<RecoveredReceiveOperationMeta> {
+    let mut balance = Amount::ZERO;
+
+    for _ in 0..300 {
+        balance = client.get_balance_for_btc().await?;
+
+        if balance != Amount::ZERO {
+            break;
+        }
+
+        sleep_in_test(
+            "Waiting for the contract scan to claim the recovered receive",
+            Duration::from_millis(200),
+        )
+        .await;
+    }
+
+    // The claim credits the contract amount minus the lnv2 input fee.
+    assert!(
+        balance >= Amount::from_msats(900_000),
+        "Expected the recovered contract to be claimed, balance is {balance}"
+    );
+
+    // The rediscovered operation is recorded under the contract-derived
+    // operation id with a recovered receive meta.
+    let recovered_operation = client
+        .operation_log()
+        .get_operation(operation_id)
+        .await
+        .ok_or(anyhow::anyhow!("Recovered operation not found"))?;
+
+    let recovered_meta = match recovered_operation.meta::<LightningOperationMeta>() {
+        LightningOperationMeta::RecoveredReceive(meta) => meta,
+        meta => panic!("Operation meta is not a recovered receive variant: {meta:?}"),
+    };
+
+    // The invoice was lost with the original database, so the receive event
+    // reports the contract amount with a zero gateway fee rather than
+    // decoding the contract expiration as a fee.
+    let mut events = pin!(ln_event_stream(client));
+
+    let Some(LnEvent::Receive(receive)) = events.next().await else {
+        panic!("Expected Receive event");
+    };
+
+    assert_eq!(receive.operation_id, operation_id);
+    assert_eq!(receive.fee, Amount::ZERO);
+    assert_eq!(receive.amount, recovered_meta.contract.commitment.amount);
+
+    Ok(recovered_meta)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn scan_recovers_direct_receive_after_restore_from_seed() -> anyhow::Result<()> {
+    const RESTORE_SK: [u8; 64] = [0x21; 64];
+
+    let fixtures = fixtures();
+    let fed = fixtures.new_fed_degraded().await;
+
+    // The original client creates an invoice, then loses its database before
+    // the payment arrives.
+    let (contract, operation_id) = receive_and_lose_db(&fed, root_secret(&RESTORE_SK)).await?;
+
+    // A gateway funds the contract while the original client is gone.
+    let funder = fed.new_client().await;
+
+    funder
+        .get_first_module::<DummyClientModule>()?
+        .mock_receive(sats(10_000), AmountUnit::BITCOIN)
+        .await?;
+
+    fund_incoming_contract(&funder, contract.clone()).await?;
+
+    // The restored client has the seed but a fresh database. The incoming
+    // contract scan rediscovers the funded contract via the static module
+    // key and claims it without any local operation history.
+    let restored = fed
+        .join_client_with_db(MemDatabase::new().into(), root_secret(&RESTORE_SK))
+        .await;
+
+    let recovered_meta = await_recovered_receive(&restored, operation_id).await?;
+
+    // The automatic scan attaches the client's configured custom metadata,
+    // exactly like the lnurl branch of the same loop.
+    assert!(
+        recovered_meta.custom_meta.get("timestamp").is_some(),
+        "Expected the configured custom meta, got {:?}",
+        recovered_meta.custom_meta
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn rescan_recovers_direct_receive_missed_by_earlier_scan() -> anyhow::Result<()> {
+    const RESTORE_SK: [u8; 64] = [0x22; 64];
+
+    let fixtures = fixtures();
+    let fed = fixtures.new_fed_degraded().await;
+
+    let (contract, operation_id) = receive_and_lose_db(&fed, root_secret(&RESTORE_SK)).await?;
+
+    let funder = fed.new_client().await;
+
+    funder
+        .get_first_module::<DummyClientModule>()?
+        .mock_receive(sats(10_000), AmountUnit::BITCOIN)
+        .await?;
+
+    fund_incoming_contract(&funder, contract.clone()).await?;
+
+    // Simulate a database restored from seed by a client from before direct
+    // receives were recovered by the scan: its persisted cursor has already
+    // advanced past the funded contract, so the tail scan alone never
+    // revisits it and only a manual rescan can rediscover it.
+    let lnv2_module_id = funder
+        .get_first_instance(&LightningClientModule::kind())
+        .expect("lnv2 module is registered");
+
+    let db: Database = MemDatabase::new().into();
+
+    {
+        let (module_db, _) = db.with_prefix_module_id(lnv2_module_id);
+
+        let mut dbtx = module_db.begin_transaction().await;
+
+        // Raw write of the module's IncomingContractStreamIndexKey (prefix
+        // 0x42), which is private to the module: cursor already at the
+        // stream tip of one funded contract.
+        dbtx.raw_insert_bytes(&[0x42], &1u64.consensus_encode_to_vec())
+            .await?;
+
+        dbtx.commit_tx().await;
+    }
+
+    let restored = fed.join_client_with_db(db, root_secret(&RESTORE_SK)).await;
+
+    // The tail scan starts at the cursor, which is already past the funded
+    // contract, so it never records the recovery on its own.
+    assert!(
+        restored
+            .operation_log()
+            .get_operation(operation_id)
+            .await
+            .is_none(),
+        "The tail scan must not recover a contract behind the persisted cursor"
+    );
+
+    let operation_ids = restored
+        .get_first_module::<LightningClientModule>()?
+        .rescan_incoming_contracts(Value::Null)
+        .await?;
+
+    assert!(
+        operation_ids.contains(&operation_id),
+        "Expected the rescan to record the recovery of the funded contract, got {operation_ids:?}"
+    );
+
+    let recovered_meta = await_recovered_receive(&restored, operation_id).await?;
+
+    // A manual rescan uses the metadata passed by its caller.
+    assert_eq!(recovered_meta.custom_meta, Value::Null);
 
     Ok(())
 }


### PR DESCRIPTION
Stacked on #8935; the base of this PR is that branch, so only the scan-recovery commit shows here.

## Summary

A funded incoming contract for a direct (invoice) receive becomes unreachable if the client restores from seed before the claim lands: lnv2 has no backup, and while the lnurl scan rediscovers lnurl-keyed contracts after a restore, nothing ever looks for contracts locked to the static module key. This PR extends the incoming contract scan to also try the static module key, so a restored client rediscovers and claims funded direct-receive contracts, and adds a manual `rescan_incoming_contracts` break-glass API for wallets whose scan cursor had already advanced past their contracts.

## Details

The incoming contract scan already walks the federation-wide contract stream and tries `recover_contract_keys` with the lnurl keypair on every contract. This adds a second attempt with the static module keypair when the lnurl key does not match:

- On a client whose database still contains the original operation, the contract-derived operation id skips the contract, so live receives on the same database are unaffected. (A second live client on the same seed will now race the first device's pending direct receives, as lnurl receives always have; concurrent same-seed clients remain unsupported, and seed recovery cannot distinguish a replacement device from a concurrent one.)
- On a restored client the scan starts at stream index 0, rediscovers the funded contract and starts a receive state machine that claims it - including contracts funded only after the restore. The federation removes claimed contracts from the stream during input processing, so the scan only ever sees contracts that are still claimable.
- The final state of scan-discovered receives is not awaited inline: the persisted state machine drives the claim, and per #8935 a rejected claim fails visibly and is re-driven manually with `reclaim_receive`.
- A new `RecoveredReceive` operation meta marks these operations, carrying the scan's configured custom metadata. The invoice is unrecoverable (lost with the database), so the receive payment event reports the contract amount with a zero gateway fee; reusing the lnurl meta instead would have decoded the direct contract's real expiration timestamp as a fee-encoded value.
- Recording a recovery can silently fail (`manual_operation_start` maps any commit failure to its swallowed duplicate-operation error), so the scan verifies the operation exists before advancing the cursor past a contract, and otherwise holds the cursor and re-processes the batch - idempotently, thanks to the contract-derived operation ids.
- Clients that restored from seed before this change already advanced the cursor past every contract their restore should have rediscovered, and the tail scan never revisits them. Instead of an automatic background sweep (with marker keys, resume state, and a dedicated task), recovery for that population is a manual, stateless API: `rescan_incoming_contracts` walks the stream below the captured cursor in bounded batches (on a sparse stream the final batch may also touch contracts above the cursor - harmless, since recording is idempotent and whichever caller records first wins), records recoveries idempotently, returns the newly recorded operation ids so callers can subscribe, processes the full range before erroring so one failed contract does not hide later recoverable ones, and errors when any recovery failed to record so the caller re-runs it. Exposed as the `rescan-incoming-contracts` CLI command.

## Reviewing

- The scan cost grows by one ECDH-and-compare per non-lnurl contract; the expensive threshold decryption only runs when the claim key actually matches.
- Contracts enter the stream only when funded and leave it when claimed, so unpaid invoices and settled receives never surface here.
- `LightningOperationMeta` gains a variant; external consumers matching on it exhaustively will need a new arm.

## Testing

- `scan_recovers_direct_receive_after_restore_from_seed`: creates an invoice, shuts the original client down, funds the contract while it is gone, and asserts a client restored from the same seed into a fresh database claims the contract automatically, records it with `RecoveredReceive` meta carrying the configured custom metadata, and emits the zero-fee receive event.
- `rescan_recovers_direct_receive_missed_by_earlier_scan`: seeds the restored database with a scan cursor already advanced past the funded contract (as a pre-upgrade restore left it), asserts the tail scan alone does not recover it, then asserts `rescan_incoming_contracts` returns the recovered operation id and the contract is claimed.
- Full lnv2 integration suite (11 tests), `cargo clippy --all-features -- -D warnings`, and `just final-lint` pass.

Fixes #8934

