### PR TITLE
chore(tbs): use expect instead of unwrap in unblind_signature

### DIFF
--- a/crypto/tbs/src/lib.rs
+++ b/crypto/tbs/src/lib.rs
@@ -255,7 +255,10 @@ pub fn verify_blinded_signature(
 }
 
 pub fn unblind_signature(blinding_key: BlindingKey, blinded_sig: BlindedSignature) -> Signature {
-    let sig = blinded_sig.0 * blinding_key.0.invert().unwrap();
+    let sig = blinded_sig.0
+        * blinding_key.0.invert().expect(
+            "scalar inversion only fails for zero, which keygen only produces with negligible probability",
+        );
     Signature(sig.to_affine())
 }
 


### PR DESCRIPTION
### Summary

Replaces the bare `.unwrap()` on blinding key scalar inversion in `tbs::unblind_signature` with an `.expect()` documenting why the inversion cannot fail. This is the minimal alternative to #8844 requested [here](https://github.com/fedimint/fedimint/pull/8844#discussion_r2251632457).

### Details

Scalar inversion only fails for the zero scalar. Blinding keys are generated client-side either as `Scalar::random(OsRng)` or derived via HKDF through `Scalar::from_bytes_wide`, so a zero blinding key only occurs with negligible probability (~2^-255) unless key generation is broken. Panicking with a message stating that invariant is preferable to threading a `Result` through the mint clients' issuance paths for a case that cannot occur in practice.

### Reviewing

One-line change plus formatting; no behavior change for any input that can actually occur.

### Testing

`just final-lint` (lint hook, clippy `--all-targets -D warnings`, cargo-sort-check) and `cargo test -p fedimint-tbs` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PmrZKhKuqrB7HUBSXPK2hD
