### PR TITLE
fix(gw): remove wait from gateway's reissue endpoint

### DIFF
--- a/gateway/fedimint-gateway-client/src/ecash_commands.rs
+++ b/gateway/fedimint-gateway-client/src/ecash_commands.rs
@@ -80,8 +80,6 @@ pub enum EcashCommands {
         /// E-cash notes (`OOBNotes` for v1 or `ECash` for v2)
         #[clap(long)]
         notes: String,
-        #[arg(long = "no-wait", action = clap::ArgAction::SetFalse)]
-        wait: bool,
     },
 }
 
@@ -183,9 +181,9 @@ impl EcashCommands {
 
                 Ok(CliOutput::SpendEcash(response))
             }
-            Self::Receive { notes, wait } => {
+            Self::Receive { notes } => {
                 let response =
-                    receive_ecash(client, base_url, ReceiveEcashPayload { notes, wait }).await?;
+                    receive_ecash(client, base_url, ReceiveEcashPayload { notes }).await?;
                 Ok(CliOutput::ReceiveEcash(response))
             }
         }

--- a/gateway/fedimint-gateway-common/src/lib.rs
+++ b/gateway/fedimint-gateway-common/src/lib.rs
@@ -240,8 +240,6 @@ pub struct SpendEcashResponse {
 pub struct ReceiveEcashPayload {
     /// Can be OOBNotes (v1) or ECash (v2)
     pub notes: String,
-    #[serde(default)]
-    pub wait: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -1547,38 +1547,35 @@ impl Gateway {
                     failure_reason: e.to_string(),
                 }
             })?;
-            if payload.wait {
-                let mut updates = mint
-                    .subscribe_reissue_external_notes(operation_id)
-                    .await
-                    .map_err(|e| PublicGatewayError::ReceiveEcashError {
-                        failure_reason: format!("Could not subscribe to reissue operation: {e}"),
-                    })?
-                    .into_stream();
 
-                // Only `Done` and `Failed` are terminal for this stream. Ending on
-                // `Created` or `Issuing` means the outputs were never finalized, so
-                // their blind signatures were never verified, and reporting the
-                // notes' claimed amount would credit e-cash the gateway does not
-                // hold.
-                let mut reissued = false;
-                while let Some(update) = updates.next().await {
-                    match update {
-                        ReissueExternalNotesState::Failed(failure_reason) => {
-                            return Err(PublicGatewayError::ReceiveEcashError { failure_reason });
-                        }
-                        ReissueExternalNotesState::Done => reissued = true,
-                        ReissueExternalNotesState::Created | ReissueExternalNotesState::Issuing => {
-                        }
+            let mut updates = mint
+                .subscribe_reissue_external_notes(operation_id)
+                .await
+                .map_err(|e| PublicGatewayError::ReceiveEcashError {
+                    failure_reason: format!("Could not subscribe to reissue operation: {e}"),
+                })?
+                .into_stream();
+
+            // Only `Done` and `Failed` are terminal for this stream. Ending on
+            // `Created` or `Issuing` means the outputs were never finalized, so
+            // their blind signatures were never verified, and reporting the notes'
+            // claimed amount would credit e-cash the gateway does not hold.
+            let mut reissued = false;
+            while let Some(update) = updates.next().await {
+                match update {
+                    ReissueExternalNotesState::Failed(failure_reason) => {
+                        return Err(PublicGatewayError::ReceiveEcashError { failure_reason });
                     }
+                    ReissueExternalNotesState::Done => reissued = true,
+                    ReissueExternalNotesState::Created | ReissueExternalNotesState::Issuing => {}
                 }
+            }
 
-                if !reissued {
-                    return Err(PublicGatewayError::ReceiveEcashError {
-                        failure_reason: "Reissue operation ended before the notes were reissued"
-                            .to_string(),
-                    });
-                }
+            if !reissued {
+                return Err(PublicGatewayError::ReceiveEcashError {
+                    failure_reason: "Reissue operation ended before the notes were reissued"
+                        .to_string(),
+                });
             }
 
             Ok(ReceiveEcashResponse { amount })
@@ -1598,20 +1595,18 @@ impl Gateway {
                     failure_reason: e.to_string(),
                 })?;
 
-            if payload.wait {
-                let final_state = mint
-                    .await_final_receive_operation_state(operation_id)
-                    .await
-                    .map_err(|e| PublicGatewayError::ReceiveEcashError {
-                        failure_reason: e.to_string(),
-                    })?;
-                match final_state {
-                    fedimint_mintv2_client::FinalReceiveOperationState::Success => {}
-                    fedimint_mintv2_client::FinalReceiveOperationState::Rejected => {
-                        return Err(PublicGatewayError::ReceiveEcashError {
-                            failure_reason: "ECash receive was rejected".to_string(),
-                        });
-                    }
+            let final_state = mint
+                .await_final_receive_operation_state(operation_id)
+                .await
+                .map_err(|e| PublicGatewayError::ReceiveEcashError {
+                    failure_reason: e.to_string(),
+                })?;
+            match final_state {
+                fedimint_mintv2_client::FinalReceiveOperationState::Success => {}
+                fedimint_mintv2_client::FinalReceiveOperationState::Rejected => {
+                    return Err(PublicGatewayError::ReceiveEcashError {
+                        failure_reason: "ECash receive was rejected".to_string(),
+                    });
                 }
             }
 

--- a/gateway/fedimint-gateway-ui/src/federation.rs
+++ b/gateway/fedimint-gateway-ui/src/federation.rs
@@ -34,8 +34,6 @@ use crate::{
 #[derive(Deserialize)]
 pub struct ReceiveEcashForm {
     pub notes: String,
-    #[serde(default)]
-    pub wait: bool,
 }
 
 pub fn scripts() -> Markup {
@@ -505,8 +503,6 @@ pub fn render<E: Display>(
                                      hx-target=(format!("#receive-result-{}", fed.federation_id))
                                      hx-swap="innerHTML"
                                 {
-                                    input type="hidden" name="wait" value="true";
-
                                     div class="mb-3" {
                                         label class="form-label" for=(format!("receive-notes-{}", fed.federation_id)) {
                                             "Ecash Notes"
@@ -1114,10 +1110,7 @@ pub async fn receive_ecash_handler<E: Display>(
     };
 
     // Construct payload with string notes
-    let payload = ReceiveEcashPayload {
-        notes: notes_str,
-        wait: form.wait,
-    };
+    let payload = ReceiveEcashPayload { notes: notes_str };
 
     let markup = match state.api.handle_receive_ecash_msg(payload).await {
         Ok(response) => {


### PR DESCRIPTION
Removes `wait` from the gateway's reissue endpoint so that integrating applications (CLI, UI) never falsely indicate that the ecash was received when it actually wasn't