### PR TITLE
docs(lnv2): name SnapshotTooOld in the lnurl receive rationale

### DIFF
--- a/modules/fedimint-lnv2-client/src/lib.rs
+++ b/modules/fedimint-lnv2-client/src/lib.rs
@@ -1289,11 +1289,13 @@ impl LightningClientModule {
         // Read the stream cursor with a short-lived transaction. It must NOT stay open
         // across the long-poll below: RocksDB's optimistic transactions validate a
         // commit against bounded memtable history, so a transaction held open
-        // for minutes fails with a spurious `WriteConflict` once enough
-        // concurrent writes flush that history — and the panicking
+        // for minutes fails with `DatabaseError::SnapshotTooOld` once enough
+        // concurrent writes flush that history — not because anything conflicted,
+        // but because the backend can no longer tell — and the panicking
         // `commit_tx()` then killed this task permanently, silently
         // stalling every future receive for the lifetime of the process. Long-lived
         // clients (daemons) hit this reproducibly under concurrent lnv2 activity.
+        // See <https://github.com/fedimint/fedimint/issues/8872>.
         let stream_index = self
             .client_ctx
             .module_db()
@@ -1329,11 +1331,11 @@ impl LightningClientModule {
         // Advance the cursor in its own short transaction. This is the only writer of
         // this key and it runs in a single sequential loop, so there is no concurrent
         // writer to guard against; and because this transaction is short-lived — opened
-        // after the long-poll and committed immediately — it cannot hit the spurious
-        // `WriteConflict` that a transaction held open across the long-poll would, so a
-        // plain `commit_tx()` is safe. Ordering is unchanged: the cursor only moves
-        // after the batch above was processed, and a crash in between re-fetches the
-        // same batch on the next iteration.
+        // after the long-poll and committed immediately — it cannot hit the
+        // `SnapshotTooOld` failure that a transaction held open across the long-poll
+        // would, so a plain `commit_tx()` is safe. Ordering is unchanged: the cursor
+        // only moves after the batch above was processed, and a crash in between
+        // re-fetches the same batch on the next iteration.
         let mut dbtx = self.client_ctx.module_db().begin_transaction().await;
 
         dbtx.insert_entry(&IncomingContractStreamIndexKey, &next_index)


### PR DESCRIPTION
## Summary

#8874 split two RocksDB commit failures that had been collapsed into one error:
`Busy` — another transaction wrote a key this one also wrote — stays
`DatabaseError::WriteConflict`, while `TryAgain` — the snapshot is older than the
write history RocksDB still retains, so it cannot tell whether anything
conflicted — became the new `DatabaseError::SnapshotTooOld`.

The comments in `receive_lnurl` explaining why its transactions are deliberately
short describe that second failure, and were written when it still surfaced as a
`WriteConflict`. They now name an error that no longer describes the failure they
guard against, which is misleading in the one place a reader goes to find out why
the code is shaped this way.

## Changes

- Name `DatabaseError::SnapshotTooOld` in both comments, and say why it is not a
  conflict: the snapshot outran the retained write history, so the backend cannot
  tell whether anything raced — not that anything did.
- Link #8872, so the rationale points at the case rather than restating it.

No behaviour change; comments only. The design the comments describe — a
short-lived read before the long-poll and a separate short-lived write after it —
is unchanged, and is what keeps this path clear of both failures.

## Test Plan

- [x] `cargo check -p fedimint-lnv2-client`
- [x] `cargo fmt`
- [x] Claims verified against the current code: the `Busy`/`TryAgain` mapping in
      `fedimint-rocksdb/src/lib.rs`, `commit_tx()` still panicking via `.expect()`
      in `fedimint-core/src/db/mod.rs`, and the failure mode as pinned by
      `test_long_lived_transaction_fails_without_key_overlap`.

## Breaking Changes

None.
