### PR TITLE
feat(client): let modules stay usable while they recover

### DIFF
--- a/fedimint-client-module/src/module/init.rs
+++ b/fedimint-client-module/src/module/init.rs
@@ -5,6 +5,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
+use anyhow::bail;
 use fedimint_api_client::api::{DynGlobalApi, DynModuleApi};
 use fedimint_bitcoind::DynBitcoindRpc;
 use fedimint_connectors::ConnectorRegistry;
@@ -379,8 +380,24 @@ pub trait ClientModuleInit: ModuleInit + Sized {
         <Self::Module as ClientModule>::kind()
     }
 
+    /// Whether this module implements [`Self::recover`].
+    ///
+    /// A module that leaves this at `false` is left out of a recovering
+    /// client's recovery entirely: no recovery is started for it and it is
+    /// initialized as it would be on any other client open, rather than being
+    /// held back for a recovery that would do nothing.
+    ///
+    /// Must be overridden together with [`Self::recover`]: overriding only the
+    /// recovery leaves it unreachable, and overriding only this makes the
+    /// module's recovery fail.
+    fn supports_recovery(&self) -> bool {
+        false
+    }
+
     /// Recover the state of the client module, optionally from an existing
     /// snapshot.
+    ///
+    /// Only called for modules whose [`Self::supports_recovery`] is `true`.
     ///
     /// On success, returns the total amount recovered from this module, if the
     /// module tracks it (`None` for modules that can't determine the amount at
@@ -394,12 +411,10 @@ pub trait ClientModuleInit: ModuleInit + Sized {
         _args: &ClientModuleRecoverArgs<Self>,
         _snapshot: Option<&<Self::Module as ClientModule>::Backup>,
     ) -> anyhow::Result<Option<Amount>> {
-        warn!(
-            target: LOG_CLIENT,
-            kind = %<Self::Module as ClientModule>::kind(),
-            "Module does not support recovery, completing without doing anything"
-        );
-        Ok(None)
+        bail!(
+            "Module kind {} claims to support recovery without implementing it",
+            <Self::Module as ClientModule>::kind()
+        )
     }
 
     /// Initialize a [`ClientModule`] instance from its config

--- a/fedimint-client-module/src/module/init.rs
+++ b/fedimint-client-module/src/module/init.rs
@@ -204,6 +204,56 @@ where
     }
 }
 
+/// How a module's recovery relates to using the module.
+///
+/// A recovering client runs a recovery for every module that has one, and only
+/// the modules that can be used while that recovery runs join the module
+/// registry; the rest become available once the client is reopened with their
+/// recovery complete. This is a module's declaration of which of those it is,
+/// returned from [`ClientModuleInit::recovery_mode`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecoveryMode {
+    /// The module implements no recovery.
+    ///
+    /// It is left out of a recovering client's recovery entirely: no recovery
+    /// is started for it and it is initialized as it would be on any other
+    /// client open, rather than being held back for a recovery that would do
+    /// nothing.
+    None,
+    /// The module has a recovery and cannot be used while it runs.
+    ///
+    /// The recovery runs, but the module stays out of the module registry — and
+    /// is therefore unusable — until the client is reopened with the recovery
+    /// complete.
+    Unusable,
+    /// The module has a recovery and can be used while it runs.
+    ///
+    /// [`ClientModuleInit::prepare_recovery`] commits the boundary between the
+    /// recovery and live operation, after which the module is initialized and
+    /// usable straight away, with its recovery running in the background.
+    Usable,
+}
+
+/// Arguments to [`ClientModuleInit::prepare_recovery`], which runs before the
+/// module exists and so gets only what it takes to record where the recovery
+/// ends and live operation begins.
+pub struct ClientModuleRecoveryPrepareArgs {
+    pub db: Database,
+    pub module_api: DynModuleApi,
+}
+
+impl ClientModuleRecoveryPrepareArgs {
+    /// Database isolated for this module instance
+    pub fn db(&self) -> &Database {
+        &self.db
+    }
+
+    /// Api of this module instance
+    pub fn module_api(&self) -> &DynModuleApi {
+        &self.module_api
+    }
+}
+
 pub struct ClientModuleRecoverArgs<C>
 where
     C: ClientModuleInit,
@@ -380,24 +430,45 @@ pub trait ClientModuleInit: ModuleInit + Sized {
         <Self::Module as ClientModule>::kind()
     }
 
-    /// Whether this module implements [`Self::recover`].
+    /// How this module's recovery relates to using the module, see
+    /// [`RecoveryMode`].
     ///
-    /// A module that leaves this at `false` is left out of a recovering
-    /// client's recovery entirely: no recovery is started for it and it is
-    /// initialized as it would be on any other client open, rather than being
-    /// held back for a recovery that would do nothing.
+    /// Must be overridden together with [`Self::recover`]: leaving this at
+    /// [`RecoveryMode::None`] while implementing a recovery leaves that
+    /// recovery unreachable, and overriding only this makes the module's
+    /// recovery fail.
+    fn recovery_mode(&self) -> RecoveryMode {
+        RecoveryMode::None
+    }
+
+    /// Commit the boundary between a recovery and live operation.
     ///
-    /// Must be overridden together with [`Self::recover`]: overriding only the
-    /// recovery leaves it unreachable, and overriding only this makes the
-    /// module's recovery fail.
-    fn supports_recovery(&self) -> bool {
-        false
+    /// Called on every client open that starts or resumes a recovery, before
+    /// [`Self::init`] and before the module joins the module registry.
+    ///
+    /// [`RecoveryMode::Usable`] is a claim that the recovery and the live
+    /// module cannot interfere: the recovery must not rewrite state the module
+    /// also writes, and must not rediscover what the live module is about to
+    /// do. Whatever separates the two has to be recorded durably *here*,
+    /// because everything after this point can run concurrently with the
+    /// module. If this fails the client fails to open and neither the module
+    /// nor its recovery is started, so [`Self::recover`] may rely on the
+    /// boundary having been committed.
+    ///
+    /// Only called for modules whose [`Self::recovery_mode`] is
+    /// [`RecoveryMode::Usable`].
+    async fn prepare_recovery(
+        &self,
+        _args: &ClientModuleRecoveryPrepareArgs,
+    ) -> anyhow::Result<()> {
+        Ok(())
     }
 
     /// Recover the state of the client module, optionally from an existing
     /// snapshot.
     ///
-    /// Only called for modules whose [`Self::supports_recovery`] is `true`.
+    /// Only called for modules whose [`Self::recovery_mode`] is not
+    /// [`RecoveryMode::None`].
     ///
     /// On success, returns the total amount recovered from this module, if the
     /// module tracks it (`None` for modules that can't determine the amount at
@@ -412,7 +483,7 @@ pub trait ClientModuleInit: ModuleInit + Sized {
         _snapshot: Option<&<Self::Module as ClientModule>::Backup>,
     ) -> anyhow::Result<Option<Amount>> {
         bail!(
-            "Module kind {} claims to support recovery without implementing it",
+            "Module kind {} declares a recovery mode without implementing a recovery",
             <Self::Module as ClientModule>::kind()
         )
     }

--- a/fedimint-client/src/client.rs
+++ b/fedimint-client/src/client.rs
@@ -1933,6 +1933,23 @@ impl Client {
             .all(RecoveryStatus::is_successfully_done)
     }
 
+    /// Whether every module of this client can be used right now.
+    ///
+    /// A module that cannot be used while it recovers is left out of the module
+    /// registry, and only becomes available once the client is reopened with
+    /// its recovery complete. This reports whether any module is currently held
+    /// back that way, so an application can tell whether it has to wait for
+    /// [`Self::wait_for_all_recoveries`] and reopen before it can do anything,
+    /// or can go ahead right away with a recovery still running.
+    ///
+    /// Always `true` for a client that is not recovering.
+    pub fn all_modules_usable(&self) -> bool {
+        self.client_recovery_status_receiver
+            .borrow()
+            .keys()
+            .all(|module_instance_id| self.modules.get(*module_instance_id).is_some())
+    }
+
     /// Wait for all module recoveries to finish
     ///
     /// Returns `Ok(())` once every module recovery completed, or an error as

--- a/fedimint-client/src/client/builder.rs
+++ b/fedimint-client/src/client/builder.rs
@@ -3,7 +3,7 @@ use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::{bail, ensure};
+use anyhow::{Context as _, bail, ensure};
 use bitcoin::key::Secp256k1;
 use fedimint_api_client::api::global_api::with_cache::GlobalFederationApiWithCacheExt as _;
 use fedimint_api_client::api::global_api::with_request_hook::{
@@ -15,7 +15,7 @@ use fedimint_bitcoind::DynBitcoindRpc;
 use fedimint_client_module::api::ClientRawFederationApiExt as _;
 use fedimint_client_module::meta::LegacyMetaSource;
 use fedimint_client_module::module::init::{
-    BitcoindRpcFactory, BitcoindRpcNoChainIdFactory, ClientModuleInit,
+    BitcoindRpcFactory, BitcoindRpcNoChainIdFactory, ClientModuleInit, RecoveryMode,
 };
 use fedimint_client_module::module::recovery::RecoveryProgress;
 use fedimint_client_module::module::{
@@ -868,9 +868,24 @@ impl ClientBuilder {
                 // recover, so holding it back for one would only keep it out of
                 // the registry — and therefore unusable — until the client is
                 // reopened, in exchange for a recovery that does nothing.
+                let recovery_mode = module_init.recovery_mode();
+
                 let requires_recovery = init_state
                     .does_require_recovery()
-                    .filter(|_| module_init.supports_recovery());
+                    .filter(|_| recovery_mode != RecoveryMode::None);
+
+                // A module that may be used while it recovers has to commit
+                // the boundary between its recovery and live operation before
+                // either exists, so the recovery below never runs without the
+                // boundary it assumes.
+                if requires_recovery.is_some() && recovery_mode == RecoveryMode::Usable {
+                    module_init
+                        .prepare_recovery(db.clone(), module_instance_id, api.clone())
+                        .await
+                        .with_context(|| {
+                            format!("Failed to prepare recovery of module {module_instance_id}")
+                        })?;
+                }
 
                 let recovery = match requires_recovery {
                     Some(snapshot) => {
@@ -928,43 +943,49 @@ impl ClientBuilder {
                     _ => None,
                 };
 
-                match recovery {
-                    Some((recovery, recovery_progress_rx)) => {
-                        module_recoveries.insert(module_instance_id, recovery);
-                        module_recovery_progress_receivers
-                            .insert(module_instance_id, recovery_progress_rx);
-                    }
-                    _ => {
-                        let module = module_init
-                            .init(
-                                final_client.clone(),
-                                fed_id,
-                                config.global.api_endpoints.len(),
-                                module_config,
-                                db.clone(),
-                                module_instance_id,
-                                common_api_versions.core,
-                                api_version,
-                                // This is a divergence from the legacy client, where the child
-                                // secret keys were derived using
-                                // *module kind*-specific derivation paths.
-                                // Since the new client has to support multiple, segregated modules
-                                // of the same kind we have to use
-                                // the instance id instead.
-                                root_secret.derive_module_secret(module_instance_id),
-                                notifier.clone(),
-                                api.clone(),
-                                self.admin_creds.as_ref().map(|cred| cred.auth.clone()),
-                                task_group.clone(),
-                                client_span.clone(),
-                                connectors.clone(),
-                                user_bitcoind_rpc.clone(),
-                                self.bitcoind_rpc_no_chain_id_factory.clone(),
-                            )
-                            .await?;
+                // A module that is not recovering is always initialized, a
+                // recovering one only if it may be used while its recovery
+                // runs. The rest stay out of the module registry, and so
+                // unusable, until the client is reopened with their recovery
+                // complete.
+                let initialize_module = recovery.is_none() || recovery_mode == RecoveryMode::Usable;
 
-                        modules.register_module(module_instance_id, kind, module);
-                    }
+                if let Some((recovery, recovery_progress_rx)) = recovery {
+                    module_recoveries.insert(module_instance_id, recovery);
+                    module_recovery_progress_receivers
+                        .insert(module_instance_id, recovery_progress_rx);
+                }
+
+                if initialize_module {
+                    let module = module_init
+                        .init(
+                            final_client.clone(),
+                            fed_id,
+                            config.global.api_endpoints.len(),
+                            module_config,
+                            db.clone(),
+                            module_instance_id,
+                            common_api_versions.core,
+                            api_version,
+                            // This is a divergence from the legacy client, where the child
+                            // secret keys were derived using
+                            // *module kind*-specific derivation paths.
+                            // Since the new client has to support multiple, segregated modules
+                            // of the same kind we have to use
+                            // the instance id instead.
+                            root_secret.derive_module_secret(module_instance_id),
+                            notifier.clone(),
+                            api.clone(),
+                            self.admin_creds.as_ref().map(|cred| cred.auth.clone()),
+                            task_group.clone(),
+                            client_span.clone(),
+                            connectors.clone(),
+                            user_bitcoind_rpc.clone(),
+                            self.bitcoind_rpc_no_chain_id_factory.clone(),
+                        )
+                        .await?;
+
+                    modules.register_module(module_instance_id, kind, module);
                 }
             }
             modules

--- a/fedimint-client/src/client/builder.rs
+++ b/fedimint-client/src/client/builder.rs
@@ -864,7 +864,15 @@ impl ClientBuilder {
                         )
                     };
 
-                let recovery = match init_state.does_require_recovery() {
+                // A module that does not implement recovery has nothing to
+                // recover, so holding it back for one would only keep it out of
+                // the registry — and therefore unusable — until the client is
+                // reopened, in exchange for a recovery that does nothing.
+                let requires_recovery = init_state
+                    .does_require_recovery()
+                    .filter(|_| module_init.supports_recovery());
+
+                let recovery = match requires_recovery {
                     Some(snapshot) => {
                         match db
                             .begin_transaction_nc()

--- a/fedimint-client/src/module_init.rs
+++ b/fedimint-client/src/module_init.rs
@@ -7,6 +7,7 @@ use fedimint_bitcoind::DynBitcoindRpc;
 use fedimint_client_module::db::ClientModuleMigrationFn;
 use fedimint_client_module::module::init::{
     BitcoindRpcNoChainIdFactory, ClientModuleInit, ClientModuleInitArgs, ClientModuleRecoverArgs,
+    ClientModuleRecoveryPrepareArgs, RecoveryMode,
 };
 use fedimint_client_module::module::recovery::{DynModuleBackup, RecoveryProgress};
 use fedimint_client_module::module::{ClientContext, DynClientModule, FinalClientIface};
@@ -39,8 +40,16 @@ pub trait IClientModuleInit: IDynCommonModuleInit + fmt::Debug + MaybeSend + May
     /// See [`ClientModuleInit::supported_api_versions`]
     fn supported_api_versions(&self) -> MultiApiVersion;
 
-    /// See [`ClientModuleInit::supports_recovery`]
-    fn supports_recovery(&self) -> bool;
+    /// See [`ClientModuleInit::recovery_mode`]
+    fn recovery_mode(&self) -> RecoveryMode;
+
+    /// See [`ClientModuleInit::prepare_recovery`]
+    async fn prepare_recovery(
+        &self,
+        db: Database,
+        instance_id: ModuleInstanceId,
+        api: DynGlobalApi,
+    ) -> anyhow::Result<()>;
 
     #[allow(clippy::too_many_arguments)]
     async fn recover(
@@ -114,8 +123,26 @@ where
         <Self as ClientModuleInit>::supported_api_versions(self)
     }
 
-    fn supports_recovery(&self) -> bool {
-        <Self as ClientModuleInit>::supports_recovery(self)
+    fn recovery_mode(&self) -> RecoveryMode {
+        <Self as ClientModuleInit>::recovery_mode(self)
+    }
+
+    async fn prepare_recovery(
+        &self,
+        db: Database,
+        instance_id: ModuleInstanceId,
+        api: DynGlobalApi,
+    ) -> anyhow::Result<()> {
+        let (module_db, _global_dbtx_access_token) = db.with_prefix_module_id(instance_id);
+
+        <Self as ClientModuleInit>::prepare_recovery(
+            self,
+            &ClientModuleRecoveryPrepareArgs {
+                db: module_db,
+                module_api: api.with_module(instance_id),
+            },
+        )
+        .await
     }
 
     async fn recover(

--- a/fedimint-client/src/module_init.rs
+++ b/fedimint-client/src/module_init.rs
@@ -39,6 +39,9 @@ pub trait IClientModuleInit: IDynCommonModuleInit + fmt::Debug + MaybeSend + May
     /// See [`ClientModuleInit::supported_api_versions`]
     fn supported_api_versions(&self) -> MultiApiVersion;
 
+    /// See [`ClientModuleInit::supports_recovery`]
+    fn supports_recovery(&self) -> bool;
+
     #[allow(clippy::too_many_arguments)]
     async fn recover(
         &self,
@@ -109,6 +112,10 @@ where
 
     fn supported_api_versions(&self) -> MultiApiVersion {
         <Self as ClientModuleInit>::supported_api_versions(self)
+    }
+
+    fn supports_recovery(&self) -> bool {
+        <Self as ClientModuleInit>::supports_recovery(self)
     }
 
     async fn recover(

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -836,6 +836,10 @@ impl ClientModuleInit for MintClientInit {
         })
     }
 
+    fn supports_recovery(&self) -> bool {
+        true
+    }
+
     async fn recover(
         &self,
         args: &ClientModuleRecoverArgs<Self>,

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -58,7 +58,7 @@ use events::{NoteSpent, OOBNotesReissued, OOBNotesSpent, ReceivePaymentEvent, Se
 use fedimint_api_client::api::DynModuleApi;
 use fedimint_client_module::db::{ClientModuleMigrationFn, migrate_state};
 use fedimint_client_module::module::init::{
-    ClientModuleInit, ClientModuleInitArgs, ClientModuleRecoverArgs,
+    ClientModuleInit, ClientModuleInitArgs, ClientModuleRecoverArgs, RecoveryMode,
 };
 use fedimint_client_module::module::recovery::RecoveryProgress;
 use fedimint_client_module::module::{
@@ -836,8 +836,8 @@ impl ClientModuleInit for MintClientInit {
         })
     }
 
-    fn supports_recovery(&self) -> bool {
-        true
+    fn recovery_mode(&self) -> RecoveryMode {
+        RecoveryMode::Unusable
     }
 
     async fn recover(

--- a/modules/fedimint-mintv2-client/src/lib.rs
+++ b/modules/fedimint-mintv2-client/src/lib.rs
@@ -152,6 +152,10 @@ impl ClientModuleInit for MintClientInit {
             .expect("no version conflicts")
     }
 
+    fn supports_recovery(&self) -> bool {
+        true
+    }
+
     async fn recover(
         &self,
         args: &ClientModuleRecoverArgs<Self>,

--- a/modules/fedimint-mintv2-client/src/lib.rs
+++ b/modules/fedimint-mintv2-client/src/lib.rs
@@ -38,6 +38,7 @@ use fedimint_client::transaction::{
 use fedimint_client_module::db::ClientModuleMigrationFn;
 use fedimint_client_module::module::init::{
     ClientModuleInit, ClientModuleInitArgs, ClientModuleRecoverArgs,
+    ClientModuleRecoveryPrepareArgs, RecoveryMode,
 };
 use fedimint_client_module::module::recovery::{NoModuleBackup, RecoveryProgress};
 use fedimint_client_module::module::{
@@ -152,8 +153,42 @@ impl ClientModuleInit for MintClientInit {
             .expect("no version conflicts")
     }
 
-    fn supports_recovery(&self) -> bool {
-        true
+    fn recovery_mode(&self) -> RecoveryMode {
+        RecoveryMode::Usable
+    }
+
+    async fn prepare_recovery(&self, args: &ClientModuleRecoveryPrepareArgs) -> anyhow::Result<()> {
+        if args
+            .db()
+            .begin_transaction_nc()
+            .await
+            .get_value(&RecoveryStateKey)
+            .await
+            .is_some()
+        {
+            return Ok(());
+        }
+
+        // The total is the number of items the federation had processed when
+        // the recovery began, so every note this client issues from here on
+        // lands beyond it and is never rediscovered by the scan. Committing
+        // that bound before the module is initialized is what lets the module
+        // be used while its own recovery is still running: the two cannot
+        // arrive at the same note.
+        let state = RecoveryState {
+            next_index: 0,
+            total_items: args.module_api().fetch_recovery_count().await?,
+            requests: BTreeMap::new(),
+            nonces: BTreeSet::new(),
+        };
+
+        let mut dbtx = args.db().begin_transaction().await;
+
+        dbtx.insert_entry(&RecoveryStateKey, &state).await;
+
+        dbtx.commit_tx().await;
+
+        Ok(())
     }
 
     async fn recover(
@@ -161,22 +196,13 @@ impl ClientModuleInit for MintClientInit {
         args: &ClientModuleRecoverArgs<Self>,
         _snapshot: Option<&NoModuleBackup>,
     ) -> anyhow::Result<Option<Amount>> {
-        let mut state = if let Some(state) = args
+        let mut state = args
             .db()
             .begin_transaction_nc()
             .await
             .get_value(&RecoveryStateKey)
             .await
-        {
-            state
-        } else {
-            RecoveryState {
-                next_index: 0,
-                total_items: args.module_api().fetch_recovery_count().await?,
-                requests: BTreeMap::new(),
-                nonces: BTreeSet::new(),
-            }
-        };
+            .expect("Prepare recovery commits the state before the recovery is started");
 
         if state.next_index == state.total_items {
             return Ok(None);

--- a/modules/fedimint-mintv2-tests/tests/tests.rs
+++ b/modules/fedimint-mintv2-tests/tests/tests.rs
@@ -364,10 +364,16 @@ async fn test_client_recovery(
         .recover_client_with_db(MemDatabase::new().into(), root_secret.clone())
         .await;
 
-    // The dummy module implements no recovery, so it is not held back for one:
-    // it is usable on the recovering client right away, rather than only after
-    // the mint has finished recovering and the client has been reopened.
+    // Neither module is held back by the recovery: the dummy module implements
+    // none, and the mint fixed the extent of its own before it was initialized.
+    // So both are usable while the recovery is still running, rather than only
+    // once it has finished and the client has been reopened.
+    ensure!(
+        recovering_client.all_modules_usable(),
+        "A module was held back by the recovery"
+    );
     recovering_client.get_first_module::<DummyClientModule>()?;
+    recovering_client.get_first_module::<MintClientModule>()?;
 
     recovering_client.wait_for_all_recoveries().await?;
 
@@ -379,22 +385,32 @@ async fn test_client_recovery(
         "recovery-completed event amount mismatch: expected {expected_balance}, got {event_amount:?}"
     );
 
-    // A module that did recover is only registered on the next client open, so
-    // the mint is available only after reopening. This is documented behavior -
-    // see gateway's client.rs:94-97
-    let recovered_client = fed
-        .open_client_with_db(recovering_client.db().clone(), root_secret)
-        .await;
-
-    recovered_client
+    // The recovered notes are signed and land in the very client that ran the
+    // recovery, without it having to be reopened first.
+    recovering_client
         .wait_for_all_active_state_machines()
         .await?;
 
-    let recovered_balance = recovered_client.get_balance_for_btc().await?;
+    let recovered_balance = recovering_client.get_balance_for_btc().await?;
 
     ensure!(
         recovered_balance == expected_balance,
         "Recovery balance mismatch: expected {expected_balance}, got {recovered_balance}"
+    );
+
+    // Reopening must neither restart the recovery nor duplicate what it
+    // recovered.
+    let reopened_client = fed
+        .open_client_with_db(recovering_client.db().clone(), root_secret)
+        .await;
+
+    reopened_client.wait_for_all_active_state_machines().await?;
+
+    let reopened_balance = reopened_client.get_balance_for_btc().await?;
+
+    ensure!(
+        reopened_balance == expected_balance,
+        "Balance changed on reopen: expected {expected_balance}, got {reopened_balance}"
     );
 
     Ok(())

--- a/modules/fedimint-mintv2-tests/tests/tests.rs
+++ b/modules/fedimint-mintv2-tests/tests/tests.rs
@@ -364,6 +364,11 @@ async fn test_client_recovery(
         .recover_client_with_db(MemDatabase::new().into(), root_secret.clone())
         .await;
 
+    // The dummy module implements no recovery, so it is not held back for one:
+    // it is usable on the recovering client right away, rather than only after
+    // the mint has finished recovering and the client has been reopened.
+    recovering_client.get_first_module::<DummyClientModule>()?;
+
     recovering_client.wait_for_all_recoveries().await?;
 
     // The mintv2 module's recovery-completed event reports the total value of
@@ -374,8 +379,9 @@ async fn test_client_recovery(
         "recovery-completed event amount mismatch: expected {expected_balance}, got {event_amount:?}"
     );
 
-    // After recovery completes, we need to reopen the client for modules to be
-    // available. This is documented behavior - see gateway's client.rs:94-97
+    // A module that did recover is only registered on the next client open, so
+    // the mint is available only after reopening. This is documented behavior -
+    // see gateway's client.rs:94-97
     let recovered_client = fed
         .open_client_with_db(recovering_client.db().clone(), root_secret)
         .await;

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -414,6 +414,10 @@ impl ClientModuleInit for WalletClientInit {
         })
     }
 
+    fn supports_recovery(&self) -> bool {
+        true
+    }
+
     /// Wallet recovery
     ///
     /// Uses slice-based recovery if supported by the federation, otherwise

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -41,7 +41,7 @@ use client_db::{DbKeyPrefix, PegInTweakIndexKey, SupportsSafeDepositKey, TweakId
 use fedimint_api_client::api::{DynModuleApi, FederationResult};
 use fedimint_bitcoind::{BitcoindTracked, DynBitcoindRpc, IBitcoindRpc, create_esplora_rpc};
 use fedimint_client_module::module::init::{
-    ClientModuleInit, ClientModuleInitArgs, ClientModuleRecoverArgs,
+    ClientModuleInit, ClientModuleInitArgs, ClientModuleRecoverArgs, RecoveryMode,
 };
 use fedimint_client_module::module::recovery::RecoveryProgress;
 use fedimint_client_module::module::{ClientContext, ClientModule, IClientModule, OutPointRange};
@@ -414,8 +414,8 @@ impl ClientModuleInit for WalletClientInit {
         })
     }
 
-    fn supports_recovery(&self) -> bool {
-        true
+    fn recovery_mode(&self) -> RecoveryMode {
+        RecoveryMode::Unusable
     }
 
     /// Wallet recovery


### PR DESCRIPTION
A recovering client routes every module into `module_recoveries`, which keeps it out of the module registry — and therefore unusable — until the client is reopened. Two commits, both narrowing that.

**Skip modules that implement no recovery.** The decision is made from the client init state alone, so modules that never override `ClientModuleInit::recover` (lnv2, walletv2, lnv1, dummy) are held back for a recovery that returns immediately having done nothing. `ClientModuleInit::recovery_mode` gates enrollment; only mint, mintv2 and wallet override it, and both are `RecoveryMode::Unusable`.

**Let mintv2 stay usable while it recovers.** Its notes come from ground random tweaks rather than a shared derivation counter (unlike mint v1, which restores `NextECashNoteIndexKey`), so its recovery only ever adds notes and can never arrive at one the live module is issuing. What it needs is a boundary: the scan covers items `[0, total)`, so anything issued after `total` is read is beyond it. Fetching that lazily inside the recovery leaves a window where a live issuance still falls inside the scanned range, and a note reconstructed twice panics on `insert_new_entry`. `RecoveryMode::Usable` declares that a module may be used while it recovers, and `ClientModuleInit::prepare_recovery` runs before the module is initialized to commit the boundary; on failure the module is held back as if it were `Unusable`.

Also adds `Client::all_modules_usable`, so an application can tell whether it must wait and reopen or can go ahead with a recovery still running.

### Reviewing

- mintv2 is `PrimaryModulePriority::HIGH`, so during recovery it is primary with an empty note set: receives work, spends fail with "Insufficient funds" until the recovery lands. Honest, but new.
- `recovery_mode` and `recover` must be overridden together, which is a footgun in one direction — a module overriding only `recover` silently stops recovering. The default `recover` now bails instead of warning, covering the other direction. Happy to make `recover` required instead if the churn on downstream implementors is acceptable.
- `prepare_recovery` adds one API round-trip to the client-open path, and only on a fresh recovery.