### PR TITLE
fix(ln): recover stranded recurring receives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4054,6 +4054,7 @@ version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
+ "axum 0.8.9",
  "bitcoin_hashes",
  "fedimint-client",
  "fedimint-client-module",

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -1093,6 +1093,35 @@ impl LightningClientModule {
         let invoice = invoice_builder
             .build_signed(|msg| self.secp.sign_ecdsa_recoverable(msg, &node_secret_key))?;
 
+        let (operation_id, output, output_preimage) = self.create_lightning_receive_offer_output(
+            amount,
+            &invoice,
+            receiving_key,
+            expiry_time,
+        )?;
+
+        Ok((operation_id, invoice, output, *output_preimage.as_ref()))
+    }
+
+    fn create_lightning_receive_offer_output(
+        &self,
+        amount: Amount,
+        invoice: &Bolt11Invoice,
+        receiving_key: ReceivingKey,
+        expiry_time: Option<u64>,
+    ) -> anyhow::Result<(
+        OperationId,
+        ClientOutputBundle<LightningOutput, LightningClientStateMachines>,
+        sha256::Hash,
+    )> {
+        let preimage_key = receiving_key.public_key().serialize();
+        let preimage = sha256::Hash::hash(&preimage_key);
+        let payment_hash = sha256::Hash::hash(&preimage.to_byte_array());
+        ensure!(
+            invoice.payment_hash() == &payment_hash,
+            "Invoice payment hash does not match the receiving key"
+        );
+
         let operation_id = OperationId(*invoice.payment_hash().as_ref());
 
         let sm_invoice = invoice.clone();
@@ -1121,7 +1150,6 @@ impl LightningClientModule {
 
         Ok((
             operation_id,
-            invoice,
             ClientOutputBundle::new(
                 vec![ClientOutput {
                     output: ln_output,
@@ -1131,7 +1159,7 @@ impl LightningClientModule {
                     state_machines: sm_gen,
                 }],
             ),
-            *preimage.as_ref(),
+            preimage,
         ))
     }
 
@@ -1809,7 +1837,8 @@ impl LightningClientModule {
             self.client_ctx
                 .make_client_inputs(ClientInputBundle::new_no_sm(vec![client_input])),
         );
-        let extra_meta = serde_json::to_value(extra_meta).expect("extra_meta is serializable");
+        let extra_meta =
+            serde_json::to_value(extra_meta).context("Failed to serialize invoice metadata")?;
         let operation_meta_gen = move |change_range: OutPointRange| LightningOperationMeta {
             variant: LightningOperationMetaVariant::Claim {
                 out_points: change_range.into_iter().collect(),

--- a/modules/fedimint-ln-client/src/recurring/mod.rs
+++ b/modules/fedimint-ln-client/src/recurring/mod.rs
@@ -15,6 +15,7 @@ use bitcoin::secp256k1::SECP256K1;
 use fedimint_client_module::OperationId;
 use fedimint_client_module::module::ClientContext;
 use fedimint_client_module::oplog::UpdateStreamOrOutcome;
+use fedimint_client_module::transaction::TransactionBuilder;
 use fedimint_core::BitcoinHash;
 use fedimint_core::config::FederationId;
 use fedimint_core::core::ModuleKind;
@@ -38,6 +39,7 @@ use tokio::select;
 use tokio::sync::Notify;
 use tracing::{debug, trace, warn};
 
+use crate::api::LnFederationApi;
 use crate::db::{RecurringPaymentCodeKey, RecurringPaymentCodeKeyPrefix};
 use crate::receive::LightningReceiveError;
 use crate::{
@@ -234,7 +236,26 @@ impl LightningClientModule {
         invoice_idx: u64,
         invoice: lightning_invoice::Bolt11Invoice,
     ) {
-        // TODO: validate invoice hash etc.
+        let operation_id = OperationId(*invoice.payment_hash().as_ref());
+        let offer_was_found = match client
+            .self_ref()
+            .module_api
+            .offer_exists(*invoice.payment_hash())
+            .await
+        {
+            Ok(exists) => exists,
+            Err(error) => {
+                warn!(
+                    target: LOG_CLIENT_RECURRING,
+                    ?operation_id,
+                    invoice_index=%invoice_idx,
+                    err = %error.fmt_compact(),
+                    "Could not query incoming contract offer, will retry"
+                );
+                return;
+            }
+        };
+
         let mut dbtx = client.module_db().begin_transaction().await;
         let old_payment_code_entry = dbtx
             .get_value(&crate::db::RecurringPaymentCodeKey {
@@ -255,34 +276,39 @@ impl LightningClientModule {
         )
         .await;
 
-        // We want to increment the invoice counter even if the operation creation
-        // fails. This should never happen and if it does, we'd rather miss an invoice
-        // than get stuck in an infinite loop.
+        // An invalid invoice must not block every later index for this payment code.
         let mut dbtx_nc = dbtx.to_ref_nc();
-        if let Ok(operation_id) = Self::create_recurring_receive_operation(
+        match Self::create_recurring_receive_operation(
             client,
             &mut dbtx_nc,
             &old_payment_code_entry,
             invoice_idx,
             invoice,
+            offer_was_found,
         )
         .await
         {
-            client
-                .log_event(
-                    &mut dbtx_nc,
-                    RecurringInvoiceCreatedEvent {
-                        payment_code_idx,
-                        invoice_idx,
-                        operation_id,
-                    },
-                )
-                .await;
-        } else {
-            debug_assert!(
-                false,
-                "Recurring invoice operation creation failed, this should never happen"
-            );
+            Ok(operation_id) => {
+                client
+                    .log_event(
+                        &mut dbtx_nc,
+                        RecurringInvoiceCreatedEvent {
+                            payment_code_idx,
+                            invoice_idx,
+                            operation_id,
+                        },
+                    )
+                    .await;
+            }
+            Err(error) => {
+                warn!(
+                    target: LOG_CLIENT_RECURRING,
+                    payment_code_key=?old_payment_code_entry.root_keypair.public_key(),
+                    invoice_index=%invoice_idx,
+                    err = %error.fmt_compact_anyhow(),
+                    "Failed to create recurring receive operation"
+                );
+            }
         }
         drop(dbtx_nc);
 
@@ -296,6 +322,7 @@ impl LightningClientModule {
         payment_code: &RecurringPaymentCodeEntry,
         invoice_index: u64,
         invoice: lightning_invoice::Bolt11Invoice,
+        offer_was_found: bool,
     ) -> anyhow::Result<OperationId> {
         // TODO: pipe secure secp context to here
         let invoice_key =
@@ -309,52 +336,78 @@ impl LightningClientModule {
             invoice_index=%invoice_index,
             "Creating recurring receive operation"
         );
-        let ln_state =
-            LightningClientStateMachines::Receive(crate::receive::LightningReceiveStateMachine {
-                operation_id,
-                // TODO: technically we want a state that doesn't assume the offer was accepted
-                // since we haven't checked, but for an MVP this is good enough
-                state: crate::receive::LightningReceiveStates::ConfirmedInvoice(
-                    crate::receive::LightningReceiveConfirmedInvoice {
-                        invoice: invoice.clone(),
-                        receiving_key: crate::ReceivingKey::Personal(invoice_key),
-                    },
-                ),
-            });
+        let operation_meta = LightningOperationMeta {
+            variant: LightningOperationMetaVariant::RecurringPaymentReceive(
+                ReurringPaymentReceiveMeta {
+                    payment_code_id: PaymentCodeRootKey(payment_code.root_keypair.public_key())
+                        .to_payment_code_id(),
+                    invoice: invoice.clone(),
+                },
+            ),
+            extra_meta: serde_json::Value::Null,
+        };
+        let receiving_key = crate::ReceivingKey::Personal(invoice_key);
 
-        if let Err(e) = client
-            .manual_operation_start_dbtx(
+        if offer_was_found {
+            let ln_state = LightningClientStateMachines::Receive(
+                crate::receive::LightningReceiveStateMachine {
+                    operation_id,
+                    state: crate::receive::LightningReceiveStates::ConfirmedInvoice(
+                        crate::receive::LightningReceiveConfirmedInvoice {
+                            invoice,
+                            receiving_key,
+                        },
+                    ),
+                },
+            );
+
+            client
+                .manual_operation_start_dbtx(
+                    dbtx,
+                    operation_id,
+                    "ln",
+                    operation_meta,
+                    vec![client.make_dyn_state(ln_state)],
+                )
+                .await?;
+            return Ok(operation_id);
+        }
+
+        warn!(
+            target: LOG_CLIENT_RECURRING,
+            ?operation_id,
+            payment_code_key=?payment_code.root_keypair.public_key(),
+            invoice_index=%invoice_index,
+            "Incoming contract offer missing from federation; registering it from the recipient client"
+        );
+
+        let amount = fedimint_core::Amount::from_msats(
+            invoice.amount_milli_satoshis().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Recurring invoice for operation {operation_id:?} has no amount, cannot register offer"
+                )
+            })?,
+        );
+        let expiry_time = Some(invoice.expiry_time().as_secs());
+        let (_, output, _) = client.self_ref().create_lightning_receive_offer_output(
+            amount,
+            &invoice,
+            receiving_key,
+            expiry_time,
+        )?;
+        let output = client.make_client_outputs(output);
+        let tx = TransactionBuilder::new().with_outputs(output);
+        client
+            .finalize_and_submit_transaction_dbtx(
                 dbtx,
                 operation_id,
                 "ln",
-                LightningOperationMeta {
-                    variant: LightningOperationMetaVariant::RecurringPaymentReceive(
-                        ReurringPaymentReceiveMeta {
-                            payment_code_id: PaymentCodeRootKey(
-                                payment_code.root_keypair.public_key(),
-                            )
-                            .to_payment_code_id(),
-                            invoice,
-                        },
-                    ),
-                    extra_meta: serde_json::Value::Null,
-                },
-                vec![client.make_dyn_state(ln_state)],
+                move |_| operation_meta.clone(),
+                tx,
             )
-            .await
-        {
-            warn!(
-                target: LOG_CLIENT_RECURRING,
-                ?operation_id,
-                payment_code_key=?payment_code.root_keypair.public_key(),
-                invoice_index=%invoice_index,
-                err = %e.fmt_compact_anyhow(),
-                "Failed to create recurring receive operation"
-            );
-            Err(e)
-        } else {
-            Ok(operation_id)
-        }
+            .await?;
+
+        Ok(operation_id)
     }
 
     pub async fn subscribe_ln_recurring_receive(

--- a/modules/fedimint-ln-tests/Cargo.toml
+++ b/modules/fedimint-ln-tests/Cargo.toml
@@ -13,6 +13,7 @@ path = "tests/tests.rs"
 
 [dependencies]
 anyhow = { workspace = true }
+axum = { workspace = true }
 bitcoin_hashes = { workspace = true }
 fedimint-client = { workspace = true }
 fedimint-client-module = { workspace = true }

--- a/modules/fedimint-ln-tests/tests/tests.rs
+++ b/modules/fedimint-ln-tests/tests/tests.rs
@@ -3,6 +3,9 @@ use std::time::Duration;
 
 use anyhow::bail;
 use assert_matches::assert_matches;
+use axum::extract::{Path, State};
+use axum::routing::{get, put};
+use axum::{Json, Router};
 use bitcoin_hashes::{Hash, sha256};
 use fedimint_client::transaction::{
     ClientOutput, ClientOutputBundle, ClientOutputSM, TransactionBuilder, TxSubmissionStates,
@@ -13,7 +16,7 @@ use fedimint_client_module::oplog::OperationLogEntry;
 use fedimint_core::core::{IntoDynInstance, OperationId};
 use fedimint_core::module::{AmountUnit, Amounts, CommonModuleInit as _};
 use fedimint_core::util::backoff_util::aggressive_backoff_long;
-use fedimint_core::util::{BoxStream, NextOrPending, retry};
+use fedimint_core::util::{BoxStream, NextOrPending, SafeUrl, retry};
 use fedimint_core::{Amount, sats, secp256k1};
 use fedimint_dummy_client::{DummyClientInit, DummyClientModule};
 use fedimint_dummy_server::DummyInit;
@@ -23,11 +26,12 @@ use fedimint_ln_client::receive::{
     LightningReceiveError, LightningReceiveStateMachine, LightningReceiveStates,
     LightningReceiveSubmittedOffer,
 };
+use fedimint_ln_client::recurring::RecurringPaymentProtocol;
 use fedimint_ln_client::{
     InternalPayState, LightningClientInit, LightningClientModule, LightningClientStateMachines,
     LightningOperationMeta, LightningOperationMetaVariant, LnPayState, LnReceiveState,
     MockGatewayConnection, OutgoingLightningPayment, PayType, ReceivingKey,
-    create_incoming_contract_output,
+    create_incoming_contract_output, tweak_user_key,
 };
 use fedimint_ln_common::contracts::incoming::IncomingContractOffer;
 use fedimint_ln_common::contracts::{EncryptedPreimage, PreimageKey};
@@ -43,6 +47,7 @@ use lightning_invoice::{
 };
 use rand::rngs::OsRng;
 use secp256k1::Keypair;
+use tokio::sync::watch;
 
 pub async fn ln_operation(
     client: &ClientHandleArc,
@@ -145,6 +150,112 @@ async fn await_client_tx_accepted(
         .next()
         .await
         .expect("tx either accepted or rejected")
+}
+
+async fn await_mock_recurring_invoice(
+    Path((_, invoice_index)): Path<(String, u64)>,
+    State(mut invoice_rx): State<watch::Receiver<Option<Bolt11Invoice>>>,
+) -> Json<Bolt11Invoice> {
+    if invoice_index != 1 {
+        return std::future::pending().await;
+    }
+
+    loop {
+        if let Some(invoice) = invoice_rx.borrow().clone() {
+            return Json(invoice);
+        }
+        invoice_rx
+            .changed()
+            .await
+            .expect("test keeps the invoice sender alive");
+    }
+}
+
+#[allow(clippy::literal_string_with_formatting_args)]
+#[tokio::test(flavor = "multi_thread")]
+async fn recurring_receive_registers_missing_offer() -> anyhow::Result<()> {
+    let (invoice_tx, invoice_rx) = watch::channel(None);
+    let recurringd = Router::new()
+        .route(
+            "/lnv1/paycodes",
+            put(|| async {
+                Json(serde_json::json!({
+                    "recurring_payment_code": "LNURL test payment code"
+                }))
+            }),
+        )
+        .route(
+            "/lnv1/paycodes/recipient/{root_key}/generated/{invoice_index}",
+            get(await_mock_recurring_invoice),
+        )
+        .with_state(invoice_rx);
+    let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0)).await?;
+    let recurringd_api = SafeUrl::parse(&format!("http://{}/", listener.local_addr()?))?;
+    let recurringd_task = tokio::spawn(async move {
+        axum::serve(listener, recurringd)
+            .await
+            .expect("mock recurringd server failed");
+    });
+
+    let fixtures = fixtures();
+    let fed = fixtures.new_fed_degraded().await;
+    let client = fed.new_client().await;
+    let ln_module = client.get_first_module::<LightningClientModule>()?;
+    let payment_code = ln_module
+        .register_recurring_payment_code(
+            RecurringPaymentProtocol::LNURL,
+            recurringd_api,
+            "[[\"text/plain\", \"test\"]]",
+        )
+        .await?;
+
+    let invoice_index = 1;
+    let invoice_key = tweak_user_key(
+        &secp256k1::Secp256k1::new(),
+        payment_code.root_keypair.public_key(),
+        invoice_index,
+    );
+    let preimage = sha256::Hash::hash(&invoice_key.serialize());
+    let payment_hash = sha256::Hash::hash(&preimage.to_byte_array());
+    let secp = secp256k1::Secp256k1::new();
+    let (node_secret_key, node_public_key) = secp.generate_keypair(&mut OsRng);
+    let invoice = InvoiceBuilder::new(Currency::Regtest)
+        .amount_milli_satoshis(100_000)
+        .description("missing recurring offer".to_owned())
+        .payment_hash(payment_hash)
+        .payment_secret(PaymentSecret([0; 32]))
+        .current_timestamp()
+        .min_final_cltv_expiry_delta(18)
+        .payee_pub_key(node_public_key)
+        .expiry_time(Duration::from_secs(60))
+        .build_signed(|message| secp.sign_ecdsa_recoverable(message, &node_secret_key))?;
+
+    assert!(!ln_module.api.offer_exists(payment_hash).await?);
+    invoice_tx.send_replace(Some(invoice));
+
+    tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            if matches!(ln_module.api.offer_exists(payment_hash).await, Ok(true)) {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await?;
+
+    let operation_id = OperationId(*payment_hash.as_ref());
+    let mut receive_updates = ln_module
+        .subscribe_ln_recurring_receive(operation_id)
+        .await?
+        .into_stream();
+    assert_eq!(receive_updates.ok().await?, LnReceiveState::Created);
+    assert_matches!(
+        receive_updates.ok().await?,
+        LnReceiveState::WaitingForPayment { .. }
+    );
+
+    recurringd_task.abort();
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
Closes #8894

recurringd can serve an LNv1 recurring invoice whose incoming-contract offer is absent from federation consensus, typically after a recurringd restart. The recipient client trusted that invoice, entered `ConfirmedInvoice` directly, and waited forever for a contract that can never be funded.

- before recording a recurring receive, the client now checks whether the offer exists in consensus. a confirmed absence is recovered through the normal LNv1 offer path: the client validates the invoice payment hash against its own receiving key and submits the offer together with the receive operation
- an inconclusive federation read leaves the invoice index untouched so the invoice is retried instead of skipped
- an operation-creation failure logs a warning instead of tripping a debug assertion

The included test `recurring_receive_registers_missing_offer` drives a mock recurringd that serves an invoice with no matching offer. It times out with `deadline has elapsed` without the client change and reaches `WaitingForPayment` with it.
