### PR TITLE
fix: change decrypted preimage status to return error

### DIFF
--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -21,8 +21,8 @@ use fedimint_core::encoding::btc::NetworkLegacyEncodingWrapper;
 use fedimint_core::envs::{FM_ENABLE_MODULE_LNV1_ENV, is_env_var_set_opt};
 use fedimint_core::module::audit::Audit;
 use fedimint_core::module::{
-    Amounts, ApiEndpoint, ApiEndpointContext, ApiVersion, CoreConsensusVersion, InputMeta,
-    ModuleConsensusVersion, ModuleInit, TransactionItemAmounts, public_api_endpoint,
+    Amounts, ApiEndpoint, ApiEndpointContext, ApiError, ApiVersion, CoreConsensusVersion,
+    InputMeta, ModuleConsensusVersion, ModuleInit, TransactionItemAmounts, public_api_endpoint,
 };
 use fedimint_core::secp256k1::{Message, PublicKey, SECP256K1};
 use fedimint_core::task::sleep;
@@ -882,14 +882,14 @@ impl ServerModule for Lightning {
                 GET_DECRYPTED_PREIMAGE_STATUS,
                 ApiVersion::new(0, 0),
                 async |module: &Lightning, context, contract_id: ContractId| -> (IncomingContractAccount, DecryptedPreimageStatus) {
-                    Ok(module.get_decrypted_preimage_status(context, contract_id).await)
+                    module.get_decrypted_preimage_status(context, contract_id).await
                 }
             },
             public_api_endpoint! {
                 AWAIT_PREIMAGE_DECRYPTION,
                 ApiVersion::new(0, 0),
                 async |module: &Lightning, context, contract_id: ContractId| -> (IncomingContractAccount, Option<Preimage>) {
-                    Ok(module.wait_preimage_decrypted(context, contract_id).await)
+                    module.wait_preimage_decrypted(context, contract_id).await
                 }
             },
             public_api_endpoint! {
@@ -1066,29 +1066,33 @@ impl Lightning {
         &self,
         context: &mut ApiEndpointContext,
         contract_id: ContractId,
-    ) -> (IncomingContractAccount, DecryptedPreimageStatus) {
+    ) -> Result<(IncomingContractAccount, DecryptedPreimageStatus), ApiError> {
         let f_contract = context.wait_key_exists(ContractKey(contract_id));
         let contract = f_contract.await;
-        let incoming_contract_account = Self::get_incoming_contract_account(contract);
-        match &incoming_contract_account.contract.decrypted_preimage {
-            DecryptedPreimage::Some(key) => (
-                incoming_contract_account.clone(),
-                DecryptedPreimageStatus::Some(Preimage(sha256::Hash::hash(&key.0).to_byte_array())),
-            ),
-            DecryptedPreimage::Pending => {
-                (incoming_contract_account, DecryptedPreimageStatus::Pending)
-            }
-            DecryptedPreimage::Invalid => {
-                (incoming_contract_account, DecryptedPreimageStatus::Invalid)
-            }
-        }
+        let incoming_contract_account = Self::get_incoming_contract_account(contract)?;
+        Ok(
+            match &incoming_contract_account.contract.decrypted_preimage {
+                DecryptedPreimage::Some(key) => (
+                    incoming_contract_account.clone(),
+                    DecryptedPreimageStatus::Some(Preimage(
+                        sha256::Hash::hash(&key.0).to_byte_array(),
+                    )),
+                ),
+                DecryptedPreimage::Pending => {
+                    (incoming_contract_account, DecryptedPreimageStatus::Pending)
+                }
+                DecryptedPreimage::Invalid => {
+                    (incoming_contract_account, DecryptedPreimageStatus::Invalid)
+                }
+            },
+        )
     }
 
     async fn wait_preimage_decrypted(
         &self,
         context: &mut ApiEndpointContext,
         contract_id: ContractId,
-    ) -> (IncomingContractAccount, Option<Preimage>) {
+    ) -> Result<(IncomingContractAccount, Option<Preimage>), ApiError> {
         let future =
             context.wait_value_matches(ContractKey(contract_id), |contract| {
                 match &contract.contract {
@@ -1101,29 +1105,39 @@ impl Lightning {
             });
 
         let decrypt_preimage = future.await;
-        let incoming_contract_account = Self::get_incoming_contract_account(decrypt_preimage);
-        match incoming_contract_account
-            .clone()
-            .contract
-            .decrypted_preimage
-        {
-            DecryptedPreimage::Some(key) => (
-                incoming_contract_account,
-                Some(Preimage(sha256::Hash::hash(&key.0).to_byte_array())),
-            ),
-            _ => (incoming_contract_account, None),
-        }
+        let incoming_contract_account = Self::get_incoming_contract_account(decrypt_preimage)?;
+        Ok(
+            match incoming_contract_account
+                .clone()
+                .contract
+                .decrypted_preimage
+            {
+                DecryptedPreimage::Some(key) => (
+                    incoming_contract_account,
+                    Some(Preimage(sha256::Hash::hash(&key.0).to_byte_array())),
+                ),
+                _ => (incoming_contract_account, None),
+            },
+        )
     }
 
-    fn get_incoming_contract_account(contract: ContractAccount) -> IncomingContractAccount {
-        if let FundedContract::Incoming(incoming) = contract.contract {
-            return IncomingContractAccount {
+    /// `ContractKey` is shared by incoming and outgoing contracts, so a caller
+    /// can always reach this with the id of an outgoing contract - every client
+    /// that pays an invoice has one to hand. It has to be an error rather than
+    /// a panic: the endpoints below are public and unauthenticated, and only
+    /// the jsonrpsee transport contains a panicking handler.
+    fn get_incoming_contract_account(
+        contract: ContractAccount,
+    ) -> Result<IncomingContractAccount, ApiError> {
+        match contract.contract {
+            FundedContract::Incoming(incoming) => Ok(IncomingContractAccount {
                 amount: contract.amount,
                 contract: incoming.contract,
-            };
+            }),
+            FundedContract::Outgoing(_) => Err(ApiError::bad_request(
+                "Contract is not an incoming contract".to_string(),
+            )),
         }
-
-        panic!("Contract is not an IncomingContractAccount");
     }
 
     async fn list_gateways(

--- a/modules/fedimint-ln-tests/tests/tests.rs
+++ b/modules/fedimint-ln-tests/tests/tests.rs
@@ -16,6 +16,7 @@ use fedimint_core::util::{BoxStream, NextOrPending};
 use fedimint_core::{Amount, sats, secp256k1};
 use fedimint_dummy_client::{DummyClientInit, DummyClientModule};
 use fedimint_dummy_server::DummyInit;
+use fedimint_ln_client::api::LnFederationApi;
 use fedimint_ln_client::receive::{
     LightningReceiveError, LightningReceiveStateMachine, LightningReceiveStates,
     LightningReceiveSubmittedOffer,
@@ -371,6 +372,60 @@ async fn cannot_pay_same_external_invoice_twice() -> anyhow::Result<()> {
 
     let same_balance = client.get_balance_for_btc().await?;
     assert_eq!(prev_balance, same_balance);
+
+    drop(gw);
+
+    Ok(())
+}
+
+/// `GET_DECRYPTED_PREIMAGE_STATUS` is a public, unauthenticated endpoint whose
+/// `ContractKey` lookup resolves for outgoing contracts as well as incoming
+/// ones, and every client that pays an invoice holds an outgoing contract id.
+/// Passing one used to panic the guardian's API handler; only the jsonrpsee
+/// transport contains such a panic, the iroh one lets it take the process down.
+#[tokio::test(flavor = "multi_thread")]
+async fn preimage_status_of_an_outgoing_contract_is_an_error() -> anyhow::Result<()> {
+    let fixtures = fixtures();
+    let fed = fixtures.new_fed_degraded().await;
+    let gw = gateway(&fixtures, &fed).await;
+    let client = fed.new_client().await;
+    let dummy_module = client.get_first_module::<DummyClientModule>()?;
+
+    dummy_module
+        .mock_receive(sats(1000), AmountUnit::BITCOIN)
+        .await?;
+
+    let other_ln = FakeLightningTest::new();
+    let invoice = other_ln.invoice(Amount::from_sats(100), None)?;
+
+    let OutgoingLightningPayment {
+        payment_type,
+        contract_id,
+        fee: _,
+    } = pay_invoice(&client, invoice, Some(gw.http_gateway_id().await)).await?;
+    let PayType::Lightning(operation_id) = payment_type else {
+        panic!("Expected lightning payment!")
+    };
+
+    // The contract has to exist before it is queried, otherwise the endpoint
+    // long-polls for it.
+    let ln_module = client.get_first_module::<LightningClientModule>()?;
+    let mut sub = ln_module
+        .subscribe_ln_pay(operation_id)
+        .await?
+        .into_stream();
+    assert_eq!(sub.ok().await?, LnPayState::Created);
+    assert_matches!(sub.ok().await?, LnPayState::Funded { .. });
+
+    let error = ln_module
+        .api
+        .get_decrypted_preimage_status(contract_id)
+        .await
+        .expect_err("An outgoing contract has no decrypted preimage status");
+    assert!(
+        error.to_string().contains("not an incoming contract"),
+        "Expected the guardians to reject the contract kind, got: {error}"
+    );
 
     drop(gw);
 


### PR DESCRIPTION
`get_incoming_contract` previously would panic if the contract ID existed, but wasn't the right type (`Incoming` vs `Outgoing`). This changes it to return an `Error`.