### PR TITLE
fix(server): bound JSON-RPC metric method labels

### DIFF
--- a/fedimint-server/src/metrics/jsonrpsee.rs
+++ b/fedimint-server/src/metrics/jsonrpsee.rs
@@ -5,7 +5,9 @@
 //! <https://github.com/paritytech/jsonrpsee/blob/bf5952fb663bdb8193b9f8a43182454c143b0e7d/server/src/middleware/rpc/layer/logger.rs#L1>
 
 use std::borrow::Cow;
+use std::collections::HashSet;
 use std::pin::Pin;
+use std::sync::Arc;
 use std::task;
 use std::task::Poll;
 
@@ -20,11 +22,9 @@ use super::{JSONRPC_API_REQUEST_DURATION_SECONDS, JSONRPC_API_REQUEST_RESPONSE_C
 
 #[pin_project]
 pub struct ResponseFuture<F> {
-    #[pin]
-    method: String,
+    method: &'static str,
     #[pin]
     fut: F,
-    #[pin]
     timer: Option<HistogramTimer>,
 }
 
@@ -38,7 +38,7 @@ impl<F: Future<Output = MethodResponse>> Future for ResponseFuture<F> {
     type Output = F::Output;
 
     fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
-        let mut projected = self.project();
+        let projected = self.project();
         let res = projected.fut.poll(cx);
         if let Poll::Ready(res) = &res
             && let Some(timer) = projected.timer.take()
@@ -47,7 +47,7 @@ impl<F: Future<Output = MethodResponse>> Future for ResponseFuture<F> {
 
             JSONRPC_API_REQUEST_RESPONSE_CODE
                 .with_label_values(&[
-                    projected.method.as_str(),
+                    *projected.method,
                     &if let Some(code) = res.as_error_code() {
                         Cow::Owned(code.to_string())
                     } else {
@@ -67,19 +67,35 @@ impl<F: Future<Output = MethodResponse>> Future for ResponseFuture<F> {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
-pub struct MetricsLayer;
+const UNKNOWN_METHOD: &str = "unknown";
+
+#[derive(Clone, Debug)]
+pub struct MetricsLayer {
+    methods: Arc<HashSet<&'static str>>,
+}
+
+impl MetricsLayer {
+    pub fn new(methods: impl IntoIterator<Item = &'static str>) -> Self {
+        Self {
+            methods: Arc::new(methods.into_iter().collect()),
+        }
+    }
+}
 
 impl<S> tower::Layer<S> for MetricsLayer {
     type Service = MetricsService<S>;
 
     fn layer(&self, service: S) -> Self::Service {
-        MetricsService { service }
+        MetricsService {
+            service,
+            methods: self.methods.clone(),
+        }
     }
 }
 
 pub struct MetricsService<S> {
     pub(crate) service: S,
+    methods: Arc<HashSet<&'static str>>,
 }
 
 impl<'a, S> RpcServiceT<'a> for MetricsService<S>
@@ -89,14 +105,117 @@ where
     type Future = ResponseFuture<S::Future>;
 
     fn call(&self, req: Request<'a>) -> Self::Future {
+        let method = self
+            .methods
+            .get(req.method_name())
+            .copied()
+            .unwrap_or(UNKNOWN_METHOD);
         let timer = JSONRPC_API_REQUEST_DURATION_SECONDS
-            .with_label_values(&[req.method_name()])
+            .with_label_values(&[method])
             .start_timer();
 
         ResponseFuture {
-            method: req.method.to_string(),
+            method,
             fut: self.service.call(req),
             timer: Some(timer),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::borrow::Cow;
+
+    use fedimint_metrics::prometheus::core::Collector;
+    use fedimint_metrics::prometheus::proto::Metric;
+    use futures::future::{Ready, ready};
+    use jsonrpsee::types::{Id, ResponsePayload};
+
+    use super::*;
+
+    const REGISTERED_METHOD: &str = "metrics_test_registered";
+    const UNREGISTERED_METHODS: [&str; 3] = [
+        "metrics_test_unregistered",
+        "metrics_test_unregistered_!@#$%^&*()",
+        "metrics_test_unregistered_with_a_very_long_attacker_controlled_suffix",
+    ];
+
+    struct SuccessService;
+
+    impl<'a> RpcServiceT<'a> for SuccessService {
+        type Future = Ready<MethodResponse>;
+
+        fn call(&self, _request: Request<'a>) -> Self::Future {
+            ready(MethodResponse::response(
+                Id::Number(1),
+                ResponsePayload::success("ok").into(),
+                usize::MAX,
+            ))
+        }
+    }
+
+    fn has_method_label(metric: &Metric, method: &str) -> bool {
+        metric
+            .get_label()
+            .iter()
+            .any(|label| label.name() == "method" && label.value() == method)
+    }
+
+    fn duration_count(method: &str) -> u64 {
+        JSONRPC_API_REQUEST_DURATION_SECONDS
+            .collect()
+            .into_iter()
+            .flat_map(|family| family.metric)
+            .filter(|metric| has_method_label(metric, method))
+            .map(|metric| metric.histogram.sample_count())
+            .sum()
+    }
+
+    fn response_count(method: &str) -> u64 {
+        JSONRPC_API_REQUEST_RESPONSE_CODE
+            .collect()
+            .into_iter()
+            .flat_map(|family| family.metric)
+            .filter(|metric| has_method_label(metric, method))
+            .map(|metric| metric.counter.value() as u64)
+            .sum()
+    }
+
+    #[tokio::test]
+    async fn bounds_method_labels_for_all_jsonrpc_metrics() {
+        let service = MetricsService {
+            service: SuccessService,
+            methods: Arc::new([REGISTERED_METHOD].into_iter().collect()),
+        };
+        let duration_before = [
+            duration_count(REGISTERED_METHOD),
+            duration_count(UNKNOWN_METHOD),
+        ];
+        let response_before = [
+            response_count(REGISTERED_METHOD),
+            response_count(UNKNOWN_METHOD),
+        ];
+
+        for method in std::iter::once(REGISTERED_METHOD).chain(UNREGISTERED_METHODS) {
+            service
+                .call(Request::new(Cow::Borrowed(method), None, Id::Number(1)))
+                .await;
+        }
+
+        assert_eq!(duration_count(REGISTERED_METHOD) - duration_before[0], 1);
+        assert_eq!(
+            duration_count(UNKNOWN_METHOD) - duration_before[1],
+            UNREGISTERED_METHODS.len() as u64
+        );
+        assert_eq!(response_count(REGISTERED_METHOD) - response_before[0], 1);
+        assert_eq!(
+            response_count(UNKNOWN_METHOD) - response_before[1],
+            UNREGISTERED_METHODS.len() as u64
+        );
+
+        for method in UNREGISTERED_METHODS {
+            assert_eq!(duration_count(method), 0);
+            assert_eq!(response_count(method), 0);
         }
     }
 }

--- a/fedimint-server/src/net/api/mod.rs
+++ b/fedimint-server/src/net/api/mod.rs
@@ -108,7 +108,10 @@ pub async fn spawn<T>(
     ServerBuilder::new()
         .max_connections(max_connections)
         .enable_ws_ping(PingConfig::new().ping_interval(Duration::from_secs(10)))
-        .set_rpc_middleware(RpcServiceBuilder::new().layer(metrics::jsonrpsee::MetricsLayer))
+        .set_rpc_middleware(
+            RpcServiceBuilder::new()
+                .layer(metrics::jsonrpsee::MetricsLayer::new(module.method_names())),
+        )
         .set_http_middleware(builder)
         .build(&api_bind.to_string())
         .await


### PR DESCRIPTION
*Posted by Tau*

### Summary

JSON-RPC request metrics currently use the client-supplied method name directly, so unsupported requests can create arbitrary metric content and unbounded label cardinality. This change preserves canonical labels for registered RPC methods and maps every other input to one fixed `unknown` label. The producer now enforces the cardinality and privacy boundary instead of depending on downstream string sanitization.

### Details

The middleware emits the request-duration histogram before dispatch and the response-code counter after the response future completes. It snapshots the names registered in the server's `RpcModule`, classifies each request once against that set, and retains the classified static label for both emission points.

For example, a registered `status` request remains `method="status"`, while unsupported inputs such as `private-user-data` and a long arbitrary string both become `method="unknown"`. This keeps supported per-method observability while preventing client-controlled names from producing new series.

### Reviewing

Please verify that the registered method snapshot matches the methods dispatched by the module and that both metric emission paths reuse the classified label. The change intentionally does not treat length or character filtering as the primary boundary.

### Testing

A focused producer-path regression drives the middleware with one registered request and several arbitrary unregistered requests. It inspects the collected duration histogram and response-code counter, checking canonical and `unknown` count deltas and confirming that no unregistered request string appears as a label.
