### PR TITLE
fix(wallet): record peg-out change as an already-claimed peg-in

### DIFF
--- a/modules/fedimint-wallet-server/src/db.rs
+++ b/modules/fedimint-wallet-server/src/db.rs
@@ -12,7 +12,10 @@ use serde::Serialize;
 use strum_macros::EnumIter;
 
 use crate::common::{RecoveryItem, WalletInput};
-use crate::{PendingTransaction, SpendableUTXO, UnsignedTransaction, Wallet, WalletOutputOutcome};
+use crate::{
+    PEG_OUT_CHANGE_VOUT, PendingTransaction, SpendableUTXO, UnsignedTransaction, Wallet,
+    WalletOutputOutcome,
+};
 
 #[repr(u8)]
 #[derive(Clone, EnumIter, Debug)]
@@ -325,6 +328,45 @@ pub async fn migrate_to_v2(
     for (index, item) in recovery_items.into_iter().enumerate() {
         ctx.dbtx()
             .insert_new_entry(&RecoveryItemKey(index as u64), &item)
+            .await;
+    }
+
+    Ok(())
+}
+
+/// Migrate to v3, backfilling the change outputs of all peg-outs made so far.
+///
+/// Change outputs pay to the peg-in descriptor and so are indistinguishable
+/// from user deposits; going forward they are recorded as claimed when the
+/// peg-out is created, but transactions built before that change have no such
+/// record. Every peg-out we ever made is still listed under
+/// [`PegOutBitcoinTransaction`], which is never removed, so the set is
+/// recoverable in full.
+pub async fn migrate_to_v3(
+    mut ctx: ServerModuleDbMigrationFnContext<'_, Wallet>,
+) -> Result<(), anyhow::Error> {
+    let mut dbtx = ctx.dbtx();
+
+    let change_outpoints = dbtx
+        .find_by_prefix(&PegOutBitcoinTransactionPrefix)
+        .await
+        .map(|(_, outcome)| {
+            let WalletOutputOutcome::V0(outcome) = outcome else {
+                // Only V0 outcomes have ever been written, but an unknown variant
+                // carries no txid we could derive a change outpoint from.
+                return None;
+            };
+
+            Some(OutPoint {
+                txid: outcome.0,
+                vout: PEG_OUT_CHANGE_VOUT,
+            })
+        })
+        .collect::<Vec<_>>()
+        .await;
+
+    for outpoint in change_outpoints.into_iter().flatten() {
+        dbtx.insert_entry(&ClaimedPegInOutpointKey(outpoint), &())
             .await;
     }
 

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -117,11 +117,17 @@ use crate::db::{
     PegOutBitcoinTransaction, PegOutBitcoinTransactionPrefix, PegOutNonceKey, PegOutTxSignatureCI,
     PegOutTxSignatureCIPrefix, PendingTransactionKey, PendingTransactionPrefixKey, UTXOKey,
     UTXOPrefixKey, UnsignedTransactionKey, UnsignedTransactionPrefixKey, UnspentTxOutKey,
-    UnspentTxOutPrefix, migrate_to_v1, migrate_to_v2,
+    UnspentTxOutPrefix, migrate_to_v1, migrate_to_v2, migrate_to_v3,
 };
 use crate::metrics::WALLET_BLOCK_COUNT;
 
 mod metrics;
+
+/// Output index of the change output in every peg-out transaction we build.
+///
+/// `StatelessWallet::create_tx` always emits `[destination, change]`, and we
+/// always pay ourselves change to avoid losing value to dust.
+pub const PEG_OUT_CHANGE_VOUT: u32 = 1;
 
 #[derive(Debug, Clone)]
 pub struct WalletInit;
@@ -484,6 +490,10 @@ impl ServerModuleInit for WalletInit {
         migrations.insert(
             DatabaseVersion(1),
             Box::new(|ctx| migrate_to_v2(ctx).boxed()),
+        );
+        migrations.insert(
+            DatabaseVersion(2),
+            Box::new(|ctx| migrate_to_v3(ctx).boxed()),
         );
         migrations
     }
@@ -894,6 +904,20 @@ impl ServerModule for Wallet {
         for input in &tx.psbt.unsigned_tx.input {
             dbtx.remove_entry(&UTXOKey(input.previous_output)).await;
         }
+
+        // Our own change output pays to the peg-in descriptor, so it is
+        // indistinguishable from a user deposit. Record it as claimed now, in the same
+        // dbtx that spends the inputs, so it is never a peg-in candidate. Doing this at
+        // confirmation time instead would leave it claimable while the transaction is
+        // in flight.
+        dbtx.insert_entry(
+            &ClaimedPegInOutpointKey(bitcoin::OutPoint {
+                txid,
+                vout: PEG_OUT_CHANGE_VOUT,
+            }),
+            &(),
+        )
+        .await;
 
         dbtx.insert_new_entry(&UnsignedTransactionKey(txid), &tx)
             .await;
@@ -2175,7 +2199,7 @@ impl StatelessWallet<'_> {
         }
 
         // We always pay ourselves change back to ensure that we don't lose anything due
-        // to dust
+        // to dust. The change output is always at index `PEG_OUT_CHANGE_VOUT`.
         let change = total_selected_value - fees - peg_out_amount;
         let output: Vec<TxOut> = vec![
             TxOut {

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -33,8 +33,13 @@ use fedimint_wallet_client::{
 use fedimint_wallet_common::config::WalletConfig;
 use fedimint_wallet_common::tweakable::Tweakable;
 use fedimint_wallet_common::txoproof::PegInProof;
-use fedimint_wallet_common::{PegOutFees, Rbf, TxOutputSummary};
-use fedimint_wallet_server::WalletInit;
+use fedimint_wallet_common::{
+    PegOutFees, Rbf, TxOutputSummary, WalletOutputError, WalletOutputOutcome,
+};
+use fedimint_wallet_server::db::{
+    ClaimedPegInOutpointKey, PegOutBitcoinTransaction, UnsignedTransactionKey,
+};
+use fedimint_wallet_server::{PEG_OUT_CHANGE_VOUT, WalletInit};
 use futures::stream::StreamExt;
 use secp256k1::rand::rngs::OsRng;
 use tokio::select;
@@ -855,6 +860,214 @@ async fn peg_ins_that_are_unconfirmed_are_rejected() -> anyhow::Result<()> {
             .await,
         Ok(_)
     );
+    dbtx.commit_tx().await;
+    Ok(())
+}
+
+/// Our peg-out change pays to the peg-in descriptor, so on-chain it looks
+/// exactly like a user deposit. It has to be booked as an already-claimed
+/// peg-in as soon as the peg-out is created, otherwise it stays a valid
+/// peg-in candidate while the transaction is in flight.
+#[tokio::test(flavor = "multi_thread")]
+async fn peg_out_change_is_recorded_as_claimed() -> anyhow::Result<()> {
+    skip_if_not_wallet_test_group!("1");
+    let fixtures = fixtures();
+    let bitcoin = fixtures.bitcoin();
+    let bitcoin = bitcoin.lock_exclusive().await;
+    let dyn_bitcoin_rpc = fixtures.server_bitcoin_rpc();
+    let db = MemDatabase::new().into_database();
+    let task_group = TaskGroup::new();
+
+    let (wallet_server_cfg, _) = build_wallet_server_configs()?;
+    let module_instance_id = 1;
+    let wallet_config: WalletConfig = wallet_server_cfg[0].to_typed()?;
+    let finality_delay = wallet_config.consensus.finality_delay;
+
+    let root_secret =
+        PlainRootSecretStrategy::to_root_secret(&PlainRootSecretStrategy::random(&mut OsRng));
+    let secp = fedimint_core::secp256k1::Secp256k1::new();
+    let pk = root_secret.to_secp_key(&secp).public_key();
+    let peg_in_address = wallet_config
+        .consensus
+        .peg_in_descriptor
+        .tweak(&pk, secp256k1::SECP256K1)
+        .address(wallet_config.consensus.network.0)?;
+
+    let mut wallet = fedimint_wallet_server::Wallet::new(
+        wallet_server_cfg[0].to_typed()?,
+        &db,
+        &task_group,
+        PeerId::from(0),
+        DynGlobalApi::new(
+            ConnectorRegistry::build_from_testing_env()?.bind().await?,
+            [(
+                PeerId::from(0),
+                SafeUrl::from_str("ws://dummy.xyz").unwrap(),
+            )]
+            .into(),
+            None,
+        )?
+        .with_module(module_instance_id),
+        ServerBitcoinRpcMonitor::new(
+            fixtures.server_bitcoin_rpc(),
+            Duration::from_secs(1),
+            &TaskGroup::new(),
+        ),
+    )
+    .await?;
+
+    let mut dbtx = db.begin_transaction().await;
+
+    // Fund the federation wallet with a peg-in so a peg-out has UTXOs to spend
+    bitcoin.mine_blocks(finality_delay.into()).await;
+    let block_count = dyn_bitcoin_rpc.get_block_count().await? as u32;
+    sync_wallet_to_block(
+        &mut dbtx
+            .to_ref_with_prefix_module_id(module_instance_id)
+            .0
+            .into_nc(),
+        &mut wallet,
+        block_count - finality_delay,
+    )
+    .await?;
+
+    let (proof, transaction) = bitcoin
+        .send_and_mine_block(&peg_in_address, bsats(PEG_IN_AMOUNT_SATS))
+        .await;
+    bitcoin.mine_blocks(finality_delay.into()).await;
+
+    let block_count = dyn_bitcoin_rpc.get_block_count().await? as u32;
+    sync_wallet_to_block(
+        &mut dbtx
+            .to_ref_with_prefix_module_id(module_instance_id)
+            .0
+            .into_nc(),
+        &mut wallet,
+        block_count - finality_delay,
+    )
+    .await?;
+
+    let output_index = transaction
+        .output
+        .iter()
+        .position(|o| o.script_pubkey == peg_in_address.script_pubkey())
+        .context("expected to find peg-in output")?;
+    let peg_in_input = fedimint_wallet_common::WalletInput::new_v0(PegInProof::new(
+        proof,
+        transaction,
+        output_index.try_into()?,
+        pk,
+    )?);
+
+    wallet
+        .process_input(
+            &mut dbtx
+                .to_ref_with_prefix_module_id(module_instance_id)
+                .0
+                .into_nc(),
+            &peg_in_input,
+            InPoint {
+                txid: TransactionId::all_zeros(),
+                in_idx: 0,
+            },
+        )
+        .await?;
+
+    // Withdraw, leaving change
+    let recipient = bitcoin.get_new_address().await;
+    let out_point = fedimint_core::OutPoint {
+        txid: TransactionId::all_zeros(),
+        out_idx: 0,
+    };
+
+    // The declared fee has to match the weight of the transaction the wallet
+    // actually builds, which depends on how many UTXOs get selected. Ask for it
+    // the same way a client would before withdrawing.
+    let fee_rate = wallet
+        .consensus_fee_rate(
+            &mut dbtx
+                .to_ref_with_prefix_module_id(module_instance_id)
+                .0
+                .into_nc(),
+        )
+        .await;
+    let weight_probe = fedimint_wallet_common::WalletOutput::new_v0_peg_out(
+        recipient.clone(),
+        bsats(PEG_OUT_AMOUNT_SATS),
+        PegOutFees::new(fee_rate.sats_per_kvb, 0),
+    );
+    let total_weight = match wallet
+        .process_output(
+            &mut dbtx
+                .to_ref_with_prefix_module_id(module_instance_id)
+                .0
+                .into_nc(),
+            &weight_probe,
+            out_point,
+        )
+        .await
+    {
+        Err(WalletOutputError::TxWeightIncorrect(_, actual)) => actual,
+        other => bail!("expected a weight mismatch while probing for the fee, got {other:?}"),
+    };
+
+    let peg_out_output = fedimint_wallet_common::WalletOutput::new_v0_peg_out(
+        recipient,
+        bsats(PEG_OUT_AMOUNT_SATS),
+        PegOutFees::new(fee_rate.sats_per_kvb, total_weight),
+    );
+
+    wallet
+        .process_output(
+            &mut dbtx
+                .to_ref_with_prefix_module_id(module_instance_id)
+                .0
+                .into_nc(),
+            &peg_out_output,
+            out_point,
+        )
+        .await?;
+
+    let mut module_dbtx = dbtx.to_ref_with_prefix_module_id(module_instance_id).0;
+
+    let WalletOutputOutcome::V0(outcome) = module_dbtx
+        .get_value(&PegOutBitcoinTransaction(out_point))
+        .await
+        .context("expected the peg-out to record its bitcoin transaction")?
+    else {
+        bail!("expected a V0 peg-out outcome");
+    };
+
+    let change_outpoint = bitcoin::OutPoint {
+        txid: outcome.0,
+        vout: PEG_OUT_CHANGE_VOUT,
+    };
+
+    // The change output exists and is ours
+    let unsigned = module_dbtx
+        .get_value(&UnsignedTransactionKey(outcome.0))
+        .await
+        .context("expected an unsigned peg-out transaction")?;
+    let change_out = unsigned
+        .psbt
+        .unsigned_tx
+        .output
+        .get(PEG_OUT_CHANGE_VOUT as usize)
+        .context("expected a change output")?;
+    assert!(
+        change_out.value > bitcoin::Amount::ZERO,
+        "expected the peg-out to leave non-dust change"
+    );
+
+    assert!(
+        module_dbtx
+            .get_value(&ClaimedPegInOutpointKey(change_outpoint))
+            .await
+            .is_some(),
+        "peg-out change outpoint should be recorded as claimed when the peg-out is created"
+    );
+
+    drop(module_dbtx);
     dbtx.commit_tx().await;
     Ok(())
 }


### PR DESCRIPTION
## Summary

Our peg-out change output pays to the peg-in descriptor, which means that on-chain it is indistinguishable from a user deposit, and structurally eligible to be handed back to us as a peg-in. Claiming it is already impossible, but only because of a single cryptographic assumption that is checked late. This adds a second, structural layer that does not depend on that assumption: the change outpoint is recorded under `ClaimedPegInOutpoint` as soon as the peg-out is created, so the existing double-claim guard rejects it outright.

## Details

`StatelessWallet::create_tx` always pays change back to the federation, tweaking the peg-in descriptor with the peg-out nonce. That output is a normal member of the peg-in descriptor family, so nothing in the shape of a peg-in input rules it out: the UTXO lookup, the script check and the tx-out check all pass for it.

What actually stops it is `Transaction::validate_signatures`, which requires a BIP-340 signature over the txid by the input's tweak key. For change outputs that key is `nonce_from_idx`, i.e. `0x02 || sha256(nonce_idx)` — a NUMS point whose discrete log nobody knows, so the required signature cannot be produced. That guarantee is solid, but it is the only thing in the path, and it is evaluated after `process_input` has already run and written its state; correctness there relies on the whole transaction being discarded on failure.

That is a thin margin for something this close to the balance sheet, and it is sensitive to changes that look unrelated: the nonce derivation, what `process_input` returns as the input's `pub_key`, or the order of input processing versus signature validation. This change adds a layer that holds regardless of any of them.

Two design points worth calling out:

- **Recorded at creation, not at confirmation.** `recognize_change_utxo` would be the intuitive place, but it runs only once the peg-out confirms, which would leave the outpoint unrecorded for the whole in-flight period. Writing it in `process_output` puts it in the same dbtx that removes the spent `UTXOKey` rows, so there is no interval where the outpoint is both out of the spendable set and unrecorded.
- **Backfill.** Change outputs from peg-outs made before this change have no record. `PegOutBitcoinTransaction` is never pruned and still lists every peg-out we have ever made, so a migration recovers the full set from it. It uses `insert_entry` rather than `insert_new_entry` so it cannot trip over keys `migrate_to_v1` already wrote.

No consensus version bump. The only inputs whose treatment changes are ones that would need a signature nobody can produce, so no reachable transaction changes outcome, and the new key is not audited and so cannot perturb the balance sheet between upgraded and non-upgraded peers.

## Reviewing

The assumption worth checking is that change is always at output index 1. It holds in `create_tx` today, which always emits `[destination, change]`, and I introduced `PEG_OUT_CHANGE_VOUT` rather than leaving a bare index now that a second place depends on it. I did not audit the module's full history, so if change was ever laid out differently, the backfill would write keys for outpoints that were never ours — harmless, but pointless.

Also worth being aware of: RBF replacements record only the original txid in `WalletOutputOutcome`, so their change outputs are not covered by the backfill. That is moot under the default configuration, which rejects RBF withdrawals, but not if a federation ran with `FM_UNSAFE_ENABLE_RBF_WITHDRAWAL`.

## Testing

Adds `peg_out_change_is_recorded_as_claimed`, which pegs in, pegs out, and asserts the resulting change outpoint is recorded as claimed. It also asserts the peg-out actually left non-dust change, so it cannot pass vacuously against a transaction with nothing to protect. I confirmed it fails without the `process_output` change.

The existing migration tests exercise the backfill, since the stored server snapshot contains a `PegOutBitcoinTransaction` row.

The rest of the wallet suite passes unchanged, except `verify_auto_consensus_voting`, which fails identically on an unmodified tree here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019S2j2HWeQgFgsCZ8sVq2UX
