### PR TITLE
fix: divide by zero fix for gateway registration

### DIFF
--- a/fedimint-core/src/amount.rs
+++ b/fedimint-core/src/amount.rs
@@ -82,6 +82,12 @@ impl Amount {
         Ok(Self::from(btc_amt))
     }
 
+    pub fn saturating_add(self, other: Self) -> Self {
+        Self {
+            msats: self.msats.saturating_add(other.msats),
+        }
+    }
+
     pub fn saturating_sub(self, other: Self) -> Self {
         Self {
             msats: self.msats.saturating_sub(other.msats),

--- a/fedimint-recurringd/src/lib.rs
+++ b/fedimint-recurringd/src/lib.rs
@@ -845,7 +845,7 @@ fn select_preferred_gateway(
 /// the fee the payment is later funded with. `to_amount` saturates, so a
 /// gateway announcing a fee too large to represent simply ranks last.
 fn gateway_fee_msat(gateway: &LightningGateway, amount: Amount) -> u64 {
-    gateway.fees.to_amount(&amount).msats
+    gateway.fees.to_amount_legacy(&amount).msats
 }
 
 fn sort_gateways_by_preference(

--- a/fedimint-recurringd/src/lib.rs
+++ b/fedimint-recurringd/src/lib.rs
@@ -21,6 +21,7 @@ use fedimint_core::task::timeout;
 use fedimint_core::util::{FmtCompact, FmtCompactAnyhow, SafeUrl};
 use fedimint_core::{Amount, BitcoinHash, runtime};
 use fedimint_derive_secret::DerivableSecret;
+use fedimint_ln_client::common::config::FeeToAmount as _;
 use fedimint_ln_client::common::{LightningGateway, LightningGatewayAnnouncement};
 use fedimint_ln_client::recurring::{
     PaymentCodeId, PaymentCodeRootKey, RecurringPaymentError, RecurringPaymentProtocol,
@@ -840,12 +841,11 @@ fn select_preferred_gateway(
         .map(|gateway| gateway.gateway.clone())
 }
 
+/// Ranks gateways by what they would actually charge, so selection agrees with
+/// the fee the payment is later funded with. `to_amount` saturates, so a
+/// gateway announcing a fee too large to represent simply ranks last.
 fn gateway_fee_msat(gateway: &LightningGateway, amount: Amount) -> u64 {
-    let proportional_fee =
-        (u128::from(amount.msats) * u128::from(gateway.fees.proportional_millionths)) / 1_000_000;
-
-    u64::from(gateway.fees.base_msat)
-        .saturating_add(u64::try_from(proportional_fee).unwrap_or(u64::MAX))
+    gateway.fees.to_amount(&amount).msats
 }
 
 fn sort_gateways_by_preference(

--- a/modules/fedimint-gw-client/src/pay.rs
+++ b/modules/fedimint-gw-client/src/pay.rs
@@ -650,7 +650,10 @@ impl GatewayPayInvoice {
             .ok_or(OutgoingContractError::InvoiceMissingAmount)?;
 
         let gateway_fee = routing_fees.to_amount(&payment_amount);
-        let necessary_contract_amount = payment_amount + gateway_fee;
+        // Saturating: our own configured fee is bounded, but this rate is read
+        // back from a federation-served announcement, so a fee that overflows
+        // the sum must fail the funding check below rather than panic us.
+        let necessary_contract_amount = payment_amount.saturating_add(gateway_fee);
         if account.amount < necessary_contract_amount {
             return Err(OutgoingContractError::Underfunded(
                 necessary_contract_amount,

--- a/modules/fedimint-gw-client/src/pay.rs
+++ b/modules/fedimint-gw-client/src/pay.rs
@@ -649,7 +649,14 @@ impl GatewayPayInvoice {
             .amount()
             .ok_or(OutgoingContractError::InvoiceMissingAmount)?;
 
+        // Require only the fee the rate names, not the larger amount today's
+        // clients compute with `to_amount_legacy`. Overfunding is already
+        // accepted, so this keeps working with deployed clients while no longer
+        // rejecting a client that has moved to the corrected calculation. The
+        // contract is claimed at its full funded amount either way, so this
+        // gives up no revenue.
         let gateway_fee = routing_fees.to_amount(&payment_amount);
+
         // Saturating: our own configured fee is bounded, but this rate is read
         // back from a federation-served announcement, so a fee that overflows
         // the sum must fail the funding check below rather than panic us.
@@ -997,6 +1004,7 @@ mod tests {
     use fedimint_core::secp256k1::{self, SecretKey};
     use fedimint_ln_client::pay::PaymentData;
     use fedimint_ln_common::PrunedInvoice;
+    use fedimint_ln_common::config::FeeToAmount as _;
     use fedimint_ln_common::contracts::IdentifiableContract as _;
     use fedimint_ln_common::contracts::outgoing::{OutgoingContract, OutgoingContractAccount};
     use lightning_invoice::RoutingFees;
@@ -1032,8 +1040,12 @@ mod tests {
     }
 
     fn payment_data(payment_hash: sha256::Hash) -> PaymentData {
+        payment_data_of(payment_hash, INVOICE_AMOUNT)
+    }
+
+    fn payment_data_of(payment_hash: sha256::Hash, amount: Amount) -> PaymentData {
         PaymentData::PrunedInvoice(PrunedInvoice {
-            amount: INVOICE_AMOUNT,
+            amount,
             destination: secp256k1::PublicKey::from_keypair(&gateway_keypair()),
             destination_features: vec![],
             payment_hash,
@@ -1061,6 +1073,27 @@ mod tests {
         .map(|_| ())
     }
 
+    /// Validates a contract funded with `funded` against an invoice for
+    /// `invoice_amount` at `routing_fees`.
+    fn validate_funding(
+        invoice_amount: Amount,
+        funded: Amount,
+        routing_fees: RoutingFees,
+    ) -> Result<(), OutgoingContractError> {
+        let hash = sha256::Hash::hash(b"preimage");
+        let mut account = contract_account(hash);
+        account.amount = funded;
+
+        GatewayPayInvoice::validate_outgoing_account(
+            &account,
+            gateway_keypair(),
+            CONSENSUS_BLOCK_COUNT,
+            &payment_data_of(hash, invoice_amount),
+            routing_fees,
+        )
+        .map(|_| ())
+    }
+
     /// Guards against the fixture being invalid for some unrelated reason,
     /// which would make the rejection test below pass vacuously.
     #[test]
@@ -1068,6 +1101,47 @@ mod tests {
         let hash = sha256::Hash::hash(b"preimage");
 
         assert_eq!(validate(hash, hash), Ok(()));
+    }
+
+    /// At the gateway default of 3_000 ppm the two fee calculations disagree,
+    /// and a client funding either amount must be paid. Requiring only the
+    /// corrected fee accepts a client that has moved off `to_amount_legacy`
+    /// without rejecting the deployed ones that still overfund.
+    #[test]
+    fn accepts_both_the_corrected_and_the_legacy_fee() {
+        let invoice_amount = Amount::from_msats(1_000_000);
+        let fees = RoutingFees {
+            base_msat: 0,
+            proportional_millionths: 3_000,
+        };
+
+        let corrected = fees.to_amount(&invoice_amount);
+        let legacy = fees.to_amount_legacy(&invoice_amount);
+        assert!(corrected < legacy, "the fixture must exercise the gap");
+
+        for fee in [corrected, legacy] {
+            assert_eq!(
+                validate_funding(invoice_amount, invoice_amount + fee, fees),
+                Ok(())
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_a_contract_below_the_corrected_fee() {
+        let invoice_amount = Amount::from_msats(1_000_000);
+        let fees = RoutingFees {
+            base_msat: 0,
+            proportional_millionths: 3_000,
+        };
+
+        let necessary = invoice_amount + fees.to_amount(&invoice_amount);
+        let funded = necessary - Amount::from_msats(1);
+
+        assert_eq!(
+            validate_funding(invoice_amount, funded, fees),
+            Err(OutgoingContractError::Underfunded(necessary, funded))
+        );
     }
 
     #[test]

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -863,7 +863,7 @@ impl LightningClientModule {
                 .context("MissingInvoiceAmount")?,
         );
 
-        let gateway_fee = gateway.fees.to_amount(&invoice_amount);
+        let gateway_fee = gateway.fees.to_amount_legacy(&invoice_amount);
         // A gateway announcement carries an unvalidated fee rate, and clients
         // union the announcements they receive from each guardian, so one
         // guardian that has not upgraded still serves a rate large enough to
@@ -1205,7 +1205,7 @@ impl LightningClientModule {
                 // large to represent simply ranks last.
                 let total_fee = amount_msat.map_or_else(
                     || msats(u64::from(ann.info.fees.base_msat)),
-                    |amt| ann.info.fees.to_amount(&msats(amt)),
+                    |amt| ann.info.fees.to_amount_legacy(&msats(amt)),
                 );
                 (status.clone(), total_fee)
             })
@@ -1941,7 +1941,7 @@ impl LightningClientModule {
             // Saturating: an unfundable fee has to read as unaffordable to the
             // binary search, not panic it.
             |invoice_amount: Amount| {
-                invoice_amount.saturating_add(gateway.fees.to_amount(&invoice_amount))
+                invoice_amount.saturating_add(gateway.fees.to_amount_legacy(&invoice_amount))
             },
             |contract_amount: Amount| self.send_fee_quote(contract_amount),
         )

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -65,7 +65,7 @@ use fedimint_core::task::{MaybeSend, MaybeSync, timeout};
 use fedimint_core::util::update_merge::UpdateMerge;
 use fedimint_core::util::{BoxStream, FmtCompactAnyhow as _, backoff_util, retry};
 use fedimint_core::{
-    Amount, OutPoint, apply, async_trait_maybe_send, push_db_pair_items, runtime, secp256k1,
+    Amount, OutPoint, apply, async_trait_maybe_send, msats, push_db_pair_items, runtime, secp256k1,
 };
 use fedimint_derive_secret::{ChildId, DerivableSecret};
 use fedimint_ln_common::client::GatewayApi;
@@ -864,7 +864,14 @@ impl LightningClientModule {
         );
 
         let gateway_fee = gateway.fees.to_amount(&invoice_amount);
-        let contract_amount = invoice_amount + gateway_fee;
+        // A gateway announcement carries an unvalidated fee rate, and clients
+        // union the announcements they receive from each guardian, so one
+        // guardian that has not upgraded still serves a rate large enough to
+        // overflow the contract amount. Refuse the payment instead of panicking
+        // the state machine that funds it.
+        let contract_amount = invoice_amount
+            .checked_add(gateway_fee)
+            .context("Gateway fee is too large to fund an outgoing contract for this invoice")?;
 
         let user_sk = Keypair::new(&self.secp, &mut rng);
 
@@ -1194,14 +1201,13 @@ impl LightningClientModule {
         let sorted_gateways = sorted_gateways
             .into_iter()
             .sorted_by_key(|(ann, status)| {
-                let total_fee_msat: u64 =
-                    amount_msat.map_or(u64::from(ann.info.fees.base_msat), |amt| {
-                        u64::from(ann.info.fees.base_msat)
-                            + ((u128::from(amt)
-                                * u128::from(ann.info.fees.proportional_millionths))
-                                / 1_000_000) as u64
-                    });
-                (status.clone(), total_fee_msat)
+                // `to_amount` saturates, so a gateway announcing a fee too
+                // large to represent simply ranks last.
+                let total_fee = amount_msat.map_or_else(
+                    || msats(u64::from(ann.info.fees.base_msat)),
+                    |amt| ann.info.fees.to_amount(&msats(amt)),
+                );
+                (status.clone(), total_fee)
             })
             .collect::<Vec<_>>();
 
@@ -1932,7 +1938,11 @@ impl LightningClientModule {
             balance,
             Amount::from_msats(1),
             balance,
-            |invoice_amount: Amount| invoice_amount + gateway.fees.to_amount(&invoice_amount),
+            // Saturating: an unfundable fee has to read as unaffordable to the
+            // binary search, not panic it.
+            |invoice_amount: Amount| {
+                invoice_amount.saturating_add(gateway.fees.to_amount(&invoice_amount))
+            },
             |contract_amount: Amount| self.send_fee_quote(contract_amount),
         )
         .await

--- a/modules/fedimint-ln-common/src/config.rs
+++ b/modules/fedimint-ln-common/src/config.rs
@@ -89,40 +89,49 @@ impl Default for FeeConsensus {
 /// Trait for converting a fee type to specific `Amount`,
 /// relative to a given payment `Amount`
 pub trait FeeToAmount {
-    /// Calculates fee `Amount` given a payment `Amount`
+    /// The fee the rate names: `base_msat + floor(payment * ppm / 1_000_000)`.
+    ///
+    /// Never larger than [`FeeToAmount::to_amount_legacy`], which is why a
+    /// gateway validates outgoing contracts against this one: it accepts both
+    /// what deployed clients fund today and what they will fund once they move
+    /// off the legacy calculation.
     fn to_amount(&self, payment: &Amount) -> Amount;
+
+    /// The fee deployed LNv1 clients fund an outgoing contract with:
+    /// `base_msat + floor(payment / floor(1_000_000 / ppm))`.
+    ///
+    /// Truncating the divisor before dividing over-charges every rate that does
+    /// not divide `1_000_000` exactly — the default 3_000 ppm bills 0.3003% —
+    /// and bills a flat 100% above 500_000 ppm. Wrong, but a client that funds
+    /// less than this is rejected as `Underfunded` by every gateway still
+    /// validating with it, so clients keep funding it until the fleet has
+    /// rolled over. New callers want [`FeeToAmount::to_amount`].
+    fn to_amount_legacy(&self, payment: &Amount) -> Amount;
 }
 
 impl FeeToAmount for RoutingFees {
-    /// Prices `payment` at this fee schedule.
-    ///
-    /// The result is
-    /// `base_msat + floor(payment / floor(1_000_000 /
-    /// proportional_millionths))`, with a margin of zero when the rate is
-    /// zero. Note the inner `floor`: the divisor is truncated before it is
-    /// used, so every rate that does not divide `1_000_000` exactly charges
-    /// slightly more than the rate it names, and any rate above `500_000`
-    /// charges a flat one hundred percent. That is not the arithmetic the
-    /// rate implies, but it is the arithmetic every already-deployed LNv1
-    /// gateway validates outgoing contracts with, and a client that funds
-    /// less than its gateway expects has its payment rejected as
-    /// `Underfunded`. Correcting it therefore cannot be done here alone;
-    /// see the callers in `fedimint-ln-client` and `fedimint-gw-client`.
-    ///
-    /// A rate above `1_000_000` prices the payment above its own value, which
-    /// this form cannot express — the truncated divisor is zero. Such a fee
-    /// saturates the margin to `u64::MAX` so that callers reject it, and the
-    /// final addition saturates rather than overflowing. The value arrives in
-    /// a gateway registration served by a public API endpoint, and clients
-    /// union the announcements they get from each guardian, so no bound on it
-    /// can be assumed here even though `register_gateway` now rejects one:
-    /// an absurd fee has to surface as an absurd `Amount` the caller rejects,
-    /// never as a panic taking down the whole client.
     fn to_amount(&self, payment: &Amount) -> Amount {
+        // Widened to `u128`: the rate arrives unvalidated in a gateway
+        // registration, and clients union the announcements they get from each
+        // guardian, so it is not bounded by what `register_gateway` accepts.
+        // An absurd fee has to surface as an absurd `Amount` the caller
+        // rejects, never as an overflow.
+        let margin_fee =
+            u128::from(payment.msats) * u128::from(self.proportional_millionths) / 1_000_000;
+
+        msats(
+            u64::try_from(margin_fee)
+                .unwrap_or(u64::MAX)
+                .saturating_add(u64::from(self.base_msat)),
+        )
+    }
+
+    fn to_amount_legacy(&self, payment: &Amount) -> Amount {
         let margin_fee = match 1_000_000_u64.checked_div(u64::from(self.proportional_millionths)) {
             // A zero rate has no margin at all.
             None => 0,
-            // A rate above one million: unrepresentable, so price it out of range.
+            // Above one million ppm the divisor truncates to zero, which used to
+            // panic. There is no representable divisor, so price it out of range.
             Some(0) => u64::MAX,
             Some(divisor) => payment.msats / divisor,
         };

--- a/modules/fedimint-ln-common/src/config.rs
+++ b/modules/fedimint-ln-common/src/config.rs
@@ -94,103 +94,42 @@ pub trait FeeToAmount {
 }
 
 impl FeeToAmount for RoutingFees {
+    /// Prices `payment` at this fee schedule.
+    ///
+    /// The result is
+    /// `base_msat + floor(payment / floor(1_000_000 /
+    /// proportional_millionths))`, with a margin of zero when the rate is
+    /// zero. Note the inner `floor`: the divisor is truncated before it is
+    /// used, so every rate that does not divide `1_000_000` exactly charges
+    /// slightly more than the rate it names, and any rate above `500_000`
+    /// charges a flat one hundred percent. That is not the arithmetic the
+    /// rate implies, but it is the arithmetic every already-deployed LNv1
+    /// gateway validates outgoing contracts with, and a client that funds
+    /// less than its gateway expects has its payment rejected as
+    /// `Underfunded`. Correcting it therefore cannot be done here alone;
+    /// see the callers in `fedimint-ln-client` and `fedimint-gw-client`.
+    ///
+    /// A rate above `1_000_000` prices the payment above its own value, which
+    /// this form cannot express — the truncated divisor is zero. Such a fee
+    /// saturates the margin to `u64::MAX` so that callers reject it, and the
+    /// final addition saturates rather than overflowing. The value arrives in
+    /// a gateway registration served by a public API endpoint, and clients
+    /// union the announcements they get from each guardian, so no bound on it
+    /// can be assumed here even though `register_gateway` now rejects one:
+    /// an absurd fee has to surface as an absurd `Amount` the caller rejects,
+    /// never as a panic taking down the whole client.
     fn to_amount(&self, payment: &Amount) -> Amount {
-        // `proportional_millionths` arrives in a gateway registration served by a
-        // public API endpoint, and clients union the announcements they get from
-        // each guardian, so no bound on it can be assumed here even once
-        // guardians validate it. Compute the margin in `u128` and saturate on the
-        // way back down: an absurd fee has to surface as an absurd `Amount` the
-        // caller rejects, never as a panic taking down the whole client.
-        //
-        // Multiplying before dividing is also what makes this agree with the
-        // other places that price the same fee — `PaymentFee::absolute_fee`, the
-        // gateway ranking in `fedimint-ln-client`, and `fedimint-recurringd`.
-        // Dividing `1_000_000` by the rate first, as this used to, truncates the
-        // divisor and overcharges: 3_000 millionths billed 0.3003% rather than
-        // 0.3%, and any rate above 500_000 billed a flat 100%.
-        let margin_fee =
-            u128::from(payment.msats) * u128::from(self.proportional_millionths) / 1_000_000;
+        let margin_fee = match 1_000_000_u64.checked_div(u64::from(self.proportional_millionths)) {
+            // A zero rate has no margin at all.
+            None => 0,
+            // A rate above one million: unrepresentable, so price it out of range.
+            Some(0) => u64::MAX,
+            Some(divisor) => payment.msats / divisor,
+        };
 
-        msats(
-            u64::try_from(margin_fee)
-                .unwrap_or(u64::MAX)
-                .saturating_add(u64::from(self.base_msat)),
-        )
+        msats(margin_fee.saturating_add(u64::from(self.base_msat)))
     }
 }
 
 #[cfg(test)]
-mod tests {
-    use fedimint_core::{Amount, msats};
-    use lightning_invoice::RoutingFees;
-
-    use super::FeeToAmount;
-
-    fn fees(base_msat: u32, proportional_millionths: u32) -> RoutingFees {
-        RoutingFees {
-            base_msat,
-            proportional_millionths,
-        }
-    }
-
-    /// A rate above one million used to make `1_000_000 / rate` truncate to
-    /// zero, and the division by it panicked. The value reaches this code
-    /// straight off the wire, so it has to price instead of panic.
-    #[test]
-    fn rate_above_one_million_does_not_panic() {
-        assert_eq!(
-            fees(0, 1_000_001).to_amount(&msats(1_000_000)),
-            msats(1_000_001)
-        );
-
-        // The whole range that used to panic, including its top end.
-        assert_eq!(
-            fees(0, u32::MAX).to_amount(&msats(1_000_000)),
-            msats(u64::from(u32::MAX))
-        );
-    }
-
-    #[test]
-    fn fee_is_the_stated_fraction_of_the_payment() {
-        // 100 millionths of 1_000_000 msat is 0.01%.
-        assert_eq!(fees(0, 100).to_amount(&msats(1_000_000)), msats(100));
-
-        // 3_000 millionths is 0.3% exactly. The old divisor form billed 3_003
-        // here, because `1_000_000 / 3_000` truncated 333.33 to 333.
-        assert_eq!(fees(0, 3_000).to_amount(&msats(1_000_000)), msats(3_000));
-
-        // A rate this side of one million is not a flat 100% either: the old
-        // form truncated the divisor to 1 for everything above 500_000.
-        assert_eq!(
-            fees(0, 600_000).to_amount(&msats(1_000_000)),
-            msats(600_000)
-        );
-
-        assert_eq!(
-            fees(0, 1_000_000).to_amount(&msats(1_000_000)),
-            msats(1_000_000)
-        );
-    }
-
-    #[test]
-    fn base_fee_is_added_to_the_margin() {
-        assert_eq!(fees(500, 0).to_amount(&msats(1_000_000)), msats(500));
-        assert_eq!(fees(500, 100).to_amount(&msats(1_000_000)), msats(600));
-        assert_eq!(fees(500, 0).to_amount(&Amount::ZERO), msats(500));
-    }
-
-    /// Neither the margin nor the base fee added to it may overflow `u64`.
-    #[test]
-    fn absurd_fees_saturate_rather_than_overflow() {
-        assert_eq!(
-            fees(u32::MAX, u32::MAX).to_amount(&msats(u64::MAX)),
-            msats(u64::MAX)
-        );
-
-        // The margin alone fits, but adding the base fee to it does not.
-        assert_eq!(
-            fees(u32::MAX, 1_000_000).to_amount(&msats(u64::MAX)),
-            msats(u64::MAX)
-        );
-    }
-}
+mod tests;

--- a/modules/fedimint-ln-common/src/config.rs
+++ b/modules/fedimint-ln-common/src/config.rs
@@ -95,14 +95,102 @@ pub trait FeeToAmount {
 
 impl FeeToAmount for RoutingFees {
     fn to_amount(&self, payment: &Amount) -> Amount {
-        let base_fee = u64::from(self.base_msat);
-        let margin_fee: u64 = if self.proportional_millionths > 0 {
-            let fee_percent = 1_000_000 / u64::from(self.proportional_millionths);
-            payment.msats / fee_percent
-        } else {
-            0
-        };
+        // `proportional_millionths` arrives in a gateway registration served by a
+        // public API endpoint, and clients union the announcements they get from
+        // each guardian, so no bound on it can be assumed here even once
+        // guardians validate it. Compute the margin in `u128` and saturate on the
+        // way back down: an absurd fee has to surface as an absurd `Amount` the
+        // caller rejects, never as a panic taking down the whole client.
+        //
+        // Multiplying before dividing is also what makes this agree with the
+        // other places that price the same fee — `PaymentFee::absolute_fee`, the
+        // gateway ranking in `fedimint-ln-client`, and `fedimint-recurringd`.
+        // Dividing `1_000_000` by the rate first, as this used to, truncates the
+        // divisor and overcharges: 3_000 millionths billed 0.3003% rather than
+        // 0.3%, and any rate above 500_000 billed a flat 100%.
+        let margin_fee =
+            u128::from(payment.msats) * u128::from(self.proportional_millionths) / 1_000_000;
 
-        msats(base_fee + margin_fee)
+        msats(
+            u64::try_from(margin_fee)
+                .unwrap_or(u64::MAX)
+                .saturating_add(u64::from(self.base_msat)),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use fedimint_core::{Amount, msats};
+    use lightning_invoice::RoutingFees;
+
+    use super::FeeToAmount;
+
+    fn fees(base_msat: u32, proportional_millionths: u32) -> RoutingFees {
+        RoutingFees {
+            base_msat,
+            proportional_millionths,
+        }
+    }
+
+    /// A rate above one million used to make `1_000_000 / rate` truncate to
+    /// zero, and the division by it panicked. The value reaches this code
+    /// straight off the wire, so it has to price instead of panic.
+    #[test]
+    fn rate_above_one_million_does_not_panic() {
+        assert_eq!(
+            fees(0, 1_000_001).to_amount(&msats(1_000_000)),
+            msats(1_000_001)
+        );
+
+        // The whole range that used to panic, including its top end.
+        assert_eq!(
+            fees(0, u32::MAX).to_amount(&msats(1_000_000)),
+            msats(u64::from(u32::MAX))
+        );
+    }
+
+    #[test]
+    fn fee_is_the_stated_fraction_of_the_payment() {
+        // 100 millionths of 1_000_000 msat is 0.01%.
+        assert_eq!(fees(0, 100).to_amount(&msats(1_000_000)), msats(100));
+
+        // 3_000 millionths is 0.3% exactly. The old divisor form billed 3_003
+        // here, because `1_000_000 / 3_000` truncated 333.33 to 333.
+        assert_eq!(fees(0, 3_000).to_amount(&msats(1_000_000)), msats(3_000));
+
+        // A rate this side of one million is not a flat 100% either: the old
+        // form truncated the divisor to 1 for everything above 500_000.
+        assert_eq!(
+            fees(0, 600_000).to_amount(&msats(1_000_000)),
+            msats(600_000)
+        );
+
+        assert_eq!(
+            fees(0, 1_000_000).to_amount(&msats(1_000_000)),
+            msats(1_000_000)
+        );
+    }
+
+    #[test]
+    fn base_fee_is_added_to_the_margin() {
+        assert_eq!(fees(500, 0).to_amount(&msats(1_000_000)), msats(500));
+        assert_eq!(fees(500, 100).to_amount(&msats(1_000_000)), msats(600));
+        assert_eq!(fees(500, 0).to_amount(&Amount::ZERO), msats(500));
+    }
+
+    /// Neither the margin nor the base fee added to it may overflow `u64`.
+    #[test]
+    fn absurd_fees_saturate_rather_than_overflow() {
+        assert_eq!(
+            fees(u32::MAX, u32::MAX).to_amount(&msats(u64::MAX)),
+            msats(u64::MAX)
+        );
+
+        // The margin alone fits, but adding the base fee to it does not.
+        assert_eq!(
+            fees(u32::MAX, 1_000_000).to_amount(&msats(u64::MAX)),
+            msats(u64::MAX)
+        );
     }
 }

--- a/modules/fedimint-ln-common/src/config/tests.rs
+++ b/modules/fedimint-ln-common/src/config/tests.rs
@@ -10,45 +10,103 @@ fn fees(base_msat: u32, proportional_millionths: u32) -> RoutingFees {
     }
 }
 
-/// A rate above one million used to make `1_000_000 / rate` truncate to zero,
-/// and the division by it panicked. The value reaches this code straight off
-/// the wire, so it has to price instead of panic — and it prices out of range,
-/// because a fee larger than the payment is one no caller should fund.
 #[test]
-fn rate_above_one_million_prices_out_of_range_rather_than_panicking() {
+fn fee_is_the_stated_fraction_of_the_payment() {
+    assert_eq!(fees(0, 100).to_amount(&msats(1_000_000)), msats(100));
+    assert_eq!(fees(0, 3_000).to_amount(&msats(1_000_000)), msats(3_000));
     assert_eq!(
-        fees(0, 1_000_001).to_amount(&msats(1_000_000)),
-        msats(u64::MAX)
-    );
-
-    // The whole range that used to panic, including its top end.
-    assert_eq!(
-        fees(0, u32::MAX).to_amount(&msats(1_000_000)),
-        msats(u64::MAX)
+        fees(0, 600_000).to_amount(&msats(1_000_000)),
+        msats(600_000)
     );
 }
 
-/// The rate is applied through a truncated divisor, which is what every
-/// deployed LNv1 gateway validates against. Changing these numbers changes
-/// what a client must fund, so it cannot be done without a rollout plan.
+/// The legacy form truncates the divisor before dividing, so it charges more
+/// than the rate names. These numbers are what deployed clients fund, so
+/// changing them breaks those clients against every gateway.
 #[test]
-fn margin_uses_the_truncated_divisor() {
-    // 100 divides 1_000_000 exactly: 0.01% of 1_000_000 msat, as named.
-    assert_eq!(fees(0, 100).to_amount(&msats(1_000_000)), msats(100));
+fn legacy_fee_uses_the_truncated_divisor() {
+    // 100 divides 1_000_000 exactly, so the two forms agree.
+    assert_eq!(fees(0, 100).to_amount_legacy(&msats(1_000_000)), msats(100));
 
-    // 3_000 does not: `1_000_000 / 3_000` truncates 333.33 to 333, so the
-    // stated 0.3% is billed as 0.3003%. This is the gateway default fee.
-    assert_eq!(fees(0, 3_000).to_amount(&msats(1_000_000)), msats(3_003));
+    // 3_000 does not: `1_000_000 / 3_000` truncates 333.33 to 333, billing the
+    // stated 0.3% as 0.3003%. This is the gateway default fee.
+    assert_eq!(
+        fees(0, 3_000).to_amount_legacy(&msats(1_000_000)),
+        msats(3_003)
+    );
 
     // Above 500_000 the divisor truncates to 1, a flat one hundred percent.
     assert_eq!(
-        fees(0, 600_000).to_amount(&msats(1_000_000)),
+        fees(0, 600_000).to_amount_legacy(&msats(1_000_000)),
         msats(1_000_000)
     );
+}
 
+/// The whole rollout rests on this: a gateway validating with `to_amount`
+/// accepts a contract funded with either form, so clients can move off
+/// `to_amount_legacy` one at a time.
+#[test]
+fn corrected_fee_never_exceeds_the_legacy_fee() {
+    let rates = [
+        0,
+        1,
+        100,
+        999,
+        3_000,
+        10_000,
+        15_000,
+        499_999,
+        500_001,
+        999_999,
+        1_000_000,
+        1_000_001,
+        u32::MAX,
+    ];
+    let payments = [
+        0,
+        1,
+        333,
+        1_000,
+        333_000,
+        1_000_000,
+        21_000_000_000,
+        u64::MAX,
+    ];
+
+    for rate in rates {
+        for payment in payments {
+            let fees = fees(7, rate);
+            let payment = msats(payment);
+
+            assert!(
+                fees.to_amount(&payment) <= fees.to_amount_legacy(&payment),
+                "rate {rate} at {payment}: corrected {} exceeds legacy {}",
+                fees.to_amount(&payment),
+                fees.to_amount_legacy(&payment),
+            );
+        }
+    }
+}
+
+/// A rate above one million used to make `1_000_000 / rate` truncate to zero,
+/// and the division by it panicked. The value reaches this code straight off
+/// the wire, so it has to price instead of panic.
+#[test]
+fn rate_above_one_million_does_not_panic() {
     assert_eq!(
-        fees(0, 1_000_000).to_amount(&msats(1_000_000)),
-        msats(1_000_000)
+        fees(0, 1_000_001).to_amount(&msats(1_000_000)),
+        msats(1_000_001)
+    );
+    assert_eq!(
+        fees(0, u32::MAX).to_amount(&msats(1_000_000)),
+        msats(u64::from(u32::MAX))
+    );
+
+    // The legacy form has no representable divisor here, so it prices out of
+    // range rather than guessing at an amount deployed clients never funded.
+    assert_eq!(
+        fees(0, 1_000_001).to_amount_legacy(&msats(1_000_000)),
+        msats(u64::MAX)
     );
 }
 
@@ -57,6 +115,12 @@ fn base_fee_is_added_to_the_margin() {
     assert_eq!(fees(500, 0).to_amount(&msats(1_000_000)), msats(500));
     assert_eq!(fees(500, 100).to_amount(&msats(1_000_000)), msats(600));
     assert_eq!(fees(500, 0).to_amount(&Amount::ZERO), msats(500));
+
+    assert_eq!(fees(500, 0).to_amount_legacy(&msats(1_000_000)), msats(500));
+    assert_eq!(
+        fees(500, 100).to_amount_legacy(&msats(1_000_000)),
+        msats(600)
+    );
 }
 
 /// Neither the margin nor the base fee added to it may overflow `u64`.
@@ -66,10 +130,18 @@ fn absurd_fees_saturate_rather_than_overflow() {
         fees(u32::MAX, u32::MAX).to_amount(&msats(u64::MAX)),
         msats(u64::MAX)
     );
+    assert_eq!(
+        fees(u32::MAX, u32::MAX).to_amount_legacy(&msats(u64::MAX)),
+        msats(u64::MAX)
+    );
 
     // The margin alone fits, but adding the base fee to it does not.
     assert_eq!(
         fees(u32::MAX, 1_000_000).to_amount(&msats(u64::MAX)),
+        msats(u64::MAX)
+    );
+    assert_eq!(
+        fees(u32::MAX, 1_000_000).to_amount_legacy(&msats(u64::MAX)),
         msats(u64::MAX)
     );
 }

--- a/modules/fedimint-ln-common/src/config/tests.rs
+++ b/modules/fedimint-ln-common/src/config/tests.rs
@@ -1,0 +1,75 @@
+use fedimint_core::{Amount, msats};
+use lightning_invoice::RoutingFees;
+
+use super::FeeToAmount;
+
+fn fees(base_msat: u32, proportional_millionths: u32) -> RoutingFees {
+    RoutingFees {
+        base_msat,
+        proportional_millionths,
+    }
+}
+
+/// A rate above one million used to make `1_000_000 / rate` truncate to zero,
+/// and the division by it panicked. The value reaches this code straight off
+/// the wire, so it has to price instead of panic — and it prices out of range,
+/// because a fee larger than the payment is one no caller should fund.
+#[test]
+fn rate_above_one_million_prices_out_of_range_rather_than_panicking() {
+    assert_eq!(
+        fees(0, 1_000_001).to_amount(&msats(1_000_000)),
+        msats(u64::MAX)
+    );
+
+    // The whole range that used to panic, including its top end.
+    assert_eq!(
+        fees(0, u32::MAX).to_amount(&msats(1_000_000)),
+        msats(u64::MAX)
+    );
+}
+
+/// The rate is applied through a truncated divisor, which is what every
+/// deployed LNv1 gateway validates against. Changing these numbers changes
+/// what a client must fund, so it cannot be done without a rollout plan.
+#[test]
+fn margin_uses_the_truncated_divisor() {
+    // 100 divides 1_000_000 exactly: 0.01% of 1_000_000 msat, as named.
+    assert_eq!(fees(0, 100).to_amount(&msats(1_000_000)), msats(100));
+
+    // 3_000 does not: `1_000_000 / 3_000` truncates 333.33 to 333, so the
+    // stated 0.3% is billed as 0.3003%. This is the gateway default fee.
+    assert_eq!(fees(0, 3_000).to_amount(&msats(1_000_000)), msats(3_003));
+
+    // Above 500_000 the divisor truncates to 1, a flat one hundred percent.
+    assert_eq!(
+        fees(0, 600_000).to_amount(&msats(1_000_000)),
+        msats(1_000_000)
+    );
+
+    assert_eq!(
+        fees(0, 1_000_000).to_amount(&msats(1_000_000)),
+        msats(1_000_000)
+    );
+}
+
+#[test]
+fn base_fee_is_added_to_the_margin() {
+    assert_eq!(fees(500, 0).to_amount(&msats(1_000_000)), msats(500));
+    assert_eq!(fees(500, 100).to_amount(&msats(1_000_000)), msats(600));
+    assert_eq!(fees(500, 0).to_amount(&Amount::ZERO), msats(500));
+}
+
+/// Neither the margin nor the base fee added to it may overflow `u64`.
+#[test]
+fn absurd_fees_saturate_rather_than_overflow() {
+    assert_eq!(
+        fees(u32::MAX, u32::MAX).to_amount(&msats(u64::MAX)),
+        msats(u64::MAX)
+    );
+
+    // The margin alone fits, but adding the base fee to it does not.
+    assert_eq!(
+        fees(u32::MAX, 1_000_000).to_amount(&msats(u64::MAX)),
+        msats(u64::MAX)
+    );
+}

--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -1502,6 +1502,22 @@ impl Lightning {
 
         let gateway_id = gateway.info.gateway_id;
 
+        // The announced fee feeds the fee arithmetic of every client that selects
+        // this gateway, so refuse to serve a rate that prices a payment above its
+        // own value. This is a totality bound rather than fee policy — a correct
+        // gateway keeps its fees far below it, and the gateway's own send limits
+        // still apply on top — so it costs no honest registration anything.
+        //
+        // It is defense in depth only: clients union the announcements they
+        // receive from each guardian, so one guardian that has not yet upgraded
+        // still serves an over-limit registration to everyone. The arithmetic in
+        // `RoutingFees::to_amount` is what actually has to hold.
+        anyhow::ensure!(
+            gateway.info.fees.proportional_millionths <= 1_000_000,
+            "Gateway registration fee of {} proportional millionths exceeds the payment itself",
+            gateway.info.fees.proportional_millionths
+        );
+
         // Reject a forged proof outright rather than silently downgrading it to an
         // unsigned registration, which would hide a misconfigured gateway.
         if let Some(auth) = &gateway.auth {
@@ -3015,6 +3031,39 @@ mod tests {
         );
 
         assert!(server.list_gateways(&mut dbtx.to_ref_nc()).await.is_empty());
+    }
+
+    /// A rate above one million prices a payment above its own value, and used
+    /// to panic every client that computed a fee with it. Refuse to store one.
+    #[test_log::test(tokio::test)]
+    async fn registration_with_absurd_proportional_fee_is_rejected() {
+        let (server, db, _tg) = build_server();
+        let mut dbtx = db.begin_transaction().await;
+        let mut dbtx = dbtx.to_ref_with_prefix_module_id(42).0;
+
+        let gateway = Keypair::new(SECP256K1, &mut OsRng);
+        let gateway_id = gateway.public_key();
+
+        let mut absurd = announcement(gateway_id, "https://gw.example/v1");
+        absurd.info.fees.proportional_millionths = 1_000_001;
+
+        let err = server
+            .register_gateway(&mut dbtx.to_ref_nc(), absurd)
+            .await
+            .expect_err("a fee larger than the payment must be rejected");
+        assert!(err.to_string().contains("exceeds the payment itself"));
+        assert!(server.list_gateways(&mut dbtx.to_ref_nc()).await.is_empty());
+
+        // The bound itself is still a legal registration: it is a totality
+        // check, not a judgement about what a reasonable fee looks like.
+        let mut at_limit = announcement(gateway_id, "https://gw.example/v1");
+        at_limit.info.fees.proportional_millionths = 1_000_000;
+
+        server
+            .register_gateway(&mut dbtx.to_ref_nc(), at_limit)
+            .await
+            .expect("a fee equal to the payment is within the bound");
+        assert_eq!(server.list_gateways(&mut dbtx.to_ref_nc()).await.len(), 1);
     }
 
     /// A captured proof must not be replayable to roll a gateway back to


### PR DESCRIPTION
Fixes: https://github.com/fedimint/fedimint/issues/8975

We have a divide by 0 issue when a gateway registers a 1M ppm fee. This fixes that issue and also rejects gateway registrations with pathological fees. Right now we only reject 1M ppm, but we can tighten this in the future.