### PR TITLE
fix(bitcoind): configure esplora request timeouts (backport #8709 to v0.10)

### DIFF
--- a/fedimint-bitcoind/src/lib.rs
+++ b/fedimint-bitcoind/src/lib.rs
@@ -23,6 +23,8 @@ use fedimint_metrics::HistogramExt as _;
 
 use crate::metrics::{BITCOIND_RPC_DURATION_SECONDS, BITCOIND_RPC_REQUESTS_TOTAL};
 
+const ESPLORA_CLIENT_TIMEOUT_SECONDS: u64 = 60;
+
 #[cfg(feature = "bitcoincore")]
 pub mod bitcoincore;
 
@@ -169,10 +171,11 @@ pub struct EsploraClient {
 
 impl EsploraClient {
     pub fn new(url: &SafeUrl) -> anyhow::Result<Self> {
-        Ok(Self {
-            // URL needs to have any trailing path including '/' removed
-            client: Builder::new(url.as_str().trim_end_matches('/')).build_async()?,
-        })
+        let client = Builder::new(url.as_str().trim_end_matches('/'))
+            .timeout(ESPLORA_CLIENT_TIMEOUT_SECONDS)
+            .build_async()?;
+
+        Ok(Self { client })
     }
 }
 

--- a/fedimint-server-bitcoin-rpc/src/esplora.rs
+++ b/fedimint-server-bitcoin-rpc/src/esplora.rs
@@ -23,6 +23,7 @@ const SIGNET: &str = "00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633b
 // <https://github.com/bitcoin/bitcoin/blob/d82283950f5ff3b2116e705f931c6e89e5fdd0be/src/kernel/chainparams.cpp#L478>
 const REGTEST: &str = "0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206";
 
+const ESPLORA_CLIENT_TIMEOUT_SECONDS: u64 = 60;
 #[derive(Debug)]
 pub struct EsploraClient {
     client: esplora_client::AsyncClient,
@@ -40,7 +41,8 @@ impl EsploraClient {
         // URL needs to have any trailing path including '/' removed
         let without_trailing = url.as_str().trim_end_matches('/');
 
-        let builder = esplora_client::Builder::new(without_trailing);
+        let builder =
+            esplora_client::Builder::new(without_trailing).timeout(ESPLORA_CLIENT_TIMEOUT_SECONDS);
         let client = builder.build_async()?;
         Ok(Self {
             client,


### PR DESCRIPTION
Backport of #8709 (merged to `master` 2026-06-16; also backported to `releases/v0.11` in #8967) onto `releases/v0.10`.

## Why

`releases/v0.10` constructs the Esplora client with no per-request timeout — `EsploraClient::new`
calls `Builder::new(..).build_async()` directly. When an Esplora endpoint accepts a connection and
then never responds, a single request hangs forever, the surrounding retry/backoff loop never
re-fires, and wallet recovery never self-heals (issue #8678).

This is the branch that feeds Fedi's downstream fork (`fedibtc/fedimint`), so the recovery hang
stranding real users (e.g. Afribit Kibera) needs the fix here to reach them via a 0.10-based fork tag.

## What

Cherry-pick of `5e754b7` — sets a 60s request timeout on both the client-side
(`fedimint-bitcoind`) and server-side (`fedimint-server-bitcoin-rpc`) Esplora backends, so a
stalled request errors and the existing backoff retries. Applied cleanly (2 files, +10/-5).

## Testing

- `cargo check -q -p fedimint-bitcoind -p fedimint-server-bitcoin-rpc` — passes
- `cargo fmt -p fedimint-bitcoind -p fedimint-server-bitcoin-rpc -- --check` — passes

## Note

The timeout only makes the existing backoff re-fire — it does not rescue a genuinely dead endpoint;
a federation pointed at an unreachable Esplora URL will still not complete recovery.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WeLSiFWwSAd9XKi3v5XL13)_