### PR TITLE
fix(ci): raise the cross-compile timeout to 45 minutes

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -303,7 +303,10 @@ jobs:
           - host: linux
             runs-on: [self-hosted, linux, x64]
             build-in-pr: true
-            timeout: 20
+            # a warm cache builds each target in ~1-2 minutes, but a change
+            # touching fedimint-core rebuilds the whole workspace per target,
+            # and a cold aarch64-android build does not fit in 20 minutes
+            timeout: 45
 
 
     runs-on: ${{ matrix.runs-on }}


### PR DESCRIPTION
## Summary

The cross-compile matrix in `ci-nix.yml` caps every target at 20 minutes. That cap is fine on a warm cache but too tight for a merge-queue run that has to rebuild the workspace, so broad PRs get their `aarch64-android` job cancelled and can never merge. This raises the cap to 45 minutes.

## Details

With a warm Nix/cachix cache each cross target builds in one to two minutes — on a recent MQ run (`pr-8990`) `aarch64-android` finished in 94 seconds — so the 20 minute cap was never load-bearing.

A change that touches `fedimint-core` invalidates the cache for the whole workspace, and the cold `aarch64-android` build then runs past 20 minutes and is cancelled. The other targets stay fast even cold (armv7 70s, x86_64 24s, wasm32 42s in the same attempt), so `aarch64-android` is the only one that hits the wall.

Re-queueing does not help: a cancelled job never reaches the cachix push step, so nothing from the partial build is cached and the next attempt starts cold again. #8997 hit the same ~20 minute wall on three consecutive queue attempts, at 20m23s, 20m25s and 20m21s.

Splitting the offending PR would not help either — each piece still invalidates `fedimint-core` and pays the same cold build, several times over.

45 minutes leaves comfortable headroom over a full cold workspace build while still bounding a genuinely hung job. The fast path is unaffected: the timeout only bites when everything has to be rebuilt from scratch.

## Reviewing

The only question worth an opinion is the number. 45 is a guess at "a cold full-workspace build plus headroom"; if you would rather bound it tighter, 30 would likely have been enough for #8997 but leaves little room as the workspace grows.

Note the timeout applies to all four toolchains, since the matrix carries it in a single `include` entry — that is fine, as the other three are far from the limit either way.

## Testing

CI itself is the test: the `cross` job only runs in the merge queue (and on release-branch PRs), so this change is exercised when it merges. #8997 can be re-queued afterwards to confirm the cold `aarch64-android` build completes.