### PR TITLE
feat: simplify names for uniffi exports

### DIFF
--- a/fedimint-client-module/uniffi.toml
+++ b/fedimint-client-module/uniffi.toml
@@ -1,0 +1,2 @@
+[bindings.kotlin]
+package_name = "org.fedimint.sdk.clientmodule"

--- a/fedimint-client/uniffi.toml
+++ b/fedimint-client/uniffi.toml
@@ -1,0 +1,2 @@
+[bindings.kotlin]
+package_name = "org.fedimint.sdk.client"

--- a/fedimint-core/uniffi.toml
+++ b/fedimint-core/uniffi.toml
@@ -1,0 +1,2 @@
+[bindings.kotlin]
+package_name = "org.fedimint.sdk.core"

--- a/fedimint-eventlog/uniffi.toml
+++ b/fedimint-eventlog/uniffi.toml
@@ -1,0 +1,2 @@
+[bindings.kotlin]
+package_name = "org.fedimint.sdk.eventlog"

--- a/modules/fedimint-ln-client/uniffi.toml
+++ b/modules/fedimint-ln-client/uniffi.toml
@@ -1,0 +1,2 @@
+[bindings.kotlin]
+package_name = "org.fedimint.sdk.ln"

--- a/modules/fedimint-ln-common/uniffi.toml
+++ b/modules/fedimint-ln-common/uniffi.toml
@@ -1,0 +1,2 @@
+[bindings.kotlin]
+package_name = "org.fedimint.sdk.lncommon"

--- a/modules/fedimint-meta-client/uniffi.toml
+++ b/modules/fedimint-meta-client/uniffi.toml
@@ -1,0 +1,2 @@
+[bindings.kotlin]
+package_name = "org.fedimint.sdk.meta"

--- a/modules/fedimint-meta-common/uniffi.toml
+++ b/modules/fedimint-meta-common/uniffi.toml
@@ -1,0 +1,2 @@
+[bindings.kotlin]
+package_name = "org.fedimint.sdk.metacommon"

--- a/modules/fedimint-mint-client/uniffi.toml
+++ b/modules/fedimint-mint-client/uniffi.toml
@@ -1,0 +1,2 @@
+[bindings.kotlin]
+package_name = "org.fedimint.sdk.mint"

--- a/modules/fedimint-wallet-client/uniffi.toml
+++ b/modules/fedimint-wallet-client/uniffi.toml
@@ -1,0 +1,2 @@
+[bindings.kotlin]
+package_name = "org.fedimint.sdk.wallet"

--- a/modules/fedimint-wallet-common/uniffi.toml
+++ b/modules/fedimint-wallet-common/uniffi.toml
@@ -1,0 +1,2 @@
+[bindings.kotlin]
+package_name = "org.fedimint.sdk.walletcommon"


### PR DESCRIPTION
## Summary
- Add UniFFI Kotlin binding configuration for Fedimint SDK crates.
- Assign stable `org.fedimint.sdk.*` package names for core, client, eventlog, and module binding outputs.
- Split common/client module packages so generated Kotlin exports have simpler, predictable namespaces.

## Testing
- Not run; PR description-only update by fedimint-bot.
