### PR TITLE
chore: Drop now unnecessary workarounds that slows down builds & checks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -370,11 +370,6 @@ literal_string_with_formatting_args = "deny"
 
 [profile.dev]
 debug = "line-tables-only"
-# Workaround: https://github.com/rust-lang/cargo/issues/12457 which causes
-#             https://github.com/ipetkov/crane/issues/370
-[profile.dev.build-override]
-debug = false
-opt-level = 3
 
 # in dev mode optimize crates that are perf-critical (usually just crypto crates)
 [profile.dev.package]
@@ -406,9 +401,6 @@ secp256k1-sys = { opt-level = 3 }
 subtle = { opt-level = 3 }
 tikv-jemalloc-sys = { opt-level = 3 }
 zeroize = { opt-level = 3 }
-
-[profile.dev.package."*"] # external dependencies
-opt-level = 1
 
 [profile.ci]
 debug = "line-tables-only"


### PR DESCRIPTION
https://github.com/rust-lang/cargo/issues/12457 has long been fixed. No
need to workaround it. In debug profile, we shouldn't enable optimizations
unless it's proven to give tangible benefits.
