### PR TITLE
chore(ci): test against v0.11.2 and v0.10.1

### DIFF
--- a/.github/workflows/ci-backwards-compatibility.yml
+++ b/.github/workflows/ci-backwards-compatibility.yml
@@ -53,14 +53,14 @@ jobs:
           # run a slimmed down back-compat test for PR push or each major version for merge queue
           if [[ "${{ github.event_name }}" == "merge_group" ]]; then
             PERFIT_METRIC="90S3yoXDQ-SXB0UbXG4qHQ"
-            VERSIONS_TO_TEST="v0.9.1 v0.10.0 v0.11.1"
+            VERSIONS_TO_TEST="v0.9.1 v0.10.1 v0.11.2"
             # Run only a random sample of tests to keep merge queue fast.
             # With multiple versions x multiple test combos, 25% still
             # gives good coverage for catching version-specific regressions.
             export FM_BACKCOMPAT_TEST_SAMPLE_PERCENT=25
           else
             PERFIT_METRIC="aPuCAjrFT7uE5Oax_T4sMw"
-            VERSIONS_TO_TEST="v0.10.0"
+            VERSIONS_TO_TEST="v0.10.1"
             # PRs only test one version (vs three in merge queue), but the
             # full test matrix is still ~37 combos and takes ~23 min.
             # Since the merge queue will re-run these tests anyway, sample

--- a/.github/workflows/upgrade-tests.yml
+++ b/.github/workflows/upgrade-tests.yml
@@ -60,7 +60,7 @@ jobs:
           # read versions from manually triggered workflows
           # default needed for cron or manual workflow without params
           VERSIONS="${{ github.event.inputs.versions }}"
-          VERSIONS=${VERSIONS:="v0.9.1 current, v0.10.0 current, v0.11.1 current"}
+          VERSIONS=${VERSIONS:="v0.9.1 current, v0.10.1 current, v0.11.2 current"}
 
           # if empty, defaults to all test kinds within script
           export TEST_KINDS="${{ github.event.inputs.test_kinds }}"

--- a/justfile.fedimint.just
+++ b/justfile.fedimint.just
@@ -22,13 +22,13 @@ test-ci-all:
 test-count:
   ./scripts/tests/test-cov.sh
 
-test-compatibility *VERSIONS="v0.9.1 v0.10.0 v0.11.1":
+test-compatibility *VERSIONS="v0.9.1 v0.10.1 v0.11.2":
   ./scripts/tests/test-ci-all-backcompat.sh {{VERSIONS}}
 
 test-full-compatibility *VERSIONS="v0.4.4":
   env FM_FULL_VERSION_MATRIX=1 ./scripts/tests/test-ci-all-backcompat.sh {{VERSIONS}}
 
-test-upgrades *VERSIONS="v0.9.1 current, v0.10.0 current, v0.11.1 current":
+test-upgrades *VERSIONS="v0.9.1 current, v0.10.1 current, v0.11.2 current":
   ./scripts/tests/upgrade-test.sh {{VERSIONS}}
 
 # `cargo udeps` check


### PR DESCRIPTION
## Summary

Point the back-compat and upgrade test matrices at the newly released `v0.11.2` and `v0.10.1` instead of `v0.11.1` and `v0.10.0`.

## Details

`v0.11.2` and `v0.10.1` are security releases on the 0.11 and 0.10 lines and are now the current releases of those lines, superseding `v0.11.1` and `v0.10.0`. Per `docs/release-process.md`, master's test matrices are updated after a release so that back-compat and upgrade tests run against the versions users are actually running.

The per-PR and merge-queue matrices track the newest release of each supported line rather than every historical patch release. `v0.9.1` stays as-is: it is still the newest release of the 0.9 line. The full version matrix is run separately from the release test branches (`FM_FULL_VERSION_MATRIX=1` / `just test-full-compatibility`), so nothing is lost by keeping these lists thin.

Both lists keep their current length (three entries for the merge queue, one for PR pushes), so merge-queue and PR CI time is unchanged.

Files touched:
- `.github/workflows/ci-backwards-compatibility.yml` — merge-queue and PR-push version lists
- `.github/workflows/upgrade-tests.yml` — default upgrade version pairs
- `justfile.fedimint.just` — defaults for `just test-compatibility` and `just test-upgrades`

## Testing

CI itself is the test: the back-compat job on this PR runs against `v0.10.1`, and the merge-queue run will exercise `v0.9.1 v0.10.1 v0.11.2`. The upgrade tests run on cron/manual dispatch with the new defaults.
