### PR TITLE
feat: Onchain Sweep (including Federation Fees)

### DIFF
--- a/devimint/src/gatewayd.rs
+++ b/devimint/src/gatewayd.rs
@@ -781,6 +781,25 @@ impl<'a> GatewayClient {
         .await?;
         Ok(serde_json::from_value(value)?)
     }
+
+    /// Sweeps the gateway's entire ecash balance for a federation on chain via
+    /// `--amount all`.
+    pub async fn pegout_all(&self, fed_id: String, address: Address) -> Result<WithdrawResponse> {
+        let value = cmd!(
+            self,
+            "ecash",
+            "pegout",
+            "--federation-id",
+            fed_id,
+            "--amount",
+            "all",
+            "--address",
+            address
+        )
+        .out_json()
+        .await?;
+        Ok(serde_json::from_value(value)?)
+    }
 }
 
 #[derive(Clone)]

--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -39,7 +39,9 @@ use crate::cli::{CommonArgs, cleanup_on_exit, exec_user_command, setup};
 use crate::envs::{FM_DATA_DIR_ENV, FM_DEVIMINT_RUN_DEPRECATED_TESTS_ENV};
 use crate::federation::Client;
 use crate::util::{LoadTestTool, ProcessManager, almost_equal, poll};
-use crate::version_constants::{VERSION_0_10_0_ALPHA, VERSION_0_11_0_ALPHA, VERSION_0_12_0_ALPHA};
+use crate::version_constants::{
+    VERSION_0_10_0_ALPHA, VERSION_0_11_0_ALPHA, VERSION_0_12_0_ALPHA, VERSION_0_13_0_ALPHA,
+};
 use crate::{DevFed, Gatewayd, LightningNode, Lnd, cmd, dev_fed};
 
 pub struct Stats {
@@ -1188,6 +1190,51 @@ pub async fn cli_tests(dev_fed: DevFed) -> Result<()> {
         4_000,
     )
     .unwrap();
+
+    // ## Withdraw everything
+    //
+    // `module wallet withdraw --amount all` was added in 0.13.0-alpha; before
+    // that the module CLI rejected "all" outright.
+    if fedimint_cli_version >= *VERSION_0_13_0_ALPHA {
+        info!("Testing client withdraw all");
+
+        let pre_sweep_balance = client.balance().await?;
+        let address = bitcoind.get_new_address().await?;
+
+        // Sweeping the whole balance has to leave room for the mint's per-note
+        // fees on top of the on-chain fee. With base fees enabled (the default)
+        // a naive `balance - onchain_fee` is underfunded and note selection
+        // rejects the peg-out.
+        let sweep_res = cmd!(
+            client,
+            "module",
+            "wallet",
+            "withdraw",
+            "--amount",
+            "all",
+            "--address",
+            &address
+        )
+        .out_json()
+        .await?;
+
+        let txid: Txid = sweep_res["txid"]
+            .as_str()
+            .expect("sweep should return a txid")
+            .parse()?;
+
+        bitcoind.poll_get_transaction(txid).await?;
+
+        // A sweep cannot always drain to exactly zero — the fee is stepwise in
+        // the amount, so a sub-denomination remainder can be left behind — but
+        // it must move all but a negligible part of the balance.
+        let post_sweep_balance = client.balance().await?;
+
+        assert!(
+            post_sweep_balance < pre_sweep_balance / 100,
+            "Sweep left {post_sweep_balance} msats of {pre_sweep_balance} msats behind",
+        );
+    }
 
     // # peer-version command
     let peer_0_fedimintd_version = cmd!(client, "dev", "peer-version", "--peer-id", "0")

--- a/fedimint-cli/src/client.rs
+++ b/fedimint-cli/src/client.rs
@@ -580,16 +580,15 @@ pub async fn handle_command(
             let wallet_module = client.get_first_module::<WalletClientModule>()?;
             let address = address.require_network(wallet_module.get_network())?;
             let (amount, fees) = match amount {
-                // If the amount is "all", then we need to subtract the fees from
-                // the amount we are withdrawing
+                // The on-chain fee is only part of the cost of withdrawing
+                // everything: funding the peg-out output also incurs the
+                // federation's per-note fees. The returned fees are quoted at
+                // the returned amount, so they must be used together.
                 BitcoinAmountOrAll::All => {
-                    let balance =
-                        bitcoin::Amount::from_sat(client.get_balance_for_btc().await?.msats / 1000);
-                    let fees = wallet_module.get_withdraw_fees(&address, balance).await?;
-                    let Some(amount) = balance.checked_sub(fees.amount()) else {
-                        bail!("Not enough funds to pay fees");
-                    };
-                    (amount, fees)
+                    let balance = client.get_balance_for_btc().await?;
+                    wallet_module
+                        .max_withdrawable_amount(&address, balance)
+                        .await?
                 }
                 BitcoinAmountOrAll::Amount(amount) => (
                     amount,

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -519,31 +519,24 @@ async fn calculate_max_withdrawable(
         )));
     };
 
-    let peg_out_fees = wallet_module
-        .get_withdraw_fees(
-            address,
-            bitcoin::Amount::from_sat(balance.sats_round_down()),
-        )
-        .await?;
-
-    let max_withdrawable_before_mint_fees = balance
-        .checked_sub(peg_out_fees.amount().into())
-        .ok_or_else(|| AdminGatewayError::WithdrawError {
-            failure_reason: "Insufficient balance to cover peg-out fees".to_string(),
+    let (max_withdrawable, peg_out_fees) = wallet_module
+        .max_withdrawable_amount(address, balance)
+        .await
+        .map_err(|err| AdminGatewayError::WithdrawError {
+            failure_reason: err.fmt_compact_anyhow().to_string(),
         })?;
 
-    // MintV2 doesn't have fee estimation - only compute fees for MintV1
-    let mint_fees = if let Ok(mint_module) = client.get_first_module::<MintClientModule>() {
-        mint_module.estimate_spend_all_fees().await
-    } else {
-        Amount::ZERO
-    };
-
-    let max_withdrawable = max_withdrawable_before_mint_fees.saturating_sub(mint_fees);
+    // Everything the balance does not become an on-chain payment or miner fee
+    // is the federation fee: the peg-out output fee, the mint input fees on the
+    // funding notes, any change output fees and dust. This is exact by
+    // construction, so it needs no separate estimate.
+    let federation_fees = balance
+        .saturating_sub(Amount::from_sats(max_withdrawable.to_sat()))
+        .saturating_sub(Amount::from_sats(peg_out_fees.amount().to_sat()));
 
     Ok(WithdrawDetails {
-        amount: max_withdrawable,
-        mint_fees: Some(mint_fees),
+        amount: Amount::from_sats(max_withdrawable.to_sat()),
+        mint_fees: Some(federation_fees),
         peg_out_fees,
     })
 }
@@ -2875,33 +2868,27 @@ impl IAdminGateway for Gateway {
             }
             // CLI flow: fetch fees (existing behavior for backwards compatibility)
             None => match amount {
-                // If the amount is "all", then we need to subtract the fees from
-                // the amount we are withdrawing
+                // The on-chain fee is only part of the cost of withdrawing
+                // everything: funding the peg-out output also incurs the
+                // federation's per-note fees. The returned fees are quoted at
+                // the returned amount, so they must be used together.
                 BitcoinAmountOrAll::All => {
-                    let balance = bitcoin::Amount::from_sat(
-                        client
-                            .value()
-                            .get_balance_for_btc()
-                            .await
-                            .map_err(|err| {
-                                AdminGatewayError::Unexpected(anyhow!(
-                                    "Balance not available: {}",
-                                    err.fmt_compact_anyhow()
-                                ))
-                            })?
-                            .msats
-                            / 1000,
-                    );
-                    let fees = wallet_module.get_withdraw_fees(&address, balance).await?;
-                    let withdraw_amount = balance.checked_sub(fees.amount());
-                    if withdraw_amount.is_none() {
-                        return Err(AdminGatewayError::WithdrawError {
+                    let balance = client.value().get_balance_for_btc().await.map_err(|err| {
+                        AdminGatewayError::Unexpected(anyhow!(
+                            "Balance not available: {}",
+                            err.fmt_compact_anyhow()
+                        ))
+                    })?;
+
+                    wallet_module
+                        .max_withdrawable_amount(&address, balance)
+                        .await
+                        .map_err(|err| AdminGatewayError::WithdrawError {
                             failure_reason: format!(
-                                "Insufficient funds. Balance: {balance} Fees: {fees:?}"
+                                "Insufficient funds. Balance: {balance}: {}",
+                                err.fmt_compact_anyhow()
                             ),
-                        });
-                    }
-                    (withdraw_amount.expect("checked above"), fees)
+                        })?
                 }
                 BitcoinAmountOrAll::Amount(amount) => (
                     amount,

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -406,23 +406,25 @@ async fn withdraw_v2(
 
     let withdraw_amount = match amount {
         BitcoinAmountOrAll::All => {
-            let balance = bitcoin::Amount::from_sat(
-                client
-                    .get_balance_for_btc()
-                    .await
-                    .map_err(|err| {
-                        AdminGatewayError::Unexpected(anyhow!(
-                            "Balance not available: {}",
-                            err.fmt_compact_anyhow()
-                        ))
-                    })?
-                    .msats
-                    / 1000,
-            );
-            balance
-                .checked_sub(fee)
-                .ok_or_else(|| AdminGatewayError::WithdrawError {
-                    failure_reason: format!("Insufficient funds. Balance: {balance} Fee: {fee}"),
+            let balance = client.get_balance_for_btc().await.map_err(|err| {
+                AdminGatewayError::Unexpected(anyhow!(
+                    "Balance not available: {}",
+                    err.fmt_compact_anyhow()
+                ))
+            })?;
+
+            // The on-chain fee is only part of the cost: funding the wallet
+            // output also incurs the federation's per-note fees. `fee` is
+            // passed on to `send` below so both are computed against the same
+            // on-chain fee.
+            wallet_module
+                .max_sendable_amount(balance, fee)
+                .await
+                .map_err(|err| AdminGatewayError::WithdrawError {
+                    failure_reason: format!(
+                        "Insufficient funds. Balance: {balance} Fee: {fee}: {}",
+                        err.fmt_compact_anyhow()
+                    ),
                 })?
         }
         BitcoinAmountOrAll::Amount(a) => a,
@@ -479,14 +481,7 @@ async fn calculate_max_withdrawable(
         ))
     })?;
 
-    let peg_out_fees = if let Ok(wallet_module) = client.get_first_module::<WalletClientModule>() {
-        wallet_module
-            .get_withdraw_fees(
-                address,
-                bitcoin::Amount::from_sat(balance.sats_round_down()),
-            )
-            .await?
-    } else if let Ok(wallet_module) =
+    if let Ok(wallet_module) =
         client.get_first_module::<fedimint_walletv2_client::WalletClientModule>()
     {
         let fee = wallet_module
@@ -495,12 +490,41 @@ async fn calculate_max_withdrawable(
             .map_err(|e| AdminGatewayError::WithdrawError {
                 failure_reason: e.to_string(),
             })?;
-        PegOutFees::from_amount(fee)
-    } else {
+
+        let max_withdrawable = wallet_module
+            .max_sendable_amount(balance, fee)
+            .await
+            .map_err(|err| AdminGatewayError::WithdrawError {
+                failure_reason: err.fmt_compact_anyhow().to_string(),
+            })?;
+
+        // Everything the balance does not become an on-chain payment or miner
+        // fee is the federation fee: the wallet output fee, the mint input
+        // fees on the funding notes, any change output fees and dust. This is
+        // exact by construction, so it needs no separate estimate.
+        let federation_fees = balance
+            .saturating_sub(Amount::from_sats(max_withdrawable.to_sat()))
+            .saturating_sub(Amount::from_sats(fee.to_sat()));
+
+        return Ok(WithdrawDetails {
+            amount: Amount::from_sats(max_withdrawable.to_sat()),
+            mint_fees: Some(federation_fees),
+            peg_out_fees: PegOutFees::from_amount(fee),
+        });
+    }
+
+    let Ok(wallet_module) = client.get_first_module::<WalletClientModule>() else {
         return Err(AdminGatewayError::Unexpected(anyhow!(
             "No wallet module found"
         )));
     };
+
+    let peg_out_fees = wallet_module
+        .get_withdraw_fees(
+            address,
+            bitcoin::Amount::from_sat(balance.sats_round_down()),
+        )
+        .await?;
 
     let max_withdrawable_before_mint_fees = balance
         .checked_sub(peg_out_fees.amount().into())

--- a/gateway/fedimint-gateway-ui/src/federation.rs
+++ b/gateway/fedimint-gateway-ui/src/federation.rs
@@ -820,10 +820,14 @@ pub async fn withdraw_preview_handler<E: Display>(
                                     td { "Peg-out Fee" }
                                     td { (format!("{} sats", response.peg_out_fees.amount().to_sat())) }
                                 }
-                                @if let Some(mint_fee) = response.mint_fees {
+                                // Covers every on-federation fee the withdrawal
+                                // incurs, not just the mint's: for walletv2 the
+                                // wallet module's own per-output fee is the
+                                // larger part of it.
+                                @if let Some(federation_fee) = response.mint_fees {
                                     tr {
-                                        td { "Mint Fee (est.)" }
-                                        td { (format!("~{} sats", mint_fee.sats_round_down())) }
+                                        td { "Federation Fee (est.)" }
+                                        td { (format!("~{} sats", federation_fee.sats_round_down())) }
                                     }
                                 }
                                 tr {

--- a/gateway/integration_tests/src/main.rs
+++ b/gateway/integration_tests/src/main.rs
@@ -535,12 +535,40 @@ async fn liquidity_test() -> anyhow::Result<()> {
                 .pegout_gateways(500_000_000, gateways.clone())
                 .await?;
 
+            info!(target: LOG_TEST, "Testing pegging-out the entire ecash balance...");
+            // Sweeping the full balance has to leave room for the federation's
+            // per-note fees on top of the on-chain fee. With base fees enabled
+            // (the default) a naive `balance - onchain_fee` is underfunded and
+            // note selection rejects the peg-out. Only one gateway is drained:
+            // the required feerate doubles per pending federation transaction,
+            // and the federation needs a non-dust change UTXO of its own.
+            let bitcoind = dev_fed.bitcoind().await?;
+            let fed_id = federation.calculate_federation_id();
+            let sweep_balance = gw_lnd.client().ecash_balance(fed_id.clone()).await?;
+            assert!(sweep_balance > 0, "Gateway has no ecash left to sweep");
+
+            let pegout_address = bitcoind.get_new_address().await?;
+            let sweep = gw_lnd
+                .client()
+                .pegout_all(fed_id.clone(), pegout_address)
+                .await?;
+            bitcoind.mine_blocks(21).await?;
+            bitcoind.poll_get_transaction(sweep.txid).await?;
+
+            // A sweep cannot always drain to exactly zero — fees are stepwise in
+            // the amount, so sub-denomination dust can be left behind — but it
+            // must move all but a negligible remainder.
+            let remaining = gw_lnd.client().ecash_balance(fed_id).await?;
+            assert!(
+                remaining < sweep_balance / 100,
+                "Sweep left {remaining} msats of {sweep_balance} msats behind",
+            );
+
             info!(target: LOG_TEST, "Testing only admin can send onchain...");
             let send_result = gw_lnd.client().with_password("secondbest").send_onchain(dev_fed.bitcoind().await?, BitcoinAmountOrAll::All, 10).await;
             assert!(send_result.is_err(), "Only admins can send onchain");
 
             info!(target: LOG_TEST, "Testing sending onchain...");
-            let bitcoind = dev_fed.bitcoind().await?;
             for gw in &gateways {
                 let txid = gw
                     .client()

--- a/modules/fedimint-wallet-client/src/cli.rs
+++ b/modules/fedimint-wallet-client/src/cli.rs
@@ -101,16 +101,19 @@ async fn withdraw(
     address: bitcoin::Address<NetworkUnchecked>,
 ) -> anyhow::Result<serde_json::Value> {
     let address = address.require_network(module.get_network())?;
-    let amount = match amount {
+    let (amount, fees) = match amount {
+        // The on-chain fee is only part of the cost of withdrawing everything:
+        // funding the peg-out output also incurs the federation's per-note
+        // fees. The returned fees are quoted at the returned amount, so they
+        // must be used together.
         BitcoinAmountOrAll::All => {
-            bail!(
-                "The 'all' option is not supported in the module CLI. \
-                Use `fedimint-cli withdraw --amount all` instead."
-            );
+            let balance = module.client_ctx.get_balance_for_btc().await?;
+            module.max_withdrawable_amount(&address, balance).await?
         }
-        BitcoinAmountOrAll::Amount(amount) => amount,
+        BitcoinAmountOrAll::Amount(amount) => {
+            (amount, module.get_withdraw_fees(&address, amount).await?)
+        }
     };
-    let fees = module.get_withdraw_fees(&address, amount).await?;
     let absolute_fees = fees.amount();
 
     info!("Attempting withdraw with fees: {fees:?}");

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -48,7 +48,8 @@ use fedimint_client_module::module::{ClientContext, ClientModule, IClientModule,
 use fedimint_client_module::oplog::UpdateStreamOrOutcome;
 use fedimint_client_module::sm::{Context, DynState, ModuleNotifier, State, StateTransition};
 use fedimint_client_module::transaction::{
-    ClientOutput, ClientOutputBundle, ClientOutputSM, FeeQuote, FeeQuoteRequest, TransactionBuilder,
+    ClientOutput, ClientOutputBundle, ClientOutputSM, FeeQuote, FeeQuoteRequest,
+    TransactionBuilder, max_affordable_send_amount,
 };
 use fedimint_client_module::{DynGlobalClientContext, sm_enum_variant_translation};
 use fedimint_core::core::{Decoder, IntoDynInstance, ModuleInstanceId, ModuleKind, OperationId};
@@ -896,6 +897,84 @@ impl WalletClientModule {
                 },
             )
             .await
+    }
+
+    /// Finds the largest amount that can be withdrawn in full out of
+    /// `balance` — the amount a "withdraw everything" sweep should use —
+    /// together with the peg-out fees to submit it with.
+    ///
+    /// Withdrawing `amount` submits a peg-out output worth `amount +
+    /// peg_out_fees` (the on-chain miner fee is carried inside the output, see
+    /// [`WalletOutputV0::amount`]) and funding that output costs an additional
+    /// federation fee — the peg-out output fee, the mint input fees on the
+    /// funding notes, any mint change output fees and sub-denomination dust —
+    /// as quoted by [`Self::send_fee_quote`].
+    ///
+    /// Both returned values must be passed to [`Self::withdraw`] together. The
+    /// federation rebuilds the peg-out for the exact amount submitted and
+    /// rejects it unless the declared `total_weight` matches what it computed
+    /// (`WalletOutputError::TxWeightIncorrect`), so the fees are re-quoted here
+    /// at the amount being returned rather than at the balance.
+    ///
+    /// This costs exactly two [`Self::get_withdraw_fees`] round trips. The
+    /// first, at the full balance, is an upper bound on the miner fee — the
+    /// federation selects UTXOs until they cover the amount, so the weight is
+    /// monotone in it — and sizing the withdrawal against that upper bound can
+    /// only leave the result more affordable once the true, smaller fee
+    /// replaces it. The maximum itself is then found by binary search over the
+    /// real fee quote (see [`max_affordable_send_amount`]), which needs no
+    /// further round trips because [`Self::send_fee_quote`] is a local dry-run.
+    ///
+    /// Sizing against the upper bound means a sweep may leave a small
+    /// remainder behind. The quote is point-in-time: if the federation's UTXO
+    /// set or feerate moves before the peg-out is processed it is rejected, and
+    /// the caller should retry with a fresh quote.
+    ///
+    /// Returns an error if the balance cannot cover the destination's dust
+    /// limit plus fees.
+    pub async fn max_withdrawable_amount(
+        &self,
+        address: &bitcoin::Address,
+        balance: fedimint_core::Amount,
+    ) -> anyhow::Result<(bitcoin::Amount, PegOutFees)> {
+        // Upper bound on the miner fee: the weight only grows as the federation
+        // has to reach for more UTXOs, so no smaller withdrawal costs more.
+        let max_fees = self
+            .get_withdraw_fees(
+                address,
+                bitcoin::Amount::from_sat(balance.sats_round_down()),
+            )
+            .await?;
+        let max_fee_msats = fedimint_core::Amount::from_sats(max_fees.amount().to_sat());
+
+        let max = max_affordable_send_amount(
+            balance,
+            fedimint_core::Amount::from_sats(address.script_pubkey().minimal_non_dust().to_sat()),
+            balance,
+            // A peg-out funds a whole number of sats, so round the probe up to
+            // the next sat before adding the miner fee; the solver searches
+            // millisatoshis.
+            |amount: fedimint_core::Amount| {
+                fedimint_core::Amount::from_sats(amount.msats.div_ceil(1000)) + max_fee_msats
+            },
+            |funded: fedimint_core::Amount| {
+                self.send_fee_quote(bitcoin::Amount::from_sat(funded.msats / 1000))
+            },
+        )
+        .await
+        .ok_or_else(|| anyhow!("Balance is too low to withdraw any amount after fees"))?;
+
+        // `gross_up` rounded up to whole satoshis, so the largest affordable
+        // amount already sits on a satoshi boundary; no value is lost here.
+        let amount = bitcoin::Amount::from_sat(max.msats.div_ceil(1000));
+
+        // Re-quote at the amount actually being withdrawn. This is the fee the
+        // federation recomputes for that amount, so the declared weight
+        // matches; it is at most `max_fees`, which is what keeps `amount`
+        // affordable.
+        let fees = self.get_withdraw_fees(address, amount).await?;
+
+        Ok((amount, fees))
     }
 
     /// Returns a summary of the wallet's coins

--- a/modules/fedimint-walletv2-client/src/cli.rs
+++ b/modules/fedimint-walletv2-client/src/cli.rs
@@ -3,6 +3,7 @@ use std::{ffi, iter};
 use bitcoin::Address;
 use bitcoin::address::NetworkUnchecked;
 use clap::{Parser, Subcommand};
+use fedimint_core::BitcoinAmountOrAll;
 use fedimint_eventlog::EventLogId;
 use serde::Serialize;
 use serde_json::Value;
@@ -21,7 +22,8 @@ enum Opts {
     /// Send an onchain payment.
     Send {
         address: Address<NetworkUnchecked>,
-        value: bitcoin::Amount,
+        /// Value to send, or "all" to sweep the entire balance.
+        value: BitcoinAmountOrAll,
         #[arg(long)]
         fee: Option<bitcoin::Amount>,
     },
@@ -75,15 +77,37 @@ pub(crate) async fn handle_cli_command(
             address,
             value,
             fee,
-        } => json(
-            wallet
-                .await_final_send_operation_state(
-                    wallet
-                        .send(address, value, fee, serde_json::Value::Null)
-                        .await?,
-                )
-                .await?,
-        ),
+        } => {
+            // Resolve the on-chain fee up front so the same value sizes the
+            // sweep and funds the send: the required feerate rises with each
+            // pending federation transaction, and a value computed against a
+            // stale fee would be rejected.
+            let fee = match fee {
+                Some(fee) => fee,
+                None => wallet.send_fee().await?,
+            };
+
+            let value = match value {
+                // The on-chain fee is only part of the cost of sending
+                // everything: funding the wallet output also incurs the
+                // federation's per-note fees.
+                BitcoinAmountOrAll::All => {
+                    let balance = wallet.client_ctx.get_balance_for_btc().await?;
+                    wallet.max_sendable_amount(balance, fee).await?
+                }
+                BitcoinAmountOrAll::Amount(value) => value,
+            };
+
+            json(
+                wallet
+                    .await_final_send_operation_state(
+                        wallet
+                            .send(address, value, Some(fee), serde_json::Value::Null)
+                            .await?,
+                    )
+                    .await?,
+            )
+        }
         Opts::Receive => json(wallet.receive().await),
         Opts::AwaitReceive { position } => json(wallet.await_receive(position).await?),
     };

--- a/modules/fedimint-walletv2-client/src/lib.rs
+++ b/modules/fedimint-walletv2-client/src/lib.rs
@@ -28,7 +28,7 @@ use fedimint_api_client::api::{DynModuleApi, FederationResult};
 use fedimint_client::DynGlobalClientContext;
 use fedimint_client::transaction::{
     ClientInput, ClientInputBundle, ClientInputSM, ClientOutput, ClientOutputBundle,
-    ClientOutputSM, FeeQuote, FeeQuoteRequest, TransactionBuilder,
+    ClientOutputSM, FeeQuote, FeeQuoteRequest, TransactionBuilder, max_affordable_send_amount,
 };
 use fedimint_client_module::db::ClientModuleMigrationFn;
 use fedimint_client_module::module::init::{ClientModuleInit, ClientModuleInitArgs};
@@ -294,6 +294,66 @@ impl WalletClientModule {
                 },
             )
             .await
+    }
+
+    /// Finds the largest value that can be sent on chain in full out of
+    /// `balance` — the amount a "send everything" sweep should use.
+    ///
+    /// Sending `value` costs `value + fee` (the on-chain miner fee is carried
+    /// inside the wallet output, see [`Self::send`]) *plus* the federation fee
+    /// of funding that output — the wallet output fee, the mint input fees on
+    /// the funding notes, any mint change output fees and sub-denomination
+    /// dust — as quoted by [`Self::send_fee_quote`]. This returns the largest
+    /// `value` satisfying
+    ///
+    /// ```text
+    /// value + fee + send_fee_quote(value + fee).total() <= balance
+    /// ```
+    ///
+    /// `balance` is the client's current Bitcoin balance (e.g. from
+    /// `Client::get_balance_for_btc`). `fee` is the on-chain fee from
+    /// [`Self::send_fee`]; pass the *same* value on to [`Self::send`], since
+    /// the required feerate rises with each pending federation transaction and
+    /// a value computed against a stale fee would be rejected.
+    ///
+    /// The maximum is found by binary search over the real fee quote (see
+    /// [`max_affordable_send_amount`]) rather than by subtracting a single
+    /// quote: the federation fee is charged per note, so note selection,
+    /// denomination rounding, change and dust move it in steps as the value
+    /// crosses thresholds, and a quote taken at the full balance would fail
+    /// outright — funding it is the very thing that is unaffordable.
+    ///
+    /// The quote is point-in-time and moves with the balance; [`Self::send`]
+    /// remains the source of truth. Note that it cannot account for the
+    /// federation's own on-chain constraints — a send whose change UTXO would
+    /// fall below the dust limit is still rejected by the guardians.
+    ///
+    /// Returns an error if the balance cannot cover even the dust limit plus
+    /// fees.
+    pub async fn max_sendable_amount(
+        &self,
+        balance: Amount,
+        fee: bitcoin::Amount,
+    ) -> anyhow::Result<bitcoin::Amount> {
+        let fee_msats = Amount::from_sats(fee.to_sat());
+
+        let max = max_affordable_send_amount(
+            balance,
+            Amount::from_sats(self.cfg.dust_limit.to_sat()),
+            balance,
+            // The solver searches millisatoshis, but a send funds a whole
+            // number of satoshis. Rounding the probe up to the next satoshi
+            // keeps the predicate conservative and makes the value handed to
+            // the quote below an exact satoshi multiple.
+            |value: Amount| Amount::from_sats(value.msats.div_ceil(1000)) + fee_msats,
+            |funded: Amount| self.send_fee_quote(bitcoin::Amount::from_sat(funded.msats / 1000)),
+        )
+        .await
+        .ok_or_else(|| anyhow!("Balance is too low to send any amount on chain after fees"))?;
+
+        // `gross_up` rounded up to whole satoshis, so the largest affordable
+        // amount already sits on a satoshi boundary; no value is lost here.
+        Ok(bitcoin::Amount::from_sat(max.msats.div_ceil(1000)))
     }
 
     /// Fetch the current fee required to claim an onchain deposit (peg-in).

--- a/modules/fedimint-walletv2-tests/bin/tests.rs
+++ b/modules/fedimint-walletv2-tests/bin/tests.rs
@@ -5,7 +5,9 @@ use bitcoin::address::NetworkUnchecked;
 use bitcoin::{Address, Txid};
 use devimint::external::Bitcoind;
 use devimint::federation::Client;
-use devimint::version_constants::{VERSION_0_11_0_ALPHA, VERSION_0_12_0_ALPHA};
+use devimint::version_constants::{
+    VERSION_0_11_0_ALPHA, VERSION_0_12_0_ALPHA, VERSION_0_13_0_ALPHA,
+};
 use devimint::{cmd, util};
 use fedimint_core::runtime::sleep;
 use fedimint_core::task::sleep_in_test;
@@ -399,6 +401,54 @@ async fn main() -> anyhow::Result<()> {
             await_no_pending_txs(&client).await?;
 
             ensure_tx_chain_length(&client, 6).await?;
+
+            // `send ... all` was added in 0.13.0-alpha; older CLIs parse the
+            // value as a plain amount and reject "all".
+            if fedimint_cli_version >= *VERSION_0_13_0_ALPHA {
+                info!("Sweep the entire remaining balance onchain...");
+
+                let sweep_address = bitcoind.get_new_address().await?;
+
+                // A sweep can only spend notes that exist when it runs. The
+                // aborted send above is refunded by the mint's input state
+                // machine, which settles independently of the federation's
+                // bitcoin transactions — `await_final_send_operation_state`
+                // returns as soon as the send aborts, while the refunded notes
+                // are still being reissued. Wait for every in-flight state
+                // machine to finish, or that refund lands after the sweep and
+                // looks like funds left behind.
+                cmd!(client, "dev", "wait-complete").run().await?;
+
+                let pre_sweep_balance = client.balance().await?;
+
+                // Sweeping the whole balance has to leave room for the mint's
+                // per-note fees and the wallet module's own output fee on top
+                // of the on-chain fee. With base fees enabled (the default) a
+                // naive `balance - onchain_fee` is underfunded and note
+                // selection rejects the send.
+                let value = cmd!(client, "module", "walletv2", "send", sweep_address, "all")
+                    .out_json()
+                    .await?;
+
+                let FinalSendState::Success(txid) = serde_json::from_value(value)? else {
+                    panic!("Sweep send operation failed");
+                };
+
+                bitcoind.poll_get_transaction(txid).await?;
+
+                // A sweep cannot always drain to exactly zero — the fee is
+                // stepwise in the amount, so a sub-denomination remainder can
+                // be left behind — but it must move all but a negligible part
+                // of the balance.
+                let post_sweep_balance = client.balance().await?;
+
+                ensure!(
+                    post_sweep_balance < pre_sweep_balance / 100,
+                    "Sweep left {post_sweep_balance} msats of {pre_sweep_balance} msats behind"
+                );
+
+                await_no_pending_txs(&client).await?;
+            }
 
             block_miner.abort();
 


### PR DESCRIPTION
We've had the ability to sweep a wallet using the `--all` flag for awhile, but this has been broken since we introduced non-zero "module" fees (mint and wallet). It's a non-trivial problem because each module could have a ppm fee (which is dependent on the amount) and for withdrawing onchain, there is a onchain fee.

This PR reuses `max_spendable_amount` from earlier work to compute a fee quote for the inputs and outputs of a transaction. With this and the onchain fee, this allows us to estimate a max that we can withdraw from the wallet.

Note: Because walletv1 and walletv2 have different fee structures and walletv1 has > 1 UTXO, these cases needed to be handled separately. For walletv1, `get_withdraw_fees` is now called twice: once to get a max onchain fee estimate, and another to get the actual fee that will be paid after the federation fees are subtracted. 

Tests have been added and I have manually tested via the Lightning Gateway UI.