### PR TITLE
feat(client): expose conservative Lightning sweep fees

### DIFF
--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -1304,6 +1304,11 @@ impl LightningClientModule {
             .await
     }
 
+    /// Federation fee charged for creating one outgoing Lightning contract.
+    pub fn outgoing_contract_fee(&self) -> Amount {
+        self.cfg.fee_consensus.contract_output
+    }
+
     /// Pays a LN invoice with our available funds using the supplied `gateway`
     /// if one was provided and the invoice is not an internal one. If none is
     /// supplied only internal payments are possible.

--- a/modules/fedimint-lnv2-client/src/lib.rs
+++ b/modules/fedimint-lnv2-client/src/lib.rs
@@ -519,6 +519,11 @@ impl LightningClientModule {
             .map_err(|_| RoutingInfoError::FailedToRequestRoutingInfo)
     }
 
+    /// Federation fee charged for an outgoing Lightning contract of `amount`.
+    pub fn outgoing_contract_fee(&self, amount: Amount) -> Amount {
+        self.cfg.fee_consensus.fee(amount)
+    }
+
     /// Pay an invoice. For testing you can optionally specify a gateway to
     /// route with, otherwise a gateway will be selected automatically. If the
     /// invoice was created by a gateway connected to our federation, the same

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -1507,6 +1507,24 @@ impl MintClientModule {
         self.get_note_counts_by_denomination(dbtx).await
     }
 
+    /// Net value available when every economical note is used as transaction
+    /// funding, after paying the mint input fee for each note.
+    pub async fn get_spendable_balance(&self) -> Amount {
+        let mut dbtx = self.client_ctx.module_db().begin_transaction_nc().await;
+        let note_counts = self.get_note_counts_by_denomination(&mut dbtx).await;
+
+        note_counts
+            .iter()
+            .filter_map(|(amount, count)| {
+                amount
+                    .checked_sub(self.cfg.fee_consensus.fee(amount))
+                    .and_then(|net| net.checked_mul(count as u64))
+            })
+            .fold(Amount::ZERO, |acc, value| {
+                acc.checked_add(value).expect("spendable balance overflow")
+            })
+    }
+
     /// Estimates the total fees to spend all currently held notes.
     ///
     /// This is useful for calculating max withdrawable amounts, where all

--- a/modules/fedimint-mintv2-client/src/lib.rs
+++ b/modules/fedimint-mintv2-client/src/lib.rs
@@ -533,6 +533,24 @@ impl ClientModule for MintClientModule {
 }
 
 impl MintClientModule {
+    /// Net value available when every note is used as transaction funding,
+    /// after paying the mint input fee for each note.
+    pub async fn get_spendable_balance(&self) -> Amount {
+        let mut dbtx = self.client_ctx.module_db().begin_transaction_nc().await;
+        self.get_count_by_denomination_dbtx(&mut dbtx)
+            .await
+            .into_iter()
+            .filter_map(|(denomination, count)| {
+                let amount = denomination.amount();
+                amount
+                    .checked_sub(self.cfg.fee_consensus.fee(amount))
+                    .and_then(|net| net.checked_mul(count))
+            })
+            .fold(Amount::ZERO, |acc, value| {
+                acc.checked_add(value).expect("spendable balance overflow")
+            })
+    }
+
     async fn select_funding_input(
         &self,
         dbtx: &mut DatabaseTransaction<'_>,


### PR DESCRIPTION
## Motivation

Clients sweeping an entire ecash balance over Lightning need to account for mint input fees and the outgoing Lightning contract fee before requesting an invoice. The nominal balance alone can overestimate what is sendable, causing exact-balance payments to fail during transaction construction.

## Change

Expose the net value of all economical notes from both mint client generations and the outgoing contract fee from both Lightning client generations. Callers can use these values to choose a conservative maximum recipient amount while supporting legacy and v2 federations.

This is needed by the Fleet Manager Lightning revenue sweep work in fedibtc/manifold#245.

## Verification

`cargo fmt --all -- --check`

`cargo check -p fedimint-ln-client -p fedimint-lnv2-client -p fedimint-mint-client -p fedimint-mintv2-client`