### PR TITLE
feat(bip445): add FROST threshold signatures and a secp256k1 DKG

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3137,6 +3137,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "fedimint-bip445"
+version = "0.13.0-alpha"
+dependencies = [
+ "bitcoin",
+ "fedimint-core",
+ "hex",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "secp256k1",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "fedimint-bitcoind"
 version = "0.13.0-alpha"
 dependencies = [
@@ -4719,6 +4733,7 @@ dependencies = [
  "rayon",
  "rcgen",
  "scopeguard",
+ "secp256k1",
  "serde",
  "serde_json",
  "sha3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 [workspace]
 members = [
     "crypto/aead",
+    "crypto/bip445",
     "crypto/derive-secret",
     "crypto/hkdf",
     "crypto/tbs",
@@ -179,6 +180,7 @@ esplora-client = { version = "0.12.3", default-features = false, features = [
 fedimint-aead = { path = "./crypto/aead", version = "=0.13.0-alpha" }
 fedimint-api-client = { path = "./fedimint-api-client", version = "=0.13.0-alpha" }
 fedimint-bip39 = { path = "./fedimint-bip39", version = "=0.13.0-alpha" }
+fedimint-bip445 = { path = "./crypto/bip445", version = "=0.13.0-alpha" }
 fedimint-bitcoind = { path = "./fedimint-bitcoind", version = "=0.13.0-alpha" }
 fedimint-build = { path = "./fedimint-build", version = "=0.13.0-alpha" }
 fedimint-client = { path = "./fedimint-client", version = "=0.13.0-alpha" }

--- a/crypto/bip445/Cargo.toml
+++ b/crypto/bip445/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+authors = { workspace = true }
+description = "fedimint-bip445 is a helper cryptography library for threshold schnorr signatures"
+edition = { workspace = true }
+license = { workspace = true }
+name = "fedimint-bip445"
+readme = { workspace = true }
+repository = { workspace = true }
+version = { workspace = true }
+
+[features]
+default = []
+unstable = []
+
+[lib]
+name = "bip445"
+path = "src/lib.rs"
+
+[dependencies]
+bitcoin = { workspace = true }
+fedimint-core = { workspace = true }
+rand = { workspace = true }
+rand_chacha = { workspace = true }
+secp256k1 = { workspace = true, features = [
+    "global-context",
+    "rand-std",
+    "serde",
+] }
+serde = { workspace = true }
+
+[dev-dependencies]
+hex = { workspace = true }
+serde_json = { workspace = true }
+
+[lints]
+workspace = true

--- a/crypto/bip445/src/lib.rs
+++ b/crypto/bip445/src/lib.rs
@@ -1,0 +1,462 @@
+//! # Threshold Schnorr Signatures
+//!
+//! This library implements the FROST threshold signature scheme as specified
+//! in BIP 445 over secp256k1, producing BIP340 signatures for use with
+//! taproot. The implementation is validated against the BIP 445 test vectors.
+//!
+//! Signing runs in two broadcast rounds among the signing set: exchange of
+//! the public nonce pairs and exchange of the signature shares. The single
+//! binding coefficient ties every signature share to the exact signing set,
+//! nonce set and message, which makes the scheme secure under concurrent
+//! signing sessions without a nonce commitment round.
+//!
+//! BIP 445's accumulated tweak context is deliberately omitted: callers
+//! tweak the secret key shares and the aggregate public key externally,
+//! which is equivalent since additive tweaks pass through Lagrange
+//! interpolation.
+
+use std::collections::BTreeMap;
+
+use bitcoin::hashes::{Hash as BitcoinHash, HashEngine, sha256};
+use fedimint_core::encoding::{Decodable, Encodable};
+use rand::SeedableRng;
+use rand::rngs::OsRng;
+use rand_chacha::ChaChaRng;
+use secp256k1::{Message, Parity, PublicKey, SECP256K1, Scalar, SecretKey, constants, schnorr};
+use serde::{Deserialize, Serialize};
+
+const TAG_NONCECOEF: &[u8] = b"BIP0445/noncecoef";
+const TAG_CHALLENGE: &[u8] = b"BIP0340/challenge";
+
+/// Our share of the threshold secret key.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Encodable, Decodable, Serialize, Deserialize)]
+pub struct SecretKeyShare(pub SecretKey);
+
+/// The public key corresponding to one peer's secret key share.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Encodable, Decodable, Serialize, Deserialize)]
+pub struct PublicKeyShare(pub PublicKey);
+
+/// The public key of the federation; its x-only form is the BIP340 public
+/// key our signatures verify under.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Encodable, Decodable, Serialize, Deserialize)]
+pub struct AggregatePublicKey(pub PublicKey);
+
+/// The secret nonce pair for one signing session. Signing two different
+/// sessions with the same nonce leaks the secret key share.
+#[derive(Debug)]
+pub struct SecretNonce(SecretKey, SecretKey);
+
+/// The public nonce pair of one peer for one signing session.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Encodable, Decodable, Serialize, Deserialize)]
+pub struct PublicNonce(pub PublicKey, pub PublicKey);
+
+/// One peer's additive share of the final signature's response scalar.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Encodable, Decodable, Serialize, Deserialize)]
+pub struct SignatureShare(pub SecretKey);
+
+impl std::hash::Hash for SignatureShare {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        state.write(&self.0.secret_bytes());
+    }
+}
+
+/// Derives the public key share for a secret key share.
+pub fn derive_pk_share(sks: &SecretKeyShare) -> PublicKeyShare {
+    PublicKeyShare(sks.0.public_key(SECP256K1))
+}
+
+/// Generates a fresh random nonce pair for one signing session.
+pub fn generate_nonce() -> (SecretNonce, PublicNonce) {
+    let nonce = SecretNonce(SecretKey::new(&mut OsRng), SecretKey::new(&mut OsRng));
+
+    let public_nonce = derive_public_nonce(&nonce);
+
+    (nonce, public_nonce)
+}
+
+/// Derives the nonce pair for one signing session from a seed. The caller
+/// must guarantee that a seed is used for at most one signing session, since
+/// signing two different sessions with the same nonce leaks the secret key
+/// share.
+pub fn derive_nonce(seed: &[u8; 32]) -> SecretNonce {
+    let mut rng = ChaChaRng::from_seed(*seed);
+
+    SecretNonce(SecretKey::new(&mut rng), SecretKey::new(&mut rng))
+}
+
+/// Derives the public nonce pair for a secret nonce pair.
+pub fn derive_public_nonce(nonce: &SecretNonce) -> PublicNonce {
+    PublicNonce(nonce.0.public_key(SECP256K1), nonce.1.public_key(SECP256K1))
+}
+
+/// Creates our signature share for the message. The keys of the nonces define
+/// the signing set, which has to contain our identity. The secret nonce is
+/// consumed since signing twice with the same nonce leaks our secret key
+/// share.
+/// # Panics
+/// If nonces is empty
+pub fn sign_share(
+    msg: [u8; 32],
+    sks: &SecretKeyShare,
+    nonce: SecretNonce,
+    nonces: &BTreeMap<u64, PublicNonce>,
+    identity: u64,
+    pk: &AggregatePublicKey,
+) -> SignatureShare {
+    let (binding, group_nonce, challenge) = session_values(&msg, nonces, pk);
+
+    let lambda = lagrange_multiplier(nonces, identity);
+
+    // BIP340 verifies against the even-y points for the x-only aggregate
+    // nonce and public key, so we sign for their negations if necessary.
+
+    let SecretNonce(first, second) = nonce;
+
+    let (first, second) = match group_nonce.x_only_public_key().1 {
+        Parity::Even => (first, second),
+        Parity::Odd => (first.negate(), second.negate()),
+    };
+
+    let sks = match pk.0.x_only_public_key().1 {
+        Parity::Even => sks.0,
+        Parity::Odd => sks.0.negate(),
+    };
+
+    let share = sks
+        .mul_tweak(&key_scalar(&lambda))
+        .expect("A product of nonzero scalars is nonzero")
+        .mul_tweak(&challenge)
+        .expect("The challenge is zero with negligible probability");
+
+    let second = second
+        .mul_tweak(&binding)
+        .expect("The binding coefficient is zero with negligible probability");
+
+    SignatureShare(
+        first
+            .add_tweak(&key_scalar(&second))
+            .expect("The sum is zero with negligible probability since our nonces are random")
+            .add_tweak(&key_scalar(&share))
+            .expect("The sum is zero with negligible probability since our nonces are random"),
+    )
+}
+
+/// Verifies a peer's signature share against its public key share and the
+/// nonces of the signing set.
+pub fn verify_signature_share(
+    msg: [u8; 32],
+    peer: u64,
+    pks: &PublicKeyShare,
+    share: &SignatureShare,
+    nonces: &BTreeMap<u64, PublicNonce>,
+    pk: &AggregatePublicKey,
+) -> bool {
+    let Some(nonce) = nonces.get(&peer) else {
+        return false;
+    };
+
+    let (binding, group_nonce, challenge) = session_values(&msg, nonces, pk);
+
+    let lambda = lagrange_multiplier(nonces, peer);
+
+    let Ok(second) = nonce.1.mul_tweak(SECP256K1, &binding) else {
+        return false;
+    };
+
+    let Ok(effective_nonce) = nonce.0.combine(&second) else {
+        return false;
+    };
+
+    let effective_nonce = match group_nonce.x_only_public_key().1 {
+        Parity::Even => effective_nonce,
+        Parity::Odd => effective_nonce.negate(SECP256K1),
+    };
+
+    let pks = match pk.0.x_only_public_key().1 {
+        Parity::Even => pks.0,
+        Parity::Odd => pks.0.negate(SECP256K1),
+    };
+
+    let Ok(coefficient) = lambda.mul_tweak(&challenge) else {
+        return false;
+    };
+
+    let Ok(share_point) = pks.mul_tweak(SECP256K1, &key_scalar(&coefficient)) else {
+        return false;
+    };
+
+    let Ok(expected) = effective_nonce.combine(&share_point) else {
+        return false;
+    };
+
+    share.0.public_key(SECP256K1) == expected
+}
+
+/// Combines the exact threshold of valid signature shares into a BIP340
+/// signature. The responsibility of verifying the shares and supplying the
+/// shares of exactly the signing set that created them lies with the caller.
+/// # Panics
+/// If nonces or shares is empty
+pub fn aggregate_signature_shares(
+    msg: [u8; 32],
+    nonces: &BTreeMap<u64, PublicNonce>,
+    shares: &BTreeMap<u64, SignatureShare>,
+    pk: &AggregatePublicKey,
+) -> schnorr::Signature {
+    let (_, group_nonce, _) = session_values(&msg, nonces, pk);
+
+    let response = shares
+        .values()
+        .map(|share| share.0)
+        .reduce(|accumulator, share| {
+            accumulator
+                .add_tweak(&key_scalar(&share))
+                .expect("The intermediate sums are zero with negligible probability")
+        })
+        .expect("We have at least one share");
+
+    let mut bytes = [0; 64];
+
+    bytes[..32].copy_from_slice(&group_nonce.x_only_public_key().0.serialize());
+    bytes[32..].copy_from_slice(&response.secret_bytes());
+
+    schnorr::Signature::from_slice(&bytes).expect("We provided exactly 64 bytes")
+}
+
+/// Verifies a BIP340 signature under the aggregate public key.
+pub fn verify(msg: [u8; 32], signature: &schnorr::Signature, pk: &AggregatePublicKey) -> bool {
+    SECP256K1
+        .verify_schnorr(
+            signature,
+            &Message::from_digest(msg),
+            &pk.0.x_only_public_key().0,
+        )
+        .is_ok()
+}
+
+/// The binding coefficient, group nonce and challenge of the signing session
+/// defined by the message, the nonces of the signing set and the aggregate
+/// public key.
+fn session_values(
+    msg: &[u8],
+    nonces: &BTreeMap<u64, PublicNonce>,
+    pk: &AggregatePublicKey,
+) -> (Scalar, PublicKey, Scalar) {
+    let halves = aggregate_nonce_halves(nonces);
+
+    session_values_from(msg, &serialize_ids(nonces.keys().copied()), &halves, pk)
+}
+
+fn session_values_from(
+    msg: &[u8],
+    ids: &[u8],
+    halves: &(Option<PublicKey>, Option<PublicKey>),
+    pk: &AggregatePublicKey,
+) -> (Scalar, PublicKey, Scalar) {
+    let pk_xonly = pk.0.x_only_public_key().0;
+
+    let signers = u32::try_from(ids.len() / 4).expect("The signing set size fits four bytes");
+
+    let binding = scalar_mod_order(tagged_hash(
+        TAG_NONCECOEF,
+        &[
+            &signers.to_be_bytes(),
+            ids,
+            &serialize_point(&halves.0),
+            &serialize_point(&halves.1),
+            &pk_xonly.serialize(),
+            msg,
+        ],
+    ));
+
+    let group_nonce = group_nonce(halves, &binding);
+
+    let challenge = scalar_mod_order(tagged_hash(
+        TAG_CHALLENGE,
+        &[
+            &group_nonce.x_only_public_key().0.serialize(),
+            &pk_xonly.serialize(),
+            msg,
+        ],
+    ));
+
+    (binding, group_nonce, challenge)
+}
+
+/// The coordinate-wise sums of the nonce pairs of the signing set, where
+/// `None` represents the point at infinity.
+fn aggregate_nonce_halves(
+    nonces: &BTreeMap<u64, PublicNonce>,
+) -> (Option<PublicKey>, Option<PublicKey>) {
+    let mut first = None;
+    let mut second = None;
+
+    for nonce in nonces.values() {
+        first = add_point(first, &nonce.0);
+        second = add_point(second, &nonce.1);
+    }
+
+    (first, second)
+}
+
+fn add_point(accumulator: Option<PublicKey>, point: &PublicKey) -> Option<PublicKey> {
+    match accumulator {
+        Some(accumulator) => accumulator.combine(point).ok(),
+        None => Some(*point),
+    }
+}
+
+fn serialize_point(point: &Option<PublicKey>) -> [u8; 33] {
+    match point {
+        Some(point) => point.serialize(),
+        None => [0; 33],
+    }
+}
+
+/// The group nonce `R1 + b * R2`; BIP 445 falls back to the generator if the
+/// sum is the point at infinity so that a valid BIP340 signature exists.
+fn group_nonce(halves: &(Option<PublicKey>, Option<PublicKey>), binding: &Scalar) -> PublicKey {
+    let second = halves.1.map(|second| {
+        second
+            .mul_tweak(SECP256K1, binding)
+            .expect("The binding coefficient is zero with negligible probability")
+    });
+
+    let sum = match (halves.0, second) {
+        (Some(first), Some(second)) => first.combine(&second).ok(),
+        (Some(first), None) => Some(first),
+        (None, second) => second,
+    };
+
+    sum.unwrap_or_else(|| key_from_u64(1).public_key(SECP256K1))
+}
+
+/// The sorted participant identifiers, each serialized as four big-endian
+/// bytes, as bound into the binding coefficient.
+fn serialize_ids(ids: impl Iterator<Item = u64>) -> Vec<u8> {
+    let mut ids = ids
+        .map(|id| u32::try_from(id).expect("A participant identifier fits four bytes"))
+        .collect::<Vec<u32>>();
+
+    ids.sort_unstable();
+
+    ids.into_iter().flat_map(u32::to_be_bytes).collect()
+}
+
+fn tagged_hash(tag: &[u8], chunks: &[&[u8]]) -> [u8; 32] {
+    let tag = sha256::Hash::hash(tag);
+
+    let mut engine = sha256::Hash::engine();
+
+    engine.input(tag.as_byte_array());
+    engine.input(tag.as_byte_array());
+
+    for chunk in chunks {
+        engine.input(chunk);
+    }
+
+    sha256::Hash::from_engine(engine).to_byte_array()
+}
+
+/// Interprets 32 bytes as a big-endian integer modulo the curve order, as
+/// required by BIP340 and BIP445. A single conditional subtraction suffices
+/// since the curve order exceeds 2^255.
+fn scalar_mod_order(mut bytes: [u8; 32]) -> Scalar {
+    if let Ok(scalar) = Scalar::from_be_bytes(bytes) {
+        return scalar;
+    }
+
+    let mut borrow = 0;
+
+    for i in (0..32).rev() {
+        let diff = i32::from(bytes[i]) - i32::from(constants::CURVE_ORDER[i]) - borrow;
+
+        bytes[i] = diff.rem_euclid(256) as u8;
+        borrow = i32::from(diff < 0);
+    }
+
+    Scalar::from_be_bytes(bytes).expect("The value is reduced below the curve order")
+}
+
+/// The Lagrange multiplier at zero for the peer's evaluation point in the
+/// signing set given by the keys of the nonces.
+fn lagrange_multiplier(nonces: &BTreeMap<u64, PublicNonce>, identity: u64) -> SecretKey {
+    let mut numerator = key_from_u64(1);
+    let mut denominator = key_from_u64(1);
+
+    for peer in nonces.keys().copied().filter(|peer| *peer != identity) {
+        numerator = numerator
+            .mul_tweak(&scalar_from_u64(peer + 1))
+            .expect("A product of nonzero scalars is nonzero");
+
+        denominator = denominator
+            .mul_tweak(&key_scalar(&difference(peer, identity)))
+            .expect("A product of nonzero scalars is nonzero");
+    }
+
+    numerator
+        .mul_tweak(&key_scalar(&invert(&denominator)))
+        .expect("A product of nonzero scalars is nonzero")
+}
+
+/// The difference (a + 1) - (b + 1) of two distinct evaluation points as a
+/// field element.
+fn difference(a: u64, b: u64) -> SecretKey {
+    if a > b {
+        key_from_u64(a - b)
+    } else {
+        key_from_u64(b - a).negate()
+    }
+}
+
+/// The modular inverse of a nonzero scalar via Fermat's little theorem, since
+/// rust-secp256k1 does not expose modular inversion.
+fn invert(key: &SecretKey) -> SecretKey {
+    let mut exponent = constants::CURVE_ORDER;
+
+    exponent[31] -= 2; // no borrow occurs since the order ends in 0x41
+
+    let mut accumulator = key_from_u64(1);
+
+    for byte in exponent {
+        for bit in (0..8).rev() {
+            accumulator = accumulator
+                .mul_tweak(&key_scalar(&accumulator))
+                .expect("A product of nonzero scalars is nonzero");
+
+            if (byte >> bit) & 1 == 1 {
+                accumulator = accumulator
+                    .mul_tweak(&key_scalar(key))
+                    .expect("A product of nonzero scalars is nonzero");
+            }
+        }
+    }
+
+    accumulator
+}
+
+fn key_scalar(key: &SecretKey) -> Scalar {
+    Scalar::from_be_bytes(key.secret_bytes()).expect("A secret key is a valid scalar")
+}
+
+fn scalar_from_u64(value: u64) -> Scalar {
+    let mut bytes = [0; 32];
+
+    bytes[24..].copy_from_slice(&value.to_be_bytes());
+
+    Scalar::from_be_bytes(bytes).expect("A u64 is smaller than the curve order")
+}
+
+fn key_from_u64(value: u64) -> SecretKey {
+    let mut bytes = [0; 32];
+
+    bytes[24..].copy_from_slice(&value.to_be_bytes());
+
+    SecretKey::from_slice(&bytes).expect("A nonzero u64 is a valid secret key")
+}
+
+#[cfg(test)]
+mod tests;
+
+#[cfg(test)]
+mod vector_tests;

--- a/crypto/bip445/src/tests.rs
+++ b/crypto/bip445/src/tests.rs
@@ -1,0 +1,155 @@
+use std::collections::BTreeMap;
+use std::iter::once;
+
+use bitcoin::hashes::{Hash as BitcoinHash, sha256};
+use rand::SeedableRng;
+use rand::rngs::OsRng;
+use rand_chacha::ChaChaRng;
+use secp256k1::{SECP256K1, Scalar, SecretKey, constants};
+
+use crate::{
+    AggregatePublicKey, PublicKeyShare, SecretKeyShare, SignatureShare, aggregate_signature_shares,
+    derive_pk_share, generate_nonce, invert, key_from_u64, key_scalar, scalar_from_u64,
+    scalar_mod_order, sign_share, verify, verify_signature_share,
+};
+
+fn dealer_agg_pk() -> AggregatePublicKey {
+    AggregatePublicKey(coefficient(0).public_key(SECP256K1))
+}
+
+fn dealer_pk(threshold: u64, peer: u64) -> PublicKeyShare {
+    derive_pk_share(&dealer_sk(threshold, peer))
+}
+
+fn dealer_sk(threshold: u64, peer: u64) -> SecretKeyShare {
+    let x = scalar_from_u64(peer + 1);
+
+    // We evaluate the secret polynomial of degree threshold - 1 at the point x
+    // using the Horner schema.
+
+    let y = (0..threshold)
+        .map(coefficient)
+        .rev()
+        .reduce(|accumulator, c| {
+            accumulator
+                .mul_tweak(&x)
+                .expect("The evaluation point is nonzero")
+                .add_tweak(&key_scalar(&c))
+                .expect("The intermediate values are nonzero for this dealer polynomial")
+        })
+        .expect("We have at least one coefficient");
+
+    SecretKeyShare(y)
+}
+
+fn coefficient(index: u64) -> SecretKey {
+    SecretKey::new(&mut ChaChaRng::from_seed(
+        *sha256::Hash::hash(&index.to_be_bytes()).as_byte_array(),
+    ))
+}
+
+#[test]
+fn test_roundtrip() {
+    const THRESHOLD: u64 = 3;
+
+    let message = [7_u8; 32];
+
+    let mut secret_nonces = BTreeMap::new();
+    let mut public_nonces = BTreeMap::new();
+
+    for peer in 0..THRESHOLD {
+        let (secret_nonce, public_nonce) = generate_nonce();
+
+        secret_nonces.insert(peer, secret_nonce);
+        public_nonces.insert(peer, public_nonce);
+    }
+
+    let shares = secret_nonces
+        .into_iter()
+        .map(|(peer, nonce)| {
+            let share = sign_share(
+                message,
+                &dealer_sk(THRESHOLD, peer),
+                nonce,
+                &public_nonces,
+                peer,
+                &dealer_agg_pk(),
+            );
+
+            (peer, share)
+        })
+        .collect::<BTreeMap<u64, SignatureShare>>();
+
+    for (peer, share) in &shares {
+        assert!(verify_signature_share(
+            message,
+            *peer,
+            &dealer_pk(THRESHOLD, *peer),
+            share,
+            &public_nonces,
+            &dealer_agg_pk()
+        ));
+    }
+
+    let signature = aggregate_signature_shares(message, &public_nonces, &shares, &dealer_agg_pk());
+
+    assert!(verify(message, &signature, &dealer_agg_pk()));
+}
+
+#[test]
+fn test_one_of_one() {
+    let message = [11_u8; 32];
+
+    let (secret_nonce, public_nonce) = generate_nonce();
+
+    let nonces = once((0, public_nonce)).collect::<BTreeMap<u64, _>>();
+
+    let share = sign_share(
+        message,
+        &dealer_sk(1, 0),
+        secret_nonce,
+        &nonces,
+        0,
+        &dealer_agg_pk(),
+    );
+
+    assert!(verify_signature_share(
+        message,
+        0,
+        &dealer_pk(1, 0),
+        &share,
+        &nonces,
+        &dealer_agg_pk()
+    ));
+
+    let signature = aggregate_signature_shares(
+        message,
+        &nonces,
+        &once((0, share)).collect(),
+        &dealer_agg_pk(),
+    );
+
+    assert!(verify(message, &signature, &dealer_agg_pk()));
+}
+
+#[test]
+fn test_invert() {
+    let key = SecretKey::new(&mut OsRng);
+
+    let product = invert(&key)
+        .mul_tweak(&key_scalar(&key))
+        .expect("The product of a scalar and its inverse is one");
+
+    assert_eq!(product, key_from_u64(1));
+}
+
+#[test]
+fn test_scalar_mod_order() {
+    assert_eq!(scalar_mod_order(constants::CURVE_ORDER), Scalar::ZERO);
+
+    let mut bytes = constants::CURVE_ORDER;
+
+    bytes[31] += 1;
+
+    assert_eq!(scalar_mod_order(bytes), Scalar::ONE);
+}

--- a/crypto/bip445/src/vector_tests.rs
+++ b/crypto/bip445/src/vector_tests.rs
@@ -1,0 +1,313 @@
+//! Tests against the BIP 445 test vectors, vendored from
+//! <https://github.com/siv2r/bip-frost-signing> (python/vectors) at
+//! commit 4b566d5.
+//!
+//! The nonce generation and deterministic signing vectors are not applicable:
+//! we generate nonces from the operating system RNG instead of the spec's
+//! derivation, and deterministic signing is deliberately unsupported. The
+//! sign error vectors test caller-contract violations that our typed API
+//! either cannot represent or documents as caller responsibility, and tweak
+//! test cases do not apply since callers tweak key material externally.
+
+use std::collections::BTreeMap;
+
+use secp256k1::{PublicKey, SecretKey};
+use serde_json::Value;
+
+use crate::{
+    AggregatePublicKey, PublicKeyShare, PublicNonce, SecretKeyShare, SecretNonce, SignatureShare,
+    aggregate_nonce_halves, key_scalar, serialize_ids, serialize_point, session_values_from,
+    sign_share, verify, verify_signature_share,
+};
+
+fn bytes(value: &Value) -> Vec<u8> {
+    hex::decode(value.as_str().expect("The value is a string")).expect("The value is hex")
+}
+
+fn message(value: &Value) -> Option<[u8; 32]> {
+    bytes(value).try_into().ok()
+}
+
+fn point(value: &Value) -> PublicKey {
+    PublicKey::from_slice(&bytes(value)).expect("The value is a compressed point")
+}
+
+fn public_nonce(value: &Value) -> Option<PublicNonce> {
+    let bytes = bytes(value);
+
+    Some(PublicNonce(
+        PublicKey::from_slice(&bytes[..33]).ok()?,
+        PublicKey::from_slice(&bytes[33..]).ok()?,
+    ))
+}
+
+fn aggnonce_halves(value: &Value) -> (Option<PublicKey>, Option<PublicKey>) {
+    let bytes = bytes(value);
+
+    let parse = |half: &[u8]| {
+        (half != [0; 33]).then(|| {
+            PublicKey::from_slice(half).expect("The aggregate nonce half is a compressed point")
+        })
+    };
+
+    (parse(&bytes[..33]), parse(&bytes[33..]))
+}
+
+fn indices(value: &Value) -> Vec<usize> {
+    value
+        .as_array()
+        .expect("The value is an array")
+        .iter()
+        .map(|index| index.as_u64().expect("The index is an integer") as usize)
+        .collect()
+}
+
+fn ids(value: &Value) -> Vec<u64> {
+    value
+        .as_array()
+        .expect("The value is an array")
+        .iter()
+        .map(|id| id.as_u64().expect("The id is an integer"))
+        .collect()
+}
+
+fn nonce_map(ids: &[u64], indices: &[usize], pubnonces: &[Value]) -> BTreeMap<u64, PublicNonce> {
+    ids.iter()
+        .zip(indices)
+        .map(|(id, index)| {
+            let nonce = public_nonce(&pubnonces[*index]).expect("The public nonce is valid");
+
+            (*id, nonce)
+        })
+        .collect()
+}
+
+fn serialized_aggnonce(nonces: &BTreeMap<u64, PublicNonce>) -> Vec<u8> {
+    let halves = aggregate_nonce_halves(nonces);
+
+    [serialize_point(&halves.0), serialize_point(&halves.1)].concat()
+}
+
+#[test]
+fn test_sign_verify_vectors() {
+    let vectors: Value = serde_json::from_str(include_str!("vectors/sign_verify_vectors.json"))
+        .expect("The vector file is valid json");
+
+    let mut signed = 0;
+
+    for group in vectors["test_groups"]
+        .as_array()
+        .expect("There are test groups")
+    {
+        let agg_pk = AggregatePublicKey(point(&group["thresh_pk"]));
+        let pubshares = group["pubshares"].as_array().expect("There are pubshares");
+        let pubnonces = group["pubnonces"].as_array().expect("There are pubnonces");
+        let secshares = group["secshares"].as_array().expect("There are secshares");
+        let secnonces = group["secnonces"].as_array().expect("There are secnonces");
+
+        for test in group["valid_tests"]
+            .as_array()
+            .expect("There are valid tests")
+        {
+            let Some(msg) = message(&test["msg"]) else {
+                continue; // our api signs 32-byte messages only
+            };
+
+            let ids = ids(&test["ids"]);
+            let pubshare_indices = indices(&test["pubshare_indices"]);
+            let nonces = nonce_map(&ids, &indices(&test["pubnonce_indices"]), pubnonces);
+
+            assert_eq!(
+                serialized_aggnonce(&nonces),
+                bytes(&test["aggnonce"]),
+                "aggregated nonce mismatch"
+            );
+
+            let my_id = test["my_id"].as_u64().expect("The id is an integer");
+
+            let secnonce = bytes(
+                &secnonces[test["secnonce_index"]
+                    .as_u64()
+                    .expect("The index is an integer") as usize],
+            );
+
+            let nonce = SecretNonce(
+                SecretKey::from_slice(&secnonce[..32]).expect("The first secret nonce is valid"),
+                SecretKey::from_slice(&secnonce[32..]).expect("The second secret nonce is valid"),
+            );
+
+            let sks = SecretKeyShare(
+                SecretKey::from_slice(&bytes(
+                    &secshares[test["secshare_index"]
+                        .as_u64()
+                        .expect("The index is an integer") as usize],
+                ))
+                .expect("The secret share is valid"),
+            );
+
+            let share = sign_share(msg, &sks, nonce, &nonces, my_id, &agg_pk);
+
+            assert_eq!(
+                share.0.secret_bytes().to_vec(),
+                bytes(&test["expected"]),
+                "partial signature mismatch"
+            );
+
+            let position = ids
+                .iter()
+                .position(|id| *id == my_id)
+                .expect("The id is present");
+
+            let pks = PublicKeyShare(point(&pubshares[pubshare_indices[position]]));
+
+            assert!(verify_signature_share(
+                msg, my_id, &pks, &share, &nonces, &agg_pk
+            ));
+
+            signed += 1;
+        }
+
+        for test in group["verify_fail_tests"]
+            .as_array()
+            .expect("There are fail tests")
+        {
+            let Some(msg) = message(&test["msg"]) else {
+                continue;
+            };
+
+            // A partial signature outside the scalar field is rejected by the
+            // type system before verification can run.
+            let Ok(psig) = SecretKey::from_slice(&bytes(&test["psig"])) else {
+                continue;
+            };
+
+            let ids = ids(&test["ids"]);
+            let pubshare_indices = indices(&test["pubshare_indices"]);
+            let nonces = nonce_map(&ids, &indices(&test["pubnonce_indices"]), pubnonces);
+
+            let signer_index = test["signer_index"]
+                .as_u64()
+                .expect("The index is an integer") as usize;
+
+            let pks = PublicKeyShare(point(&pubshares[pubshare_indices[signer_index]]));
+
+            assert!(!verify_signature_share(
+                msg,
+                ids[signer_index],
+                &pks,
+                &SignatureShare(psig),
+                &nonces,
+                &agg_pk
+            ));
+        }
+    }
+
+    assert!(signed > 0, "no sign vectors were exercised");
+}
+
+#[test]
+fn test_nonce_agg_vectors() {
+    let vectors: Value = serde_json::from_str(include_str!("vectors/nonce_agg_vectors.json"))
+        .expect("The vector file is valid json");
+
+    let pubnonces = vectors["pubnonces"]
+        .as_array()
+        .expect("There are pubnonces");
+
+    for test in vectors["valid_tests"]
+        .as_array()
+        .expect("There are valid tests")
+    {
+        let indices = indices(&test["pubnonce_indices"]);
+
+        let nonces: BTreeMap<u64, PublicNonce> = indices
+            .iter()
+            .enumerate()
+            .map(|(id, index)| {
+                let nonce = public_nonce(&pubnonces[*index]).expect("The public nonce is valid");
+
+                (id as u64, nonce)
+            })
+            .collect();
+
+        assert_eq!(serialized_aggnonce(&nonces), bytes(&test["expected"]));
+    }
+
+    for test in vectors["error_tests"]
+        .as_array()
+        .expect("There are error tests")
+    {
+        let indices = indices(&test["pubnonce_indices"]);
+
+        let signer_index = test["error"]["signer_index"]
+            .as_u64()
+            .expect("The index is an integer") as usize;
+
+        // An invalid public nonce is rejected by the type system at decoding.
+        assert!(public_nonce(&pubnonces[indices[signer_index]]).is_none());
+    }
+}
+
+#[test]
+fn test_sig_agg_vectors() {
+    let vectors: Value = serde_json::from_str(include_str!("vectors/sig_agg_vectors.json"))
+        .expect("The vector file is valid json");
+
+    let mut aggregated = 0;
+
+    for group in vectors["test_groups"]
+        .as_array()
+        .expect("There are test groups")
+    {
+        let agg_pk = AggregatePublicKey(point(&group["thresh_pk"]));
+
+        for test in group["valid_tests"]
+            .as_array()
+            .expect("There are valid tests")
+        {
+            if !test["tweak_indices"]
+                .as_array()
+                .expect("There are tweak indices")
+                .is_empty()
+            {
+                continue; // we tweak key material externally
+            }
+
+            let Some(msg) = message(&test["msg"]) else {
+                continue;
+            };
+
+            let ids = serialize_ids(ids(&test["ids"]).into_iter());
+            let halves = aggnonce_halves(&test["aggnonce"]);
+
+            let (_, group_nonce, _) = session_values_from(&msg, &ids, &halves, &agg_pk);
+
+            let response = test["psigs"]
+                .as_array()
+                .expect("There are partial signatures")
+                .iter()
+                .map(|psig| SecretKey::from_slice(&bytes(psig)).expect("The psig is valid"))
+                .reduce(|accumulator, psig| {
+                    accumulator
+                        .add_tweak(&key_scalar(&psig))
+                        .expect("The intermediate sums are nonzero")
+                })
+                .expect("There is at least one partial signature");
+
+            let mut signature = group_nonce.x_only_public_key().0.serialize().to_vec();
+
+            signature.extend(response.secret_bytes());
+
+            assert_eq!(signature, bytes(&test["expected"]), "signature mismatch");
+
+            let signature = secp256k1::schnorr::Signature::from_slice(&signature)
+                .expect("The signature is 64 bytes");
+
+            assert!(verify(msg, &signature, &agg_pk));
+
+            aggregated += 1;
+        }
+    }
+
+    assert!(aggregated > 0, "no sig agg vectors were exercised");
+}

--- a/crypto/bip445/src/vectors/nonce_agg_vectors.json
+++ b/crypto/bip445/src/vectors/nonce_agg_vectors.json
@@ -1,0 +1,57 @@
+{
+    "pubnonces": [
+        "020151C80F435648DF67A22B749CD798CE54E0321D034B92B709B567D60A42E66603BA47FBC1834437B3212E89A84D8425E7BF12E0245D98262268EBDCB385D50641",
+        "03FF406FFD8ADB9CD29877E4985014F66A59F6CD01C0E88CAA8E5F3166B1F676A60248C264CDD57D3C24D79990B0F865674EB62A0F9018277A95011B41BFC193B833",
+        "020151C80F435648DF67A22B749CD798CE54E0321D034B92B709B567D60A42E6660279BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798",
+        "03FF406FFD8ADB9CD29877E4985014F66A59F6CD01C0E88CAA8E5F3166B1F676A60379BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798",
+        "04FF406FFD8ADB9CD29877E4985014F66A59F6CD01C0E88CAA8E5F3166B1F676A60248C264CDD57D3C24D79990B0F865674EB62A0F9018277A95011B41BFC193B833",
+        "03FF406FFD8ADB9CD29877E4985014F66A59F6CD01C0E88CAA8E5F3166B1F676A60248C264CDD57D3C24D79990B0F865674EB62A0F9018277A95011B41BFC193B831",
+        "03FF406FFD8ADB9CD29877E4985014F66A59F6CD01C0E88CAA8E5F3166B1F676A602FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC30"
+    ],
+    "valid_tests": [
+        {
+            "tc_id": 1,
+            "comment": "Two well-formed public nonces",
+            "pubnonce_indices": [0, 1],
+            "expected": "035FE1873B4F2967F52FEA4A06AD5A8ECCBE9D0FD73068012C894E2E87CCB5804B024725377345BDE0E9C33AF3C43C0A29A9249F2F2956FA8CFEB55C8573D0262DC8"
+        },
+        {
+            "tc_id": 2,
+            "comment": "Second halves sum to the point at infinity, which is serialized as the all-zero encoding",
+            "pubnonce_indices": [2, 3],
+            "expected": "035FE1873B4F2967F52FEA4A06AD5A8ECCBE9D0FD73068012C894E2E87CCB5804B000000000000000000000000000000000000000000000000000000000000000000"
+        }
+    ],
+    "error_tests": [
+        {
+            "tc_id": 3,
+            "comment": "Public nonce is invalid: first half has an unknown tag 0x04",
+            "pubnonce_indices": [0, 4],
+            "error": {
+                "type": "InvalidContributionError",
+                "signer_index": 1,
+                "contrib": "pubnonce"
+            }
+        },
+        {
+            "tc_id": 4,
+            "comment": "Public nonce is invalid: second half is not a point on the curve",
+            "pubnonce_indices": [5, 1],
+            "error": {
+                "type": "InvalidContributionError",
+                "signer_index": 0,
+                "contrib": "pubnonce"
+            }
+        },
+        {
+            "tc_id": 5,
+            "comment": "Public nonce is invalid: second half's x-coordinate exceeds the field size",
+            "pubnonce_indices": [6, 1],
+            "error": {
+                "type": "InvalidContributionError",
+                "signer_index": 0,
+                "contrib": "pubnonce"
+            }
+        }
+    ]
+}

--- a/crypto/bip445/src/vectors/sig_agg_vectors.json
+++ b/crypto/bip445/src/vectors/sig_agg_vectors.json
@@ -1,0 +1,454 @@
+{
+    "test_groups": [
+        {
+            "tg_id": "2of3",
+            "t": 2,
+            "n": 3,
+            "thresh_pk": "02D772A09F5F675783D275ED9F6AAEDB2ECCBC74171B37AC23AE3BBD9D7AE2CDAA",
+            "pubshares": [
+                "039EE3335AF48DFE23702AB353F4AF20D401F67A130DF783CC8457323A860A2FB4",
+                "0284DC4AB2CB78A621EB87FA1F14BCE2B725AFEAAC981ADCBAFF5CC2D417D2A63A",
+                "036441EC2D4C1266201CD89B69549A2F5B2188612A0D434153E625FB38173DD509"
+            ],
+            "tweaks": [
+                "E8F791FF9225A2AF0102AFFF4A9A723D9612A682A25EBE79802B263CDFCD83BB",
+                "AE2EA797CC0FE72AC5B97B97F3C6957D7E4199A167A58EB08BCAFFDA70AC0455",
+                "F52ECBC565B3D8BEA2DFD5B75A4F457E54369809322E4120831626F290FA87E0",
+                "1969AD73CC177FA0B4FCED6DF1F7BF9907E665FDE9BA196A74FED0A3CF5AEF9D"
+            ],
+            "valid_tests": [
+                {
+                    "tc_id": 1,
+                    "comment": "Minimum threshold subset of signers, no tweaks",
+                    "ids": [0, 1],
+                    "pubshare_indices": [0, 1],
+                    "aggnonce": "030F261BFE5DF0AE3EC06BB7A1D6394A3AF206968281F03B70D25FB84D49036CE203BE48277630579C72160430C819AABB1DFA20FF70749666080BB886B728476261",
+                    "tweak_indices": [],
+                    "is_xonly": [],
+                    "psigs": [
+                        "93DDE8C9CEE714EB5BDF2BE00FEC3327F9CF386D3AC672F0DA734FFC08E7A041",
+                        "4368B9CD58815001630403FA8F6319CFD4849E95F13379FA431A288FD230E872"
+                    ],
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "expected": "74B202858D1B9B1113A5615E20CDB41CD6CAEE2DC125EB32AEA1A7C189621C12D746A297276864ECBEE32FDA9F4F4CF7CE53D7032BF9ECEB1D8D788BDB1888B3"
+                },
+                {
+                    "tc_id": 2,
+                    "comment": "Reordering the signer set leaves the aggregate signature unchanged, because the partial signatures are summed and the identifiers are sorted before they are bound into the binding value",
+                    "ids": [1, 0],
+                    "pubshare_indices": [1, 0],
+                    "aggnonce": "030F261BFE5DF0AE3EC06BB7A1D6394A3AF206968281F03B70D25FB84D49036CE203BE48277630579C72160430C819AABB1DFA20FF70749666080BB886B728476261",
+                    "tweak_indices": [],
+                    "is_xonly": [],
+                    "psigs": [
+                        "4368B9CD58815001630403FA8F6319CFD4849E95F13379FA431A288FD230E872",
+                        "93DDE8C9CEE714EB5BDF2BE00FEC3327F9CF386D3AC672F0DA734FFC08E7A041"
+                    ],
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "expected": "74B202858D1B9B1113A5615E20CDB41CD6CAEE2DC125EB32AEA1A7C189621C12D746A297276864ECBEE32FDA9F4F4CF7CE53D7032BF9ECEB1D8D788BDB1888B3"
+                },
+                {
+                    "tc_id": 3,
+                    "comment": "Aggregation with three tweaks applied (one x-only, two plain)",
+                    "ids": [0, 1],
+                    "pubshare_indices": [0, 1],
+                    "aggnonce": "030F261BFE5DF0AE3EC06BB7A1D6394A3AF206968281F03B70D25FB84D49036CE203BE48277630579C72160430C819AABB1DFA20FF70749666080BB886B728476261",
+                    "tweak_indices": [0, 1, 2],
+                    "is_xonly": [true, false, false],
+                    "psigs": [
+                        "CC60DFBCAEE58593EF5A58C757621FE8E6644925945B973527268D6493C1CB0E",
+                        "6BF7AC278EA83796031547BAA813C4FBF2D7B25B70EC59DD46ECB82C9104A5B0"
+                    ],
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "expected": "E2308F92DE70BC5F612D329F69F141BF4E886797B25539FCBDF39096B53E0F081093777BBF7DAF39BD06D299CB3860D43F647FC3A36507E2A57061D031F5696E"
+                },
+                {
+                    "tc_id": 4,
+                    "comment": "All signers participate, no tweaks",
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "aggnonce": "02CBC2E41AF87290A1401D49927FC30D7F40A404C4DF3E5FC734014188DBC44E1503C15312EDC691EB213F3B8AAC195D251A390563CD5E313D738A89DAEB4DA80746",
+                    "tweak_indices": [],
+                    "is_xonly": [],
+                    "psigs": [
+                        "0187D09300F20F940B837AA93AB9F4863821C044627931F402D4ACDA618C0E15",
+                        "09955F6B6CF09ED383F33C1BFCFE059E79E9D26FECC0095F4A31F22E7ED242AE",
+                        "012450173674FA82C0048E8DA589C450E742469CD2C81AAACE071297D9F1072C"
+                    ],
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "expected": "0128035A92709B871A9E7CD6871E52B475114EE189D5E56AC5B9E6EE861274690C418015A457A8EA4F7B4552DD41BE75994DD951220155FE1B0DB1A0BA4F57EF"
+                }
+            ],
+            "error_tests": [
+                {
+                    "tc_id": 5,
+                    "comment": "Partial signature equals the group order, which is out of range",
+                    "ids": [0, 1],
+                    "pubshare_indices": [0, 1],
+                    "aggnonce": "030F261BFE5DF0AE3EC06BB7A1D6394A3AF206968281F03B70D25FB84D49036CE203BE48277630579C72160430C819AABB1DFA20FF70749666080BB886B728476261",
+                    "tweak_indices": [],
+                    "is_xonly": [],
+                    "psigs": [
+                        "93DDE8C9CEE714EB5BDF2BE00FEC3327F9CF386D3AC672F0DA734FFC08E7A041",
+                        "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141"
+                    ],
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "InvalidContributionError",
+                        "signer_index": 1,
+                        "contrib": "psig"
+                    }
+                },
+                {
+                    "tc_id": 6,
+                    "comment": "Number of partial signatures does not match the number of signers",
+                    "ids": [0, 1],
+                    "pubshare_indices": [0, 1],
+                    "aggnonce": "030F261BFE5DF0AE3EC06BB7A1D6394A3AF206968281F03B70D25FB84D49036CE203BE48277630579C72160430C819AABB1DFA20FF70749666080BB886B728476261",
+                    "tweak_indices": [],
+                    "is_xonly": [],
+                    "psigs": [
+                        "93DDE8C9CEE714EB5BDF2BE00FEC3327F9CF386D3AC672F0DA734FFC08E7A041"
+                    ],
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The psigs and ids arrays must have the same length."
+                    }
+                }
+            ]
+        },
+        {
+            "tg_id": "1of3",
+            "t": 1,
+            "n": 3,
+            "thresh_pk": "03D1939BE87D18EA5AB302E27077D16B2C2FD93516F91514BA049933D348DA441F",
+            "pubshares": [
+                "03D1939BE87D18EA5AB302E27077D16B2C2FD93516F91514BA049933D348DA441F",
+                "03D1939BE87D18EA5AB302E27077D16B2C2FD93516F91514BA049933D348DA441F",
+                "03D1939BE87D18EA5AB302E27077D16B2C2FD93516F91514BA049933D348DA441F"
+            ],
+            "tweaks": [
+                "E8F791FF9225A2AF0102AFFF4A9A723D9612A682A25EBE79802B263CDFCD83BB",
+                "AE2EA797CC0FE72AC5B97B97F3C6957D7E4199A167A58EB08BCAFFDA70AC0455",
+                "F52ECBC565B3D8BEA2DFD5B75A4F457E54369809322E4120831626F290FA87E0",
+                "1969AD73CC177FA0B4FCED6DF1F7BF9907E665FDE9BA196A74FED0A3CF5AEF9D"
+            ],
+            "valid_tests": [
+                {
+                    "tc_id": 7,
+                    "comment": "Minimum threshold subset of signers, no tweaks",
+                    "ids": [0],
+                    "pubshare_indices": [0],
+                    "aggnonce": "026805DC7B318F796C360BB82F85FA0C106AB8775FECF892A0A7F85FB66720CBAB039509CF07C0A787AB8628C84E1F6F5E9CA424496D6ED4AC36722E5602E0C32C57",
+                    "tweak_indices": [],
+                    "is_xonly": [],
+                    "psigs": [
+                        "B7C3FA9AEA2B0989D150B57433233015A269CB56232B1DE2AFE573491D960B2C"
+                    ],
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "expected": "3EA6A192ECA9027F78FA5354DDCB5315C8C2AB067F9BB679D36DF70D4F78E397B7C3FA9AEA2B0989D150B57433233015A269CB56232B1DE2AFE573491D960B2C"
+                },
+                {
+                    "tc_id": 8,
+                    "comment": "Aggregation with three tweaks applied (one x-only, two plain)",
+                    "ids": [0],
+                    "pubshare_indices": [0],
+                    "aggnonce": "026805DC7B318F796C360BB82F85FA0C106AB8775FECF892A0A7F85FB66720CBAB039509CF07C0A787AB8628C84E1F6F5E9CA424496D6ED4AC36722E5602E0C32C57",
+                    "tweak_indices": [0, 1, 2],
+                    "is_xonly": [true, false, false],
+                    "psigs": [
+                        "BBC0D36C2FA70A62BA1B6E0A59FFB7C62EE36643B6D19E40180A267DB5F48869"
+                    ],
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "expected": "31C4E26F6FF48E6BF58FFC7BCCB6429B48A8926D38815858B4DAF9676D25C1EDB3FA2D48AFD3C625E9D4954ADA10544DA3A035959026DA6E6638833B1CFF9CF8"
+                },
+                {
+                    "tc_id": 9,
+                    "comment": "All signers participate, no tweaks",
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "aggnonce": "0277E716756BAEFD922DCD339D083FEB1C0263B06999328492331FB876A225EEA3033910C4FC151C7AA914B4D2AC97B3F09C56A36A5F95F14043D90210CC1FCD4245",
+                    "tweak_indices": [],
+                    "is_xonly": [],
+                    "psigs": [
+                        "DD3ED1A5C5A6C46F715EB15C5E108681B993C6D456D95F5577C1C0CF1596D439",
+                        "97F8FC6A3EB65E25F3850341B8D58851564F12EF88D996C53916C75578595CFD",
+                        "70D2353C98ABF7AC476B77537C5231C75A429690826BE7117842A3779BC596BA"
+                    ],
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "expected": "4C622E9A2E1B3F4BF03A93A4B62B1546B0A33696ECE1008330274609801B439DE60A034C9D091A41AC4F2BF19338409BAF76936DB2D63CF06948CD0F597F86AF"
+                }
+            ],
+            "error_tests": [
+                {
+                    "tc_id": 10,
+                    "comment": "Partial signature equals the group order, which is out of range",
+                    "ids": [0],
+                    "pubshare_indices": [0],
+                    "aggnonce": "026805DC7B318F796C360BB82F85FA0C106AB8775FECF892A0A7F85FB66720CBAB039509CF07C0A787AB8628C84E1F6F5E9CA424496D6ED4AC36722E5602E0C32C57",
+                    "tweak_indices": [],
+                    "is_xonly": [],
+                    "psigs": [
+                        "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141"
+                    ],
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "InvalidContributionError",
+                        "signer_index": 0,
+                        "contrib": "psig"
+                    }
+                },
+                {
+                    "tc_id": 11,
+                    "comment": "Number of partial signatures does not match the number of signers",
+                    "ids": [0],
+                    "pubshare_indices": [0],
+                    "aggnonce": "026805DC7B318F796C360BB82F85FA0C106AB8775FECF892A0A7F85FB66720CBAB039509CF07C0A787AB8628C84E1F6F5E9CA424496D6ED4AC36722E5602E0C32C57",
+                    "tweak_indices": [],
+                    "is_xonly": [],
+                    "psigs": [],
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The psigs and ids arrays must have the same length."
+                    }
+                }
+            ]
+        },
+        {
+            "tg_id": "3of3",
+            "t": 3,
+            "n": 3,
+            "thresh_pk": "023E94D6A68620D3F60221A4186786274A711221A8BBB31A5388DFA6718E8EF7BB",
+            "pubshares": [
+                "03A3E932BA9DD0063D721590B6EF21DD4566A97B203343FDE9DA5815DB9BE049CA",
+                "0201E5FEAC0DB5059C32B045F37799101A96262B3C88CE85D610451FC21A0457FF",
+                "03EF72D10D1DFE4E786619536A458507CAF105FCCDB8173DAF2E358054AF2FA4A2"
+            ],
+            "tweaks": [
+                "E8F791FF9225A2AF0102AFFF4A9A723D9612A682A25EBE79802B263CDFCD83BB",
+                "AE2EA797CC0FE72AC5B97B97F3C6957D7E4199A167A58EB08BCAFFDA70AC0455",
+                "F52ECBC565B3D8BEA2DFD5B75A4F457E54369809322E4120831626F290FA87E0",
+                "1969AD73CC177FA0B4FCED6DF1F7BF9907E665FDE9BA196A74FED0A3CF5AEF9D"
+            ],
+            "valid_tests": [
+                {
+                    "tc_id": 12,
+                    "comment": "Minimum threshold subset of signers, no tweaks",
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "aggnonce": "030CC8DD7811033474FAD57D2DD03801584ED6A68CD1A73B3301C3DD1F685BBF7802DE9250BDBEF74C5EC1854A171EC8F5BD06CBDDCFB78384435AC62E5B359ACF2C",
+                    "tweak_indices": [],
+                    "is_xonly": [],
+                    "psigs": [
+                        "305FE509F00F665AAC836D1E49FF2539D3A11A9B20462457A49EBE28BED06728",
+                        "2C2DF99912A2EE3E694F3808AFA14B15C990AF29621B33850AC1E23D08B84C18",
+                        "ADEC5E2C1FBA9B5E028BF4BA0EAA3F41683D1BE26F20D4842CD865031B0F1F91"
+                    ],
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "expected": "386DC4546A4FB1D79FE9C40C06488DD271EF541325E492643794413EADFA280C0A7A3CCF226CEFF7185E99E1084AAF924AC008C042398C251C66A6DC12619190"
+                },
+                {
+                    "tc_id": 13,
+                    "comment": "Reordering the signer set leaves the aggregate signature unchanged, because the partial signatures are summed and the identifiers are sorted before they are bound into the binding value",
+                    "ids": [2, 1, 0],
+                    "pubshare_indices": [2, 1, 0],
+                    "aggnonce": "030CC8DD7811033474FAD57D2DD03801584ED6A68CD1A73B3301C3DD1F685BBF7802DE9250BDBEF74C5EC1854A171EC8F5BD06CBDDCFB78384435AC62E5B359ACF2C",
+                    "tweak_indices": [],
+                    "is_xonly": [],
+                    "psigs": [
+                        "ADEC5E2C1FBA9B5E028BF4BA0EAA3F41683D1BE26F20D4842CD865031B0F1F91",
+                        "2C2DF99912A2EE3E694F3808AFA14B15C990AF29621B33850AC1E23D08B84C18",
+                        "305FE509F00F665AAC836D1E49FF2539D3A11A9B20462457A49EBE28BED06728"
+                    ],
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "expected": "386DC4546A4FB1D79FE9C40C06488DD271EF541325E492643794413EADFA280C0A7A3CCF226CEFF7185E99E1084AAF924AC008C042398C251C66A6DC12619190"
+                },
+                {
+                    "tc_id": 14,
+                    "comment": "Aggregation with three tweaks applied (one x-only, two plain)",
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "aggnonce": "030CC8DD7811033474FAD57D2DD03801584ED6A68CD1A73B3301C3DD1F685BBF7802DE9250BDBEF74C5EC1854A171EC8F5BD06CBDDCFB78384435AC62E5B359ACF2C",
+                    "tweak_indices": [0, 1, 2],
+                    "is_xonly": [true, false, false],
+                    "psigs": [
+                        "E6DD426B51E8CD40C1731714028497174ED24C3FFD8DD42977BC909C4EB9CBA6",
+                        "A3C2B9914E16CC923D88FC56A57A81ADAE615EABF0AA393010FD6A081208AADE",
+                        "EE2AE76EA4BC9D291832D84D9E81C3B11986E02CF326E9CE4EEBF772B46E1EAB"
+                    ],
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "expected": "9E225C551791D819F757C1D07A9A4888D3AD051E116548A3C021BA590DB185582BFD18A0DFF9AD8137CA33BB8CBDD9534BE7DA7F03929BB10A913FD815467861"
+                }
+            ],
+            "error_tests": [
+                {
+                    "tc_id": 15,
+                    "comment": "Partial signature equals the group order, which is out of range",
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "aggnonce": "030CC8DD7811033474FAD57D2DD03801584ED6A68CD1A73B3301C3DD1F685BBF7802DE9250BDBEF74C5EC1854A171EC8F5BD06CBDDCFB78384435AC62E5B359ACF2C",
+                    "tweak_indices": [],
+                    "is_xonly": [],
+                    "psigs": [
+                        "305FE509F00F665AAC836D1E49FF2539D3A11A9B20462457A49EBE28BED06728",
+                        "2C2DF99912A2EE3E694F3808AFA14B15C990AF29621B33850AC1E23D08B84C18",
+                        "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141"
+                    ],
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "InvalidContributionError",
+                        "signer_index": 2,
+                        "contrib": "psig"
+                    }
+                },
+                {
+                    "tc_id": 16,
+                    "comment": "Number of partial signatures does not match the number of signers",
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "aggnonce": "030CC8DD7811033474FAD57D2DD03801584ED6A68CD1A73B3301C3DD1F685BBF7802DE9250BDBEF74C5EC1854A171EC8F5BD06CBDDCFB78384435AC62E5B359ACF2C",
+                    "tweak_indices": [],
+                    "is_xonly": [],
+                    "psigs": [
+                        "305FE509F00F665AAC836D1E49FF2539D3A11A9B20462457A49EBE28BED06728",
+                        "2C2DF99912A2EE3E694F3808AFA14B15C990AF29621B33850AC1E23D08B84C18"
+                    ],
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The psigs and ids arrays must have the same length."
+                    }
+                }
+            ]
+        },
+        {
+            "tg_id": "3of5",
+            "t": 3,
+            "n": 5,
+            "thresh_pk": "03E1AEA00A7B8D0E0393664FEBBD31569A02CAF223D9AD83E90331DC18B1987358",
+            "pubshares": [
+                "02F333EDD2B6F532C2EF6C42E803B633A42289D0567A75C50EB1C8CF85EC480E8F",
+                "025322F63602ECCF146541B7C9EE4D1FCB84EC139471420472182AE968676A387F",
+                "0230639CEC0A83982E176D6905CE0620FDC57E151565A39D0E0821B8E753AE85B0",
+                "026E1A50E672FEDD3F3C378D6121E5702B050669DBC241D2C2299880152CD207BD",
+                "02DC06C4CA919DE70B4B8281901CCF9471AB91FBFBEE1A8C570D83911CAAF9E2FA"
+            ],
+            "tweaks": [
+                "E8F791FF9225A2AF0102AFFF4A9A723D9612A682A25EBE79802B263CDFCD83BB",
+                "AE2EA797CC0FE72AC5B97B97F3C6957D7E4199A167A58EB08BCAFFDA70AC0455",
+                "F52ECBC565B3D8BEA2DFD5B75A4F457E54369809322E4120831626F290FA87E0",
+                "1969AD73CC177FA0B4FCED6DF1F7BF9907E665FDE9BA196A74FED0A3CF5AEF9D"
+            ],
+            "valid_tests": [
+                {
+                    "tc_id": 17,
+                    "comment": "Minimum threshold subset of signers, no tweaks",
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "aggnonce": "0391D52F656B3CA3E66AC5DAEF5B0D347F7E85B7DD7A9EBA10E9827AE23FB76E93031610E184E540470139F7626253F27E8871D6354941CC9FF94A07D83F61BB4CD5",
+                    "tweak_indices": [],
+                    "is_xonly": [],
+                    "psigs": [
+                        "603EC1EA86B284E28CEFD59C85F8DDC6DFE81C0744F59D8FB5BEB29F1C27F38B",
+                        "0E1CB1C6B75847D62D7DE29DA5B61E66386F512C1BFFD12C202D2D28D5455314",
+                        "B3890F87993310B2AE0887E0C8D51CD27898A713FF48C2197D280BDA313A4A2C"
+                    ],
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "expected": "2ACEEC78D476DB0C7000D548B010023BCD9E54008B966147A232003DA91AA79021E48338D73DDD6B6876401AF4841900D6413760B0F5909993418D1552714F8A"
+                },
+                {
+                    "tc_id": 18,
+                    "comment": "Reordering the signer set leaves the aggregate signature unchanged, because the partial signatures are summed and the identifiers are sorted before they are bound into the binding value",
+                    "ids": [2, 1, 0],
+                    "pubshare_indices": [2, 1, 0],
+                    "aggnonce": "0391D52F656B3CA3E66AC5DAEF5B0D347F7E85B7DD7A9EBA10E9827AE23FB76E93031610E184E540470139F7626253F27E8871D6354941CC9FF94A07D83F61BB4CD5",
+                    "tweak_indices": [],
+                    "is_xonly": [],
+                    "psigs": [
+                        "B3890F87993310B2AE0887E0C8D51CD27898A713FF48C2197D280BDA313A4A2C",
+                        "0E1CB1C6B75847D62D7DE29DA5B61E66386F512C1BFFD12C202D2D28D5455314",
+                        "603EC1EA86B284E28CEFD59C85F8DDC6DFE81C0744F59D8FB5BEB29F1C27F38B"
+                    ],
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "expected": "2ACEEC78D476DB0C7000D548B010023BCD9E54008B966147A232003DA91AA79021E48338D73DDD6B6876401AF4841900D6413760B0F5909993418D1552714F8A"
+                },
+                {
+                    "tc_id": 19,
+                    "comment": "Aggregation with three tweaks applied (one x-only, two plain)",
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "aggnonce": "0391D52F656B3CA3E66AC5DAEF5B0D347F7E85B7DD7A9EBA10E9827AE23FB76E93031610E184E540470139F7626253F27E8871D6354941CC9FF94A07D83F61BB4CD5",
+                    "tweak_indices": [0, 1, 2],
+                    "is_xonly": [true, false, false],
+                    "psigs": [
+                        "F7AD2F8DACC5D22A0F68007BB0AA3D6555F229AA3E3EE3D58ECA5AB5DEE1EC61",
+                        "296C561EDB37E9DD750190B526FD96F3EEA362CFF3DEEA614697ABE2963CF4E0",
+                        "83F2306CD21A2F003817258B4D33904771AA229AED0226A72739E8EF2BDD7BF3"
+                    ],
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "expected": "75220B52F1BD906E4314713F2DF189B52FEC6A333F42505D1F1C2A65EF3ED47A17360AADFD3FFCE1E89052420936B4991B2FD0E20F7D5FF7115231FBDB2E767D"
+                },
+                {
+                    "tc_id": 20,
+                    "comment": "All signers participate, no tweaks",
+                    "ids": [0, 1, 2, 3, 4],
+                    "pubshare_indices": [0, 1, 2, 3, 4],
+                    "aggnonce": "03536024F21D3C18E0F094D15E9DDA07740754905570A1B68CAFAC743A6C213745037C9EA6730CD21904C131FF4A6C62480A7BABAA75F0A4F63F1AFD8DEE9FDD699D",
+                    "tweak_indices": [],
+                    "is_xonly": [],
+                    "psigs": [
+                        "B665467100EDB9354041CDC8DF97CE74F08DDA6757DF8D0AF54D6502B9215595",
+                        "5D70B8D37BF0DB381CE15E3AAB9F59BECD54AD32AC19A216093881B8F6458BB6",
+                        "5CB137BBB9B24156B7DBD53377DC359357EB39A473B4CC7DD1E524240BEBBFA6",
+                        "E47D9384AD761C6409272AAB2E71F97001F4B70E256404A97AC645B368E00EA9",
+                        "BD1E4B209897C847EDD8E0DF6C46C88DC4CDAFA1C4021132E31CE5DC51DC789E"
+                    ],
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "expected": "C26D81CC4C703A46A3FE3B6E3FE884FB908348F462DB7368C4A754BDB662C4DE122315A57C9EBA700BFF0CC19DCC1FC8AC83913A533A30C7EED71AC9056C6475"
+                }
+            ],
+            "error_tests": [
+                {
+                    "tc_id": 21,
+                    "comment": "Partial signature equals the group order, which is out of range",
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "aggnonce": "0391D52F656B3CA3E66AC5DAEF5B0D347F7E85B7DD7A9EBA10E9827AE23FB76E93031610E184E540470139F7626253F27E8871D6354941CC9FF94A07D83F61BB4CD5",
+                    "tweak_indices": [],
+                    "is_xonly": [],
+                    "psigs": [
+                        "603EC1EA86B284E28CEFD59C85F8DDC6DFE81C0744F59D8FB5BEB29F1C27F38B",
+                        "0E1CB1C6B75847D62D7DE29DA5B61E66386F512C1BFFD12C202D2D28D5455314",
+                        "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141"
+                    ],
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "InvalidContributionError",
+                        "signer_index": 2,
+                        "contrib": "psig"
+                    }
+                },
+                {
+                    "tc_id": 22,
+                    "comment": "Number of partial signatures does not match the number of signers",
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "aggnonce": "0391D52F656B3CA3E66AC5DAEF5B0D347F7E85B7DD7A9EBA10E9827AE23FB76E93031610E184E540470139F7626253F27E8871D6354941CC9FF94A07D83F61BB4CD5",
+                    "tweak_indices": [],
+                    "is_xonly": [],
+                    "psigs": [
+                        "603EC1EA86B284E28CEFD59C85F8DDC6DFE81C0744F59D8FB5BEB29F1C27F38B",
+                        "0E1CB1C6B75847D62D7DE29DA5B61E66386F512C1BFFD12C202D2D28D5455314"
+                    ],
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The psigs and ids arrays must have the same length."
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/crypto/bip445/src/vectors/sign_verify_vectors.json
+++ b/crypto/bip445/src/vectors/sign_verify_vectors.json
@@ -1,0 +1,1529 @@
+{
+    "test_groups": [
+        {
+            "tg_id": "2of3",
+            "t": 2,
+            "n": 3,
+            "thresh_pk": "02D772A09F5F675783D275ED9F6AAEDB2ECCBC74171B37AC23AE3BBD9D7AE2CDAA",
+            "pubshares": [
+                "039EE3335AF48DFE23702AB353F4AF20D401F67A130DF783CC8457323A860A2FB4",
+                "0284DC4AB2CB78A621EB87FA1F14BCE2B725AFEAAC981ADCBAFF5CC2D417D2A63A",
+                "036441EC2D4C1266201CD89B69549A2F5B2188612A0D434153E625FB38173DD509",
+                "020000000000000000000000000000000000000000000000000000000000000007",
+                "02A5363A0993E3E2096EF80B7B4DA1EDF650DBF02CAE168BB4ACC0E90A24CED0FD"
+            ],
+            "pubnonces": [
+                "03FC0D3E212D25027356A2C9BB7EDC3B900DEA5E32AB10C03868E01C8490F9D36202C61389B6469B4345E00640CDC7ECA301547B97D30FC11AF410E23AD7B4BF69EE",
+                "03706F00353EA69C0836BF63C2884D2DE5AFE549A33EC87427CA8B5CF4666B28AE021B6300D0545E0B225C2DFC67AE33A9B0259B62809740363717E05CDA4CC9EBFC",
+                "02B7F6EF566DD2DDAA6AF38371A41F80F93A90B9F407B5BDB8ED763F00103DB0FC039C677604E7B75FF6E47C42B0249A3BAA9CC6B17E68D6D78E21ABA9D04BF40745",
+                "0200000000000000000000000000000000000000000000000000000000000000090287BF891D2A6DEAEBADC909352AA9405D1428C15F4B75F04DAE642A95C2548480",
+                "020F261BFE5DF0AE3EC06BB7A1D6394A3AF206968281F03B70D25FB84D49036CE202BE48277630579C72160430C819AABB1DFA20FF70749666080BB886B728476261"
+            ],
+            "secshares": [
+                "53442FA9BD72EEA0A42DF6F2D2D76A2C0D3A3DFA2BE2F820F41ADE976B8259FB",
+                "5A7F9BD41F4B544664C54D777D43303CB5302434F9903B9B552C4E552BF02201",
+                "61BB07FE8123B9EC255CA3FC27AEF64D5D260A6FC73D7F15B63DBE12EC5DEA07",
+                "0000000000000000000000000000000000000000000000000000000000000000"
+            ],
+            "secnonces": [
+                "67AFBE2B50F521569B9C1D943F8FE20620B8C25FA81E9788718AF6EE87D5275C9A485A634FE41558E4E108FBB52C5CF616C0CDF02BC0C10A99359FF6C1BD705C",
+                "6E5AABD814F30045744DC470103D44BCD846284D7A763F9BA3F5C73DCE20BF459FCEDE0DFFF09B9E0150CE5A2C05D3199B4B0987A18C49E9273DEADBBA40B4D6",
+                "762F4601AC206E1F1497EB541202B727CC19FA0450289C778B5D5F4F1A4B53F4D63D312CC2C9196D08FD62F3958FE8BBC66B8517D10DE534F6A641D0E6E5EBCB",
+                "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                "67AFBE2B50F521569B9C1D943F8FE20620B8C25FA81E9788718AF6EE87D5275C0000000000000000000000000000000000000000000000000000000000000000"
+            ],
+            "valid_tests": [
+                {
+                    "tc_id": 1,
+                    "comment": "Minimum threshold subset of signers",
+                    "my_id": 0,
+                    "ids": [0, 1],
+                    "pubshare_indices": [0, 1],
+                    "pubnonce_indices": [0, 1],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "030F261BFE5DF0AE3EC06BB7A1D6394A3AF206968281F03B70D25FB84D49036CE203BE48277630579C72160430C819AABB1DFA20FF70749666080BB886B728476261",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "expected": "93DDE8C9CEE714EB5BDF2BE00FEC3327F9CF386D3AC672F0DA734FFC08E7A041"
+                },
+                {
+                    "tc_id": 2,
+                    "comment": "Reordering the signer set leaves the partial signature unchanged, because the identifiers are sorted before they are bound into the binding value",
+                    "my_id": 0,
+                    "ids": [1, 0],
+                    "pubshare_indices": [1, 0],
+                    "pubnonce_indices": [1, 0],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "030F261BFE5DF0AE3EC06BB7A1D6394A3AF206968281F03B70D25FB84D49036CE203BE48277630579C72160430C819AABB1DFA20FF70749666080BB886B728476261",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "expected": "93DDE8C9CEE714EB5BDF2BE00FEC3327F9CF386D3AC672F0DA734FFC08E7A041"
+                },
+                {
+                    "tc_id": 3,
+                    "comment": "A different threshold subset gives a different partial signature, since the Lagrange coefficients depend on the signer set",
+                    "my_id": 0,
+                    "ids": [0, 2],
+                    "pubshare_indices": [0, 2],
+                    "pubnonce_indices": [0, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "03E0D6D449A7CDEC17785A2CF14A4FC52368FC6C8EB00F02F3B218A73FF687388B032947BCD7430962690DBA0594715D16F5C2136F7516AB75A10A0EDB3D5BBAD46E",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "expected": "2551E5EB416900877F817CACA417F517980E62015A24995D4B43F4FCCD08785A"
+                },
+                {
+                    "tc_id": 4,
+                    "comment": "All signers participate, signed by a non-first member of the signer set",
+                    "my_id": 1,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "pubnonce_indices": [0, 1, 2],
+                    "secshare_index": 1,
+                    "secnonce_index": 1,
+                    "aggnonce": "02CBC2E41AF87290A1401D49927FC30D7F40A404C4DF3E5FC734014188DBC44E1503C15312EDC691EB213F3B8AAC195D251A390563CD5E313D738A89DAEB4DA80746",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "expected": "09955F6B6CF09ED383F33C1BFCFE059E79E9D26FECC0095F4A31F22E7ED242AE"
+                },
+                {
+                    "tc_id": 5,
+                    "comment": "Aggregate nonce is the point at infinity, so the final nonce point falls back to the generator G",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "pubnonce_indices": [0, 1, 4],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "expected": "70E450AF543413AD3F1C3595B843EC8D7A9ED4693C86756DEEF7EB1D0461F7C1"
+                },
+                {
+                    "tc_id": 6,
+                    "comment": "Empty message",
+                    "my_id": 0,
+                    "ids": [0, 1],
+                    "pubshare_indices": [0, 1],
+                    "pubnonce_indices": [0, 1],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "030F261BFE5DF0AE3EC06BB7A1D6394A3AF206968281F03B70D25FB84D49036CE203BE48277630579C72160430C819AABB1DFA20FF70749666080BB886B728476261",
+                    "msg": "",
+                    "expected": "9019CFAC70EFADC7891B158B77C0C80EBBF4F88468F1670BB1B74627BE68E9B5"
+                },
+                {
+                    "tc_id": 7,
+                    "comment": "Non-standard message length (38 bytes)",
+                    "my_id": 0,
+                    "ids": [0, 1],
+                    "pubshare_indices": [0, 1],
+                    "pubnonce_indices": [0, 1],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "030F261BFE5DF0AE3EC06BB7A1D6394A3AF206968281F03B70D25FB84D49036CE203BE48277630579C72160430C819AABB1DFA20FF70749666080BB886B728476261",
+                    "msg": "2626262626262626262626262626262626262626262626262626262626262626262626262626",
+                    "expected": "301C26EC3635BCD8359BFF82312E378583D6A470BD091EC3E9CC4A56CB50BB81"
+                }
+            ],
+            "sign_error_tests": [
+                {
+                    "tc_id": 8,
+                    "comment": "Signer's identifier is absent from the signer set",
+                    "my_id": 2,
+                    "ids": [0, 1],
+                    "pubshare_indices": [0, 1],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "030F261BFE5DF0AE3EC06BB7A1D6394A3AF206968281F03B70D25FB84D49036CE203BE48277630579C72160430C819AABB1DFA20FF70749666080BB886B728476261",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The signer's id must be present in the participant identifier list."
+                    }
+                },
+                {
+                    "tc_id": 9,
+                    "comment": "Signer set contains a duplicate id",
+                    "my_id": 0,
+                    "ids": [0, 1, 1],
+                    "pubshare_indices": [0, 1, 1],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "030F261BFE5DF0AE3EC06BB7A1D6394A3AF206968281F03B70D25FB84D49036CE203BE48277630579C72160430C819AABB1DFA20FF70749666080BB886B728476261",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The participant identifier list contains duplicate elements."
+                    }
+                },
+                {
+                    "tc_id": 10,
+                    "comment": "Signer's public share is not in the public share list",
+                    "my_id": 1,
+                    "ids": [1, 2],
+                    "pubshare_indices": [1, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "033334D94EBA8ED8D3CD7CDD4430F0EE85A207917A12DF12DFE08E1861B004A6D4033D71B2938B48516AB2EE546C5EC36D0EFFBF0B3E290E9084CE5606394395EE5A",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The signer's pubshare must be included in the list of pubshares."
+                    }
+                },
+                {
+                    "tc_id": 11,
+                    "comment": "A public share is not a valid point",
+                    "my_id": 0,
+                    "ids": [0, 1],
+                    "pubshare_indices": [0, 3],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "030F261BFE5DF0AE3EC06BB7A1D6394A3AF206968281F03B70D25FB84D49036CE203BE48277630579C72160430C819AABB1DFA20FF70749666080BB886B728476261",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "Invalid pubshare at index 1."
+                    }
+                },
+                {
+                    "tc_id": 12,
+                    "comment": "Public shares of the signer set interpolate to the point at infinity",
+                    "my_id": 0,
+                    "ids": [0, 1],
+                    "pubshare_indices": [0, 4],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "030F261BFE5DF0AE3EC06BB7A1D6394A3AF206968281F03B70D25FB84D49036CE203BE48277630579C72160430C819AABB1DFA20FF70749666080BB886B728476261",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The threshold pubkey must not be the point at infinity."
+                    }
+                },
+                {
+                    "tc_id": 13,
+                    "comment": "A signer id is outside the valid range [0, n-1]",
+                    "my_id": 1,
+                    "ids": [3, 1],
+                    "pubshare_indices": [0, 1],
+                    "secshare_index": 1,
+                    "secnonce_index": 1,
+                    "aggnonce": "030F261BFE5DF0AE3EC06BB7A1D6394A3AF206968281F03B70D25FB84D49036CE203BE48277630579C72160430C819AABB1DFA20FF70749666080BB886B728476261",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The participant identifier at index 0 is out of range."
+                    }
+                },
+                {
+                    "tc_id": 14,
+                    "comment": "Signer set's public shares do not match the threshold public key",
+                    "my_id": 0,
+                    "ids": [0, 1],
+                    "pubshare_indices": [1, 0],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "030F261BFE5DF0AE3EC06BB7A1D6394A3AF206968281F03B70D25FB84D49036CE203BE48277630579C72160430C819AABB1DFA20FF70749666080BB886B728476261",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The provided key material is incorrect."
+                    }
+                },
+                {
+                    "tc_id": 15,
+                    "comment": "Aggregate nonce is invalid: first half has an unknown tag 0x04",
+                    "my_id": 0,
+                    "ids": [0, 1],
+                    "pubshare_indices": [0, 1],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "048465FCF0BBDBCF443AABCCE533D42B4B5A10966AC09A49655E8C42DAAB8FCD61037496A3CC86926D452CAFCFD55D25972CA1675D549310DE296BFF42F72EEEA8C9",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "InvalidContributionError",
+                        "signer_index": null,
+                        "contrib": "aggnonce"
+                    }
+                },
+                {
+                    "tc_id": 16,
+                    "comment": "Aggregate nonce is invalid: second half is not a point on the curve",
+                    "my_id": 0,
+                    "ids": [0, 1],
+                    "pubshare_indices": [0, 1],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "028465FCF0BBDBCF443AABCCE533D42B4B5A10966AC09A49655E8C42DAAB8FCD61020000000000000000000000000000000000000000000000000000000000000009",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "InvalidContributionError",
+                        "signer_index": null,
+                        "contrib": "aggnonce"
+                    }
+                },
+                {
+                    "tc_id": 17,
+                    "comment": "Aggregate nonce is invalid: second half's x-coordinate exceeds the field size",
+                    "my_id": 0,
+                    "ids": [0, 1],
+                    "pubshare_indices": [0, 1],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "028465FCF0BBDBCF443AABCCE533D42B4B5A10966AC09A49655E8C42DAAB8FCD6102FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC30",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "InvalidContributionError",
+                        "signer_index": null,
+                        "contrib": "aggnonce"
+                    }
+                },
+                {
+                    "tc_id": 18,
+                    "comment": "Secret nonce's first half is out of range (all-zero nonce, which may indicate nonce reuse)",
+                    "my_id": 0,
+                    "ids": [0, 1],
+                    "pubshare_indices": [0, 1],
+                    "secshare_index": 0,
+                    "secnonce_index": 3,
+                    "aggnonce": "030F261BFE5DF0AE3EC06BB7A1D6394A3AF206968281F03B70D25FB84D49036CE203BE48277630579C72160430C819AABB1DFA20FF70749666080BB886B728476261",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "first secnonce value is out of range."
+                    }
+                },
+                {
+                    "tc_id": 19,
+                    "comment": "Secret nonce's second half is out of range (zero)",
+                    "my_id": 0,
+                    "ids": [0, 1],
+                    "pubshare_indices": [0, 1],
+                    "secshare_index": 0,
+                    "secnonce_index": 4,
+                    "aggnonce": "030F261BFE5DF0AE3EC06BB7A1D6394A3AF206968281F03B70D25FB84D49036CE203BE48277630579C72160430C819AABB1DFA20FF70749666080BB886B728476261",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "second secnonce value is out of range."
+                    }
+                },
+                {
+                    "tc_id": 20,
+                    "comment": "Fewer signers than the threshold t",
+                    "my_id": 0,
+                    "ids": [0],
+                    "pubshare_indices": [0],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "030F261BFE5DF0AE3EC06BB7A1D6394A3AF206968281F03B70D25FB84D49036CE203BE48277630579C72160430C819AABB1DFA20FF70749666080BB886B728476261",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The number of signers must be between t and n."
+                    }
+                },
+                {
+                    "tc_id": 21,
+                    "comment": "Secret share is out of range (zero)",
+                    "my_id": 0,
+                    "ids": [0, 1],
+                    "pubshare_indices": [0, 1],
+                    "secshare_index": 3,
+                    "secnonce_index": 0,
+                    "aggnonce": "030F261BFE5DF0AE3EC06BB7A1D6394A3AF206968281F03B70D25FB84D49036CE203BE48277630579C72160430C819AABB1DFA20FF70749666080BB886B728476261",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The signer's secret share value is out of range."
+                    }
+                }
+            ],
+            "verify_fail_tests": [
+                {
+                    "tc_id": 22,
+                    "comment": "Negated partial signature fails the verification equation",
+                    "psig": "6C2217363118EB14A420D41FF013CCD6C0DFA47974822D4AE55F0E90C74EA100",
+                    "ids": [0, 1],
+                    "pubshare_indices": [0, 1],
+                    "pubnonce_indices": [0, 1],
+                    "signer_index": 0,
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF"
+                },
+                {
+                    "tc_id": 23,
+                    "comment": "A valid partial signature checked against the wrong signer fails the verification equation",
+                    "psig": "93DDE8C9CEE714EB5BDF2BE00FEC3327F9CF386D3AC672F0DA734FFC08E7A041",
+                    "ids": [0, 1],
+                    "pubshare_indices": [0, 1],
+                    "pubnonce_indices": [0, 1],
+                    "signer_index": 1,
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF"
+                },
+                {
+                    "tc_id": 24,
+                    "comment": "Partial signature equals the group order, which is out of range",
+                    "psig": "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141",
+                    "ids": [0, 1],
+                    "pubshare_indices": [0, 1],
+                    "pubnonce_indices": [0, 1],
+                    "signer_index": 0,
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF"
+                }
+            ],
+            "verify_error_tests": [
+                {
+                    "tc_id": 25,
+                    "comment": "Verification rejects an invalid public nonce, blaming the malicious signer",
+                    "psig": "93DDE8C9CEE714EB5BDF2BE00FEC3327F9CF386D3AC672F0DA734FFC08E7A041",
+                    "ids": [0, 1],
+                    "pubshare_indices": [0, 1],
+                    "pubnonce_indices": [3, 1],
+                    "signer_index": 0,
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "InvalidContributionError",
+                        "signer_index": 0,
+                        "contrib": "pubnonce"
+                    }
+                },
+                {
+                    "tc_id": 26,
+                    "comment": "A public share is not a valid point",
+                    "psig": "93DDE8C9CEE714EB5BDF2BE00FEC3327F9CF386D3AC672F0DA734FFC08E7A041",
+                    "ids": [0, 1],
+                    "pubshare_indices": [3, 1],
+                    "pubnonce_indices": [0, 1],
+                    "signer_index": 0,
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "Invalid pubshare at index 0."
+                    }
+                }
+            ]
+        },
+        {
+            "tg_id": "1of3",
+            "t": 1,
+            "n": 3,
+            "thresh_pk": "03D1939BE87D18EA5AB302E27077D16B2C2FD93516F91514BA049933D348DA441F",
+            "pubshares": [
+                "03D1939BE87D18EA5AB302E27077D16B2C2FD93516F91514BA049933D348DA441F",
+                "03D1939BE87D18EA5AB302E27077D16B2C2FD93516F91514BA049933D348DA441F",
+                "03D1939BE87D18EA5AB302E27077D16B2C2FD93516F91514BA049933D348DA441F",
+                "020000000000000000000000000000000000000000000000000000000000000007",
+                "0394F8592DC5FEC76CFF92200ED3BA2BCF78518B46B706A47BD55458DB31D294A7"
+            ],
+            "pubnonces": [
+                "026805DC7B318F796C360BB82F85FA0C106AB8775FECF892A0A7F85FB66720CBAB039509CF07C0A787AB8628C84E1F6F5E9CA424496D6ED4AC36722E5602E0C32C57",
+                "026805DC7B318F796C360BB82F85FA0C106AB8775FECF892A0A7F85FB66720CBAB039509CF07C0A787AB8628C84E1F6F5E9CA424496D6ED4AC36722E5602E0C32C57",
+                "026805DC7B318F796C360BB82F85FA0C106AB8775FECF892A0A7F85FB66720CBAB039509CF07C0A787AB8628C84E1F6F5E9CA424496D6ED4AC36722E5602E0C32C57",
+                "0200000000000000000000000000000000000000000000000000000000000000090287BF891D2A6DEAEBADC909352AA9405D1428C15F4B75F04DAE642A95C2548480",
+                "02FBEA8F3C4CCA7DFD6BD61F7DF7B49BE720D0DE014144457C1EEB0882B40CA76B03289A43F164E3403CDA987383887BB807EB8CF3329949DC80C3DD5D757EF4B841"
+            ],
+            "secshares": [
+                "06D47E05E97481428654563E5AE69C20C49642773B7334220E63110259A30C32",
+                "06D47E05E97481428654563E5AE69C20C49642773B7334220E63110259A30C32",
+                "06D47E05E97481428654563E5AE69C20C49642773B7334220E63110259A30C32",
+                "0000000000000000000000000000000000000000000000000000000000000000"
+            ],
+            "secnonces": [
+                "85988D37E7F2EE21FC47295E90D0FD85027CE0E71DA37B36CFB55BD471D3BA82ACE9F73C19DCD387AEF30F9E894564A47F8BE85FAAAE710DD0F442DF2A380190",
+                "85988D37E7F2EE21FC47295E90D0FD85027CE0E71DA37B36CFB55BD471D3BA82ACE9F73C19DCD387AEF30F9E894564A47F8BE85FAAAE710DD0F442DF2A380190",
+                "85988D37E7F2EE21FC47295E90D0FD85027CE0E71DA37B36CFB55BD471D3BA82ACE9F73C19DCD387AEF30F9E894564A47F8BE85FAAAE710DD0F442DF2A380190",
+                "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                "85988D37E7F2EE21FC47295E90D0FD85027CE0E71DA37B36CFB55BD471D3BA820000000000000000000000000000000000000000000000000000000000000000"
+            ],
+            "valid_tests": [
+                {
+                    "tc_id": 27,
+                    "comment": "Minimum threshold subset of signers",
+                    "my_id": 0,
+                    "ids": [0],
+                    "pubshare_indices": [0],
+                    "pubnonce_indices": [0],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "026805DC7B318F796C360BB82F85FA0C106AB8775FECF892A0A7F85FB66720CBAB039509CF07C0A787AB8628C84E1F6F5E9CA424496D6ED4AC36722E5602E0C32C57",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "expected": "B7C3FA9AEA2B0989D150B57433233015A269CB56232B1DE2AFE573491D960B2C"
+                },
+                {
+                    "tc_id": 28,
+                    "comment": "All signers participate, signed by a non-first member of the signer set",
+                    "my_id": 1,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "pubnonce_indices": [0, 1, 2],
+                    "secshare_index": 1,
+                    "secnonce_index": 1,
+                    "aggnonce": "0277E716756BAEFD922DCD339D083FEB1C0263B06999328492331FB876A225EEA3033910C4FC151C7AA914B4D2AC97B3F09C56A36A5F95F14043D90210CC1FCD4245",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "expected": "97F8FC6A3EB65E25F3850341B8D58851564F12EF88D996C53916C75578595CFD"
+                },
+                {
+                    "tc_id": 29,
+                    "comment": "Aggregate nonce is the point at infinity, so the final nonce point falls back to the generator G",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "pubnonce_indices": [0, 1, 4],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "expected": "C502C0A6CEF6DAEC244DDF522E4223C83F970C41BB99DE482858A40985C758CB"
+                },
+                {
+                    "tc_id": 30,
+                    "comment": "Empty message",
+                    "my_id": 0,
+                    "ids": [0],
+                    "pubshare_indices": [0],
+                    "pubnonce_indices": [0],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "026805DC7B318F796C360BB82F85FA0C106AB8775FECF892A0A7F85FB66720CBAB039509CF07C0A787AB8628C84E1F6F5E9CA424496D6ED4AC36722E5602E0C32C57",
+                    "msg": "",
+                    "expected": "AD2B792E93662107814068051C45B6C9F590570F19770537E4F50E1344F100F3"
+                },
+                {
+                    "tc_id": 31,
+                    "comment": "Non-standard message length (38 bytes)",
+                    "my_id": 0,
+                    "ids": [0],
+                    "pubshare_indices": [0],
+                    "pubnonce_indices": [0],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "026805DC7B318F796C360BB82F85FA0C106AB8775FECF892A0A7F85FB66720CBAB039509CF07C0A787AB8628C84E1F6F5E9CA424496D6ED4AC36722E5602E0C32C57",
+                    "msg": "2626262626262626262626262626262626262626262626262626262626262626262626262626",
+                    "expected": "DCFB825B675205E087DE88AA4DD550C31B0EF77E4A23D7A0463258CE58226B6A"
+                }
+            ],
+            "sign_error_tests": [
+                {
+                    "tc_id": 32,
+                    "comment": "Signer's identifier is absent from the signer set",
+                    "my_id": 1,
+                    "ids": [0],
+                    "pubshare_indices": [0],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "026805DC7B318F796C360BB82F85FA0C106AB8775FECF892A0A7F85FB66720CBAB039509CF07C0A787AB8628C84E1F6F5E9CA424496D6ED4AC36722E5602E0C32C57",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The signer's id must be present in the participant identifier list."
+                    }
+                },
+                {
+                    "tc_id": 33,
+                    "comment": "Signer set contains a duplicate id",
+                    "my_id": 0,
+                    "ids": [0, 1, 1],
+                    "pubshare_indices": [0, 1, 1],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "026805DC7B318F796C360BB82F85FA0C106AB8775FECF892A0A7F85FB66720CBAB039509CF07C0A787AB8628C84E1F6F5E9CA424496D6ED4AC36722E5602E0C32C57",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The participant identifier list contains duplicate elements."
+                    }
+                },
+                {
+                    "tc_id": 34,
+                    "comment": "A public share is not a valid point",
+                    "my_id": 0,
+                    "ids": [0, 1],
+                    "pubshare_indices": [0, 3],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "03FBEA8F3C4CCA7DFD6BD61F7DF7B49BE720D0DE014144457C1EEB0882B40CA76B02289A43F164E3403CDA987383887BB807EB8CF3329949DC80C3DD5D757EF4B841",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "Invalid pubshare at index 1."
+                    }
+                },
+                {
+                    "tc_id": 35,
+                    "comment": "Public shares of the signer set interpolate to the point at infinity",
+                    "my_id": 0,
+                    "ids": [0, 1],
+                    "pubshare_indices": [0, 4],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "03FBEA8F3C4CCA7DFD6BD61F7DF7B49BE720D0DE014144457C1EEB0882B40CA76B02289A43F164E3403CDA987383887BB807EB8CF3329949DC80C3DD5D757EF4B841",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The threshold pubkey must not be the point at infinity."
+                    }
+                },
+                {
+                    "tc_id": 36,
+                    "comment": "A signer id is outside the valid range [0, n-1]",
+                    "my_id": 0,
+                    "ids": [3],
+                    "pubshare_indices": [0],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "026805DC7B318F796C360BB82F85FA0C106AB8775FECF892A0A7F85FB66720CBAB039509CF07C0A787AB8628C84E1F6F5E9CA424496D6ED4AC36722E5602E0C32C57",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The participant identifier at index 0 is out of range."
+                    }
+                },
+                {
+                    "tc_id": 37,
+                    "comment": "Aggregate nonce is invalid: first half has an unknown tag 0x04",
+                    "my_id": 0,
+                    "ids": [0],
+                    "pubshare_indices": [0],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "048465FCF0BBDBCF443AABCCE533D42B4B5A10966AC09A49655E8C42DAAB8FCD61037496A3CC86926D452CAFCFD55D25972CA1675D549310DE296BFF42F72EEEA8C9",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "InvalidContributionError",
+                        "signer_index": null,
+                        "contrib": "aggnonce"
+                    }
+                },
+                {
+                    "tc_id": 38,
+                    "comment": "Aggregate nonce is invalid: second half is not a point on the curve",
+                    "my_id": 0,
+                    "ids": [0],
+                    "pubshare_indices": [0],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "028465FCF0BBDBCF443AABCCE533D42B4B5A10966AC09A49655E8C42DAAB8FCD61020000000000000000000000000000000000000000000000000000000000000009",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "InvalidContributionError",
+                        "signer_index": null,
+                        "contrib": "aggnonce"
+                    }
+                },
+                {
+                    "tc_id": 39,
+                    "comment": "Aggregate nonce is invalid: second half's x-coordinate exceeds the field size",
+                    "my_id": 0,
+                    "ids": [0],
+                    "pubshare_indices": [0],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "028465FCF0BBDBCF443AABCCE533D42B4B5A10966AC09A49655E8C42DAAB8FCD6102FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC30",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "InvalidContributionError",
+                        "signer_index": null,
+                        "contrib": "aggnonce"
+                    }
+                },
+                {
+                    "tc_id": 40,
+                    "comment": "Secret nonce's first half is out of range (all-zero nonce, which may indicate nonce reuse)",
+                    "my_id": 0,
+                    "ids": [0],
+                    "pubshare_indices": [0],
+                    "secshare_index": 0,
+                    "secnonce_index": 3,
+                    "aggnonce": "026805DC7B318F796C360BB82F85FA0C106AB8775FECF892A0A7F85FB66720CBAB039509CF07C0A787AB8628C84E1F6F5E9CA424496D6ED4AC36722E5602E0C32C57",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "first secnonce value is out of range."
+                    }
+                },
+                {
+                    "tc_id": 41,
+                    "comment": "Secret nonce's second half is out of range (zero)",
+                    "my_id": 0,
+                    "ids": [0],
+                    "pubshare_indices": [0],
+                    "secshare_index": 0,
+                    "secnonce_index": 4,
+                    "aggnonce": "026805DC7B318F796C360BB82F85FA0C106AB8775FECF892A0A7F85FB66720CBAB039509CF07C0A787AB8628C84E1F6F5E9CA424496D6ED4AC36722E5602E0C32C57",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "second secnonce value is out of range."
+                    }
+                },
+                {
+                    "tc_id": 42,
+                    "comment": "Fewer signers than the threshold t",
+                    "my_id": 0,
+                    "ids": [],
+                    "pubshare_indices": [],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "026805DC7B318F796C360BB82F85FA0C106AB8775FECF892A0A7F85FB66720CBAB039509CF07C0A787AB8628C84E1F6F5E9CA424496D6ED4AC36722E5602E0C32C57",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The number of signers must be between t and n."
+                    }
+                },
+                {
+                    "tc_id": 43,
+                    "comment": "Secret share is out of range (zero)",
+                    "my_id": 0,
+                    "ids": [0],
+                    "pubshare_indices": [0],
+                    "secshare_index": 3,
+                    "secnonce_index": 0,
+                    "aggnonce": "026805DC7B318F796C360BB82F85FA0C106AB8775FECF892A0A7F85FB66720CBAB039509CF07C0A787AB8628C84E1F6F5E9CA424496D6ED4AC36722E5602E0C32C57",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The signer's secret share value is out of range."
+                    }
+                }
+            ],
+            "verify_fail_tests": [
+                {
+                    "tc_id": 44,
+                    "comment": "Negated partial signature fails the verification equation",
+                    "psig": "BD6480B3F248A66158632C3FA405C5870EE45BE2869662EF7B39A87CDDE7D37B",
+                    "ids": [0, 1],
+                    "pubshare_indices": [0, 1],
+                    "pubnonce_indices": [0, 1],
+                    "signer_index": 0,
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF"
+                },
+                {
+                    "tc_id": 45,
+                    "comment": "A valid partial signature checked against the wrong signer fails the verification equation",
+                    "psig": "429B7F4C0DB7599EA79CD3C05BFA3A77ABCA810428B23D4C4498B60FF24E6DC6",
+                    "ids": [0, 1],
+                    "pubshare_indices": [0, 1],
+                    "pubnonce_indices": [0, 1],
+                    "signer_index": 1,
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF"
+                },
+                {
+                    "tc_id": 46,
+                    "comment": "Partial signature equals the group order, which is out of range",
+                    "psig": "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141",
+                    "ids": [0, 1],
+                    "pubshare_indices": [0, 1],
+                    "pubnonce_indices": [0, 1],
+                    "signer_index": 0,
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF"
+                }
+            ],
+            "verify_error_tests": [
+                {
+                    "tc_id": 47,
+                    "comment": "Verification rejects an invalid public nonce, blaming the malicious signer",
+                    "psig": "B7C3FA9AEA2B0989D150B57433233015A269CB56232B1DE2AFE573491D960B2C",
+                    "ids": [0],
+                    "pubshare_indices": [0],
+                    "pubnonce_indices": [3],
+                    "signer_index": 0,
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "InvalidContributionError",
+                        "signer_index": 0,
+                        "contrib": "pubnonce"
+                    }
+                },
+                {
+                    "tc_id": 48,
+                    "comment": "A public share is not a valid point",
+                    "psig": "B7C3FA9AEA2B0989D150B57433233015A269CB56232B1DE2AFE573491D960B2C",
+                    "ids": [0],
+                    "pubshare_indices": [3],
+                    "pubnonce_indices": [0],
+                    "signer_index": 0,
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "Invalid pubshare at index 0."
+                    }
+                }
+            ]
+        },
+        {
+            "tg_id": "3of3",
+            "t": 3,
+            "n": 3,
+            "thresh_pk": "023E94D6A68620D3F60221A4186786274A711221A8BBB31A5388DFA6718E8EF7BB",
+            "pubshares": [
+                "03A3E932BA9DD0063D721590B6EF21DD4566A97B203343FDE9DA5815DB9BE049CA",
+                "0201E5FEAC0DB5059C32B045F37799101A96262B3C88CE85D610451FC21A0457FF",
+                "03EF72D10D1DFE4E786619536A458507CAF105FCCDB8173DAF2E358054AF2FA4A2",
+                "020000000000000000000000000000000000000000000000000000000000000007",
+                "028FB6424719CF2E40146B4025715FDA43918A722F33A6260CB08A21E65CB9E14E"
+            ],
+            "pubnonces": [
+                "02B6418EDDC3E2D48B064BE46F71CEDE3A34594DEAC6E7F6707C8A71CB523EA58602C0B402216E9952E649B8CCFEDBAC6AA10BAEEFF4C02EEAA1148E87C7B21BDFB7",
+                "02B63A2B319D64A7BFE6634404CB9D80AAA57BAFD8AA01FC52BF77232DC0EE4B600358E8B8F6FB17FB5D92FAFAC1093773645FE32330D6E2774B4BBBCEF7DDFA5102",
+                "0364F60E66B7BC35A332B4F9688BD5CA2EF508E25C691D6A1A194097D170BBCCE602494AB47255521F0134EC7C41079A8955DA7220172A60371DC32C696AE5D61410",
+                "0200000000000000000000000000000000000000000000000000000000000000090287BF891D2A6DEAEBADC909352AA9405D1428C15F4B75F04DAE642A95C2548480",
+                "0335CCFFD0F3A9110FF368B72360D76A9940910BD2DB6C2CCC26F2C4DA984A1E9B03502D16AC8AE6322A0AE9A8CBE887158DE8236A6F1C510B2D5D06F00A851B48D0"
+            ],
+            "secshares": [
+                "D4DE571C662C319E7C4F46420F5ACBEFD2D905C3B52771C553DE1F76197D940D",
+                "0EAAC017ABA2030272B7F8EAAD68E22BF07F08950D7B570B69B2CCEF278D52C1",
+                "1E4E4344B9B59410588CCF327B766E4D298882D904F0FBF288C86B73AC5962A3",
+                "0000000000000000000000000000000000000000000000000000000000000000"
+            ],
+            "secnonces": [
+                "7B2247A3980C88714A0821F230F689F436FBF80B0B6DED33540B92CB65BA6ED149A8ADAF97EF6DBAA6015CD5BA84E4CAADB7A453508DD17FD8EE3618E119C0F9",
+                "B1456FA8F924860A665AFC2AE2746E6E2C99EBBE4BC1D0F5BD00BC52CB7DFD79A823D92911393852D4ECCC59387DB88C526FD1AD7574A3336893B618750DBDDD",
+                "C309D4BC0457A9D6031CDAC33BAFA47BAB2334445BF22D09E1936F919756D275BC09410F5D39E5D701C81BBA99E4E95F9E07FFC32C322F25604582CB242DD46A",
+                "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                "7B2247A3980C88714A0821F230F689F436FBF80B0B6DED33540B92CB65BA6ED10000000000000000000000000000000000000000000000000000000000000000"
+            ],
+            "valid_tests": [
+                {
+                    "tc_id": 49,
+                    "comment": "Minimum threshold subset of signers",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "pubnonce_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "030CC8DD7811033474FAD57D2DD03801584ED6A68CD1A73B3301C3DD1F685BBF7802DE9250BDBEF74C5EC1854A171EC8F5BD06CBDDCFB78384435AC62E5B359ACF2C",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "expected": "305FE509F00F665AAC836D1E49FF2539D3A11A9B20462457A49EBE28BED06728"
+                },
+                {
+                    "tc_id": 50,
+                    "comment": "Reordering the signer set leaves the partial signature unchanged, because the identifiers are sorted before they are bound into the binding value",
+                    "my_id": 0,
+                    "ids": [2, 1, 0],
+                    "pubshare_indices": [2, 1, 0],
+                    "pubnonce_indices": [2, 1, 0],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "030CC8DD7811033474FAD57D2DD03801584ED6A68CD1A73B3301C3DD1F685BBF7802DE9250BDBEF74C5EC1854A171EC8F5BD06CBDDCFB78384435AC62E5B359ACF2C",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "expected": "305FE509F00F665AAC836D1E49FF2539D3A11A9B20462457A49EBE28BED06728"
+                },
+                {
+                    "tc_id": 51,
+                    "comment": "All signers participate, signed by a non-first member of the signer set",
+                    "my_id": 1,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "pubnonce_indices": [0, 1, 2],
+                    "secshare_index": 1,
+                    "secnonce_index": 1,
+                    "aggnonce": "030CC8DD7811033474FAD57D2DD03801584ED6A68CD1A73B3301C3DD1F685BBF7802DE9250BDBEF74C5EC1854A171EC8F5BD06CBDDCFB78384435AC62E5B359ACF2C",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "expected": "2C2DF99912A2EE3E694F3808AFA14B15C990AF29621B33850AC1E23D08B84C18"
+                },
+                {
+                    "tc_id": 52,
+                    "comment": "Aggregate nonce is the point at infinity, so the final nonce point falls back to the generator G",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "pubnonce_indices": [0, 1, 4],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "expected": "32B9FEB07468F1364A9604E7D92B5FD2F3E32EB08BED61CE4B43A804C88D01F6"
+                },
+                {
+                    "tc_id": 53,
+                    "comment": "Empty message",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "pubnonce_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "030CC8DD7811033474FAD57D2DD03801584ED6A68CD1A73B3301C3DD1F685BBF7802DE9250BDBEF74C5EC1854A171EC8F5BD06CBDDCFB78384435AC62E5B359ACF2C",
+                    "msg": "",
+                    "expected": "73ED44A67A03A76AF50A879F37887AE2DC63027D7F84EAD9AAC47A5C79D224A1"
+                },
+                {
+                    "tc_id": 54,
+                    "comment": "Non-standard message length (38 bytes)",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "pubnonce_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "030CC8DD7811033474FAD57D2DD03801584ED6A68CD1A73B3301C3DD1F685BBF7802DE9250BDBEF74C5EC1854A171EC8F5BD06CBDDCFB78384435AC62E5B359ACF2C",
+                    "msg": "2626262626262626262626262626262626262626262626262626262626262626262626262626",
+                    "expected": "9218AFB2A486B52A8EC0ECB6C8EEF1D022F8DC8C203237D2E4267B02F41FF7F3"
+                }
+            ],
+            "sign_error_tests": [
+                {
+                    "tc_id": 55,
+                    "comment": "Signer set contains a duplicate id",
+                    "my_id": 0,
+                    "ids": [0, 1, 1],
+                    "pubshare_indices": [0, 1, 1],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "030CC8DD7811033474FAD57D2DD03801584ED6A68CD1A73B3301C3DD1F685BBF7802DE9250BDBEF74C5EC1854A171EC8F5BD06CBDDCFB78384435AC62E5B359ACF2C",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The participant identifier list contains duplicate elements."
+                    }
+                },
+                {
+                    "tc_id": 56,
+                    "comment": "A public share is not a valid point",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 3, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "030CC8DD7811033474FAD57D2DD03801584ED6A68CD1A73B3301C3DD1F685BBF7802DE9250BDBEF74C5EC1854A171EC8F5BD06CBDDCFB78384435AC62E5B359ACF2C",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "Invalid pubshare at index 1."
+                    }
+                },
+                {
+                    "tc_id": 57,
+                    "comment": "Public shares of the signer set interpolate to the point at infinity",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 4],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "030CC8DD7811033474FAD57D2DD03801584ED6A68CD1A73B3301C3DD1F685BBF7802DE9250BDBEF74C5EC1854A171EC8F5BD06CBDDCFB78384435AC62E5B359ACF2C",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The threshold pubkey must not be the point at infinity."
+                    }
+                },
+                {
+                    "tc_id": 58,
+                    "comment": "A signer id is outside the valid range [0, n-1]",
+                    "my_id": 1,
+                    "ids": [3, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 1,
+                    "secnonce_index": 1,
+                    "aggnonce": "030CC8DD7811033474FAD57D2DD03801584ED6A68CD1A73B3301C3DD1F685BBF7802DE9250BDBEF74C5EC1854A171EC8F5BD06CBDDCFB78384435AC62E5B359ACF2C",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The participant identifier at index 0 is out of range."
+                    }
+                },
+                {
+                    "tc_id": 59,
+                    "comment": "Signer set's public shares do not match the threshold public key",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 2, 1],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "030CC8DD7811033474FAD57D2DD03801584ED6A68CD1A73B3301C3DD1F685BBF7802DE9250BDBEF74C5EC1854A171EC8F5BD06CBDDCFB78384435AC62E5B359ACF2C",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The provided key material is incorrect."
+                    }
+                },
+                {
+                    "tc_id": 60,
+                    "comment": "Aggregate nonce is invalid: first half has an unknown tag 0x04",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "048465FCF0BBDBCF443AABCCE533D42B4B5A10966AC09A49655E8C42DAAB8FCD61037496A3CC86926D452CAFCFD55D25972CA1675D549310DE296BFF42F72EEEA8C9",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "InvalidContributionError",
+                        "signer_index": null,
+                        "contrib": "aggnonce"
+                    }
+                },
+                {
+                    "tc_id": 61,
+                    "comment": "Aggregate nonce is invalid: second half is not a point on the curve",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "028465FCF0BBDBCF443AABCCE533D42B4B5A10966AC09A49655E8C42DAAB8FCD61020000000000000000000000000000000000000000000000000000000000000009",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "InvalidContributionError",
+                        "signer_index": null,
+                        "contrib": "aggnonce"
+                    }
+                },
+                {
+                    "tc_id": 62,
+                    "comment": "Aggregate nonce is invalid: second half's x-coordinate exceeds the field size",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "028465FCF0BBDBCF443AABCCE533D42B4B5A10966AC09A49655E8C42DAAB8FCD6102FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC30",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "InvalidContributionError",
+                        "signer_index": null,
+                        "contrib": "aggnonce"
+                    }
+                },
+                {
+                    "tc_id": 63,
+                    "comment": "Secret nonce's first half is out of range (all-zero nonce, which may indicate nonce reuse)",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 3,
+                    "aggnonce": "030CC8DD7811033474FAD57D2DD03801584ED6A68CD1A73B3301C3DD1F685BBF7802DE9250BDBEF74C5EC1854A171EC8F5BD06CBDDCFB78384435AC62E5B359ACF2C",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "first secnonce value is out of range."
+                    }
+                },
+                {
+                    "tc_id": 64,
+                    "comment": "Secret nonce's second half is out of range (zero)",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 4,
+                    "aggnonce": "030CC8DD7811033474FAD57D2DD03801584ED6A68CD1A73B3301C3DD1F685BBF7802DE9250BDBEF74C5EC1854A171EC8F5BD06CBDDCFB78384435AC62E5B359ACF2C",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "second secnonce value is out of range."
+                    }
+                },
+                {
+                    "tc_id": 65,
+                    "comment": "Fewer signers than the threshold t",
+                    "my_id": 0,
+                    "ids": [0, 1],
+                    "pubshare_indices": [0, 1],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "030CC8DD7811033474FAD57D2DD03801584ED6A68CD1A73B3301C3DD1F685BBF7802DE9250BDBEF74C5EC1854A171EC8F5BD06CBDDCFB78384435AC62E5B359ACF2C",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The number of signers must be between t and n."
+                    }
+                },
+                {
+                    "tc_id": 66,
+                    "comment": "Secret share is out of range (zero)",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 3,
+                    "secnonce_index": 0,
+                    "aggnonce": "030CC8DD7811033474FAD57D2DD03801584ED6A68CD1A73B3301C3DD1F685BBF7802DE9250BDBEF74C5EC1854A171EC8F5BD06CBDDCFB78384435AC62E5B359ACF2C",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The signer's secret share value is out of range."
+                    }
+                }
+            ],
+            "verify_fail_tests": [
+                {
+                    "tc_id": 67,
+                    "comment": "Negated partial signature fails the verification equation",
+                    "psig": "CFA01AF60FF099A5537C92E1B600DAC4E70DC24B8F027BE41B33A0641165DA19",
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "pubnonce_indices": [0, 1, 2],
+                    "signer_index": 0,
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF"
+                },
+                {
+                    "tc_id": 68,
+                    "comment": "A valid partial signature checked against the wrong signer fails the verification equation",
+                    "psig": "305FE509F00F665AAC836D1E49FF2539D3A11A9B20462457A49EBE28BED06728",
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "pubnonce_indices": [0, 1, 2],
+                    "signer_index": 1,
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF"
+                },
+                {
+                    "tc_id": 69,
+                    "comment": "Partial signature equals the group order, which is out of range",
+                    "psig": "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141",
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "pubnonce_indices": [0, 1, 2],
+                    "signer_index": 0,
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF"
+                }
+            ],
+            "verify_error_tests": [
+                {
+                    "tc_id": 70,
+                    "comment": "Verification rejects an invalid public nonce, blaming the malicious signer",
+                    "psig": "305FE509F00F665AAC836D1E49FF2539D3A11A9B20462457A49EBE28BED06728",
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "pubnonce_indices": [3, 1, 2],
+                    "signer_index": 0,
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "InvalidContributionError",
+                        "signer_index": 0,
+                        "contrib": "pubnonce"
+                    }
+                },
+                {
+                    "tc_id": 71,
+                    "comment": "A public share is not a valid point",
+                    "psig": "305FE509F00F665AAC836D1E49FF2539D3A11A9B20462457A49EBE28BED06728",
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [3, 1, 2],
+                    "pubnonce_indices": [0, 1, 2],
+                    "signer_index": 0,
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "Invalid pubshare at index 0."
+                    }
+                }
+            ]
+        },
+        {
+            "tg_id": "3of5",
+            "t": 3,
+            "n": 5,
+            "thresh_pk": "03E1AEA00A7B8D0E0393664FEBBD31569A02CAF223D9AD83E90331DC18B1987358",
+            "pubshares": [
+                "02F333EDD2B6F532C2EF6C42E803B633A42289D0567A75C50EB1C8CF85EC480E8F",
+                "025322F63602ECCF146541B7C9EE4D1FCB84EC139471420472182AE968676A387F",
+                "0230639CEC0A83982E176D6905CE0620FDC57E151565A39D0E0821B8E753AE85B0",
+                "026E1A50E672FEDD3F3C378D6121E5702B050669DBC241D2C2299880152CD207BD",
+                "02DC06C4CA919DE70B4B8281901CCF9471AB91FBFBEE1A8C570D83911CAAF9E2FA",
+                "020000000000000000000000000000000000000000000000000000000000000007",
+                "031B21F2B4931AC17435D943ABADB969CBCD4AFE3EB71D1CD62E87F9D2BD825164"
+            ],
+            "pubnonces": [
+                "02EBD21E4F4EA2772BD4E427D98C9DC268894D18EC45E14063785B892D42921FF402FB73028B710ACBE49FC2D995757E077760CA7C1B2452791A3BDA086B91A1CEF3",
+                "02BCBEF1171F78857016B205C0C9DE61750CC21448C167AAFAFD9190962AEAFF79032798E533A65F94D1DFF901A2CB4F107D49FE6B0527E95D7AE24E4DBBB681F552",
+                "02A455D731ECDCAA59228CE82CA1B5CF45974F6E6D21EB57501BE22310F089BF69037E2647E73C022A913C87D8813D48E76D72313DF4697644C23DDE820DBEF76D4A",
+                "026730E278BDB65A8E771864103890A1F10BA5AB9B429E0843CCB45FD2D9052C6A03525D89B7C9615F846D36223D777C5D6BF134FD1981FCB2F6B94F7FA70CE668AB",
+                "034D048ED3554BE5D0F03308936060FAAA8A0889FD135E8176DC0843C4FB68A89903497442C3AC05C98A8FDDB40646A6203A6EA53E20846F8D0A863447011BE8EA71",
+                "0200000000000000000000000000000000000000000000000000000000000000090287BF891D2A6DEAEBADC909352AA9405D1428C15F4B75F04DAE642A95C2548480",
+                "0342B812EE2B499BAC6AAE1CC4F3B2E0739D0C3DCB558513DC737AAA4B7F5BF7DE023AFC98C8EBD47B2277E650056543F287E4585BC8419F472D6A3FC3E5D2B42D4A"
+            ],
+            "secshares": [
+                "77C9316A64770B17D500840E020A9478F793D37DB0E6A276CB4E6270187D6C90",
+                "74180420A784189B55F8C4667075E89C2064FF481B6ED2A23A7517AF71F6B7A8",
+                "BE6B9FB07586EBABD234EEE0A05E813DFFC14D73782085C8DFE77C1FADDA7172",
+                "56C40419CE7F844949B5037C91C45E5FDAF9E11917B31BAEFBD33133FBF258AD",
+                "3D21315CB26DE273BC79023A44A780006CBD971FA96F34904E0A95792C74AE9A",
+                "0000000000000000000000000000000000000000000000000000000000000000"
+            ],
+            "secnonces": [
+                "8A1160479C4188DA237C53639EDEFC60C24E87F91AC8972D966000680A7D07328A5318B81726CB9B16B9321264611C7DF0C737BB64941F79D403D2D503FAB3AB",
+                "38214C927297FD9F61722C93A6568A7CFE37D8BFA7C73822337FEA77AD97A325CB33A2D2CB486A6F2EE597D7ED9D5552DD096452E3AC9DFA9787019BAB7652EB",
+                "E3490427C987333662C649E5801683B8BFCB7E5F0725908DBC968AA86AF1FA2C10E4690766A547CA58136EF3DC1045A8C3ECEA532A057F1A1AF1E42761E0ECD7",
+                "EE855A53463521DECAFA1132D121644CF0BBA4A860456F26540261023D9A49910E40FA146B6B9D4B8914D57D0B14A03BF5C753067CC144C69C14D924F037EF9E",
+                "CE5F5A722536E56561C5C1258A8E6A38480A7D00F79645460CCA3DE7F10E480308EF46C644D01F0FCB05950F384C655198101BDD83C604A8484FCCB49914CC39",
+                "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                "8A1160479C4188DA237C53639EDEFC60C24E87F91AC8972D966000680A7D07320000000000000000000000000000000000000000000000000000000000000000"
+            ],
+            "valid_tests": [
+                {
+                    "tc_id": 72,
+                    "comment": "Minimum threshold subset of signers",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "pubnonce_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "0391D52F656B3CA3E66AC5DAEF5B0D347F7E85B7DD7A9EBA10E9827AE23FB76E93031610E184E540470139F7626253F27E8871D6354941CC9FF94A07D83F61BB4CD5",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "expected": "603EC1EA86B284E28CEFD59C85F8DDC6DFE81C0744F59D8FB5BEB29F1C27F38B"
+                },
+                {
+                    "tc_id": 73,
+                    "comment": "Reordering the signer set leaves the partial signature unchanged, because the identifiers are sorted before they are bound into the binding value",
+                    "my_id": 0,
+                    "ids": [2, 1, 0],
+                    "pubshare_indices": [2, 1, 0],
+                    "pubnonce_indices": [2, 1, 0],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "0391D52F656B3CA3E66AC5DAEF5B0D347F7E85B7DD7A9EBA10E9827AE23FB76E93031610E184E540470139F7626253F27E8871D6354941CC9FF94A07D83F61BB4CD5",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "expected": "603EC1EA86B284E28CEFD59C85F8DDC6DFE81C0744F59D8FB5BEB29F1C27F38B"
+                },
+                {
+                    "tc_id": 74,
+                    "comment": "A different threshold subset gives a different partial signature, since the Lagrange coefficients depend on the signer set",
+                    "my_id": 0,
+                    "ids": [0, 3, 4],
+                    "pubshare_indices": [0, 3, 4],
+                    "pubnonce_indices": [0, 3, 4],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "03CE3C1C182829F31DE2E6FD057A06CFA52376FEE42C3FBD487C19CFF3B5C70DC5020D9DD41C4A2B9B43DB7C4E93B7C504946446636F25C5D893E90C626286D90765",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "expected": "7945D5DEFF00BF4BF715774144C10FF5E8C25F7AC8C886C3999825D30C7C6079"
+                },
+                {
+                    "tc_id": 75,
+                    "comment": "All signers participate, signed by a non-first member of the signer set",
+                    "my_id": 1,
+                    "ids": [0, 1, 2, 3, 4],
+                    "pubshare_indices": [0, 1, 2, 3, 4],
+                    "pubnonce_indices": [0, 1, 2, 3, 4],
+                    "secshare_index": 1,
+                    "secnonce_index": 1,
+                    "aggnonce": "03536024F21D3C18E0F094D15E9DDA07740754905570A1B68CAFAC743A6C213745037C9EA6730CD21904C131FF4A6C62480A7BABAA75F0A4F63F1AFD8DEE9FDD699D",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "expected": "5D70B8D37BF0DB381CE15E3AAB9F59BECD54AD32AC19A216093881B8F6458BB6"
+                },
+                {
+                    "tc_id": 76,
+                    "comment": "Aggregate nonce is the point at infinity, so the final nonce point falls back to the generator G",
+                    "my_id": 0,
+                    "ids": [0, 1, 2, 3, 4],
+                    "pubshare_indices": [0, 1, 2, 3, 4],
+                    "pubnonce_indices": [0, 1, 2, 3, 6],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "expected": "962E2844F89EA888513CBDD6D588817CA3ECC2BBD313F6AA07B2E6CBB98BB3D6"
+                },
+                {
+                    "tc_id": 77,
+                    "comment": "Empty message",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "pubnonce_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "0391D52F656B3CA3E66AC5DAEF5B0D347F7E85B7DD7A9EBA10E9827AE23FB76E93031610E184E540470139F7626253F27E8871D6354941CC9FF94A07D83F61BB4CD5",
+                    "msg": "",
+                    "expected": "6CD257592439D8A0A0FAF9037F684534B9A685D5046042C3E3A3F76F5957CBD6"
+                },
+                {
+                    "tc_id": 78,
+                    "comment": "Non-standard message length (38 bytes)",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "pubnonce_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "0391D52F656B3CA3E66AC5DAEF5B0D347F7E85B7DD7A9EBA10E9827AE23FB76E93031610E184E540470139F7626253F27E8871D6354941CC9FF94A07D83F61BB4CD5",
+                    "msg": "2626262626262626262626262626262626262626262626262626262626262626262626262626",
+                    "expected": "1FFAA634BDB251BF1E9E7C7EBD776C9DA9D35AA6F47C65E3E4A6E8FF1F15FF3F"
+                }
+            ],
+            "sign_error_tests": [
+                {
+                    "tc_id": 79,
+                    "comment": "Signer's identifier is absent from the signer set",
+                    "my_id": 3,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "0391D52F656B3CA3E66AC5DAEF5B0D347F7E85B7DD7A9EBA10E9827AE23FB76E93031610E184E540470139F7626253F27E8871D6354941CC9FF94A07D83F61BB4CD5",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The signer's id must be present in the participant identifier list."
+                    }
+                },
+                {
+                    "tc_id": 80,
+                    "comment": "Signer set contains a duplicate id",
+                    "my_id": 0,
+                    "ids": [0, 1, 1],
+                    "pubshare_indices": [0, 1, 1],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "0391D52F656B3CA3E66AC5DAEF5B0D347F7E85B7DD7A9EBA10E9827AE23FB76E93031610E184E540470139F7626253F27E8871D6354941CC9FF94A07D83F61BB4CD5",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The participant identifier list contains duplicate elements."
+                    }
+                },
+                {
+                    "tc_id": 81,
+                    "comment": "Signer's public share is not in the public share list",
+                    "my_id": 1,
+                    "ids": [1, 2, 3],
+                    "pubshare_indices": [1, 2, 3],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "027FEAEF20E0DF0EC419CF5D4FCE8CB18D14B051A1A3A0374E9AB42F2E637BCDC802F76F1B7F5C275C6278AA61138560262606C84E66478C0E20B3980D9B029F5F3C",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The signer's pubshare must be included in the list of pubshares."
+                    }
+                },
+                {
+                    "tc_id": 82,
+                    "comment": "A public share is not a valid point",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 5, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "0391D52F656B3CA3E66AC5DAEF5B0D347F7E85B7DD7A9EBA10E9827AE23FB76E93031610E184E540470139F7626253F27E8871D6354941CC9FF94A07D83F61BB4CD5",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "Invalid pubshare at index 1."
+                    }
+                },
+                {
+                    "tc_id": 83,
+                    "comment": "Public shares of the signer set interpolate to the point at infinity",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 6],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "0391D52F656B3CA3E66AC5DAEF5B0D347F7E85B7DD7A9EBA10E9827AE23FB76E93031610E184E540470139F7626253F27E8871D6354941CC9FF94A07D83F61BB4CD5",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The threshold pubkey must not be the point at infinity."
+                    }
+                },
+                {
+                    "tc_id": 84,
+                    "comment": "A signer id is outside the valid range [0, n-1]",
+                    "my_id": 1,
+                    "ids": [5, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 1,
+                    "secnonce_index": 1,
+                    "aggnonce": "0391D52F656B3CA3E66AC5DAEF5B0D347F7E85B7DD7A9EBA10E9827AE23FB76E93031610E184E540470139F7626253F27E8871D6354941CC9FF94A07D83F61BB4CD5",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The participant identifier at index 0 is out of range."
+                    }
+                },
+                {
+                    "tc_id": 85,
+                    "comment": "Signer set's public shares do not match the threshold public key",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 2, 1],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "0391D52F656B3CA3E66AC5DAEF5B0D347F7E85B7DD7A9EBA10E9827AE23FB76E93031610E184E540470139F7626253F27E8871D6354941CC9FF94A07D83F61BB4CD5",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The provided key material is incorrect."
+                    }
+                },
+                {
+                    "tc_id": 86,
+                    "comment": "Aggregate nonce is invalid: first half has an unknown tag 0x04",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "048465FCF0BBDBCF443AABCCE533D42B4B5A10966AC09A49655E8C42DAAB8FCD61037496A3CC86926D452CAFCFD55D25972CA1675D549310DE296BFF42F72EEEA8C9",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "InvalidContributionError",
+                        "signer_index": null,
+                        "contrib": "aggnonce"
+                    }
+                },
+                {
+                    "tc_id": 87,
+                    "comment": "Aggregate nonce is invalid: second half is not a point on the curve",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "028465FCF0BBDBCF443AABCCE533D42B4B5A10966AC09A49655E8C42DAAB8FCD61020000000000000000000000000000000000000000000000000000000000000009",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "InvalidContributionError",
+                        "signer_index": null,
+                        "contrib": "aggnonce"
+                    }
+                },
+                {
+                    "tc_id": 88,
+                    "comment": "Aggregate nonce is invalid: second half's x-coordinate exceeds the field size",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "028465FCF0BBDBCF443AABCCE533D42B4B5A10966AC09A49655E8C42DAAB8FCD6102FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC30",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "InvalidContributionError",
+                        "signer_index": null,
+                        "contrib": "aggnonce"
+                    }
+                },
+                {
+                    "tc_id": 89,
+                    "comment": "Secret nonce's first half is out of range (all-zero nonce, which may indicate nonce reuse)",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 5,
+                    "aggnonce": "0391D52F656B3CA3E66AC5DAEF5B0D347F7E85B7DD7A9EBA10E9827AE23FB76E93031610E184E540470139F7626253F27E8871D6354941CC9FF94A07D83F61BB4CD5",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "first secnonce value is out of range."
+                    }
+                },
+                {
+                    "tc_id": 90,
+                    "comment": "Secret nonce's second half is out of range (zero)",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 6,
+                    "aggnonce": "0391D52F656B3CA3E66AC5DAEF5B0D347F7E85B7DD7A9EBA10E9827AE23FB76E93031610E184E540470139F7626253F27E8871D6354941CC9FF94A07D83F61BB4CD5",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "second secnonce value is out of range."
+                    }
+                },
+                {
+                    "tc_id": 91,
+                    "comment": "Fewer signers than the threshold t",
+                    "my_id": 0,
+                    "ids": [0, 1],
+                    "pubshare_indices": [0, 1],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "0391D52F656B3CA3E66AC5DAEF5B0D347F7E85B7DD7A9EBA10E9827AE23FB76E93031610E184E540470139F7626253F27E8871D6354941CC9FF94A07D83F61BB4CD5",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The number of signers must be between t and n."
+                    }
+                },
+                {
+                    "tc_id": 92,
+                    "comment": "Secret share is out of range (zero)",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 5,
+                    "secnonce_index": 0,
+                    "aggnonce": "0391D52F656B3CA3E66AC5DAEF5B0D347F7E85B7DD7A9EBA10E9827AE23FB76E93031610E184E540470139F7626253F27E8871D6354941CC9FF94A07D83F61BB4CD5",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The signer's secret share value is out of range."
+                    }
+                }
+            ],
+            "verify_fail_tests": [
+                {
+                    "tc_id": 93,
+                    "comment": "Negated partial signature fails the verification equation",
+                    "psig": "9FC13E15794D7B1D73102A637A072237DAC6C0DF6A5302AC0A13ABEDB40E4DB6",
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "pubnonce_indices": [0, 1, 2],
+                    "signer_index": 0,
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF"
+                },
+                {
+                    "tc_id": 94,
+                    "comment": "A valid partial signature checked against the wrong signer fails the verification equation",
+                    "psig": "603EC1EA86B284E28CEFD59C85F8DDC6DFE81C0744F59D8FB5BEB29F1C27F38B",
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "pubnonce_indices": [0, 1, 2],
+                    "signer_index": 1,
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF"
+                },
+                {
+                    "tc_id": 95,
+                    "comment": "Partial signature equals the group order, which is out of range",
+                    "psig": "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141",
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "pubnonce_indices": [0, 1, 2],
+                    "signer_index": 0,
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF"
+                }
+            ],
+            "verify_error_tests": [
+                {
+                    "tc_id": 96,
+                    "comment": "Verification rejects an invalid public nonce, blaming the malicious signer",
+                    "psig": "603EC1EA86B284E28CEFD59C85F8DDC6DFE81C0744F59D8FB5BEB29F1C27F38B",
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "pubnonce_indices": [5, 1, 2],
+                    "signer_index": 0,
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "InvalidContributionError",
+                        "signer_index": 0,
+                        "contrib": "pubnonce"
+                    }
+                },
+                {
+                    "tc_id": 97,
+                    "comment": "A public share is not a valid point",
+                    "psig": "603EC1EA86B284E28CEFD59C85F8DDC6DFE81C0744F59D8FB5BEB29F1C27F38B",
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [5, 1, 2],
+                    "pubnonce_indices": [0, 1, 2],
+                    "signer_index": 0,
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "Invalid pubshare at index 0."
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/fedimint-core/src/config.rs
+++ b/fedimint-core/src/config.rs
@@ -854,6 +854,7 @@ pub enum P2PMessage {
     Checksum(sha256::Hash),
     DkgG1(DkgMessageG1),
     DkgG2(DkgMessageG2),
+    DkgSecp(DkgMessageSecp),
     Encodable(Vec<u8>),
     #[encodable_default]
     Default {
@@ -874,6 +875,13 @@ pub enum DkgMessageG2 {
     Hash(sha256::Hash),
     Commitment(Vec<G2Projective>),
     Share(Scalar),
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Encodable, Decodable)]
+pub enum DkgMessageSecp {
+    Hash(sha256::Hash),
+    Commitment(Vec<secp256k1::PublicKey>),
+    Share(secp256k1::SecretKey),
 }
 
 // TODO: Remove the Serde encoding as soon as the p2p layer drops it as
@@ -912,6 +920,30 @@ impl Serialize for DkgMessageG2 {
 }
 
 impl<'de> Deserialize<'de> for DkgMessageG2 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Self::consensus_decode_hex(
+            &String::deserialize(deserializer)?,
+            &ModuleDecoderRegistry::default(),
+        )
+        .map_err(serde::de::Error::custom)
+    }
+}
+
+// TODO: Remove the Serde encoding as soon as the p2p layer drops it as
+// requirement
+impl Serialize for DkgMessageSecp {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.consensus_encode_to_hex().serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for DkgMessageSecp {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,

--- a/fedimint-server/Cargo.toml
+++ b/fedimint-server/Cargo.toml
@@ -57,6 +57,7 @@ rand_chacha = { workspace = true }
 rayon = { workspace = true }
 rcgen = { workspace = true }
 scopeguard = { workspace = true }
+secp256k1 = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha3 = { workspace = true }

--- a/fedimint-server/src/config/dkg_secp.rs
+++ b/fedimint-server/src/config/dkg_secp.rs
@@ -1,0 +1,322 @@
+use std::collections::BTreeMap;
+use std::iter::once;
+
+use anyhow::{Context, bail, ensure};
+use fedimint_core::bitcoin::hashes::sha256;
+use fedimint_core::config::{DkgMessageSecp, P2PMessage};
+use fedimint_core::encoding::Encodable as _;
+use fedimint_core::net::peers::{DynP2PConnections, Recipient};
+use fedimint_core::{NumPeers, PeerId};
+use rand::rngs::OsRng;
+use secp256k1::{PublicKey, SECP256K1, Scalar, SecretKey};
+use tracing::trace;
+
+// Implementation of the classic Pedersen DKG over secp256k1.
+
+struct DkgSecp {
+    num_peers: NumPeers,
+    identity: PeerId,
+    polynomial: Vec<SecretKey>,
+    hash_commitments: BTreeMap<PeerId, sha256::Hash>,
+    commitments: BTreeMap<PeerId, Vec<PublicKey>>,
+    sk_shares: BTreeMap<PeerId, SecretKey>,
+}
+
+impl DkgSecp {
+    fn new(num_peers: NumPeers, identity: PeerId) -> Self {
+        let polynomial = (0..num_peers.threshold())
+            .map(|_| SecretKey::new(&mut OsRng))
+            .collect::<Vec<SecretKey>>();
+
+        let commitment = polynomial
+            .iter()
+            .map(|coefficient| coefficient.public_key(SECP256K1))
+            .collect::<Vec<PublicKey>>();
+
+        DkgSecp {
+            num_peers,
+            identity,
+            polynomial,
+            hash_commitments: once((identity, commitment.consensus_hash_sha256())).collect(),
+            commitments: once((identity, commitment)).collect(),
+            sk_shares: BTreeMap::new(),
+        }
+    }
+
+    fn commitment(&self) -> Vec<PublicKey> {
+        self.polynomial
+            .iter()
+            .map(|coefficient| coefficient.public_key(SECP256K1))
+            .collect()
+    }
+
+    fn initial_message(&self) -> DkgMessageSecp {
+        DkgMessageSecp::Hash(self.commitment().consensus_hash_sha256())
+    }
+
+    /// Runs a single step of the DKG algorithm
+    fn step(&mut self, peer: PeerId, msg: DkgMessageSecp) -> anyhow::Result<DkgStepSecp> {
+        trace!(?peer, ?msg, "Running DKG secp step");
+        match msg {
+            DkgMessageSecp::Hash(hash) => {
+                ensure!(
+                    self.hash_commitments.insert(peer, hash).is_none(),
+                    "DKG secp: peer {peer} sent us two hash commitments."
+                );
+
+                if self.hash_commitments.len() == self.num_peers.total() {
+                    return Ok(DkgStepSecp::Broadcast(DkgMessageSecp::Commitment(
+                        self.commitment(),
+                    )));
+                }
+            }
+            DkgMessageSecp::Commitment(polynomial) => {
+                ensure!(
+                    *self.hash_commitments.get(&peer).with_context(|| format!(
+                        "DKG secp: hash commitment not found for peer {peer}"
+                    ))? == polynomial.consensus_hash_sha256(),
+                    "DKG secp: polynomial commitment from peer {peer} does not match the hash."
+                );
+
+                ensure!(
+                    self.num_peers.threshold() == polynomial.len(),
+                    "DKG secp: polynomial commitment from peer {peer} is of wrong degree."
+                );
+
+                ensure!(
+                    self.commitments.insert(peer, polynomial).is_none(),
+                    "DKG secp: peer {peer} sent us two commitments."
+                );
+
+                // Once everyone has send their commitments, send out the key shares...
+
+                if self.commitments.len() == self.num_peers.total() {
+                    let mut messages = vec![];
+
+                    for peer in self.num_peers.peer_ids() {
+                        let share = eval_poly_scalar(&self.polynomial, &scalar(&peer));
+
+                        if peer == self.identity {
+                            self.sk_shares.insert(self.identity, share);
+                        } else {
+                            messages.push((peer, DkgMessageSecp::Share(share)));
+                        }
+                    }
+
+                    return Ok(DkgStepSecp::Messages(messages));
+                }
+            }
+            DkgMessageSecp::Share(share) => {
+                let polynomial = self.commitments.get(&peer).with_context(|| {
+                    format!("DKG secp: polynomial commitment not found for peer {peer}.")
+                })?;
+
+                let checksum = eval_poly(polynomial, &self.identity)?;
+
+                ensure!(
+                    share.public_key(SECP256K1) == checksum,
+                    "DKG secp: share from {peer} is invalid."
+                );
+
+                ensure!(
+                    self.sk_shares.insert(peer, share).is_none(),
+                    "Peer {peer} sent us two sk shares."
+                );
+
+                if self.sk_shares.len() == self.num_peers.total() {
+                    let sks = self
+                        .sk_shares
+                        .values()
+                        .copied()
+                        .reduce(|accumulator, share| {
+                            accumulator.add_tweak(&key_scalar(&share)).expect(
+                                "The shares are hash-committed, an intermediate sum of zero is negligible",
+                            )
+                        })
+                        .expect("We have at least one share");
+
+                    let pks = (0..self.num_peers.threshold())
+                        .map(|i| {
+                            self.commitments
+                                .values()
+                                .map(|coefficients| coefficients[i])
+                                .reduce(|accumulator, coefficient| {
+                                    accumulator.combine(&coefficient).expect(
+                                        "The coefficients are hash-committed, a sum at infinity is negligible",
+                                    )
+                                })
+                                .expect("DKG secp: polynomial commitments are empty.")
+                        })
+                        .collect();
+
+                    return Ok(DkgStepSecp::Result((pks, sks)));
+                }
+            }
+        }
+
+        Ok(DkgStepSecp::Messages(vec![]))
+    }
+}
+
+/// Runs the DKG secp algorithm with our peers. We do not handle any unexpected
+/// messages and all peers are expected to be cooperative.
+pub async fn run_dkg_secp(
+    num_peers: NumPeers,
+    identity: PeerId,
+    connections: &DynP2PConnections<P2PMessage>,
+) -> anyhow::Result<(Vec<PublicKey>, SecretKey)> {
+    let mut dkg = DkgSecp::new(num_peers, identity);
+
+    connections.send(
+        Recipient::Everyone,
+        P2PMessage::DkgSecp(dkg.initial_message()),
+    );
+
+    loop {
+        for peer in num_peers.peer_ids().filter(|p| *p != identity) {
+            let message = connections
+                .receive_from_peer(peer)
+                .await
+                .context("Unexpected shutdown of p2p connections during dkg secp")?;
+
+            let message = match message {
+                P2PMessage::DkgSecp(message) => message,
+                _ => bail!("Received unexpected message during DKG secp: {message:?}"),
+            };
+
+            match dkg.step(peer, message)? {
+                DkgStepSecp::Broadcast(message) => {
+                    connections.send(Recipient::Everyone, P2PMessage::DkgSecp(message));
+                }
+                DkgStepSecp::Messages(messages) => {
+                    for (peer, message) in messages {
+                        connections.send(Recipient::Peer(peer), P2PMessage::DkgSecp(message));
+                    }
+                }
+                DkgStepSecp::Result(result) => {
+                    return Ok(result);
+                }
+            }
+        }
+    }
+}
+
+// Offset by 1, since evaluating a poly at 0 reveals the secret
+fn scalar(peer: &PeerId) -> Scalar {
+    let mut bytes = [0; 32];
+
+    bytes[24..].copy_from_slice(&(peer.to_usize() as u64 + 1).to_be_bytes());
+
+    Scalar::from_be_bytes(bytes).expect("A u64 is smaller than the curve order")
+}
+
+fn key_scalar(key: &SecretKey) -> Scalar {
+    Scalar::from_be_bytes(key.secret_bytes()).expect("A secret key is a valid scalar")
+}
+
+fn eval_poly_scalar(coefficients: &[SecretKey], x: &Scalar) -> SecretKey {
+    coefficients
+        .iter()
+        .copied()
+        .rev()
+        .reduce(|accumulator, coefficient| {
+            accumulator
+                .mul_tweak(x)
+                .expect("The evaluation point is nonzero")
+                .add_tweak(&key_scalar(&coefficient))
+                .expect("An intermediate value of our random polynomial is zero with negligible probability")
+        })
+        .expect("We have at least one coefficient")
+}
+
+/// Evaluates a public polynomial at the peer's evaluation point. Fails if an
+/// intermediate value is the point at infinity, which is negligible for
+/// commitments to random polynomials.
+pub fn eval_poly(coefficients: &[PublicKey], peer: &PeerId) -> anyhow::Result<PublicKey> {
+    let mut coefficients = coefficients.iter().copied().rev();
+
+    let mut accumulator = coefficients
+        .next()
+        .context("The polynomial commitment is empty")?;
+
+    for coefficient in coefficients {
+        accumulator = accumulator
+            .mul_tweak(SECP256K1, &scalar(peer))
+            .expect("The evaluation point is nonzero")
+            .combine(&coefficient)
+            .context("The evaluation hit the point at infinity")?;
+    }
+
+    Ok(accumulator)
+}
+
+enum DkgStepSecp {
+    Broadcast(DkgMessageSecp),
+    Messages(Vec<(PeerId, DkgMessageSecp)>),
+    Result((Vec<PublicKey>, SecretKey)),
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{BTreeMap, VecDeque};
+
+    use fedimint_core::{NumPeers, PeerId};
+    use secp256k1::SECP256K1;
+
+    use super::{DkgSecp, DkgStepSecp, eval_poly};
+
+    #[test_log::test]
+    fn test_dkg_secp() {
+        let num_peers = NumPeers::from(7);
+
+        let mut dkgs = num_peers
+            .peer_ids()
+            .map(|peer| (peer, DkgSecp::new(num_peers, peer)))
+            .collect::<BTreeMap<PeerId, DkgSecp>>();
+
+        let mut steps = dkgs
+            .iter()
+            .map(|(peer, dkg)| (*peer, DkgStepSecp::Broadcast(dkg.initial_message())))
+            .collect::<VecDeque<(PeerId, DkgStepSecp)>>();
+
+        let mut keys = BTreeMap::new();
+
+        while keys.len() < num_peers.total() {
+            match steps.pop_front().unwrap() {
+                (send_peer, DkgStepSecp::Broadcast(message)) => {
+                    for receive_peer in num_peers.peer_ids().filter(|p| *p != send_peer) {
+                        let step = dkgs
+                            .get_mut(&receive_peer)
+                            .unwrap()
+                            .step(send_peer, message.clone());
+
+                        steps.push_back((receive_peer, step.unwrap()));
+                    }
+                }
+                (send_peer, DkgStepSecp::Messages(messages)) => {
+                    for (receive_peer, message) in messages {
+                        let step = dkgs
+                            .get_mut(&receive_peer)
+                            .unwrap()
+                            .step(send_peer, message);
+
+                        steps.push_back((receive_peer, step.unwrap()));
+                    }
+                }
+                (send_peer, DkgStepSecp::Result(step_keys)) => {
+                    keys.insert(send_peer, step_keys);
+                }
+            }
+        }
+
+        assert!(steps.is_empty());
+
+        for (peer, (polynomial, sks)) in keys {
+            assert_eq!(polynomial.len(), 5);
+            assert_eq!(
+                eval_poly(&polynomial, &peer).unwrap(),
+                sks.public_key(SECP256K1)
+            );
+        }
+    }
+}

--- a/fedimint-server/src/config/mod.rs
+++ b/fedimint-server/src/config/mod.rs
@@ -43,6 +43,7 @@ use crate::net::p2p_connector::TlsConfig;
 pub mod dkg;
 pub mod dkg_g1;
 pub mod dkg_g2;
+pub mod dkg_secp;
 pub mod io;
 pub mod peer_handle;
 pub mod setup;

--- a/nix/flakebox.nix
+++ b/nix/flakebox.nix
@@ -64,6 +64,7 @@ let
     "db/migrations/.*"
     "devimint/src/cfg/.*"
     "fedimint-server/src/test_fixtures/.*"
+    "crypto/bip445/src/vectors/.*"
     "docs/.*\\.md"
     "fedimint-ui-common/assets/.*"
   ];
@@ -120,6 +121,7 @@ let
         "db/migrations/.*"
         "devimint/src/cfg/.*"
         "fedimint-server/src/test_fixtures/.*"
+        "crypto/bip445/src/vectors/.*"
         "scripts/.*"
         "docs/.*\\.md"
         "fedimint-ui-common/assets/.*"


### PR DESCRIPTION
Prepares FROST support for walletv2, which needs threshold BIP340 signatures to spend taproot outputs held by the federation.

Adds `fedimint-bip445`, a port of picomint's threshold schnorr library that implements FROST as specified in BIP 445 over secp256k1 and is validated against the BIP 445 test vectors, and `fedimint-server/src/config/dkg_secp.rs`, a Pedersen DKG over secp256k1 that mirrors the existing `dkg_g1`/`dkg_g2` and produces the key shares it signs with, along with the `DkgMessageSecp` p2p message it exchanges. Nothing calls either yet.