### PR TITLE
fix(gw): Handle `verify` endpoint over Iroh correctly

### DIFF
--- a/gateway/fedimint-gateway-server/src/iroh_server.rs
+++ b/gateway/fedimint-gateway-server/src/iroh_server.rs
@@ -294,11 +294,11 @@ async fn handle_request(
     // The handlers struct also currently does not support query parameters. The
     // LNURL-verify endpoint is the only endpoint that requires these, so we
     // handle these separately as well.
-    if request.route.starts_with("/verify") {
-        let Ok((payment_hash, query_map)) = parse_verify_route(&request.route) else {
-            // The route is the caller's input, so a route we cannot parse is their
-            // mistake, the same way the HTTP path's `Path<sha256::Hash>` extractor
-            // rejects a malformed payment hash.
+    if let Some(verify_route) = parse_verify_route(&request.route) {
+        let Ok((payment_hash, query_map)) = verify_route else {
+            // The route is the caller's input, so a payment hash we cannot parse is
+            // their mistake, the same way the HTTP path's `Path<sha256::Hash>`
+            // extractor rejects a malformed payment hash.
             return Ok((StatusCode::BAD_REQUEST, Json(json!(()))));
         };
 
@@ -342,22 +342,51 @@ fn unknown_route(route: &str) -> (StatusCode, Json<serde_json::Value>) {
 
 /// Parses the LNURL-verify route `/verify/{payment_hash}` into the payment hash
 /// and the query parameters (`?wait`) of the request.
-fn parse_verify_route(route: &str) -> anyhow::Result<(sha256::Hash, HashMap<String, String>)> {
+///
+/// Returns `None` if the route is not shaped like the verify route at all, so
+/// that the caller falls through to the regular handler lookup and answers with
+/// a 404. Only the exact `/verify/{payment_hash}` shape is this endpoint, the
+/// same way the HTTP path registers it as an exact route: neither a route that
+/// merely starts with `/verify` nor one that appends further path segments may
+/// reach this unauthenticated handler.
+fn parse_verify_route(
+    route: &str,
+) -> Option<anyhow::Result<(sha256::Hash, HashMap<String, String>)>> {
+    // Check the prefix on the raw route, so that a route the URL parser below
+    // normalizes into the verify route (`/../verify/{payment_hash}`) is not this
+    // endpoint either.
+    if !route.starts_with("/verify/") {
+        return None;
+    }
+
     // Use dummy URL for easier parsing
-    let url = Url::parse(&format!("http://localhost{route}"))?;
+    let url = Url::parse(&format!("http://localhost{route}")).ok()?;
 
     // Extract segments: /verify/<payment_hash>. The first segment is the route
-    // prefix itself, so the payment hash is the second one.
-    let payment_hash: sha256::Hash = url
-        .path_segments()
-        .and_then(|mut segments| segments.nth(1))
-        .ok_or_else(|| anyhow!("Verify route does not contain a payment hash"))?
-        .parse()?;
+    // prefix itself, so the payment hash is the second one, and there must not be
+    // a third. The prefix is re-checked here because the raw route may normalize
+    // to a different path (`/verify/../stop`).
+    let mut segments = url.path_segments()?;
+
+    if segments.next() != Some("verify") {
+        return None;
+    }
+
+    let hash_str = segments.next()?;
+
+    if segments.next().is_some() {
+        return None;
+    }
+
+    let payment_hash = match hash_str.parse::<sha256::Hash>() {
+        Ok(payment_hash) => payment_hash,
+        Err(err) => return Some(Err(anyhow!(err).context("Invalid payment hash"))),
+    };
 
     // Parse query params (?wait etc.)
     let query_map: HashMap<String, String> = url.query_pairs().into_owned().collect();
 
-    Ok((payment_hash, query_map))
+    Some(Ok((payment_hash, query_map)))
 }
 
 /// Verifies if the supplied password in the Iroh request matches the gateway's
@@ -403,6 +432,7 @@ mod tests {
         let payment_hash = sha256::Hash::hash(b"payment hash");
 
         let (parsed_hash, _query) = parse_verify_route(&format!("/verify/{payment_hash}"))
+            .expect("the route is the verify route")
             .expect("the payment hash is the second path segment, not the first");
 
         assert_eq!(parsed_hash, payment_hash);
@@ -413,6 +443,7 @@ mod tests {
         let payment_hash = sha256::Hash::hash(b"payment hash");
 
         let (parsed_hash, query) = parse_verify_route(&format!("/verify/{payment_hash}?wait"))
+            .expect("the route is the verify route")
             .expect("query parameters do not affect path parsing");
 
         assert_eq!(parsed_hash, payment_hash);
@@ -420,12 +451,38 @@ mod tests {
     }
 
     #[test]
-    fn verify_route_without_a_payment_hash_is_rejected() {
-        parse_verify_route("/verify")
-            .expect_err("a route without a payment hash has nothing to verify");
+    fn verify_route_with_a_malformed_payment_hash_is_rejected() {
         parse_verify_route("/verify/")
+            .expect("the route is shaped like the verify route")
             .expect_err("a route with an empty payment hash has nothing to verify");
         parse_verify_route("/verify/not-a-payment-hash")
+            .expect("the route is shaped like the verify route")
             .expect_err("a payment hash that is not a sha256 hash is rejected");
+    }
+
+    #[test]
+    fn only_the_exact_verify_route_reaches_the_verify_endpoint() {
+        let payment_hash = sha256::Hash::hash(b"payment hash");
+
+        // A route that is not exactly `/verify/{payment_hash}` is not this endpoint,
+        // no matter that it starts with `/verify` or contains a valid payment hash
+        // somewhere. Falling through to the handler lookup answers it with a 404,
+        // like the HTTP path's exact route does.
+        for route in [
+            "/verify".to_string(),
+            format!("/verifyfoo/{payment_hash}"),
+            format!("/verify_something/{payment_hash}?wait"),
+            format!("/verify/{payment_hash}/extra"),
+            // Routes the URL parser normalizes are not the verify route either,
+            // whether they normalize into it or out of it.
+            format!("/../verify/{payment_hash}"),
+            format!("/verify/{payment_hash}/../../stop"),
+            "/verify/../stop".to_string(),
+        ] {
+            assert!(
+                parse_verify_route(&route).is_none(),
+                "{route} must not reach the unauthenticated verify handler"
+            );
+        }
     }
 }

--- a/gateway/fedimint-gateway-server/src/iroh_server.rs
+++ b/gateway/fedimint-gateway-server/src/iroh_server.rs
@@ -10,6 +10,7 @@ use bitcoin::hashes::sha256;
 use fedimint_core::module::{FEDIMINT_GATEWAY_ALPN, IrohGatewayRequest, IrohGatewayResponse};
 use fedimint_core::net::iroh::build_iroh_endpoint;
 use fedimint_core::task::TaskGroup;
+use fedimint_core::util::FmtCompactAnyhow as _;
 use fedimint_gateway_common::STOP_ENDPOINT;
 use fedimint_logging::LOG_GATEWAY;
 use futures::FutureExt as _;
@@ -17,7 +18,7 @@ use iroh::endpoint::Incoming;
 use reqwest::StatusCode;
 use serde::de::DeserializeOwned;
 use serde_json::json;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 use url::Url;
 
 use crate::Gateway;
@@ -209,7 +210,7 @@ async fn handle_incoming_iroh_request(
                 task_group.clone(),
             ),
         )
-        .await?;
+        .await;
 
         let response = IrohGatewayResponse {
             status: status.as_u16(),
@@ -223,22 +224,27 @@ async fn handle_incoming_iroh_request(
     Ok(())
 }
 
-/// Runs a request handler, turning a panic into a 500 response for the caller
-/// that triggered it.
+/// Runs a request handler, turning a panic or an error into a 500 response for
+/// the caller that triggered it.
 ///
 /// Iroh requests are spawned on the gateway's root task group, so a panic
 /// escaping a handler trips the task group's panic guard and shuts the whole
 /// gateway down. The HTTP path does not need this: `axum::serve` spawns its
 /// connection tasks outside any task group, so a panic there only drops that
 /// one connection.
+///
+/// A failing handler has to be answered as well: propagating the error would
+/// end the connection's request loop, leaving the caller with a closed stream
+/// and no response at all. Like the HTTP path, the response body carries no
+/// details about the failure, since callers are unauthenticated.
 async fn run_handler(
     route: &str,
     handler: impl Future<Output = anyhow::Result<(StatusCode, Json<serde_json::Value>)>>,
-) -> anyhow::Result<(StatusCode, Json<serde_json::Value>)> {
+) -> (StatusCode, Json<serde_json::Value>) {
     // Using `AssertUnwindSafe` here is far from ideal. In theory this means we
     // could end up with an inconsistent state. In practice this is only the last
     // line of defense, and losing the gateway process entirely is strictly worse.
-    AssertUnwindSafe(handler)
+    let result = AssertUnwindSafe(handler)
         .catch_unwind()
         .await
         .unwrap_or_else(|_| {
@@ -249,7 +255,18 @@ async fn run_handler(
             );
 
             Ok((StatusCode::INTERNAL_SERVER_ERROR, Json(json!(()))))
-        })
+        });
+
+    result.unwrap_or_else(|err| {
+        warn!(
+            target: LOG_GATEWAY,
+            route,
+            err = %err.fmt_compact_anyhow(),
+            "Gateway API handler returned an error"
+        );
+
+        (StatusCode::INTERNAL_SERVER_ERROR, Json(json!(())))
+    })
 }
 
 /// Checks if the requested route is authenticated and will reject the request
@@ -278,16 +295,12 @@ async fn handle_request(
     // LNURL-verify endpoint is the only endpoint that requires these, so we
     // handle these separately as well.
     if request.route.starts_with("/verify") {
-        // Use dummy URL for easier parsing
-        let url = Url::parse(&format!("http://localhost{}", request.route))?;
-        // Extract segments: /verify/<payment_hash>
-        let mut segments = url.path_segments().unwrap();
-        let hash_str = segments.next();
-
-        let payment_hash: sha256::Hash = hash_str.ok_or(anyhow!("No has present"))?.parse()?;
-
-        // Parse query params (?wait etc.)
-        let query_map: HashMap<String, String> = url.query_pairs().into_owned().collect();
+        let Ok((payment_hash, query_map)) = parse_verify_route(&request.route) else {
+            // The route is the caller's input, so a route we cannot parse is their
+            // mistake, the same way the HTTP path's `Path<sha256::Hash>` extractor
+            // rejects a malformed payment hash.
+            return Ok((StatusCode::BAD_REQUEST, Json(json!(()))));
+        };
 
         let body =
             verify_bolt11_preimage_v2_get(Extension(gateway), Path(payment_hash), Query(query_map))
@@ -296,27 +309,55 @@ async fn handle_request(
         return Ok((StatusCode::OK, body));
     }
 
-    let (status, body) = match &request.params {
-        Some(params) => {
-            if let Some(handler) = handlers.get_handler_with_payload(&request.route) {
-                (
-                    StatusCode::OK,
-                    handler(Extension(gateway), params.clone()).await?,
-                )
-            } else {
-                return Err(anyhow!("Iroh handler received request with unknown route"));
-            }
-        }
-        None => {
-            if let Some(handler) = handlers.get_handler(&request.route) {
-                (StatusCode::OK, handler(Extension(gateway)).await?)
-            } else {
-                return Err(anyhow!("Iroh handler received request with unknown route"));
-            }
-        }
+    let (status, body) = if let Some(params) = &request.params {
+        let Some(handler) = handlers.get_handler_with_payload(&request.route) else {
+            return Ok(unknown_route(&request.route));
+        };
+
+        (
+            StatusCode::OK,
+            handler(Extension(gateway), params.clone()).await?,
+        )
+    } else {
+        let Some(handler) = handlers.get_handler(&request.route) else {
+            return Ok(unknown_route(&request.route));
+        };
+
+        (StatusCode::OK, handler(Extension(gateway)).await?)
     };
 
     Ok((status, body))
+}
+
+/// Response for a route that no handler is registered for.
+fn unknown_route(route: &str) -> (StatusCode, Json<serde_json::Value>) {
+    warn!(
+        target: LOG_GATEWAY,
+        route,
+        "Iroh handler received request with unknown route"
+    );
+
+    (StatusCode::NOT_FOUND, Json(json!(())))
+}
+
+/// Parses the LNURL-verify route `/verify/{payment_hash}` into the payment hash
+/// and the query parameters (`?wait`) of the request.
+fn parse_verify_route(route: &str) -> anyhow::Result<(sha256::Hash, HashMap<String, String>)> {
+    // Use dummy URL for easier parsing
+    let url = Url::parse(&format!("http://localhost{route}"))?;
+
+    // Extract segments: /verify/<payment_hash>. The first segment is the route
+    // prefix itself, so the payment hash is the second one.
+    let payment_hash: sha256::Hash = url
+        .path_segments()
+        .and_then(|mut segments| segments.nth(1))
+        .ok_or_else(|| anyhow!("Verify route does not contain a payment hash"))?
+        .parse()?;
+
+    // Parse query params (?wait etc.)
+    let query_map: HashMap<String, String> = url.query_pairs().into_owned().collect();
+
+    Ok((payment_hash, query_map))
 }
 
 /// Verifies if the supplied password in the Iroh request matches the gateway's
@@ -336,14 +377,55 @@ fn iroh_verify_password(
 
 #[cfg(test)]
 mod tests {
+    use bitcoin::hashes::Hash as _;
+
     use super::*;
 
     #[tokio::test]
     async fn panicking_handler_returns_an_error_instead_of_unwinding() {
-        let (status, _body) = run_handler("/pay_invoice", async { panic!("handler panic") })
-            .await
-            .expect("a panicking handler is contained");
+        let (status, _body) = run_handler("/pay_invoice", async { panic!("handler panic") }).await;
 
         assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[tokio::test]
+    async fn failing_handler_is_answered_instead_of_ending_the_connection() {
+        let (status, _body) = run_handler("/verify/nonsense", async {
+            Err(anyhow!("Verify route does not contain a payment hash"))
+        })
+        .await;
+
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[test]
+    fn verify_route_parses_the_payment_hash_not_the_route_prefix() {
+        let payment_hash = sha256::Hash::hash(b"payment hash");
+
+        let (parsed_hash, _query) = parse_verify_route(&format!("/verify/{payment_hash}"))
+            .expect("the payment hash is the second path segment, not the first");
+
+        assert_eq!(parsed_hash, payment_hash);
+    }
+
+    #[test]
+    fn verify_route_parses_the_wait_query_parameter() {
+        let payment_hash = sha256::Hash::hash(b"payment hash");
+
+        let (parsed_hash, query) = parse_verify_route(&format!("/verify/{payment_hash}?wait"))
+            .expect("query parameters do not affect path parsing");
+
+        assert_eq!(parsed_hash, payment_hash);
+        assert!(query.contains_key("wait"));
+    }
+
+    #[test]
+    fn verify_route_without_a_payment_hash_is_rejected() {
+        parse_verify_route("/verify")
+            .expect_err("a route without a payment hash has nothing to verify");
+        parse_verify_route("/verify/")
+            .expect_err("a route with an empty payment hash has nothing to verify");
+        parse_verify_route("/verify/not-a-payment-hash")
+            .expect_err("a payment hash that is not a sha256 hash is rejected");
     }
 }

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -62,7 +62,7 @@ use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_core::rustls::install_crypto_provider;
 use fedimint_core::secp256k1::PublicKey;
 use fedimint_core::secp256k1::schnorr::Signature;
-use fedimint_core::task::{TaskGroup, TaskHandle, TaskShutdownToken, sleep};
+use fedimint_core::task::{TaskGroup, TaskHandle, TaskShutdownToken, sleep, timeout};
 use fedimint_core::time::duration_since_epoch;
 use fedimint_core::util::backoff_util::fibonacci_max_one_hour;
 use fedimint_core::util::{FmtCompact, FmtCompactAnyhow, SafeUrl, Spanned, retry};
@@ -145,6 +145,15 @@ pub const DEFAULT_NETWORK: Network = Network::Regtest;
 /// How long code that needs to talk to the lightning node backs off before
 /// re-checking whether the gateway has (re)connected to it.
 const LIGHTNING_CONTEXT_RETRY_INTERVAL: Duration = Duration::from_secs(5);
+
+/// How long an LNURL-verify request that asked to wait blocks before reporting
+/// the payment as not settled yet.
+///
+/// The payment being waited for may never arrive, so the wait needs an upper
+/// bound to stop callers from parking a request handler indefinitely. Reporting
+/// "not settled" on expiry is a regular LNURL-verify response, so clients
+/// simply poll again.
+const VERIFY_WAIT_TIMEOUT: Duration = Duration::from_secs(30);
 
 pub type Result<T> = std::result::Result<T, PublicGatewayError>;
 pub type AdminResult<T> = std::result::Result<T, AdminGatewayError>;
@@ -3418,11 +3427,17 @@ impl Gateway {
             });
         }
 
-        let state = client
+        let module = client
             .get_first_module::<GatewayClientModuleV2>()
-            .expect("Must have client module")
-            .await_receive(operation_id)
-            .await;
+            .expect("Must have client module");
+
+        let Ok(state) = timeout(VERIFY_WAIT_TIMEOUT, module.await_receive(operation_id)).await
+        else {
+            return Ok(VerifyResponse {
+                settled: false,
+                preimage: None,
+            });
+        };
 
         let preimage = match state {
             FinalReceiveState::Success(preimage) => Ok(preimage),


### PR DESCRIPTION
Fixes: https://github.com/fedimint/fedimint/issues/8970

Parses the hash from the `verify` endpoint correctly and also adds some error handling code so the connection doesn't drop if there is a bad request.