### PR TITLE
chore: bump version to v0.10.2-alpha

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2297,7 +2297,7 @@ dependencies = [
 
 [[package]]
 name = "devimint"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "axum 0.8.7",
@@ -2730,7 +2730,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fedimint-aead"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "argon2",
@@ -2762,7 +2762,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-api-client"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2788,7 +2788,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-bip39"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "bip39",
  "fedimint-client",
@@ -2799,7 +2799,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-bitcoind"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2814,14 +2814,14 @@ dependencies = [
 
 [[package]]
 name = "fedimint-build"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "fedimint-cli"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2861,7 +2861,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2892,7 +2892,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client-module"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -2922,7 +2922,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client-rpc"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2949,7 +2949,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client-uniffi"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "fedimint-build",
@@ -2967,7 +2967,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client-wasm"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2985,7 +2985,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-connectors"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "arti-client",
@@ -3020,7 +3020,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-core"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3085,7 +3085,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-cursed-redb"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3104,7 +3104,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-db-locked"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3116,7 +3116,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dbtool"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3151,7 +3151,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-derive"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
@@ -3161,7 +3161,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-derive-secret"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "bitcoin_hashes 0.14.0",
@@ -3173,11 +3173,11 @@ dependencies = [
 
 [[package]]
 name = "fedimint-docs"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 
 [[package]]
 name = "fedimint-dummy-client"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3197,7 +3197,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dummy-common"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -3207,7 +3207,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dummy-server"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3223,7 +3223,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dummy-tests"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "fedimint-client",
@@ -3244,7 +3244,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-empty-client"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3261,7 +3261,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-empty-common"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -3271,7 +3271,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-empty-server"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3287,7 +3287,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-eventlog"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3305,7 +3305,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-fountain"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3317,7 +3317,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-fuzz"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "fedimint-core",
  "fedimint-ln-common",
@@ -3330,7 +3330,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-client"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "bcrypt",
@@ -3356,7 +3356,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-common"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -3374,7 +3374,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-server"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3451,7 +3451,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-server-db"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -3479,7 +3479,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-ui"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "async-trait",
  "axum 0.8.7",
@@ -3508,7 +3508,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gw-client"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3539,7 +3539,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gwv2-client"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3566,7 +3566,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-hkdf"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "bitcoin_hashes 0.14.0",
 ]
@@ -3614,7 +3614,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lightning"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3641,7 +3641,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-client"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3675,7 +3675,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-common"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3698,7 +3698,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-server"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3724,7 +3724,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-tests"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3753,7 +3753,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-client"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3784,7 +3784,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-common"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3805,7 +3805,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-server"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3829,7 +3829,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-tests"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3863,7 +3863,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-load-test-tool"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "clap",
@@ -3891,7 +3891,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-logging"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "console-subscriber",
@@ -3903,7 +3903,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-client"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3924,7 +3924,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-common"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -3938,7 +3938,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-server"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3957,7 +3957,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-tests"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "clap",
@@ -3971,7 +3971,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-metrics"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "axum 0.8.7",
@@ -3983,7 +3983,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-client"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -4024,7 +4024,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-common"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "bitcoin_hashes 0.14.0",
@@ -4037,7 +4037,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-server"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4064,7 +4064,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-tests"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4098,7 +4098,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-portalloc"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "dirs",
@@ -4112,7 +4112,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-recoverytool"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -4135,7 +4135,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-recurringd"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "axum 0.8.7",
@@ -4168,7 +4168,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-recurringd-tests"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "devimint",
@@ -4181,7 +4181,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-recurringdv2"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "axum 0.8.7",
@@ -4203,7 +4203,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-rocksdb"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4220,7 +4220,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -4275,7 +4275,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server-bitcoin-rpc"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4291,7 +4291,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server-core"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4309,7 +4309,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server-tests"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "bitcoin",
  "fedimint-api-client",
@@ -4329,7 +4329,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server-ui"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4354,7 +4354,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-tbs"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "bls12_381",
  "criterion",
@@ -4369,7 +4369,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-testing"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4409,7 +4409,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-testing-core"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -4470,7 +4470,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-tpe"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "bitcoin_hashes 0.14.0",
  "bls12_381",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ui-common"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "axum 0.8.7",
  "axum-extra",
@@ -4495,7 +4495,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-unknown-common"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -4505,7 +4505,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-unknown-server"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4519,14 +4519,14 @@ dependencies = [
 
 [[package]]
 name = "fedimint-util-error"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "fedimint-wallet-client"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -4556,7 +4556,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-common"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -4572,7 +4572,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-server"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4599,7 +4599,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-tests"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4632,7 +4632,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wasm-tests"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "fedimint-client",
@@ -4653,7 +4653,7 @@ dependencies = [
 
 [[package]]
 name = "fedimintd"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -4687,7 +4687,7 @@ dependencies = [
 
 [[package]]
 name = "fedimintd-envs"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 
 [[package]]
 name = "ff"
@@ -5004,7 +5004,7 @@ dependencies = [
 
 [[package]]
 name = "gateway-tests"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "clap",
@@ -6906,7 +6906,7 @@ dependencies = [
 
 [[package]]
 name = "lnurlp"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ keywords = ["bitcoin", "lightning", "chaumian", "e-cash", "federated"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/fedimint/fedimint"
-version = "0.10.1-rc.0"
+version = "0.10.2-alpha"
 
 [workspace.metadata]
 authors = ["The Fedimint Developers"]
@@ -157,7 +157,7 @@ criterion = "0.5.1"
 # We need to pin this arti's `curve25519-dalek` dependency, due to `https://rustsec.org/advisories/RUSTSEC-2024-0344` vulnerability
 # It's been updated by https://gitlab.torproject.org/tpo/core/arti/-/merge_requests/2211, should be removed in next release.
 curve25519-dalek = ">=4.1.3"
-devimint = { path = "./devimint", version = "=0.10.1-rc.0" }
+devimint = { path = "./devimint", version = "=0.10.2-alpha" }
 dirs = "6.0.0"
 erased-serde = "0.4"
 esplora-client = { version = "0.12.0", default-features = false, features = [
@@ -167,63 +167,63 @@ esplora-client = { version = "0.12.0", default-features = false, features = [
 ] }
 tor-rtcompat = { version = "0.33.0" }
 
-fedimint-aead = { path = "./crypto/aead", version = "=0.10.1-rc.0" }
-fedimint-api-client = { path = "./fedimint-api-client", version = "=0.10.1-rc.0" }
-fedimint-bip39 = { path = "./fedimint-bip39", version = "=0.10.1-rc.0" }
-fedimint-bitcoind = { path = "./fedimint-bitcoind", version = "=0.10.1-rc.0" }
-fedimint-build = { path = "./fedimint-build", version = "=0.10.1-rc.0" }
-fedimint-client = { path = "./fedimint-client", version = "=0.10.1-rc.0" }
-fedimint-client-module = { path = "./fedimint-client-module", version = "=0.10.1-rc.0" }
-fedimint-client-rpc = { path = "./fedimint-client-rpc", version = "=0.10.1-rc.0" }
-fedimint-connectors = { path = "./fedimint-connectors", version = "=0.10.1-rc.0" }
-fedimint-core = { path = "./fedimint-core", version = "=0.10.1-rc.0" }
-fedimint-cursed-redb = { path = "./fedimint-cursed-redb", version = "=0.10.1-rc.0" }
-fedimint-db-locked = { path = "./fedimint-db-locked", version = "=0.10.1-rc.0" }
-fedimint-derive = { path = "./fedimint-derive", version = "=0.10.1-rc.0" }
-fedimint-derive-secret = { path = "./crypto/derive-secret", version = "=0.10.1-rc.0" }
-fedimint-dummy-client = { path = "./modules/fedimint-dummy-client", version = "=0.10.1-rc.0" }
-fedimint-dummy-common = { path = "./modules/fedimint-dummy-common", version = "=0.10.1-rc.0" }
-fedimint-dummy-server = { path = "./modules/fedimint-dummy-server", version = "=0.10.1-rc.0" }
-fedimint-empty-common = { path = "./modules/fedimint-empty-common", version = "=0.10.1-rc.0" }
-fedimint-eventlog = { path = "./fedimint-eventlog", version = "=0.10.1-rc.0" }
-fedimint-gateway-common = { package = "fedimint-gateway-common", path = "./gateway/fedimint-gateway-common", version = "=0.10.1-rc.0" }
-fedimint-gateway-server = { package = "fedimint-gateway-server", path = "./gateway/fedimint-gateway-server", version = "=0.10.1-rc.0" }
-fedimint-gateway-server-db = { package = "fedimint-gateway-server-db", path = "./gateway/fedimint-gateway-server-db", version = "=0.10.1-rc.0" }
-fedimint-gateway-ui = { package = "fedimint-gateway-ui", path = "./gateway/fedimint-gateway-ui", version = "=0.10.1-rc.0" }
-fedimint-gw-client = { path = "./modules/fedimint-gw-client", version = "=0.10.1-rc.0" }
-fedimint-gwv2-client = { path = "./modules/fedimint-gwv2-client", version = "=0.10.1-rc.0" }
-fedimint-lightning = { package = "fedimint-lightning", path = "./gateway/fedimint-lightning", version = "=0.10.1-rc.0" }
-fedimint-ln-client = { path = "./modules/fedimint-ln-client", version = "=0.10.1-rc.0" }
-fedimint-ln-common = { path = "./modules/fedimint-ln-common", version = "=0.10.1-rc.0" }
-fedimint-ln-server = { path = "./modules/fedimint-ln-server", version = "=0.10.1-rc.0" }
-fedimint-lnv2-client = { path = "./modules/fedimint-lnv2-client", version = "=0.10.1-rc.0" }
-fedimint-lnv2-common = { path = "./modules/fedimint-lnv2-common", version = "=0.10.1-rc.0" }
-fedimint-lnv2-server = { path = "./modules/fedimint-lnv2-server", version = "=0.10.1-rc.0" }
-fedimint-logging = { path = "./fedimint-logging", version = "=0.10.1-rc.0" }
-fedimint-meta-client = { path = "./modules/fedimint-meta-client", version = "=0.10.1-rc.0" }
-fedimint-meta-common = { path = "./modules/fedimint-meta-common", version = "=0.10.1-rc.0" }
-fedimint-meta-server = { path = "./modules/fedimint-meta-server", version = "=0.10.1-rc.0" }
-fedimint-metrics = { path = "./fedimint-metrics", version = "=0.10.1-rc.0" }
-fedimint-mint-client = { path = "./modules/fedimint-mint-client", version = "=0.10.1-rc.0" }
-fedimint-mint-common = { path = "./modules/fedimint-mint-common", version = "=0.10.1-rc.0" }
-fedimint-mint-server = { path = "./modules/fedimint-mint-server", version = "=0.10.1-rc.0" }
-fedimint-portalloc = { path = "utils/portalloc", version = "=0.10.1-rc.0" }
-fedimint-rocksdb = { path = "./fedimint-rocksdb", version = "=0.10.1-rc.0" }
-fedimint-server = { path = "./fedimint-server", version = "=0.10.1-rc.0" }
-fedimint-server-bitcoin-rpc = { path = "./fedimint-server-bitcoin-rpc", version = "=0.10.1-rc.0" }
-fedimint-server-core = { path = "./fedimint-server-core", version = "=0.10.1-rc.0" }
-fedimint-server-ui = { path = "./fedimint-server-ui", version = "=0.10.1-rc.0" }
-fedimint-testing = { path = "./fedimint-testing", version = "=0.10.1-rc.0" }
-fedimint-testing-core = { path = "./fedimint-testing-core", version = "=0.10.1-rc.0" }
-fedimint-ui-common = { path = "./fedimint-ui-common", version = "=0.10.1-rc.0" }
-fedimint-unknown-common = { path = "./modules/fedimint-unknown-common", version = "=0.10.1-rc.0" }
-fedimint-unknown-server = { path = "./modules/fedimint-unknown-server", version = "=0.10.1-rc.0" }
-fedimint-util-error = { path = "./fedimint-util-error", version = "=0.10.1-rc.0" }
-fedimint-wallet-client = { path = "./modules/fedimint-wallet-client", version = "=0.10.1-rc.0" }
-fedimint-wallet-common = { path = "./modules/fedimint-wallet-common", version = "=0.10.1-rc.0" }
-fedimint-wallet-server = { path = "./modules/fedimint-wallet-server", version = "=0.10.1-rc.0" }
-fedimintd = { path = "./fedimintd", version = "=0.10.1-rc.0" }
-fedimintd-envs = { path = "./fedimintd-envs", version = "=0.10.1-rc.0" }
+fedimint-aead = { path = "./crypto/aead", version = "=0.10.2-alpha" }
+fedimint-api-client = { path = "./fedimint-api-client", version = "=0.10.2-alpha" }
+fedimint-bip39 = { path = "./fedimint-bip39", version = "=0.10.2-alpha" }
+fedimint-bitcoind = { path = "./fedimint-bitcoind", version = "=0.10.2-alpha" }
+fedimint-build = { path = "./fedimint-build", version = "=0.10.2-alpha" }
+fedimint-client = { path = "./fedimint-client", version = "=0.10.2-alpha" }
+fedimint-client-module = { path = "./fedimint-client-module", version = "=0.10.2-alpha" }
+fedimint-client-rpc = { path = "./fedimint-client-rpc", version = "=0.10.2-alpha" }
+fedimint-connectors = { path = "./fedimint-connectors", version = "=0.10.2-alpha" }
+fedimint-core = { path = "./fedimint-core", version = "=0.10.2-alpha" }
+fedimint-cursed-redb = { path = "./fedimint-cursed-redb", version = "=0.10.2-alpha" }
+fedimint-db-locked = { path = "./fedimint-db-locked", version = "=0.10.2-alpha" }
+fedimint-derive = { path = "./fedimint-derive", version = "=0.10.2-alpha" }
+fedimint-derive-secret = { path = "./crypto/derive-secret", version = "=0.10.2-alpha" }
+fedimint-dummy-client = { path = "./modules/fedimint-dummy-client", version = "=0.10.2-alpha" }
+fedimint-dummy-common = { path = "./modules/fedimint-dummy-common", version = "=0.10.2-alpha" }
+fedimint-dummy-server = { path = "./modules/fedimint-dummy-server", version = "=0.10.2-alpha" }
+fedimint-empty-common = { path = "./modules/fedimint-empty-common", version = "=0.10.2-alpha" }
+fedimint-eventlog = { path = "./fedimint-eventlog", version = "=0.10.2-alpha" }
+fedimint-gateway-common = { package = "fedimint-gateway-common", path = "./gateway/fedimint-gateway-common", version = "=0.10.2-alpha" }
+fedimint-gateway-server = { package = "fedimint-gateway-server", path = "./gateway/fedimint-gateway-server", version = "=0.10.2-alpha" }
+fedimint-gateway-server-db = { package = "fedimint-gateway-server-db", path = "./gateway/fedimint-gateway-server-db", version = "=0.10.2-alpha" }
+fedimint-gateway-ui = { package = "fedimint-gateway-ui", path = "./gateway/fedimint-gateway-ui", version = "=0.10.2-alpha" }
+fedimint-gw-client = { path = "./modules/fedimint-gw-client", version = "=0.10.2-alpha" }
+fedimint-gwv2-client = { path = "./modules/fedimint-gwv2-client", version = "=0.10.2-alpha" }
+fedimint-lightning = { package = "fedimint-lightning", path = "./gateway/fedimint-lightning", version = "=0.10.2-alpha" }
+fedimint-ln-client = { path = "./modules/fedimint-ln-client", version = "=0.10.2-alpha" }
+fedimint-ln-common = { path = "./modules/fedimint-ln-common", version = "=0.10.2-alpha" }
+fedimint-ln-server = { path = "./modules/fedimint-ln-server", version = "=0.10.2-alpha" }
+fedimint-lnv2-client = { path = "./modules/fedimint-lnv2-client", version = "=0.10.2-alpha" }
+fedimint-lnv2-common = { path = "./modules/fedimint-lnv2-common", version = "=0.10.2-alpha" }
+fedimint-lnv2-server = { path = "./modules/fedimint-lnv2-server", version = "=0.10.2-alpha" }
+fedimint-logging = { path = "./fedimint-logging", version = "=0.10.2-alpha" }
+fedimint-meta-client = { path = "./modules/fedimint-meta-client", version = "=0.10.2-alpha" }
+fedimint-meta-common = { path = "./modules/fedimint-meta-common", version = "=0.10.2-alpha" }
+fedimint-meta-server = { path = "./modules/fedimint-meta-server", version = "=0.10.2-alpha" }
+fedimint-metrics = { path = "./fedimint-metrics", version = "=0.10.2-alpha" }
+fedimint-mint-client = { path = "./modules/fedimint-mint-client", version = "=0.10.2-alpha" }
+fedimint-mint-common = { path = "./modules/fedimint-mint-common", version = "=0.10.2-alpha" }
+fedimint-mint-server = { path = "./modules/fedimint-mint-server", version = "=0.10.2-alpha" }
+fedimint-portalloc = { path = "utils/portalloc", version = "=0.10.2-alpha" }
+fedimint-rocksdb = { path = "./fedimint-rocksdb", version = "=0.10.2-alpha" }
+fedimint-server = { path = "./fedimint-server", version = "=0.10.2-alpha" }
+fedimint-server-bitcoin-rpc = { path = "./fedimint-server-bitcoin-rpc", version = "=0.10.2-alpha" }
+fedimint-server-core = { path = "./fedimint-server-core", version = "=0.10.2-alpha" }
+fedimint-server-ui = { path = "./fedimint-server-ui", version = "=0.10.2-alpha" }
+fedimint-testing = { path = "./fedimint-testing", version = "=0.10.2-alpha" }
+fedimint-testing-core = { path = "./fedimint-testing-core", version = "=0.10.2-alpha" }
+fedimint-ui-common = { path = "./fedimint-ui-common", version = "=0.10.2-alpha" }
+fedimint-unknown-common = { path = "./modules/fedimint-unknown-common", version = "=0.10.2-alpha" }
+fedimint-unknown-server = { path = "./modules/fedimint-unknown-server", version = "=0.10.2-alpha" }
+fedimint-util-error = { path = "./fedimint-util-error", version = "=0.10.2-alpha" }
+fedimint-wallet-client = { path = "./modules/fedimint-wallet-client", version = "=0.10.2-alpha" }
+fedimint-wallet-common = { path = "./modules/fedimint-wallet-common", version = "=0.10.2-alpha" }
+fedimint-wallet-server = { path = "./modules/fedimint-wallet-server", version = "=0.10.2-alpha" }
+fedimintd = { path = "./fedimintd", version = "=0.10.2-alpha" }
+fedimintd-envs = { path = "./fedimintd-envs", version = "=0.10.2-alpha" }
 ff = "0.13.1"
 fs-lock = "=0.1.10"
 fs2 = "0.4.3"
@@ -235,7 +235,7 @@ gloo-timers = "0.3.0"
 group = "0.13.0"
 hex = "0.4.3"
 hex-conservative = "0.3.0"
-hkdf = { package = "fedimint-hkdf", path = "./crypto/hkdf", version = "=0.10.1-rc.0" }
+hkdf = { package = "fedimint-hkdf", path = "./crypto/hkdf", version = "=0.10.2-alpha" }
 honggfuzz = { version = "=0.5.55", default-features = false } # needs to be pinned to the same version `cargo-fuzz` binary uses
 hyper = "1.6"
 imbl = "5.0.0"
@@ -307,7 +307,7 @@ substring = "1.4.5"
 subtle = "2.6.1"
 syn = "2.0"
 tar = "0.4.44"
-tbs = { package = "fedimint-tbs", path = "./crypto/tbs", version = "=0.10.1-rc.0" }
+tbs = { package = "fedimint-tbs", path = "./crypto/tbs", version = "=0.10.2-alpha" }
 tempfile = "3.20.0"
 test-log = { version = "0.2", features = ["trace"], default-features = false }
 thiserror = "2.0.12"
@@ -326,7 +326,7 @@ tonic_lnd = { version = "0.3.0", package = "fedimint-tonic-lnd", features = [
 ] }
 tower = { version = "0.4.13", default-features = false }
 tower-http = { version = "0.6.6", features = ["cors"] }
-tpe = { package = "fedimint-tpe", path = "./crypto/tpe", version = "=0.10.1-rc.0" }
+tpe = { package = "fedimint-tpe", path = "./crypto/tpe", version = "=0.10.2-alpha" }
 tracing = "0.1.41"
 tracing-opentelemetry = "0.24.0"
 tracing-subscriber = "0.3.20"


### PR DESCRIPTION
## Summary

Bumps the `releases/v0.10` branch from `0.10.1-rc.0` to `0.10.2-alpha` now that v0.10.1 has been tagged and released.

## Details

v0.10.1 was tagged and released from the `releases/v0.10.1` branch, so the ongoing `releases/v0.10` branch no longer needs to sit on a release-candidate version. This returns it to an alpha version so further backports can land on it.

`just bump-version 0.10.1-rc.0 0.10.2-alpha` rewrites the version strings in `Cargo.toml`; `Cargo.lock` was regenerated as a side effect of a build. The lockfile change is version strings only — no dependency updates.

## Testing

`cargo clippy --offline --workspace --all-targets -- -D warnings` passes under the branch's pinned toolchain. The `Cargo.lock` diff was verified to contain nothing but `version = ` lines, with equal insertion and deletion counts.
