### PR TITLE
fix(gw): add additional fee limit verifications

### DIFF
--- a/gateway/fedimint-gateway-server-db/src/migration_tests.rs
+++ b/gateway/fedimint-gateway-server-db/src/migration_tests.rs
@@ -39,7 +39,9 @@ async fn create_gatewayd_db_data(db: Database) {
         invite_code,
         federation_index: 2,
         timelock_delta: 10,
-        fees: PaymentFee::TRANSACTION_FEE_DEFAULT.into(),
+        fees: PaymentFee::TRANSACTION_FEE_DEFAULT
+            .try_into()
+            .expect("The default transaction fee fits into RoutingFees"),
     };
 
     dbtx.insert_new_entry(
@@ -56,7 +58,9 @@ async fn create_gatewayd_db_data(db: Database) {
     let gateway_configuration = GatewayConfigurationV0 {
         password: "EXAMPLE".to_string(),
         num_route_hints: 2,
-        routing_fees: PaymentFee::TRANSACTION_FEE_DEFAULT.into(),
+        routing_fees: PaymentFee::TRANSACTION_FEE_DEFAULT
+            .try_into()
+            .expect("The default transaction fee fits into RoutingFees"),
         network: NetworkLegacyEncodingWrapper(bitcoin::Network::Regtest),
     };
 

--- a/gateway/fedimint-gateway-server/src/config.rs
+++ b/gateway/fedimint-gateway-server/src/config.rs
@@ -2,6 +2,7 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::str::FromStr;
 
+use anyhow::ensure;
 use bitcoin::Network;
 use clap::builder::BoolishValueParser;
 use clap::{ArgGroup, Parser};
@@ -158,6 +159,31 @@ impl GatewayOpts {
             } else {
                 None
             };
+
+        // The defaults are copied into the config of every federation the gateway
+        // connects to, so they have to satisfy the same limits `set_fees` enforces.
+        // Rejecting them here means a fee that cannot be announced to LNv1 clients
+        // never reaches the database.
+        let send_fees = self
+            .default_routing_fees
+            .checked_add(self.default_transaction_fees)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Total of default routing and transaction fees overflowed, they may not exceed {}",
+                    PaymentFee::SEND_FEE_LIMIT
+                )
+            })?;
+        ensure!(
+            send_fees.is_within(&PaymentFee::SEND_FEE_LIMIT),
+            "Total of default routing and transaction fees exceeded {}",
+            PaymentFee::SEND_FEE_LIMIT
+        );
+        ensure!(
+            self.default_transaction_fees
+                .is_within(&PaymentFee::RECEIVE_FEE_LIMIT),
+            "Default transaction fees exceeded RECEIVE LIMIT {}",
+            PaymentFee::RECEIVE_FEE_LIMIT
+        );
 
         // Default metrics listen to localhost on UI port + 1
         let metrics_listen = self.metrics_listen.unwrap_or_else(|| {

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -1686,12 +1686,28 @@ impl Gateway {
             }
 
             for (federation_id, federation_config) in federations {
+                // A fee that predates the fee limits may be too large to announce. Skip
+                // that federation rather than failing the whole registration pass: this
+                // runs on the root task group at startup, so an error here would keep
+                // the gateway from booting at all.
+                let routing_fees = match RoutingFees::try_from(federation_config.lightning_fee) {
+                    Ok(routing_fees) => routing_fees,
+                    Err(err) => {
+                        warn!(
+                            target: LOG_GATEWAY,
+                            %federation_id,
+                            err = %err.fmt_compact(),
+                            "Skipping registration, the configured lightning fee cannot be announced. Set a smaller fee with `set_fees`."
+                        );
+                        continue;
+                    }
+                };
+
                 let fed_manager = self.federation_manager.read().await;
                 if let Some(client) = fed_manager.client(federation_id) {
                     let client_arc = client.clone().into_value();
                     let route_hints = route_hints.clone();
                     let lightning_context = lightning_context.clone();
-                    let federation_config = federation_config.clone();
                     let registrations =
                         self.registrations.clone().into_values().collect::<Vec<_>>();
 
@@ -1709,7 +1725,7 @@ impl Gateway {
                                     .try_register_with_federation(
                                         route_hints.clone(),
                                         GW_ANNOUNCEMENT_TTL,
-                                        federation_config.lightning_fee.into(),
+                                        routing_fees,
                                         lightning_context.clone(),
                                         registration.endpoint_url,
                                         registration.keypair.public_key(),
@@ -2165,6 +2181,12 @@ impl IAdminGateway for Gateway {
             _connector: ConnectorType::Tcp,
         };
 
+        // The default fees are validated at startup, so this only fails if the gateway
+        // is running with fees that predate that check. Refuse to join a federation
+        // whose fee could not be announced rather than persisting its config.
+        let routing_fees = RoutingFees::try_from(federation_config.lightning_fee)
+            .map_err(|err| AdminGatewayError::GatewayConfigurationError(err.to_string()))?;
+
         let mnemonic = Self::load_mnemonic(&self.gateway_db)
             .await
             .expect("mnemonic should be set");
@@ -2211,7 +2233,7 @@ impl IAdminGateway for Gateway {
                     // Route hints will be updated in the background
                     Vec::new(),
                     GW_ANNOUNCEMENT_TTL,
-                    federation_config.lightning_fee.into(),
+                    routing_fees,
                     lightning_context.clone(),
                     registration.endpoint_url.clone(),
                     registration.keypair.public_key(),
@@ -2289,21 +2311,28 @@ impl IAdminGateway for Gateway {
                 transaction_fee.parts_per_million = transaction_ppm;
             }
 
-            let client =
-                federation_manager
-                    .client(federation_id)
-                    .ok_or(FederationNotConnected {
-                        federation_id_prefix: federation_id.to_prefix(),
-                    })?;
-            let client_config = client.value().config().await;
-            let contains_lnv2 = client_config
-                .modules
-                .values()
-                .any(|m| fedimint_lnv2_common::LightningCommonInit::KIND == m.kind);
+            // Changing the fees of a federation the gateway is not connected to is
+            // rejected, as it was before the fee limits applied to every federation.
+            federation_manager
+                .client(federation_id)
+                .ok_or(FederationNotConnected {
+                    federation_id_prefix: federation_id.to_prefix(),
+                })?;
+
+            // The limits are enforced for every federation, not just the ones running
+            // LNv2. An unchecked fee is persisted verbatim and is converted into
+            // `RoutingFees` on every LNv1 payment and on every registration, including
+            // the one at startup, so a fee that does not fit into the `u32` components
+            // of `RoutingFees` would leave the gateway unable to boot.
+            let send_fees = lightning_fee.checked_add(transaction_fee).ok_or_else(|| {
+                AdminGatewayError::GatewayConfigurationError(format!(
+                    "Total Send fees overflowed, they may not exceed {}",
+                    PaymentFee::SEND_FEE_LIMIT
+                ))
+            })?;
 
             // Check if the lightning fee + transaction fee is higher than the send limit
-            let send_fees = lightning_fee + transaction_fee;
-            if contains_lnv2 && !send_fees.is_within(&PaymentFee::SEND_FEE_LIMIT) {
+            if !send_fees.is_within(&PaymentFee::SEND_FEE_LIMIT) {
                 return Err(AdminGatewayError::GatewayConfigurationError(format!(
                     "Total Send fees exceeded {}",
                     PaymentFee::SEND_FEE_LIMIT
@@ -2311,7 +2340,7 @@ impl IAdminGateway for Gateway {
             }
 
             // Check if the transaction fee is higher than the receive limit
-            if contains_lnv2 && !transaction_fee.is_within(&PaymentFee::RECEIVE_FEE_LIMIT) {
+            if !transaction_fee.is_within(&PaymentFee::RECEIVE_FEE_LIMIT) {
                 return Err(AdminGatewayError::GatewayConfigurationError(format!(
                     "Transaction fees exceeded RECEIVE LIMIT {}",
                     PaymentFee::RECEIVE_FEE_LIMIT
@@ -3047,6 +3076,14 @@ impl Gateway {
         let lightning_fee = fed_config.lightning_fee;
         let transaction_fee = fed_config.transaction_fee;
 
+        // This route is public and unauthenticated, so the sum of two fees stored
+        // before the fee limits applied must not be able to panic here.
+        let send_fee_default = lightning_fee.checked_add(transaction_fee).ok_or_else(|| {
+            PublicGatewayError::Unexpected(anyhow!(
+                "The configured fees of federation {federation_id} cannot be added"
+            ))
+        })?;
+
         Ok(self
             .public_key_v2(federation_id)
             .await
@@ -3054,7 +3091,7 @@ impl Gateway {
                 lightning_public_key: context.lightning_public_key,
                 lightning_alias: Some(context.lightning_alias.clone()),
                 module_public_key,
-                send_fee_default: lightning_fee + transaction_fee,
+                send_fee_default,
                 // The base fee ensures that the gateway does not loose sats sending the payment due
                 // to fees paid on the transaction claiming the outgoing contract or
                 // subsequent transactions spending the newly issued ecash
@@ -3514,10 +3551,24 @@ impl IGatewayClientV1 for Gateway {
 
     async fn get_routing_fees(&self, federation_id: FederationId) -> Option<RoutingFees> {
         let mut gateway_dbtx = self.gateway_db.begin_transaction_nc().await;
-        gateway_dbtx
+        let lightning_fee = gateway_dbtx
             .load_federation_config(federation_id)
-            .await
-            .map(|c| c.lightning_fee.into())
+            .await?
+            .lightning_fee;
+
+        // A fee stored before the fee limits applied may not be announceable. The
+        // caller treats `None` as a federation configuration error, which is
+        // preferable to panicking in the middle of a payment.
+        RoutingFees::try_from(lightning_fee)
+            .inspect_err(|err| {
+                warn!(
+                    target: LOG_GATEWAY,
+                    %federation_id,
+                    err = %err.fmt_compact(),
+                    "Configured lightning fee cannot be used. Set a smaller fee with `set_fees`."
+                );
+            })
+            .ok()
     }
 
     async fn get_client(&self, federation_id: &FederationId) -> Option<Spanned<ClientHandleArc>> {

--- a/gateway/fedimint-gateway-server/tests/tests.rs
+++ b/gateway/fedimint-gateway-server/tests/tests.rs
@@ -929,6 +929,119 @@ async fn test_gateway_rejects_amountless_invoice() -> anyhow::Result<()> {
     .await
 }
 
+/// `set_fees` takes operator-supplied fees whose only bound is `u64`, and
+/// `/set_fees` is reachable with the lesser liquidity-manager credential. Both
+/// summing the two fee components and converting the result into `RoutingFees`
+/// must therefore be total: the conversion runs on every LNv1 payment and on
+/// the federation registration that happens at startup, so a persisted
+/// out-of-range fee boot-loops an LND gateway.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_gateway_rejects_fees_it_cannot_announce() -> anyhow::Result<()> {
+    single_federation_test(|gateway, _, fed, _, _| async move {
+        let federation_id = fed.id();
+        let routing_info_before = gateway
+            .routing_info_v2(&federation_id)
+            .await?
+            .expect("Gateway is connected to the federation");
+
+        let template = SetFeesPayload {
+            federation_id: Some(federation_id),
+            lightning_base: None,
+            lightning_parts_per_million: None,
+            transaction_base: None,
+            transaction_parts_per_million: None,
+        };
+
+        let rejected = [
+            // Overflows the addition of the lightning and transaction fee, which
+            // happens before any limit can be checked.
+            SetFeesPayload {
+                lightning_base: Some(Amount::from_msats(u64::MAX)),
+                ..template.clone()
+            },
+            SetFeesPayload {
+                lightning_parts_per_million: Some(u64::MAX),
+                ..template.clone()
+            },
+            // Sats entered where msats were expected: no overflow, but the value
+            // does not fit into the `u32` components of `RoutingFees`.
+            SetFeesPayload {
+                lightning_base: Some(Amount::from_msats(u64::from(u32::MAX) + 1)),
+                ..template.clone()
+            },
+            SetFeesPayload {
+                transaction_parts_per_million: Some(u64::from(u32::MAX) + 1),
+                ..template.clone()
+            },
+        ];
+
+        for payload in rejected {
+            let error = gateway
+                .handle_set_fees_msg(payload.clone())
+                .await
+                .expect_err(&format!("Fee outside the limits was accepted: {payload:?}"));
+            assert!(
+                error.to_string().contains("Error configuring the gateway"),
+                "Expected a gateway configuration error, got: {error}"
+            );
+        }
+
+        // A rejected fee must not have been persisted.
+        let routing_info_after = gateway
+            .routing_info_v2(&federation_id)
+            .await?
+            .expect("Gateway is connected to the federation");
+        assert_eq!(
+            routing_info_before.send_fee_default,
+            routing_info_after.send_fee_default
+        );
+        assert_eq!(
+            routing_info_before.receive_fee,
+            routing_info_after.receive_fee
+        );
+
+        Ok(())
+    })
+    .await
+}
+
+/// The fee limits used to be checked only for federations running LNv2, so a
+/// federation with LNv1 alone accepted any fee at all — including one that
+/// cannot be converted into the `RoutingFees` that LNv1 registration announces.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_gateway_enforces_fee_limits_without_lnv2() -> anyhow::Result<()> {
+    let fixtures = Fixtures::new_primary(DummyClientInit, DummyInit)
+        .with_server_only_module(UnknownInit)
+        .with_module(
+            LightningClientInit {
+                gateway_conn: Some(Arc::new(MockGatewayConnection)),
+            },
+            LightningInit,
+        );
+
+    let fed = fixtures.new_fed_degraded().await;
+    let gateway = fixtures.new_gateway().await;
+    fed.connect_gateway(&gateway).await;
+
+    let error = gateway
+        .handle_set_fees_msg(SetFeesPayload {
+            federation_id: Some(fed.id()),
+            // A base fee in sats where msats were expected.
+            lightning_base: Some(Amount::from_msats(u64::from(u32::MAX) + 1)),
+            lightning_parts_per_million: None,
+            transaction_base: None,
+            transaction_parts_per_million: None,
+        })
+        .await
+        .expect_err("Fee above the send limit was accepted for an LNv1-only federation");
+    assert!(
+        error.to_string().contains("Total Send fees exceeded"),
+        "Expected the send fee limit to be enforced, got: {error}"
+    );
+
+    Ok(())
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn test_gateway_executes_swaps_between_connected_federations() -> anyhow::Result<()> {
     multi_federation_test(|gateway, fed1, fed2, _| async move {

--- a/modules/fedimint-lnv2-common/src/gateway_api.rs
+++ b/modules/fedimint-lnv2-common/src/gateway_api.rs
@@ -1,4 +1,3 @@
-use std::ops::Add;
 use std::str::FromStr;
 
 use bitcoin::secp256k1::PublicKey;
@@ -12,6 +11,7 @@ use fedimint_ln_common::client::GatewayApi;
 use lightning_invoice::{Bolt11Invoice, RoutingFees};
 use reqwest::Method;
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
 use crate::contracts::{IncomingContract, OutgoingContract};
 use crate::endpoint_constants::{
@@ -224,6 +224,18 @@ impl PaymentFee {
         self.base <= limit.base && self.parts_per_million <= limit.parts_per_million
     }
 
+    /// Adds two fees, returning `None` if either component overflows.
+    ///
+    /// Fees reach this method straight from operator input, so the addition
+    /// has to happen before the limit checks can run. A panicking `Add` would
+    /// therefore be reachable with a fee that the limits are meant to reject.
+    pub fn checked_add(self, rhs: Self) -> Option<PaymentFee> {
+        Some(PaymentFee {
+            base: self.base.checked_add(rhs.base)?,
+            parts_per_million: self.parts_per_million.checked_add(rhs.parts_per_million)?,
+        })
+    }
+
     pub fn add_to(&self, msats: u64) -> Amount {
         Amount::from_msats(msats.saturating_add(self.absolute_fee(msats)))
     }
@@ -237,27 +249,21 @@ impl PaymentFee {
     }
 
     fn absolute_fee(&self, msats: u64) -> u64 {
+        // The base fee is bounded well below `u64::MAX` for any fee that passed
+        // the limit checks, but a fee decoded from an older database has not
+        // necessarily passed them, so saturate rather than panic.
         msats
             .saturating_mul(self.parts_per_million)
             .saturating_div(1_000_000)
-            .checked_add(self.base.msats)
-            .expect("The division creates sufficient headroom to add the base fee")
+            .saturating_add(self.base.msats)
     }
 }
 
-impl Add for PaymentFee {
-    type Output = PaymentFee;
-
-    fn add(self, rhs: Self) -> Self::Output {
-        PaymentFee {
-            base: self.base.checked_add(rhs.base).expect("fee base overflow"),
-            parts_per_million: self
-                .parts_per_million
-                .checked_add(rhs.parts_per_million)
-                .expect("fee parts per million overflow"),
-        }
-    }
-}
+/// A [`PaymentFee`] that does not fit into the `u32` components of
+/// [`RoutingFees`] and therefore cannot be announced to lightning clients.
+#[derive(Debug, Error)]
+#[error("Payment fee {0} exceeds the range of RoutingFees")]
+pub struct FeeOutOfRangeError(PaymentFee);
 
 impl From<RoutingFees> for PaymentFee {
     fn from(value: RoutingFees) -> Self {
@@ -268,13 +274,15 @@ impl From<RoutingFees> for PaymentFee {
     }
 }
 
-impl From<PaymentFee> for RoutingFees {
-    fn from(value: PaymentFee) -> Self {
-        RoutingFees {
-            base_msat: u32::try_from(value.base.msats).expect("base msat was truncated from u64"),
+impl TryFrom<PaymentFee> for RoutingFees {
+    type Error = FeeOutOfRangeError;
+
+    fn try_from(value: PaymentFee) -> Result<Self, Self::Error> {
+        Ok(RoutingFees {
+            base_msat: u32::try_from(value.base.msats).map_err(|_| FeeOutOfRangeError(value))?,
             proportional_millionths: u32::try_from(value.parts_per_million)
-                .expect("ppm was truncated from u64"),
-        }
+                .map_err(|_| FeeOutOfRangeError(value))?,
+        })
     }
 }
 
@@ -314,6 +322,7 @@ impl FromStr for PaymentFee {
 #[cfg(test)]
 mod tests {
     use fedimint_core::Amount;
+    use lightning_invoice::RoutingFees;
 
     use super::PaymentFee;
 
@@ -359,27 +368,79 @@ mod tests {
         assert!(ok.is_within(&PaymentFee::SEND_FEE_LIMIT));
     }
 
+    /// Adding two operator-supplied fees must not panic on overflow, in either
+    /// component.
     #[test]
-    #[should_panic(expected = "fee base overflow")]
-    fn payment_fee_add_panics_on_base_overflow() {
-        let _ = PaymentFee {
+    fn checked_add_reports_overflow_instead_of_panicking() {
+        let max_base = PaymentFee {
             base: Amount::from_msats(u64::MAX),
             parts_per_million: 0,
-        } + PaymentFee {
+        };
+        let one_msat = PaymentFee {
             base: Amount::from_msats(1),
             parts_per_million: 0,
         };
-    }
+        assert!(max_base.checked_add(one_msat).is_none());
 
-    #[test]
-    #[should_panic(expected = "fee parts per million overflow")]
-    fn payment_fee_add_panics_on_ppm_overflow() {
-        let _ = PaymentFee {
+        let max_ppm = PaymentFee {
             base: Amount::ZERO,
             parts_per_million: u64::MAX,
-        } + PaymentFee {
+        };
+        let one_ppm = PaymentFee {
             base: Amount::ZERO,
             parts_per_million: 1,
         };
+        assert!(max_ppm.checked_add(one_ppm).is_none());
+
+        assert_eq!(
+            PaymentFee::TRANSACTION_FEE_DEFAULT
+                .checked_add(PaymentFee::TRANSACTION_FEE_DEFAULT)
+                .expect("Two default fees fit"),
+            PaymentFee {
+                base: Amount::from_sats(4),
+                parts_per_million: 6_000,
+            }
+        );
+    }
+
+    /// A fee that outgrew the `u32`s of `RoutingFees` must surface as an error
+    /// rather than a panic: the conversion runs on every lightning payment and
+    /// on federation registration at startup, so a panic here boot-loops the
+    /// gateway.
+    #[test]
+    fn routing_fees_conversion_rejects_out_of_range_fees() {
+        let over_base = PaymentFee {
+            base: Amount::from_msats(u64::from(u32::MAX) + 1),
+            parts_per_million: 0,
+        };
+        assert!(RoutingFees::try_from(over_base).is_err());
+
+        let over_ppm = PaymentFee {
+            base: Amount::ZERO,
+            parts_per_million: u64::from(u32::MAX) + 1,
+        };
+        assert!(RoutingFees::try_from(over_ppm).is_err());
+
+        let fees = RoutingFees::try_from(PaymentFee::SEND_FEE_LIMIT)
+            .expect("The send fee limit is within range");
+        assert_eq!(fees.base_msat, 100_000);
+        assert_eq!(fees.proportional_millionths, 15_000);
+    }
+
+    /// Any fee that `set_fees` accepts is small enough for the fee arithmetic
+    /// to stay exact, and an out-of-range fee left in an old database must
+    /// saturate instead of panicking.
+    #[test]
+    fn absolute_fee_saturates_instead_of_panicking() {
+        let huge = PaymentFee {
+            base: Amount::from_msats(u64::MAX),
+            parts_per_million: u64::MAX,
+        };
+        assert_eq!(huge.fee(u64::MAX), Amount::from_msats(u64::MAX));
+
+        assert_eq!(
+            PaymentFee::TRANSACTION_FEE_DEFAULT.fee(1_000_000),
+            Amount::from_msats(2_000 + 3_000)
+        );
     }
 }


### PR DESCRIPTION
It is possible for the gateway operator to shoot themselves in the foot and set a fee that ends up panicking the gateway. This PR adds some additional logic and checking over the fees so that it cannot crash the gateway.