### PR TITLE
docs(mintv2-client): document the send chain as cancel safe

### DIFF
--- a/fedimint-client/src/client.rs
+++ b/fedimint-client/src/client.rs
@@ -902,6 +902,15 @@ impl Client {
     /// Add funding and/or change to the transaction builder as needed, finalize
     /// the transaction and submit it to the federation.
     ///
+    /// ## Cancel safety
+    /// This method is cancel safe. It performs all its work (funding the
+    /// inputs, registering the state machines, and creating the operation log
+    /// entry) inside a single `autocommit` transaction, so dropping the future
+    /// either commits that unit in full or leaves the database untouched.
+    /// Submission to the federation is not awaited here, it is carried out by
+    /// the transaction-submission state machine in the executor, so cancelling
+    /// does not abort an already-committed submission.
+    ///
     /// ## Errors
     /// The function will return an error if the operation with given ID already
     /// exists.
@@ -959,6 +968,12 @@ impl Client {
 
     /// See [`Self::finalize_and_submit_transaction`], just inside a database
     /// transaction.
+    ///
+    /// ## Cancel safety
+    /// Unlike [`Self::finalize_and_submit_transaction`], this does not own the
+    /// transaction: all writes go to the passed `dbtx`, so its cancel safety
+    /// is that of the caller's transaction. The caller is responsible for
+    /// committing (or rolling back) `dbtx` atomically.
     pub async fn finalize_and_submit_transaction_dbtx<F, M>(
         &self,
         dbtx: &mut DatabaseTransaction<'_>,

--- a/modules/fedimint-mintv2-client/src/lib.rs
+++ b/modules/fedimint-mintv2-client/src/lib.rs
@@ -681,6 +681,15 @@ impl MintClientModule {
         ClientInputBundle::new(inputs, input_sms)
     }
 
+    /// Build the blinded outputs and their output state machines for a
+    /// reissue transaction.
+    ///
+    /// # Cancel safety
+    ///
+    /// Cancel safe: this only reads pre-ground blinding tweaks from an
+    /// in-memory channel and constructs values, it performs no database
+    /// writes. Dropping the future merely discards the tweaks it had taken,
+    /// which are unbounded and regenerated in the background.
     async fn create_output_bundle(
         &self,
         operation_id: OperationId,
@@ -717,6 +726,15 @@ impl MintClientModule {
         ClientOutputBundle::new(outputs, output_sms)
     }
 
+    /// Wait for the output state machine of the given outpoint to reach a
+    /// terminal state.
+    ///
+    /// # Cancel safety
+    ///
+    /// Cancel safe: this only subscribes to the operation's state
+    /// notifications and waits, it performs no database writes. Dropping the
+    /// future stops the wait; the underlying state machine keeps running in
+    /// the executor.
     async fn await_output_sm_success(
         &self,
         operation_id: OperationId,
@@ -777,14 +795,26 @@ impl MintClientModule {
     /// smallest denomination used throughout the client. If the rounded
     /// amount cannot be covered with the ecash notes in the client's
     /// database the client will create a transaction to reissue the
-    /// required denominations. It is safe to cancel the send method call
-    /// before the reissue is complete in which case the reissued notes are
-    /// returned to the regular balance. To cancel a successful ecash send
-    /// simply receive it yourself.
+    /// required denominations. To cancel a successful ecash send simply
+    /// receive it yourself.
     ///
     /// If `include_invite` is set, the federation's invite code is embedded in
     /// the returned ecash so a recipient that has not joined the federation can
     /// do so directly from the received ecash.
+    ///
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. Every database mutation it makes happens
+    /// inside a single
+    /// [`autocommit`](fedimint_core::db::Database::autocommit) transaction
+    /// (spending the notes for the fast path, and creating the change-making
+    /// reissue transaction otherwise), so dropping the future either commits
+    /// a unit of work in full or leaves the database untouched: notes are
+    /// never removed without a persisted operation that produces the ecash or
+    /// returns the change. Federation submission is driven by a state machine
+    /// in the executor rather than awaited here, so a cancelled call cannot
+    /// abort an in-flight reissue; if change-making had already been
+    /// submitted it completes on its own and the notes return to the balance.
     pub async fn send(
         &self,
         amount: Amount,
@@ -851,6 +881,16 @@ impl MintClientModule {
         Box::pin(self.send(amount, custom_meta, include_invite)).await
     }
 
+    /// Fast path for [`Self::send`]: if exact change is already held, spend
+    /// those notes and record the send operation. Returns `None` when exact
+    /// change is not available, leaving the caller to make change.
+    ///
+    /// # Cancel safety
+    ///
+    /// All writes go to the passed `dbtx`, so this inherits the cancel safety
+    /// of that transaction: it must be run inside an `autocommit` (as `send`
+    /// does) for the note spend and the operation log entry to commit or roll
+    /// back together.
     async fn send_ecash_dbtx(
         &self,
         dbtx: &mut DatabaseTransaction<'_>,

--- a/modules/fedimint-mintv2-client/src/lib.rs
+++ b/modules/fedimint-mintv2-client/src/lib.rs
@@ -689,7 +689,8 @@ impl MintClientModule {
     /// Cancel safe: this only reads pre-ground blinding tweaks from an
     /// in-memory channel and constructs values, it performs no database
     /// writes. Dropping the future merely discards the tweaks it had taken,
-    /// which are unbounded and regenerated in the background.
+    /// which are random (so nothing is lost) and replenished by the
+    /// background grinder task.
     async fn create_output_bundle(
         &self,
         operation_id: OperationId,


### PR DESCRIPTION
Documents the cancel-safety of `MintClientModule::send` and the methods in its chain, so callers can rely on cancelling (e.g. wrapping the call in a timeout) without corrupting state or losing funds.

`send` already returned the reissued notes to the balance on cancel; this makes the guarantee explicit and adds a `# Cancel safety` section to each method that carries a non-obvious property:

- `send` - all writes happen inside a single `autocommit` transaction (the fast-path note spend, or the change-making reissue), and federation submission is driven by a state machine in the executor rather than awaited here, so dropping the future can't corrupt state or abort an in-flight reissue. Notes the one caveat: it is not cancel safe with respect to the *caller's intent*, since a cancel after the reissue commits leaves it to complete (change returns to the balance) while no ecash is produced.
- `send_ecash_dbtx` - writes go to the passed `dbtx`, so it inherits the caller's transaction and must be run inside an `autocommit` (as `send` does).
- `create_output_bundle` - in-memory only (reads pre-ground blinding tweaks from a channel), no db writes.
- `await_output_sm_success` - pure wait on the operation's state notifications, no db writes.
- `Client::finalize_and_submit_transaction` - one `autocommit` plus executor-driven submission, hence cancel safe. This is the broadly useful one: any module building on it gets the same guarantee.
- `Client::finalize_and_submit_transaction_dbtx` - the important distinction: this does *not* own the transaction, so its cancel safety is the caller's, who is responsible for committing `dbtx` atomically.

Docs only, no behavior change. Verified the intra-doc links resolve with `-D rustdoc::broken_intra_doc_links`.
