### PR TITLE
fix(gw-client): bind outgoing contract to the invoice being paid

### DIFF
--- a/modules/fedimint-gw-client/src/pay.rs
+++ b/modules/fedimint-gw-client/src/pay.rs
@@ -635,6 +635,16 @@ impl GatewayPayInvoice {
             return Err(OutgoingContractError::NotOurKey);
         }
 
+        // The contract id and the payment data reach us as independent fields of
+        // `PayInvoicePayload`, and an outgoing contract carries no invoice, so nothing
+        // ties the two together implicitly. Without this check we would pay an invoice
+        // whose preimage cannot satisfy the contract we are being paid from.
+        if account.contract.hash != payment_data.payment_hash() {
+            return Err(OutgoingContractError::InvalidOutgoingContract {
+                contract_id: account.contract.contract_id(),
+            });
+        }
+
         let payment_amount = payment_data
             .amount()
             .ok_or(OutgoingContractError::InvoiceMissingAmount)?;
@@ -973,5 +983,104 @@ impl GatewayPayCancelContract {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bitcoin::hashes::{Hash as _, sha256};
+    use bitcoin::key::Keypair;
+    use fedimint_core::Amount;
+    use fedimint_core::secp256k1::{self, SecretKey};
+    use fedimint_ln_client::pay::PaymentData;
+    use fedimint_ln_common::PrunedInvoice;
+    use fedimint_ln_common::contracts::IdentifiableContract as _;
+    use fedimint_ln_common::contracts::outgoing::{OutgoingContract, OutgoingContractAccount};
+    use lightning_invoice::RoutingFees;
+
+    use super::{GatewayPayInvoice, OutgoingContractError};
+
+    const CONSENSUS_BLOCK_COUNT: u64 = 1;
+    const INVOICE_AMOUNT: Amount = Amount::from_msats(1000);
+
+    fn gateway_keypair() -> Keypair {
+        Keypair::from_secret_key(
+            secp256k1::SECP256K1,
+            &SecretKey::from_slice(&[1; 32]).expect("Valid secret key"),
+        )
+    }
+
+    /// An account that is valid in every respect other than the payment hash,
+    /// which the caller chooses so a mismatch can be tested in isolation.
+    fn contract_account(hash: sha256::Hash) -> OutgoingContractAccount {
+        let gateway_key = secp256k1::PublicKey::from_keypair(&gateway_keypair());
+
+        OutgoingContractAccount {
+            amount: INVOICE_AMOUNT,
+            contract: OutgoingContract {
+                hash,
+                gateway_key,
+                // Comfortably beyond `CONSENSUS_BLOCK_COUNT + TIMELOCK_DELTA`
+                timelock: 100,
+                user_key: gateway_key,
+                cancelled: false,
+            },
+        }
+    }
+
+    fn payment_data(payment_hash: sha256::Hash) -> PaymentData {
+        PaymentData::PrunedInvoice(PrunedInvoice {
+            amount: INVOICE_AMOUNT,
+            destination: secp256k1::PublicKey::from_keypair(&gateway_keypair()),
+            destination_features: vec![],
+            payment_hash,
+            payment_secret: [0; 32],
+            route_hints: vec![],
+            min_final_cltv_delta: 0,
+            expiry_timestamp: u64::MAX,
+        })
+    }
+
+    fn validate(
+        contract_hash: sha256::Hash,
+        invoice_hash: sha256::Hash,
+    ) -> Result<(), OutgoingContractError> {
+        GatewayPayInvoice::validate_outgoing_account(
+            &contract_account(contract_hash),
+            gateway_keypair(),
+            CONSENSUS_BLOCK_COUNT,
+            &payment_data(invoice_hash),
+            RoutingFees {
+                base_msat: 0,
+                proportional_millionths: 0,
+            },
+        )
+        .map(|_| ())
+    }
+
+    /// Guards against the fixture being invalid for some unrelated reason,
+    /// which would make the rejection test below pass vacuously.
+    #[test]
+    fn accepts_contract_matching_the_invoice() {
+        let hash = sha256::Hash::hash(b"preimage");
+
+        assert_eq!(validate(hash, hash), Ok(()));
+    }
+
+    #[test]
+    fn rejects_contract_not_committing_to_the_invoice() {
+        // A client picks the contract id and the invoice independently, so a
+        // contract funded against an unrelated hash must not authorize paying
+        // this invoice: the preimage we would obtain cannot claim the contract,
+        // leaving the gateway out of pocket with no way to recover.
+        let contract_hash = sha256::Hash::hash(b"contract preimage");
+        let invoice_hash = sha256::Hash::hash(b"unrelated invoice preimage");
+
+        assert_eq!(
+            validate(contract_hash, invoice_hash),
+            Err(OutgoingContractError::InvalidOutgoingContract {
+                contract_id: contract_account(contract_hash).contract.contract_id(),
+            })
+        );
     }
 }


### PR DESCRIPTION
### Summary

The LNv1 gateway does not check that the outgoing contract it is being paid from actually commits to the invoice it is being asked to pay. This adds that check, bringing LNv1 in line with what LNv2 already does.

### Details

`PayInvoicePayload` carries `contract_id` and `payment_data` as independent fields, and `OutgoingContract` stores a payment hash but no invoice, so nothing ties the two together implicitly — the gateway has to compare them itself. `validate_outgoing_account` currently verifies the contract's gateway key, funding amount and timelock, and the invoice's expiry, but not the payment hash.

The practical consequence is that the gateway can be asked to pay an invoice unrelated to the contract funding it. The preimage it gets back then doesn't satisfy the contract's `hash` on the claim path, so the payment goes out but the contract can't be claimed, and its balance returns to the contract's user key once the timelock expires.

This is a gap rather than a removed check. Before #3816 the invoice lived inside `OutgoingContract` and was committed to by `contract_id`, so the binding held structurally and no explicit comparison was needed. That PR moved the invoice out for privacy and disk-space reasons, and the gateway-side comparison was never added in its place. LNv2 enforces the equivalent binding in `fedimint-gwv2-client` (`modules/fedimint-gwv2-client/src/lib.rs:312`), where the contract carries a dedicated payment-image commitment; LNv1 wasn't revisited at the time.

`OutgoingContractError::InvalidOutgoingContract` already existed for exactly this case and had never been constructed — this is its first use.

Gateway operators known to the project have been notified ahead of this PR.

### Reviewing

The check sits with the other contract-identity checks, before any amount or timelock arithmetic, so a mismatched contract is rejected before a Lightning payment is attempted.

One thing worth being aware of: `verify_preimage_authentication` might look like it already covers this, but it binds a payload to a payment hash on a first-come basis to stop a second caller stealing the preimage, and never compares anything to the contract.

Backports to the active release branches would be worthwhile — the patch applies unchanged to `releases/v0.9` through `releases/v0.12`.

### Testing

Adds unit tests to `modules/fedimint-gw-client/src/pay.rs`, which had none:

- `rejects_contract_not_committing_to_the_invoice` — the regression test.
- `accepts_contract_matching_the_invoice` — asserts the fixture is valid in every other respect (key, amount, timelock, expiry), so the test above can't pass for the wrong reason.

I confirmed the regression test actually catches the bug rather than just passing alongside it: with the new check removed, it fails with `validate_outgoing_account` returning `Ok(())`, while the positive test keeps passing.

`just final-lint` passes. Tests were also built and run against `releases/v0.9` and `releases/v0.12` worktrees with the patch applied.
