### PR TITLE
docs: point docker compose and gateway docs at v0.11.2

### DIFF
--- a/docker/fedimintd/docker-compose.yaml
+++ b/docker/fedimintd/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   fedimintd:
-    image: fedimint/fedimintd:v0.11.1
+    image: fedimint/fedimintd:v0.11.2
     ports:
       - 8173:8173/tcp # p2p tls
       - 8173:8173/udp # p2p iroh

--- a/docker/gatewayd/docker-compose.yaml
+++ b/docker/gatewayd/docker-compose.yaml
@@ -4,7 +4,7 @@
 
 services:
   gatewayd:
-    image: fedimint/gatewayd:v0.11.1
+    image: fedimint/gatewayd:v0.11.2
     command: gatewayd ldk
     restart: unless-stopped
     ports:
@@ -23,7 +23,7 @@ services:
       # REQUIRED: Set the password hash to your own password
       # Run:
       #
-      # docker run fedimint/gatewayd:v0.11.1 gateway-cli create-password-hash <REPLACE ME> | sed 's/\$/$$/g'
+      # docker run fedimint/gatewayd:v0.11.2 gateway-cli create-password-hash <REPLACE ME> | sed 's/\$/$$/g'
       #
       # Then paste the result here.
       FM_GATEWAY_BCRYPT_PASSWORD_HASH: ""

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -111,7 +111,7 @@ Or copy it from the repository at [`docker/gatewayd/docker-compose.yaml`](../doc
 2. **Generate a password hash:**
 
 ```bash
-docker run fedimint/gatewayd:v0.11.1 gateway-cli create-password-hash YOUR_PASSWORD_HERE | sed 's/\$/$$/g'
+docker run fedimint/gatewayd:v0.11.2 gateway-cli create-password-hash YOUR_PASSWORD_HERE | sed 's/\$/$$/g'
 ```
 
 3. **Configure the gateway:**


### PR DESCRIPTION
## Summary

The docker compose files and the gateway docs still pin `v0.11.1`, so anyone following them stands up a node on the release that v0.11.2 supersedes. This bumps the four references to `v0.11.2`.

## Details

v0.11.2 is a security release for the 0.11 line, so these copy-paste paths are the ones most worth keeping current:

- `docker/fedimintd/docker-compose.yaml` — `fedimint/fedimintd:v0.11.1` -> `v0.11.2`
- `docker/gatewayd/docker-compose.yaml` — the `fedimint/gatewayd` image, and the `create-password-hash` example in the comment beside it
- `docs/gateway.md` — the same `create-password-hash` command

Both images are published for amd64 and arm64 at that tag.

## Reviewing

These pins have to be updated by hand after every release, which is why they were two releases behind. There is currently no floating tag that would track this on its own: the manifest job publishes `${GITHUB_REF_NAME}`, `${VERSION_TAG}` and the commit SHA, so the only moving tag is `releases-v0.11`, which follows the branch head and therefore points at an unreleased `-alpha` for most of its life. If a `v0.11`-style major.minor pointer that moves on each final release would be useful, that is a small addition to the manifest job in `ci-nix.yml` and I am happy to send it separately.

## Testing

Documentation and compose-only change; nothing to run. The referenced tags exist on Docker Hub as multi-arch manifests.