### PR TITLE
fix(gateway): confirm contract before starting LNv1 pay state machine

### DIFF
--- a/gateway/fedimint-gateway-server/tests/tests.rs
+++ b/gateway/fedimint-gateway-server/tests/tests.rs
@@ -1953,6 +1953,48 @@ async fn test_gateway_client_rejects_amountless_invoice() -> anyhow::Result<()> 
     .await
 }
 
+/// `pay_invoice` is unauthenticated and takes a caller-supplied contract id.
+/// The gateway checks with the federation that the contract exists before
+/// persisting anything, so a fabricated id is rejected instead of parking a
+/// state machine that can never resolve.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_gateway_client_rejects_unknown_outgoing_contract() -> anyhow::Result<()> {
+    single_federation_test(
+        |gateway, other_lightning_client, fed, user_client, _| async move {
+            let gateway_client = gateway.select_client(fed.id()).await?.into_value();
+
+            let invoice = other_lightning_client.invoice(sats(1), None)?;
+            let error = gateway_client
+                .get_first_module::<GatewayClientModule>()?
+                .gateway_pay_bolt11_invoice(PayInvoicePayload {
+                    federation_id: user_client.federation_id(),
+                    contract_id: sha256(&[42; 32]).into(),
+                    payment_data: PaymentData::Invoice(invoice),
+                    preimage_auth: Hash::hash(&[42; 32]),
+                })
+                .await
+                .expect_err("a contract the federation has never seen is rejected");
+
+            assert!(
+                error.to_string().contains("has not yet been confirmed"),
+                "unexpected error: {error}"
+            );
+
+            assert!(
+                gateway_client
+                    .operation_log()
+                    .paginate_operations_rev(10, None)
+                    .await
+                    .is_empty(),
+                "a rejected contract must not persist an operation"
+            );
+
+            Ok(())
+        },
+    )
+    .await
+}
+
 /// `pay_invoice` is unauthenticated and keys its operation on the contract id,
 /// but the state machine's dedupe key covers the whole payload, so a second
 /// request that differs only in `preimage_auth` slips past it. That used to

--- a/modules/fedimint-gw-client/src/lib.rs
+++ b/modules/fedimint-gw-client/src/lib.rs
@@ -863,6 +863,22 @@ impl GatewayClientModule {
             .verify_pruned_invoice(pay_invoice_payload.payment_data)
             .await?;
 
+        // We need to check that the contract has been confirmed by the
+        // federation before we start the state machine to prevent DOS
+        // attacks. LNv1 clients retry rejected payments, so failing fast on
+        // a contract the federation cannot see yet is safe for legitimate
+        // requests that race federation confirmation.
+        self.module_api
+            .fetch_contract(pay_invoice_payload.contract_id)
+            .await
+            .map_err(|e| anyhow::anyhow!("The gateway can not reach the federation: {e}"))?
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "The outgoing contract {} has not yet been confirmed",
+                    pay_invoice_payload.contract_id
+                )
+            })?;
+
         self.client_ctx.module_db()
             .autocommit(
                 |dbtx, _| {


### PR DESCRIPTION
## Summary

- confirm the outgoing contract is visible to the federation before starting the LNv1 payment state machine
- reject fabricated or not-yet-confirmed contract IDs before writing an operation log entry
- cover the rejection path while preserving the existing valid, idempotent, and amountless-invoice behavior

## Rationale

`pay_invoice` is unauthenticated and accepts a caller-supplied contract ID. Previously, an unknown ID could start and persist a payment state machine that could never resolve. LNv2 already checks federation confirmation before starting its state machine; this applies the same guard to LNv1.

Failing fast remains safe for legitimate requests that race contract confirmation because LNv1 clients retry gateway-internal errors every 10 seconds for up to 3 minutes.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p fedimint-gw-client -p fedimint-gateway-server`
- `cargo test -p fedimint-gateway-server --test gatewayd-tests test_gateway_client_rejects_unknown_outgoing_contract`
- `cargo test -p fedimint-gateway-server --test gatewayd-tests test_gateway_client_pay_valid_invoice`
- `cargo test -p fedimint-gateway-server --test gatewayd-tests test_gateway_client_pay_invoice_is_idempotent_per_contract`
- `cargo test -p fedimint-gateway-server --test gatewayd-tests test_gateway_client_rejects_amountless_invoice`
