### PR TITLE
[Backport releases/v0.11] fix: Disconnect gateway when LNv1 or LNv2 tasks exit unexpectedly (#8653)

### DIFF
--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -100,8 +100,8 @@ use fedimint_gwv2_client::{
 use fedimint_lightning::lnd::GatewayLndClient;
 use fedimint_lightning::{
     CreateInvoiceRequest, ILnRpcClient, InterceptPaymentRequest, InterceptPaymentResponse,
-    InvoiceDescription, LightningContext, LightningRpcError, LnRpcTracked, PayInvoiceResponse,
-    PaymentAction, RouteHtlcStream, ldk,
+    InvoiceDescription, LightningContext, LightningRpcError, LnRpcTracked, Lnv2HoldInvoiceFilter,
+    PayInvoiceResponse, PaymentAction, RouteHtlcStream, ldk,
 };
 use fedimint_ln_client::pay::PaymentData;
 use fedimint_ln_common::LightningCommonInit;
@@ -883,6 +883,16 @@ impl Gateway {
                         Ok((stream, ln_client)) => (stream, ln_client),
                         Err(err) => {
                             warn!(target: LOG_GATEWAY, err = %err.fmt_compact(), "Failed to open lightning payment stream");
+                            // `route_htlcs` may have already spawned tasks into the
+                            // subgroup before failing (e.g. the LNv1 interceptor is
+                            // spawned before LNv2 setup, which can fail). Tear the
+                            // subgroup down so no stale task keeps owning the LND HTLC
+                            // stream, which would prevent the retry from taking over and
+                            // could cause it to cancel real HTLCs after `gateway_receiver`
+                            // is dropped.
+                            if let Err(err) = payment_stream_task_group.shutdown_join_all(None).await {
+                                crit!(target: LOG_GATEWAY, err = %err.fmt_compact_anyhow(), "Lightning payment stream task group shutdown");
+                            }
                             sleep(Duration::from_secs(PAYMENT_STREAM_RETRY_SECONDS)).await;
                             continue
                         }
@@ -1866,12 +1876,32 @@ impl Gateway {
                 lnd_rpc_addr,
                 lnd_tls_cert,
                 lnd_macaroon,
-            } => Box::new(GatewayLndClient::new(
-                lnd_rpc_addr,
-                lnd_tls_cert,
-                lnd_macaroon,
-                None,
-            )),
+            } => {
+                // The LND backend uses this to ignore HOLD invoices on the
+                // shared LND node that aren't federation-bound. Returns true
+                // iff there is a registered LNv2 incoming contract for the
+                // given payment hash.
+                let gateway_db = self.gateway_db.clone();
+                let lnv2_filter: Lnv2HoldInvoiceFilter = Arc::new(move |hash| {
+                    let gateway_db = gateway_db.clone();
+                    Box::pin(async move {
+                        gateway_db
+                            .begin_transaction_nc()
+                            .await
+                            .load_registered_incoming_contract(PaymentImage::Hash(hash))
+                            .await
+                            .is_some()
+                    })
+                });
+
+                Box::new(GatewayLndClient::new(
+                    lnd_rpc_addr,
+                    lnd_tls_cert,
+                    lnd_macaroon,
+                    None,
+                    lnv2_filter,
+                ))
+            }
             LightningMode::Ldk {
                 lightning_port,
                 alias,

--- a/gateway/fedimint-lightning/src/lib.rs
+++ b/gateway/fedimint-lightning/src/lib.rs
@@ -25,6 +25,7 @@ pub use fedimint_ln_common::contracts::Preimage;
 use fedimint_ln_common::route_hints::RouteHint;
 use fedimint_logging::LOG_LIGHTNING;
 use fedimint_metrics::HistogramExt as _;
+use futures::future::BoxFuture;
 use futures::stream::BoxStream;
 use lightning_invoice::Bolt11Invoice;
 use serde::{Deserialize, Serialize};
@@ -34,6 +35,14 @@ use tracing::{info, warn};
 pub const MAX_LIGHTNING_RETRIES: u32 = 10;
 
 pub type RouteHtlcStream<'a> = BoxStream<'a, InterceptPaymentRequest>;
+
+/// Returns `true` if the given payment hash corresponds to a HOLD invoice that
+/// the gateway created on behalf of a federation. Used by the LND backend to
+/// ignore unrelated HOLD invoices on a shared LND node, which would otherwise
+/// be mistaken for federation-bound payments and produce invalid responses on
+/// LND's HTLC interceptor wire.
+pub type Lnv2HoldInvoiceFilter =
+    Arc<dyn Fn(sha256::Hash) -> BoxFuture<'static, bool> + Send + Sync + 'static>;
 
 #[derive(
     Error, Debug, Serialize, Deserialize, Encodable, Decodable, Clone, Eq, PartialEq, Hash,

--- a/gateway/fedimint-lightning/src/lnd.rs
+++ b/gateway/fedimint-lightning/src/lnd.rs
@@ -47,8 +47,8 @@ use tonic_lnd::{Client as LndClient, connect};
 use tracing::{debug, info, trace, warn};
 
 use super::{
-    ChannelInfo, ILnRpcClient, LightningRpcError, ListChannelsResponse, MAX_LIGHTNING_RETRIES,
-    RouteHtlcStream,
+    ChannelInfo, ILnRpcClient, LightningRpcError, ListChannelsResponse, Lnv2HoldInvoiceFilter,
+    MAX_LIGHTNING_RETRIES, RouteHtlcStream,
 };
 use crate::{
     CloseChannelsWithPeerRequest, CloseChannelsWithPeerResponse, CreateInvoiceRequest,
@@ -69,6 +69,12 @@ pub struct GatewayLndClient {
     tls_cert: String,
     macaroon: String,
     lnd_sender: Option<mpsc::Sender<ForwardHtlcInterceptResponse>>,
+    /// Predicate used to distinguish HOLD invoices the gateway created
+    /// (federation-bound) from unrelated HOLD invoices on the same LND node.
+    /// Without this, every HOLD invoice on a shared LND would be intercepted
+    /// as if it were federation-bound, producing invalid LNv1 responses that
+    /// crash LND's htlc_interceptor stream.
+    lnv2_filter: Lnv2HoldInvoiceFilter,
 }
 
 impl GatewayLndClient {
@@ -77,6 +83,7 @@ impl GatewayLndClient {
         tls_cert: String,
         macaroon: String,
         lnd_sender: Option<mpsc::Sender<ForwardHtlcInterceptResponse>>,
+        lnv2_filter: Lnv2HoldInvoiceFilter,
     ) -> Self {
         info!(
             target: LOG_LIGHTNING,
@@ -90,6 +97,7 @@ impl GatewayLndClient {
             tls_cert,
             macaroon,
             lnd_sender,
+            lnv2_filter,
         }
     }
 
@@ -127,6 +135,7 @@ impl GatewayLndClient {
     async fn spawn_lnv2_hold_invoice_subscription(
         &self,
         task_group: &TaskGroup,
+        payment_stream_group: TaskGroup,
         gateway_sender: HtlcSubscriptionSender,
         payment_hash: Vec<u8>,
     ) -> Result<(), LightningRpcError> {
@@ -147,7 +156,8 @@ impl GatewayLndClient {
                     match stream {
                         Ok(stream) => stream.into_inner(),
                         Err(err) => {
-                            crit!(target: LOG_LIGHTNING, err = %err.fmt_compact(), "Failed to subscribe to hold invoice updates");
+                            crit!(target: LOG_LIGHTNING, err = %err.fmt_compact(), "Failed to subscribe to hold invoice updates, shutting down payment-stream subgroup to trigger gateway reconnect");
+                            payment_stream_group.shutdown();
                             return;
                         }
                     }
@@ -158,20 +168,30 @@ impl GatewayLndClient {
                 }
             };
 
-            while let Some(hold) = tokio::select! {
-                () = handle.make_shutdown_rx() => {
-                    None
-                }
-                hold_update = hold_stream.message() => {
-                    match hold_update {
-                        Ok(hold) => hold,
-                        Err(err) => {
-                            crit!(target: LOG_LIGHTNING, err = %err.fmt_compact(), "Error received over hold invoice update stream");
-                            None
+            loop {
+                let hold = tokio::select! {
+                    () = handle.make_shutdown_rx() => {
+                        info!(target: LOG_LIGHTNING, "LND HOLD Invoice Subscription received shutdown signal");
+                        break;
+                    }
+                    hold_update = hold_stream.message() => {
+                        match hold_update {
+                            Ok(Some(hold)) => hold,
+                            Ok(None) => {
+                                // LND closed the stream because the invoice
+                                // reached a terminal state (settled, canceled,
+                                // or expired).
+                                break;
+                            }
+                            Err(err) => {
+                                crit!(target: LOG_LIGHTNING, err = %err.fmt_compact(), "Error received over hold invoice update stream, shutting down payment-stream subgroup to trigger gateway reconnect");
+                                payment_stream_group.shutdown();
+                                break;
+                            }
                         }
                     }
-                }
-            } {
+                };
+
                 debug!(
                     target: LOG_LIGHTNING,
                     payment_hash = %PrettyPaymentHash(&r_hash),
@@ -180,6 +200,25 @@ impl GatewayLndClient {
                 );
 
                 if hold.state() == InvoiceState::Accepted {
+                    // Only forward HOLD invoices that the gateway created on
+                    // behalf of a federation. We check here (rather than at
+                    // the new-invoice add-event) because the contract is
+                    // saved to gateway_db *after* the HOLD invoice is created
+                    // on LND, so the add-event races registration. By the
+                    // time `Accepted` fires the HTLC has arrived, which means
+                    // the BOLT11 invoice was published and the contract is
+                    // committed.
+                    let hash = sha256::Hash::from_slice(&hold.r_hash)
+                        .expect("LND payment hashes are 32 bytes");
+                    if !(self_copy.lnv2_filter)(hash).await {
+                        trace!(
+                            target: LOG_LIGHTNING,
+                            payment_hash = %PrettyPaymentHash(&hold.r_hash),
+                            "Ignoring HOLD invoice not created by this gateway",
+                        );
+                        continue;
+                    }
+
                     let intercept = InterceptPaymentRequest {
                         payment_hash: Hash::from_slice(&hold.r_hash.clone())
                             .expect("Failed to convert to Hash"),
@@ -223,7 +262,7 @@ impl GatewayLndClient {
         let mut client = self.connect().await?;
 
         // Compute the minimum `add_index` that we need to subscribe to updates for.
-        let add_index = client
+        let first_index_offset = client
             .lightning()
             .list_invoices(ListInvoiceRequest {
                 pending_only: true,
@@ -242,8 +281,20 @@ impl GatewayLndClient {
             .into_inner()
             .first_index_offset;
 
+        // `SubscribeInvoices` only replays invoices with an `add_index` strictly
+        // greater than `add_index`, so subscribing from `first_index_offset`
+        // directly would skip the add event of the oldest pending invoice and we
+        // would never spawn a monitor for it. Subtract one so that oldest pending
+        // invoice is replayed. `saturating_sub` keeps this correct in the
+        // empty-list case where `first_index_offset` is 0.
+        let add_index = first_index_offset.saturating_sub(1);
+
         let self_copy = self.clone();
         let hold_group = task_group.make_subgroup();
+        // See the matching comment in `spawn_lnv1_htlc_interceptor`: if this
+        // task exits unexpectedly we shut down the payment-stream subgroup so
+        // the gateway transitions to `Disconnected` and reconnects.
+        let subgroup = task_group.clone();
         task_group.spawn("LND Invoice Subscription", move |handle| async move {
             let future_stream = client.lightning().subscribe_invoices(InvoiceSubscription {
                 add_index,
@@ -255,6 +306,7 @@ impl GatewayLndClient {
                         Ok(stream) => stream.into_inner(),
                         Err(err) => {
                             warn!(target: LOG_LIGHTNING, err = %err.fmt_compact(), "Failed to subscribe to all invoice updates");
+                            subgroup.shutdown();
                             return;
                         }
                     }
@@ -303,19 +355,31 @@ impl GatewayLndClient {
                     if let Err(err) = self_copy
                         .spawn_lnv2_hold_invoice_subscription(
                             &hold_group,
+                            subgroup.clone(),
                             gateway_sender.clone(),
                             payment_hash.clone(),
                         )
                         .await
                     {
+                        // Spawning failed because `connect()` exhausted its
+                        // retries, a strong signal that LND is unreachable. We
+                        // can no longer observe this invoice's `Accepted`
+                        // update, so shut down the payment-stream subgroup to
+                        // force a gateway reconnect.
                         warn!(
                             target: LOG_LIGHTNING,
                             err = %err.fmt_compact(),
                             payment_hash = %PrettyPaymentHash(&payment_hash),
-                            "Failed to spawn HOLD invoice subscription task",
+                            "Failed to spawn HOLD invoice subscription task, shutting down payment-stream subgroup to trigger gateway reconnect",
                         );
+                        subgroup.shutdown();
                     }
                 }
+            }
+
+            if !handle.is_shutting_down() {
+                warn!(target: LOG_LIGHTNING, "LND Invoice Subscription exited unexpectedly, shutting down payment-stream subgroup to trigger gateway reconnect");
+                subgroup.shutdown();
             }
         });
 
@@ -344,6 +408,12 @@ impl GatewayLndClient {
                 failure_reason: format!("Failed to get node info {status:?}"),
             })?;
 
+        // If the HTLC interceptor exits unexpectedly we shut down the
+        // payment-stream subgroup. That cascades to the lnv2 invoice
+        // subscription (and its hold-invoice subtasks), which drop their
+        // `gateway_sender` clones, closing the gateway's HTLC stream and
+        // driving the gateway back to `Disconnected` so it reconnects.
+        let subgroup = task_group.clone();
         task_group.spawn("LND HTLC Subscription", |handle| async move {
                 let future_stream = client
                     .router()
@@ -354,6 +424,7 @@ impl GatewayLndClient {
                             Ok(stream) => stream.into_inner(),
                             Err(e) => {
                                 crit!(target: LOG_LIGHTNING, err = %e.fmt_compact(), "Failed to establish htlc stream");
+                                subgroup.shutdown();
                                 return;
                             }
                         }
@@ -417,6 +488,13 @@ impl GatewayLndClient {
                                 });
                         }
                     }
+                }
+
+                // Loop exited because of an HTLC stream error or end-of-stream
+                // (the expected-shutdown case is handled above).
+                if !handle.is_shutting_down() {
+                    warn!(target: LOG_LIGHTNING, "LND HTLC Subscription exited unexpectedly, shutting down payment-stream subgroup to trigger gateway reconnect");
+                    subgroup.shutdown();
                 }
             });
 
@@ -961,6 +1039,7 @@ impl ILnRpcClient for GatewayLndClient {
             tls_cert: self.tls_cert.clone(),
             macaroon: self.macaroon.clone(),
             lnd_sender: Some(lnd_sender.clone()),
+            lnv2_filter: self.lnv2_filter.clone(),
         });
         Ok((Box::pin(ReceiverStream::new(gateway_receiver)), new_client))
     }


### PR DESCRIPTION
# Description

Backport of #8653 to `releases/v0.11`.

The automated backport could not apply this one cleanly, so it was
cherry-picked by hand from `defec7a3dcf`.

## Conflict resolution

One conflict, in `gateway/fedimint-gateway-server/src/lib.rs`.

`master` carries an `lnd_time_pref` field on `LightningMode::Lnd` that does not
exist on `releases/v0.11`, and v0.11's `GatewayLndClient::new` correspondingly
takes five arguments rather than six. The resolution keeps the incoming LNv2
HOLD-invoice filter exactly as written and drops only `lnd_time_pref` from the
match pattern and the constructor call.

Nothing else needed adapting: `releases/v0.11` already has
`load_registered_incoming_contract` and `PaymentImage`, which the filter uses.

`cargo check -p fedimint-gateway-server -p fedimint-lightning` passes.

## Why this matters for 0.11

The `LND HTLC Subscription` task exits permanently on any transport-level error
from `htlc_stream.message()` (`lnd.rs`, `Err(err) => { warn!(...); None }`
dropping out of the `while let Some(htlc)` loop). Without this fix the gateway
keeps reporting `gateway_state: Running` with all federations registered while
silently processing no incoming payments until someone restarts it manually.

This was hit in production on a v0.11.1-based gateway: a restart left a pending
HTLC inside LND, the new interceptor stream got
`Unknown: "forward does not exist: (Chan ID=0:0:0, HTLC ID=0)"`, and the task
was gone for the life of the process. Outgoing payments kept working, which
makes it easy to miss.

Suggest also taking #8655 (backport in #8954), which makes the HTLC replay that
follows any reconnect idempotent.
