### PR TITLE
chore: Set tuned jemalloc defaults in fedimintd

### DIFF
--- a/fedimintd/src/bin/main.rs
+++ b/fedimintd/src/bin/main.rs
@@ -9,6 +9,17 @@ use tikv_jemallocator::Jemalloc;
 // rocksdb suffers from memory fragmentation when using standard allocator
 static GLOBAL: Jemalloc = Jemalloc;
 
+// Without a background purge thread jemalloc only returns dirty pages to the
+// OS on allocation events inside the owning arena, so per-arena high-water
+// marks ratchet up with peak concurrency and are never released on quiescent
+// arenas. Overridable at runtime via the `MALLOC_CONF` environment variable,
+// see https://github.com/fedimint/fedimint/issues/9025.
+#[cfg(feature = "jemalloc")]
+#[allow(non_upper_case_globals)]
+#[unsafe(export_name = "malloc_conf")]
+pub static malloc_conf: &[u8] =
+    b"background_thread:true,narenas:4,dirty_decay_ms:1000,muzzy_decay_ms:1000\0";
+
 #[tokio::main]
 async fn main() -> anyhow::Result<Infallible> {
     fedimintd::run(


### PR DESCRIPTION
Applies the jemalloc tuning validated in #9025 as a compile-time default for the official `fedimintd` binary:

```
background_thread:true,narenas:4,dirty_decay_ms:1000,muzzy_decay_ms:1000
```

## Why

#9025 established that under sustained load, guardian RSS is dominated by allocator retention of transient churn, not live data: live app heap was ~2.7 MB against ~280 MB RSS, with ~1.4 GB/min of >99.9%-transient allocation churn. jemalloc's defaults (no background purge thread, `dirty_decay_ms=10s`, 4×ncpu arenas) let each arena's dirty-page high-water ratchet up with peak concurrency and never come back down on quiescent arenas.

## Measured effect (A/B on a 10-guardian regtest federation, identical load)

| config | steady-state RSS under load | idle floor after load stops |
|---|---|---|
| jemalloc defaults (9 guardians) | ~310 MB, +~9 MB per concurrent client | ~243 MB (sticky) |
| this `malloc_conf` (1 guardian) | **157–171 MB, flat** | ~157 MB |

The per-client RSS slope essentially disappears, and ~50% of steady-state RSS is returned.

## Notes for reviewers

- The compile-time `malloc_conf` symbol has the *lowest* precedence in jemalloc's config chain — operators can still override any of these options at runtime via the `MALLOC_CONF` environment variable (the build is unprefixed via rocksdb's jemalloc feature; verified empirically that `MALLOC_CONF` is the variable this binary parses).
- `narenas:4` is the most debatable knob: it trades allocation-path parallelism for less arena spread. On very-high-core-count machines with heavy load it could add contention; happy to drop it or raise it if preferred — `background_thread:true` + the decay settings carry most of the benefit.
- This only covers the official binary (`fedimintd/src/bin/main.rs`, next to the existing `#[global_allocator]`). Downstream builds that link `fedimintd` as a library and provide their own `main` won't pick it up; can move it into the lib behind the `jemalloc` feature if that's preferred.
- Verified the symbol takes effect by running the built binary with `MALLOC_CONF=stats_print:true` and checking the stats output: `opt.background_thread: true`, `opt.narenas: 4`, `opt.dirty_decay_ms: 1000`, `opt.muzzy_decay_ms: 1000`.

Closes nothing on its own — the churn *sources* (O(N²) `submit_transaction` long-poll re-validation, DB notification thundering herd, `block_in_place` thread growth) are tracked in #9025 and follow-ups are being validated separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WJ1Ssm9MbUr8ZbHawJQEfX
