### PR TITLE
fix: do not silently ignore API secrets on the Iroh API

### DIFF
--- a/fedimint-client/src/client/builder.rs
+++ b/fedimint-client/src/client/builder.rs
@@ -631,11 +631,16 @@ impl ClientBuilder {
         let iroh_enable_next = self.should_enable_iroh_next(&connectors);
         let peer_urls = get_api_urls(&db, &config, iroh_enable_next).await;
         let api = match self.admin_creds.as_ref() {
+            // The guardian password is not the federation's api secret: it
+            // authenticates individual admin requests via `ApiRequestErased::auth`,
+            // while the api secret gates the transport. Passing it here would send
+            // it as the transport credential and leave a federation that does use
+            // an api secret unreachable for admins.
             Some(admin_creds) => FederationApi::new(
                 connectors.clone(),
                 peer_urls,
                 Some(admin_creds.peer_id),
-                Some(admin_creds.auth.as_str()),
+                api_secret.as_deref(),
             )
             .with_client_ext(db.clone(), log_ordering_wakeup_tx.clone())
             .with_request_hook(&request_hook)

--- a/fedimint-connectors/src/iroh.rs
+++ b/fedimint-connectors/src/iroh.rs
@@ -294,10 +294,11 @@ impl crate::Connector for IrohConnector {
     ) -> ServerResult<DynGuaridianConnection> {
         if api_secret.is_some() {
             // There seem to be no way to pass secret over current Iroh calling
-            // convention
-            ServerError::Connection(anyhow::format_err!(
+            // convention. Connecting anyway would silently drop the credential and
+            // talk to an API that never authenticates us, so refuse instead.
+            return Err(ServerError::Connection(anyhow::format_err!(
                 "Iroh api secrets currently not supported"
-            ));
+            )));
         }
         let node_id =
             Self::node_id_from_url(url).map_err(|source| ServerError::InvalidPeerUrl {

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -12,7 +12,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::{Context as _, bail};
+use anyhow::{Context as _, bail, ensure};
 use async_channel::Sender;
 use db::{ServerDbMigrationContext, get_global_database_migrations};
 use fedimint_api_client::api::DynGlobalApi;
@@ -77,6 +77,45 @@ fn eligible_iroh_next_api_settings(
     } else {
         iroh_next_api_settings
     }
+}
+
+/// Refuse to run with API secrets that we cannot actually enforce.
+///
+/// The websocket API rejects unauthenticated requests in an HTTP middleware,
+/// but the Iroh API carries no credentials at all: every request is dispatched
+/// to the endpoint handler without any check. Serving both at once therefore
+/// leaves the whole non-privileged client API open to anyone who knows a
+/// guardian's Iroh node id, which is public information contained in every
+/// invite code. Since the `invite_code` endpoint hands out the invite code, and
+/// with it the secret itself, that also defeats the websocket API.
+///
+/// Failing to start turns that silent hole into a configuration error the
+/// operator can see and act on.
+fn ensure_api_secrets_enforceable(
+    has_iroh_api: bool,
+    force_api_secrets: &ApiSecrets,
+) -> anyhow::Result<()> {
+    ensure!(
+        !has_iroh_api || force_api_secrets.is_empty(),
+        "This federation serves its API over Iroh, which cannot authenticate clients, so the \
+         configured API secrets would not be enforced. Either unset FM_FORCE_API_SECRETS or run a \
+         federation that does not use Iroh."
+    );
+
+    Ok(())
+}
+
+#[cfg(test)]
+#[test]
+fn api_secrets_are_only_accepted_without_the_iroh_api() {
+    use std::str::FromStr as _;
+
+    let secrets = ApiSecrets::from_str("secret").expect("valid api secret");
+
+    ensure_api_secrets_enforceable(false, &secrets).expect("websocket api enforces secrets");
+    ensure_api_secrets_enforceable(true, &ApiSecrets::none()).expect("no secrets to enforce");
+    ensure_api_secrets_enforceable(true, &secrets)
+        .expect_err("the iroh api cannot enforce secrets");
 }
 
 fn resolve_iroh_next_api_bind(
@@ -201,6 +240,11 @@ pub async fn run(
 
     let iroh_next_api_settings =
         eligible_iroh_next_api_settings(cfg.private.iroh_api_sk.is_some(), iroh_next_api_settings);
+
+    ensure_api_secrets_enforceable(
+        cfg.private.iroh_api_sk.is_some() || iroh_next_api_settings.is_some(),
+        &force_api_secrets,
+    )?;
 
     let mut global_dbtx = db.begin_transaction().await;
     apply_migrations_server_dbtx(


### PR DESCRIPTION
## Summary

A federation configured with `FM_FORCE_API_SECRETS` while serving its API over Iroh does not actually enforce those secrets: the Iroh transport performs no authentication at any layer. This makes that configuration a startup error instead of a silent security hole, fixes a dead statement that let the client connect over Iroh with a secret it then dropped, and fixes the latent credential conflation that dead statement was hiding.

## Details

Authentication is enforced per transport, not centrally:

- The websocket API wraps the RPC service in `HttpAuthLayer`, which rejects requests without matching credentials before routing.
- The Iroh API (`fedimint-server/src/consensus/iroh_api.rs`) never receives the secrets at all. `IrohApiState` has no secret field, the accept loop does not inspect remote node ids, `IrohApiRequest` has no credential field, and `await_response` dispatches straight to the endpoint handler.

So with both enabled, anyone who knows a guardian's Iroh node id — public information contained in every invite code and client config — can call the entire non-privileged client API. It also defeats the websocket API it was supposed to complement: the unauthenticated `invite_code` endpoint returns an invite code with the API secret embedded, which the attacker can then use over websocket. Guardian endpoints are unaffected, since their auth is computed transport-independently in `ConsensusApi::context`.

Rather than inventing a credential field on the Iroh wire format, this refuses to start when secrets are configured alongside an Iroh API, which is what the client side already documents as unsupported. The check runs at the top of `consensus::run`, before any API is spawned, and covers both the legacy and the transitional Iroh 1.0 listener. Gating `invite_code` or adding a secret to `IrohApiRequest` then becomes unnecessary, since the combination can no longer run.

`IrohConnector::connect_guardian` meant to refuse the same combination client-side, but the refusal was a bare expression statement that constructed `ServerError::Connection` and discarded it, so the client connected anyway and silently dropped the credential. It now returns the error.

Returning that error surfaced a third problem, which is why `fedimint-client` is touched here. `ClientBuilder` passed `admin_creds.auth` — the guardian password — in the api secret slot when building a client with admin credentials. These are unrelated credentials: the password authenticates individual admin requests through `ApiRequestErased::auth`, while the api secret is a transport-level credential. While the connector's refusal was dead the password was silently discarded on Iroh, so nothing failed; with the refusal live, every admin client over Iroh stopped connecting. It also means a federation that really does use an api secret would have been unreachable for admins, since they would have been sending the password as the transport credential. It now passes the federation's api secret, matching what the cli's own `admin_client_with_db` already did.

## Reviewing

The main judgement call is refusing startup rather than implementing credentials for the Iroh transport. It is the loud-failure option, and a federation currently running both will not boot after upgrading — deliberately, since its API secret is not being enforced today. The error message names both ways out (drop the secret, or run without Iroh). If we would rather support secrets over Iroh, that is an additive wire-format change plus client plumbing, and worth its own PR.

The `fedimint-client` change is worth a careful look, since it also changes behaviour on the websocket transport: admin clients now send the federation's api secret as the transport credential rather than the guardian password. I believe that is strictly more correct, and the only users of admin creds are `fedimint-cli` and `fedimint-testing`, but it is a real behaviour change rather than a no-op.

Worth checking that `cfg.private.iroh_api_sk.is_some() || iroh_next_api_settings.is_some()` is the right predicate for "an Iroh API gets served". The Iroh 1.0 listener is already gated on the legacy key by `eligible_iroh_next_api_settings`, so the second disjunct is redundant today; it is there so the check does not silently stop covering the 1.0 listener if that gating changes.

## Testing

Added a unit test for the new check covering the three relevant combinations. No existing test or CI job configures `FM_FORCE_API_SECRETS` together with Iroh (`test-ci-all-backcompat.sh` and `upgrade-test.sh` set `FM_ENABLE_IROH=false`; devimint defaults the secrets to empty).

The credential conflation was caught by CI rather than by review: devimint's `add_lnv2_gateway` is the only step that runs `fedimint-cli --our-id N --password ...`, and it failed against Iroh federations. It presented as flaky because `lnv2_gateways_added` is a lazily evaluated `JitTryAnyhow`, so only tests that awaited it before finishing surfaced the failure, and because `fedimint-api-client` wraps the cause with `.context("Failed to connect to peer")`, which hides the underlying error in the logs. Full CI is green with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X4kKrqzmiCCfAfLnGPGWGg