### PR TITLE
fix(bitcoind): configure esplora request timeouts (backport #8709 to v0.11)

### DIFF
--- a/fedimint-bitcoind/src/lib.rs
+++ b/fedimint-bitcoind/src/lib.rs
@@ -26,6 +26,8 @@ use tracing::trace;
 
 use crate::metrics::{BITCOIND_RPC_DURATION_SECONDS, BITCOIND_RPC_REQUESTS_TOTAL};
 
+const ESPLORA_CLIENT_TIMEOUT_SECONDS: u64 = 60;
+
 #[cfg(feature = "bitcoincore")]
 pub mod bitcoincore;
 
@@ -190,10 +192,11 @@ pub struct EsploraClient {
 
 impl EsploraClient {
     pub fn new(url: &SafeUrl) -> anyhow::Result<Self> {
-        Ok(Self {
-            // URL needs to have any trailing path including '/' removed
-            client: Builder::new(url.as_str().trim_end_matches('/')).build_async()?,
-        })
+        let client = Builder::new(url.as_str().trim_end_matches('/'))
+            .timeout(ESPLORA_CLIENT_TIMEOUT_SECONDS)
+            .build_async()?;
+
+        Ok(Self { client })
     }
 }
 

--- a/fedimint-server-bitcoin-rpc/src/esplora.rs
+++ b/fedimint-server-bitcoin-rpc/src/esplora.rs
@@ -10,6 +10,7 @@ use fedimint_logging::LOG_SERVER;
 use fedimint_server_core::bitcoin_rpc::IServerBitcoinRpc;
 use tracing::info;
 
+const ESPLORA_CLIENT_TIMEOUT_SECONDS: u64 = 60;
 #[derive(Debug)]
 pub struct EsploraClient {
     client: esplora_client::AsyncClient,
@@ -27,7 +28,8 @@ impl EsploraClient {
         // URL needs to have any trailing path including '/' removed
         let without_trailing = url.as_str().trim_end_matches('/');
 
-        let builder = esplora_client::Builder::new(without_trailing);
+        let builder =
+            esplora_client::Builder::new(without_trailing).timeout(ESPLORA_CLIENT_TIMEOUT_SECONDS);
         let client = builder.build_async()?;
         Ok(Self {
             client,


### PR DESCRIPTION
> 📚 **Stacked on #8980** (base is that PR's branch, not `releases/v0.11` directly). #8980 only touches CI config (`.cargo/audit.toml`, `.lycheeignore`) so the release-branch audit/linkcheck go green. Review/merge #8980 first; GitHub will auto-retarget this PR's base to `releases/v0.11` once it merges. The diff below is this PR's own change only.

Backport of #8709 (merged to `master` 2026-06-16) onto `releases/v0.11`.

## Why

`releases/v0.11` still constructs the Esplora client with no per-request timeout — on this branch
`EsploraClient::new` calls `Builder::new(..).build_async()` directly. When an Esplora endpoint
accepts a connection and then never responds, a single request hangs forever, the surrounding
retry/backoff loop never re-fires, and wallet recovery never self-heals (issue #8678).

This is the fix currently stranding real users: multiple federations (e.g. Afribit Kibera) sit for
days at "Recovery is in progress" with a 0 balance, blocked at exactly this call. No released 0.11
tag (v0.11.0, v0.11.1, v0.11.2-alpha.1) contains the fix.

## What

Cherry-pick of `5e754b7` — sets a 60s request timeout on both the client-side
(`fedimint-bitcoind`) and server-side (`fedimint-server-bitcoin-rpc`) Esplora backends, so a
stalled request errors and the existing backoff retries. Applied cleanly (2 files, +10/-5).

## Testing

- `cargo check -q -p fedimint-bitcoind -p fedimint-server-bitcoin-rpc` — passes
- `cargo fmt -p fedimint-bitcoind -p fedimint-server-bitcoin-rpc -- --check` — passes

## Note

Intended to seed a stable **v0.11.2** release (maintainer action). The timeout only makes the
existing backoff re-fire — it does not rescue a genuinely dead endpoint; a federation pointed at an
unreachable Esplora URL will still not complete recovery.