### PR TITLE
feat(consensus): quiesce idle Aleph unit creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3090,8 +3090,7 @@ dependencies = [
 [[package]]
 name = "fedimint-aleph-bft"
 version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b21015ab681cdddedd866fe4af9169901012e9a8bd4745da8423131cccae025"
+source = "git+https://github.com/fedimint/AlephBFT.git?rev=320a66f54bd69743a19f443f3564cb13b90e7dfc#320a66f54bd69743a19f443f3564cb13b90e7dfc"
 dependencies = [
  "aleph-bft-rmc",
  "aleph-bft-types 0.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,7 @@ repository = "https://github.com/fedimint/fedimint"
 name = "fedimint"
 
 [workspace.dependencies]
-aleph-bft = { package = "fedimint-aleph-bft", version = "0.36.0", default-features = false }
+aleph-bft = { package = "fedimint-aleph-bft", git = "https://github.com/fedimint/AlephBFT.git", rev = "320a66f54bd69743a19f443f3564cb13b90e7dfc", default-features = false }
 anyhow = "1.0.98"
 aquamarine = "0.5.0"
 argon2 = "0.5.3"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -76,3 +76,20 @@ cannot overwrite a newer logical attempt, and advertised TTL uses monotonic
 elapsed time. Status assembly holds the federation-manager read lock only while
 capturing one coherent snapshot; do not clone the client solely for this public
 query because that would interfere with concurrent leave.
+
+## Experimental Aleph idle gate
+
+`FM_EXPERIMENTAL_ALEPH_IDLE_GATE` is not covered by the normal availability or
+traffic-privacy expectations. Enabling it accepts two explicit risks:
+
+- A gate fault can stall consensus. Capability leases, lifecycle fail-open
+  paths, and periodic probes are defenses in depth, not a liveness guarantee.
+- Removing continuous Aleph cover traffic exposes work timing. Authenticated
+  guardians learn which guardian first received local work and how long it
+  remains active; transport observers can correlate traffic resumption with
+  federation activity. Logs and gate metrics can preserve the same timing.
+
+The gate activates only when all guardians advertise current-session support.
+Capability expiry, mixed support, recovery, lifecycle transitions, and probes
+restore the normal full-speed creator. A faulty guardian can force that
+fail-open state but cannot increase creation beyond the normal rate.

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -26,6 +26,33 @@ transport boundary is unsupported.
 unset, guardian P2P uses Iroh's default 1.x-compatible relays. Do not configure a
 0.35-only relay as an Iroh 1.x P2P relay.
 
+## Experimental Aleph idle gate
+
+Aleph normally creates and broadcasts units continuously, including while the
+federation has no consensus work. Setting `FM_EXPERIMENTAL_ALEPH_IDLE_GATE`
+opts one guardian into an experimental protocol that can stop this cover
+traffic. The gate closes only after every configured guardian advertises a
+renewable, current-session capability lease. A mixed-version federation
+therefore keeps the normal creator running.
+
+When a guardian receives its first local consensus item after an idle period,
+it sends authenticated `Work` messages to every other guardian. These messages
+identify that guardian as the item's ingress point and their one-second
+renewals expose the duration of its local work episode. Quiescing Aleph also
+lets network observers correlate the absence and resumption of guardian
+traffic with federation activity. Gate-transition logs and metrics retain
+related timing locally. Do not enable the gate if continuous unit traffic is
+part of the deployment's privacy model.
+
+The experiment deliberately fails open: local work, any current-session peer
+`Work` lease, capability expiry, recovery, signature collection, scheduled
+shutdown, and a one-minute probe restore normal unit creation. A Byzantine
+guardian can also keep creation active by renewing `Work`; this only restores
+the default traffic and resource rate. These mechanisms reduce the chance of
+a stall but do not prove liveness. A protocol or implementation fault can stop
+consensus, so operators must coordinate the opt-in and explicitly accept that
+risk.
+
 Guardian P2P publishes only its relay address through Pkarr when one is
 available. Without a relay address, it publishes its direct IP addresses instead
 so other guardians can discover it by endpoint ID. This fallback is required for

--- a/fedimint-core/src/envs.rs
+++ b/fedimint-core/src/envs.rs
@@ -21,6 +21,11 @@ pub const FM_USE_UNKNOWN_MODULE_ENV: &str = "FM_USE_UNKNOWN_MODULE";
 pub const FM_WALLET_DISABLE_AUTOMATIC_CONSENSUS_VERSION_VOTING_ENV: &str =
     "FM_WALLET_DISABLE_AUTOMATIC_CONSENSUS_VERSION_VOTING";
 
+/// Enable the experimental Aleph idle gate, accepting liveness risk and loss
+/// of continuous cover traffic that exposes local-work timing to guardians and
+/// transport observers.
+pub const FM_EXPERIMENTAL_ALEPH_IDLE_GATE_ENV: &str = "FM_EXPERIMENTAL_ALEPH_IDLE_GATE";
+
 pub const FM_ENABLE_MODULE_LNV1_ENV: &str = "FM_ENABLE_MODULE_LNV1";
 pub const FM_ENABLE_MODULE_LNV2_ENV: &str = "FM_ENABLE_MODULE_LNV2";
 pub const FM_ENABLE_MODULE_MINT_ENV: &str = "FM_ENABLE_MODULE_MINT";

--- a/fedimint-server/src/consensus/aleph_bft/data_provider.rs
+++ b/fedimint-server/src/consensus/aleph_bft/data_provider.rs
@@ -9,6 +9,7 @@ use fedimint_core::secp256k1::schnorr;
 use tokio::sync::watch;
 
 use crate::LOG_CONSENSUS;
+use crate::consensus::aleph_bft::idle::IdleCoordinator;
 
 #[derive(
     Clone, Debug, PartialEq, Eq, Hash, parity_scale_codec::Encode, parity_scale_codec::Decode,
@@ -36,6 +37,7 @@ pub struct DataProvider {
     leftover_item: Option<ConsensusItem>,
     timestamp_sender: async_channel::Sender<Instant>,
     is_recovery: bool,
+    idle: IdleCoordinator,
 }
 
 impl DataProvider {
@@ -44,6 +46,7 @@ impl DataProvider {
         signature_receiver: watch::Receiver<Option<schnorr::Signature>>,
         timestamp_sender: async_channel::Sender<Instant>,
         is_recovery: bool,
+        idle: IdleCoordinator,
     ) -> Self {
         Self {
             mempool_item_receiver,
@@ -52,6 +55,7 @@ impl DataProvider {
             leftover_item: None,
             timestamp_sender,
             is_recovery,
+            idle,
         }
     }
 }
@@ -76,15 +80,20 @@ impl aleph_bft::DataProvider<UnitData> for DataProvider {
                 items.push(item);
             } else {
                 tracing::warn!(target: LOG_CONSENSUS, ?item, "Consensus item length is over BYTE_LIMIT");
+                self.idle.release_item(&item);
             }
         }
 
         // if the channel is empty we want to return the batch immediately in order to
         // not delay the creation of our next unit, even if the batch is empty
         while let Ok(item) = self.mempool_item_receiver.try_recv() {
+            if !self.idle.admit_item(&item) {
+                continue;
+            }
             if let ConsensusItem::Transaction(transaction) = &item
                 && !self.submitted_transactions.insert(transaction.tx_hash())
             {
+                self.idle.release_item(&item);
                 continue;
             }
 
@@ -100,6 +109,7 @@ impl aleph_bft::DataProvider<UnitData> for DataProvider {
         }
 
         if items.is_empty() {
+            self.idle.consider_idle();
             return None;
         }
 
@@ -111,6 +121,8 @@ impl aleph_bft::DataProvider<UnitData> for DataProvider {
 
         assert!(bytes.len() <= ALEPH_BFT_UNIT_BYTE_LIMIT);
 
-        Some(UnitData::Batch(bytes))
+        let data = UnitData::Batch(bytes);
+        self.idle.batch_created(&data, &items);
+        Some(data)
     }
 }

--- a/fedimint-server/src/consensus/aleph_bft/finalization_handler.rs
+++ b/fedimint-server/src/consensus/aleph_bft/finalization_handler.rs
@@ -2,6 +2,7 @@ use aleph_bft::{NodeIndex, Round};
 use fedimint_core::PeerId;
 
 use super::data_provider::UnitData;
+use super::idle::IdleCoordinator;
 
 pub struct OrderedUnit {
     pub creator: PeerId,
@@ -11,11 +12,12 @@ pub struct OrderedUnit {
 
 pub struct FinalizationHandler {
     sender: async_channel::Sender<OrderedUnit>,
+    idle: IdleCoordinator,
 }
 
 impl FinalizationHandler {
-    pub fn new(sender: async_channel::Sender<OrderedUnit>) -> Self {
-        Self { sender }
+    pub fn new(sender: async_channel::Sender<OrderedUnit>, idle: IdleCoordinator) -> Self {
+        Self { sender, idle }
     }
 }
 
@@ -25,6 +27,11 @@ impl aleph_bft::FinalizationHandler<UnitData> for FinalizationHandler {
     }
 
     fn unit_finalized(&mut self, creator: NodeIndex, round: Round, data: Option<UnitData>) {
+        if super::to_peer_id(creator) == Some(self.idle.identity())
+            && let Some(data) = &data
+        {
+            self.idle.batch_finalized(data);
+        }
         // the channel is unbounded
         self.sender
             .try_send(OrderedUnit {

--- a/fedimint-server/src/consensus/aleph_bft/idle.rs
+++ b/fedimint-server/src/consensus/aleph_bft/idle.rs
@@ -1,0 +1,598 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use aleph_bft::UnitCreationGate;
+use bitcoin::hashes::{Hash, sha256};
+use fedimint_core::encoding::{Decodable, Encodable};
+use fedimint_core::epoch::ConsensusItem;
+use fedimint_core::module::registry::ModuleRegistry;
+use fedimint_core::net::peers::{DynP2PConnections, Recipient};
+use fedimint_core::runtime::{JoinHandle, sleep, spawn};
+use fedimint_core::{NumPeers, PeerId};
+use rand::RngCore;
+use tracing::{info, warn};
+
+use crate::LOG_CONSENSUS;
+use crate::consensus::aleph_bft::data_provider::UnitData;
+use crate::metrics::{
+    ALEPH_IDLE_CAPABLE_PEERS, ALEPH_IDLE_CONTROL_MESSAGES, ALEPH_IDLE_GATE_OPEN,
+    ALEPH_IDLE_GATE_TRANSITIONS, ALEPH_IDLE_OUTSTANDING_BATCHES,
+};
+
+/// `P2PMessage::Default` extension identifier for idle-gate control messages.
+pub const ALEPH_IDLE_CONTROL_V1: u64 = 0x464d_414c_4944_4c45;
+const PROTOCOL_VERSION: u16 = 1;
+const WORK_LEASE: Duration = Duration::from_secs(5);
+const REFRESH_INTERVAL: Duration = Duration::from_secs(1);
+const CAPABILITY_INTERVAL: Duration = Duration::from_secs(30);
+const CAPABILITY_LEASE: Duration = Duration::from_secs(75);
+const PROBE_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Process-wide submission counts that survive Aleph session boundaries.
+#[derive(Default)]
+pub struct SubmissionActivity {
+    announced: AtomicU64,
+    consumed: AtomicU64,
+}
+
+impl SubmissionActivity {
+    fn announce(&self) {
+        self.announced.fetch_add(1, Ordering::SeqCst);
+    }
+
+    fn consume(&self) {
+        self.consumed.fetch_add(1, Ordering::SeqCst);
+    }
+
+    fn has_pending(&self) -> bool {
+        self.consumed.load(Ordering::SeqCst) < self.announced.load(Ordering::SeqCst)
+    }
+}
+
+#[cfg(test)]
+mod tests;
+
+/// Versioned control data carried in the backwards-decodable default envelope.
+#[derive(Debug, Clone, Eq, PartialEq, Encodable, Decodable)]
+pub enum IdleControlV1 {
+    /// Advertise support for this experimental protocol.
+    Capability {
+        protocol: u16,
+        session: u64,
+        boot_id: [u8; 16],
+    },
+    /// Renew a current-session work activation.
+    Work {
+        session: u64,
+        boot_id: [u8; 16],
+        generation: u64,
+    },
+    /// Advisory receipt acknowledgment. It never controls progress.
+    Ack {
+        session: u64,
+        boot_id: [u8; 16],
+        generation: u64,
+    },
+}
+
+#[derive(Clone, Copy)]
+struct PeerWork {
+    boot_id: [u8; 16],
+    generation: u64,
+    deadline: Instant,
+}
+
+struct State {
+    capabilities: BTreeMap<PeerId, ([u8; 16], Instant)>,
+    peer_work: BTreeMap<PeerId, PeerWork>,
+    generation: u64,
+    local_active: bool,
+    item_hashes: BTreeSet<sha256::Hash>,
+    batches: BTreeMap<sha256::Hash, Vec<sha256::Hash>>,
+    gate_open: bool,
+    force_open: bool,
+}
+
+/// Coordinates the experimental gate across submission, P2P, and finalization.
+#[derive(Clone)]
+pub struct IdleCoordinator {
+    enabled: bool,
+    session: u64,
+    identity: PeerId,
+    num_peers: NumPeers,
+    boot_id: [u8; 16],
+    gate: UnitCreationGate,
+    submission_activity: Option<Arc<SubmissionActivity>>,
+    state: Arc<Mutex<State>>,
+}
+
+/// Owns both tasks whose lifetime is restricted to one Aleph session.
+pub(crate) struct IdleSessionTasks(Vec<JoinHandle<()>>);
+
+impl IdleSessionTasks {
+    /// Start the submission observer and control-message loop when enabled.
+    pub(crate) fn start(
+        idle: IdleCoordinator,
+        submissions: async_channel::Receiver<ConsensusItem>,
+        submission_wake: Option<tokio::sync::watch::Receiver<u64>>,
+        connections: DynP2PConnections<fedimint_core::config::P2PMessage>,
+        shutdown: tokio::sync::watch::Receiver<Option<u64>>,
+        signature: tokio::sync::watch::Receiver<
+            Option<fedimint_core::secp256k1::schnorr::Signature>,
+        >,
+    ) -> Self {
+        if !idle.enabled() {
+            return Self(Vec::new());
+        }
+        let submission_wake =
+            submission_wake.expect("enabled idle gate has a submission notification channel");
+        let observer = spawn(
+            "aleph idle submission observer",
+            observe_submissions(submissions, submission_wake, idle.clone()),
+        );
+        let control = spawn("aleph idle control", {
+            let idle = idle.clone();
+            async move {
+                idle.run_control_loop(connections, shutdown, signature)
+                    .await;
+            }
+        });
+        Self(vec![observer, control])
+    }
+
+    /// Abort and join every session-scoped task before the next session starts.
+    pub(crate) async fn stop(&mut self) {
+        for task in self.0.drain(..) {
+            task.abort();
+            task.await.ok();
+        }
+    }
+}
+
+impl Drop for IdleSessionTasks {
+    fn drop(&mut self) {
+        for task in &self.0 {
+            task.abort();
+        }
+    }
+}
+
+impl IdleCoordinator {
+    /// Construct a session-scoped coordinator.
+    pub fn new(
+        enabled: bool,
+        recovery: bool,
+        session: u64,
+        identity: PeerId,
+        num_peers: NumPeers,
+        submission_activity: Option<Arc<SubmissionActivity>>,
+    ) -> Self {
+        let enabled = enabled && !recovery;
+        assert!(
+            !enabled || submission_activity.is_some(),
+            "enabled idle gate has submission activity tracking"
+        );
+        let mut boot_id = [0; 16];
+        rand::thread_rng().fill_bytes(&mut boot_id);
+        let gate = UnitCreationGate::new();
+        ALEPH_IDLE_GATE_OPEN.set(1);
+        ALEPH_IDLE_CAPABLE_PEERS.set(i64::from(enabled));
+        ALEPH_IDLE_OUTSTANDING_BATCHES.set(0);
+
+        if enabled {
+            warn!(
+                target: LOG_CONSENSUS,
+                session,
+                "Experimental Aleph idle gate enabled; this can harm liveness and leaks work timing"
+            );
+        }
+
+        Self {
+            enabled,
+            session,
+            identity,
+            num_peers,
+            boot_id,
+            gate,
+            submission_activity,
+            state: Arc::new(Mutex::new(State {
+                capabilities: BTreeMap::from([(identity, (boot_id, Instant::now()))]),
+                peer_work: BTreeMap::new(),
+                generation: 0,
+                local_active: false,
+                item_hashes: BTreeSet::new(),
+                batches: BTreeMap::new(),
+                gate_open: true,
+                force_open: false,
+            })),
+        }
+    }
+
+    /// Return the upstream unit-creation gate.
+    pub fn gate(&self) -> UnitCreationGate {
+        self.gate.clone()
+    }
+
+    /// Return whether control traffic and gating are enabled.
+    pub fn enabled(&self) -> bool {
+        self.enabled
+    }
+
+    /// Return this process's configured guardian identity.
+    pub fn identity(&self) -> PeerId {
+        self.identity
+    }
+
+    /// Permanently open this session's gate for a lifecycle-critical phase.
+    pub fn fail_open(&self, reason: &'static str) {
+        if !self.enabled {
+            return;
+        }
+        let mut state = self.state.lock().expect("idle coordinator mutex poisoned");
+        state.force_open = true;
+        self.open_locked(&mut state, reason);
+    }
+
+    /// Admit a locally submitted item, deduplicating only while it is pending
+    /// or attached to an unfinalized local batch.
+    pub fn admit_item(&self, item: &ConsensusItem) -> bool {
+        if let Some(activity) = &self.submission_activity {
+            activity.consume();
+        }
+        if !self.enabled {
+            return true;
+        }
+        let hash = item.consensus_hash::<sha256::Hash>();
+        let mut state = self.state.lock().expect("idle coordinator mutex poisoned");
+        if !state.item_hashes.insert(hash) {
+            self.reconcile_locked(&mut state);
+            return false;
+        }
+        if !state.local_active {
+            state.generation = state.generation.saturating_add(1);
+            state.local_active = true;
+            self.open_locked(&mut state, "local work");
+        }
+        true
+    }
+
+    /// Wake unit creation when the shared submission queue becomes nonempty.
+    ///
+    /// This intentionally does not remove the item from the queue. The
+    /// session's data provider remains its sole consumer, so cancellation
+    /// and session handoff cannot lose an observed submission.
+    pub fn local_submission_pending(&self) {
+        if !self.enabled {
+            return;
+        }
+        let mut state = self.state.lock().expect("idle coordinator mutex poisoned");
+        if !state.local_active {
+            state.generation = state.generation.saturating_add(1);
+            state.local_active = true;
+            self.open_locked(&mut state, "local work");
+        }
+    }
+
+    /// Release an admitted item that cannot be attached to a unit.
+    pub fn release_item(&self, item: &ConsensusItem) {
+        if self.enabled {
+            self.state
+                .lock()
+                .expect("idle coordinator mutex poisoned")
+                .item_hashes
+                .remove(&item.consensus_hash::<sha256::Hash>());
+        }
+    }
+
+    /// Record the item identities attached to a local batch.
+    pub fn batch_created(&self, data: &UnitData, items: &[ConsensusItem]) {
+        if !self.enabled {
+            return;
+        }
+        let UnitData::Batch(bytes) = data else {
+            return;
+        };
+        self.state
+            .lock()
+            .expect("idle coordinator mutex poisoned")
+            .batches
+            .insert(
+                sha256::Hash::hash(bytes),
+                items
+                    .iter()
+                    .map(Encodable::consensus_hash::<sha256::Hash>)
+                    .collect(),
+            );
+        ALEPH_IDLE_OUTSTANDING_BATCHES.set(
+            self.state
+                .lock()
+                .expect("idle coordinator mutex poisoned")
+                .batches
+                .len() as i64,
+        );
+    }
+
+    /// Retire a finalized local batch and permit identical proposals to retry.
+    pub fn batch_finalized(&self, data: &UnitData) {
+        if !self.enabled {
+            return;
+        }
+        let UnitData::Batch(bytes) = data else {
+            return;
+        };
+        let mut state = self.state.lock().expect("idle coordinator mutex poisoned");
+        if let Some(items) = state.batches.remove(&sha256::Hash::hash(bytes)) {
+            for hash in items {
+                state.item_hashes.remove(&hash);
+            }
+        }
+        ALEPH_IDLE_OUTSTANDING_BATCHES.set(state.batches.len() as i64);
+        state.local_active = self.has_local_work(&state);
+        self.reconcile_locked(&mut state);
+    }
+
+    /// Close the gate when negotiation and current work state allow it.
+    pub fn consider_idle(&self) {
+        if !self.enabled {
+            return;
+        }
+        let mut state = self.state.lock().expect("idle coordinator mutex poisoned");
+        state.local_active = self.has_local_work(&state);
+        self.reconcile_locked(&mut state);
+    }
+
+    /// Process one authenticated peer control message and return an advisory
+    /// ACK.
+    pub fn receive(&self, peer: PeerId, message: IdleControlV1) -> Option<IdleControlV1> {
+        if !self.enabled || peer == self.identity || !self.num_peers.peer_ids().any(|p| p == peer) {
+            return None;
+        }
+        let mut state = self.state.lock().expect("idle coordinator mutex poisoned");
+        match message {
+            IdleControlV1::Capability {
+                protocol,
+                session,
+                boot_id,
+            } if protocol == PROTOCOL_VERSION && session == self.session => {
+                let is_new = state
+                    .capabilities
+                    .insert(peer, (boot_id, Instant::now() + CAPABILITY_LEASE))
+                    .is_none_or(|(old_boot, _)| old_boot != boot_id);
+                if is_new {
+                    info!(
+                        target: LOG_CONSENSUS,
+                        %peer,
+                        compatible = state.capabilities.len(),
+                        total = self.num_peers.total(),
+                        "Aleph idle-gate capability received"
+                    );
+                }
+                ALEPH_IDLE_CAPABLE_PEERS.set(state.capabilities.len() as i64);
+                ALEPH_IDLE_CONTROL_MESSAGES
+                    .with_label_values(&["received", "capability", "accepted"])
+                    .inc();
+                self.reconcile_locked(&mut state);
+                None
+            }
+            IdleControlV1::Work {
+                session,
+                boot_id,
+                generation,
+            } if session == self.session => {
+                let replace = state
+                    .peer_work
+                    .get(&peer)
+                    .is_none_or(|old| old.boot_id != boot_id || generation >= old.generation);
+                if replace {
+                    state.peer_work.insert(
+                        peer,
+                        PeerWork {
+                            boot_id,
+                            generation,
+                            deadline: Instant::now() + WORK_LEASE,
+                        },
+                    );
+                    self.open_locked(&mut state, "peer work");
+                }
+                ALEPH_IDLE_CONTROL_MESSAGES
+                    .with_label_values(&[
+                        "received",
+                        "work",
+                        if replace { "accepted" } else { "stale" },
+                    ])
+                    .inc();
+                Some(IdleControlV1::Ack {
+                    session,
+                    boot_id,
+                    generation,
+                })
+            }
+            _ => None,
+        }
+    }
+
+    /// Encode an extension message using Fedimint consensus encoding.
+    pub fn encode(message: &IdleControlV1) -> Vec<u8> {
+        message.consensus_encode_to_vec()
+    }
+
+    /// Decode a bounded extension payload using Fedimint consensus encoding.
+    pub fn decode(bytes: &[u8]) -> Option<IdleControlV1> {
+        if bytes.len() > 128 {
+            return None;
+        }
+        IdleControlV1::consensus_decode_whole(bytes, &ModuleRegistry::default()).ok()
+    }
+
+    /// Run renewable capability/work advertisements and sparse fail-open
+    /// probes.
+    pub async fn run_control_loop(
+        &self,
+        connections: DynP2PConnections<fedimint_core::config::P2PMessage>,
+        shutdown: tokio::sync::watch::Receiver<Option<u64>>,
+        signature: tokio::sync::watch::Receiver<
+            Option<fedimint_core::secp256k1::schnorr::Signature>,
+        >,
+    ) {
+        if !self.enabled {
+            return;
+        }
+        let mut capability_at = None;
+        let mut probe_at = Instant::now() + PROBE_INTERVAL;
+        loop {
+            let now = Instant::now();
+            if *shutdown.borrow() == Some(self.session) {
+                self.fail_open("scheduled shutdown");
+            }
+            if signature.borrow().is_some() {
+                self.fail_open("session signature phase");
+            }
+            if capability_at.is_none_or(|sent| now.duration_since(sent) >= CAPABILITY_INTERVAL) {
+                Self::send(
+                    &connections,
+                    Recipient::Everyone,
+                    IdleControlV1::Capability {
+                        protocol: PROTOCOL_VERSION,
+                        session: self.session,
+                        boot_id: self.boot_id,
+                    },
+                );
+                capability_at = Some(now);
+            }
+            let work = {
+                let mut state = self.state.lock().expect("idle coordinator mutex poisoned");
+                state.peer_work.retain(|_, work| work.deadline > now);
+                self.reconcile_locked(&mut state);
+                state.local_active.then_some(state.generation)
+            };
+            if let Some(generation) = work {
+                Self::send(
+                    &connections,
+                    Recipient::Everyone,
+                    IdleControlV1::Work {
+                        session: self.session,
+                        boot_id: self.boot_id,
+                        generation,
+                    },
+                );
+            }
+            if now >= probe_at {
+                let mut state = self.state.lock().expect("idle coordinator mutex poisoned");
+                self.open_locked(&mut state, "forced liveness probe");
+                probe_at = now + PROBE_INTERVAL;
+            }
+            sleep(REFRESH_INTERVAL).await;
+        }
+    }
+
+    fn send(
+        connections: &DynP2PConnections<fedimint_core::config::P2PMessage>,
+        recipient: Recipient,
+        message: IdleControlV1,
+    ) {
+        let kind = match message {
+            IdleControlV1::Capability { .. } => "capability",
+            IdleControlV1::Work { .. } => "work",
+            IdleControlV1::Ack { .. } => "ack",
+        };
+        connections.send(
+            recipient,
+            fedimint_core::config::P2PMessage::Default {
+                variant: ALEPH_IDLE_CONTROL_V1,
+                bytes: Self::encode(&message),
+            },
+        );
+        ALEPH_IDLE_CONTROL_MESSAGES
+            .with_label_values(&["sent", kind, "queued"])
+            .inc();
+    }
+
+    fn reconcile_locked(&self, state: &mut State) {
+        let now = Instant::now();
+        state.peer_work.retain(|_, work| work.deadline > now);
+        state
+            .capabilities
+            .retain(|peer, (_, deadline)| *peer == self.identity || *deadline > now);
+        ALEPH_IDLE_CAPABLE_PEERS.set(state.capabilities.len() as i64);
+        let negotiated = state.capabilities.len() == self.num_peers.total();
+        let should_open =
+            state.force_open || !negotiated || state.local_active || !state.peer_work.is_empty();
+        if should_open {
+            self.open_locked(state, "fail-open or active");
+        } else if state.gate_open {
+            state.gate_open = false;
+            self.gate.close();
+            ALEPH_IDLE_GATE_OPEN.set(0);
+            ALEPH_IDLE_GATE_TRANSITIONS
+                .with_label_values(&["closed", "idle"])
+                .inc();
+            info!(target: LOG_CONSENSUS, session = self.session, "Aleph unit creation gate closed");
+        }
+    }
+
+    fn has_local_work(&self, state: &State) -> bool {
+        self.submission_activity
+            .as_ref()
+            .is_some_and(|activity| activity.has_pending())
+            || !state.batches.is_empty()
+            || !state.item_hashes.is_empty()
+    }
+
+    fn open_locked(&self, state: &mut State, reason: &'static str) {
+        if !state.gate_open {
+            state.gate_open = true;
+            self.gate.open();
+            ALEPH_IDLE_GATE_OPEN.set(1);
+            ALEPH_IDLE_GATE_TRANSITIONS
+                .with_label_values(&["open", reason])
+                .inc();
+            info!(
+                target: LOG_CONSENSUS,
+                session = self.session,
+                reason,
+                "Aleph unit creation gate opened"
+            );
+        }
+    }
+}
+
+/// Observe the shared submission queue without consuming from it.
+pub(crate) async fn observe_submissions(
+    source: async_channel::Receiver<ConsensusItem>,
+    mut wake: tokio::sync::watch::Receiver<u64>,
+    idle: IdleCoordinator,
+) {
+    loop {
+        wake.borrow_and_update();
+        if !source.is_empty()
+            || idle
+                .submission_activity
+                .as_ref()
+                .is_some_and(|activity| activity.has_pending())
+        {
+            idle.local_submission_pending();
+        }
+        if wake.changed().await.is_err() {
+            return;
+        }
+    }
+}
+
+/// Announce each opt-in submission before forwarding it into the process-wide
+/// queue, so a session transition cannot miss an enqueue-in-progress.
+pub(crate) async fn forward_notified_submissions(
+    source: async_channel::Receiver<ConsensusItem>,
+    forwarded: async_channel::Sender<ConsensusItem>,
+    notification: tokio::sync::watch::Sender<u64>,
+    activity: Arc<SubmissionActivity>,
+) {
+    while let Ok(item) = source.recv().await {
+        activity.announce();
+        notification.send_modify(|generation| *generation = generation.wrapping_add(1));
+        if forwarded.send(item).await.is_err() {
+            return;
+        }
+    }
+}

--- a/fedimint-server/src/consensus/aleph_bft/idle/tests.rs
+++ b/fedimint-server/src/consensus/aleph_bft/idle/tests.rs
@@ -1,0 +1,746 @@
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use aleph_bft::{DataProvider as _, FinalizationHandler as _, Network as _, NodeIndex};
+use fedimint_core::config::P2PMessage;
+use fedimint_core::db::mem_impl::MemDatabase;
+use fedimint_core::db::{Database, IRawDatabaseExt as _};
+use fedimint_core::encoding::{Decodable, Encodable};
+use fedimint_core::epoch::ConsensusItem;
+use fedimint_core::module::registry::ModuleRegistry;
+use fedimint_core::net::peers::fake::make_fake_peer_connection;
+use fedimint_core::net::peers::{IP2PConnections, Recipient};
+use fedimint_core::runtime::spawn;
+use fedimint_core::{NumPeers, PeerId};
+
+use super::{
+    IdleControlV1, IdleCoordinator, IdleSessionTasks, SubmissionActivity,
+    forward_notified_submissions,
+};
+use crate::consensus::aleph_bft::data_provider::{DataProvider, UnitData};
+use crate::consensus::aleph_bft::finalization_handler::FinalizationHandler;
+use crate::consensus::aleph_bft::network::Network;
+use crate::consensus::engine::terminate_aleph_session;
+
+#[derive(Clone)]
+struct RecordingConnections {
+    sent: async_channel::Sender<(Recipient, P2PMessage)>,
+}
+
+#[async_trait::async_trait]
+impl IP2PConnections<P2PMessage> for RecordingConnections {
+    fn send(&self, recipient: Recipient, message: P2PMessage) {
+        self.sent.try_send((recipient, message)).ok();
+    }
+
+    async fn receive(&self) -> Option<(PeerId, P2PMessage)> {
+        std::future::pending().await
+    }
+
+    async fn receive_from_peer(&self, _peer: PeerId) -> Option<P2PMessage> {
+        std::future::pending().await
+    }
+}
+
+fn coordinator(enabled: bool) -> IdleCoordinator {
+    IdleCoordinator::new(
+        enabled,
+        false,
+        42,
+        PeerId::from(0),
+        NumPeers::from(4),
+        enabled.then(|| Arc::new(SubmissionActivity::default())),
+    )
+}
+
+fn advertise_all(coordinator: &IdleCoordinator) {
+    for peer in 1..4 {
+        assert_eq!(
+            coordinator.receive(
+                PeerId::from(peer),
+                IdleControlV1::Capability {
+                    protocol: 1,
+                    session: 42,
+                    boot_id: [peer as u8; 16],
+                },
+            ),
+            None
+        );
+    }
+}
+
+#[test]
+fn disabled_mode_never_closes() {
+    let coordinator = coordinator(false);
+    advertise_all(&coordinator);
+    coordinator.consider_idle();
+    assert!(coordinator.state.lock().expect("mutex poisoned").gate_open);
+    assert!(coordinator.gate().is_open());
+}
+
+#[test]
+fn all_capable_idle_closes_and_one_work_opens() {
+    let coordinator = coordinator(true);
+    advertise_all(&coordinator);
+    coordinator.consider_idle();
+    assert!(!coordinator.state.lock().expect("mutex poisoned").gate_open);
+    assert!(!coordinator.gate().is_open());
+
+    let work = IdleControlV1::Work {
+        session: 42,
+        boot_id: [7; 16],
+        generation: 1,
+    };
+    assert!(matches!(
+        coordinator.receive(PeerId::from(1), work),
+        Some(IdleControlV1::Ack { generation: 1, .. })
+    ));
+    assert!(coordinator.state.lock().expect("mutex poisoned").gate_open);
+    assert!(coordinator.gate().is_open());
+}
+
+#[test]
+fn mixed_capability_and_wrong_session_fail_open() {
+    let coordinator = coordinator(true);
+    coordinator.receive(
+        PeerId::from(1),
+        IdleControlV1::Capability {
+            protocol: 1,
+            session: 42,
+            boot_id: [1; 16],
+        },
+    );
+    coordinator.consider_idle();
+    assert!(coordinator.state.lock().expect("mutex poisoned").gate_open);
+    assert!(coordinator.gate().is_open());
+
+    assert_eq!(
+        coordinator.receive(
+            PeerId::from(1),
+            IdleControlV1::Work {
+                session: 41,
+                boot_id: [1; 16],
+                generation: u64::MAX,
+            },
+        ),
+        None
+    );
+    assert!(
+        coordinator
+            .state
+            .lock()
+            .expect("mutex poisoned")
+            .peer_work
+            .is_empty()
+    );
+}
+
+#[test]
+fn control_codec_is_bounded_and_roundtrips() {
+    let message = IdleControlV1::Work {
+        session: 42,
+        boot_id: [3; 16],
+        generation: 9,
+    };
+    assert_eq!(
+        IdleCoordinator::decode(&IdleCoordinator::encode(&message)),
+        Some(message)
+    );
+    assert_eq!(IdleCoordinator::decode(&[0; 129]), None);
+    assert_eq!(IdleCoordinator::decode(&[0xff; 8]), None);
+}
+
+#[test]
+fn leases_expire_and_reboot_generation_wakes_without_quorum() {
+    let coordinator = coordinator(true);
+    advertise_all(&coordinator);
+    coordinator.consider_idle();
+
+    coordinator.receive(
+        PeerId::from(1),
+        IdleControlV1::Work {
+            session: 42,
+            boot_id: [1; 16],
+            generation: 99,
+        },
+    );
+    let old_deadline =
+        coordinator.state.lock().expect("mutex poisoned").peer_work[&PeerId::from(1)].deadline;
+    coordinator.receive(
+        PeerId::from(1),
+        IdleControlV1::Work {
+            session: 42,
+            boot_id: [1; 16],
+            generation: 98,
+        },
+    );
+    assert_eq!(
+        coordinator.state.lock().expect("mutex poisoned").peer_work[&PeerId::from(1)].deadline,
+        old_deadline
+    );
+    {
+        let mut state = coordinator.state.lock().expect("mutex poisoned");
+        state
+            .peer_work
+            .get_mut(&PeerId::from(1))
+            .expect("work")
+            .deadline = Instant::now()
+            .checked_sub(Duration::from_secs(1))
+            .expect("one second fits");
+    }
+    coordinator.consider_idle();
+    assert!(!coordinator.state.lock().expect("mutex poisoned").gate_open);
+    assert!(!coordinator.gate().is_open());
+
+    coordinator.receive(
+        PeerId::from(1),
+        IdleControlV1::Work {
+            session: 42,
+            boot_id: [2; 16],
+            generation: 0,
+        },
+    );
+    assert!(coordinator.state.lock().expect("mutex poisoned").gate_open);
+    assert!(coordinator.gate().is_open());
+}
+
+#[test]
+fn exact_items_retry_only_after_local_batch_finalization() {
+    let coordinator = coordinator(true);
+    let item = ConsensusItem::Default {
+        variant: 7,
+        bytes: vec![1, 2, 3],
+    };
+    assert!(coordinator.admit_item(&item));
+    assert!(!coordinator.admit_item(&item));
+
+    let items = vec![item.clone()];
+    let batch = UnitData::Batch(items.consensus_encode_to_vec());
+    coordinator.batch_created(&batch, &items);
+    assert!(!coordinator.admit_item(&item));
+    coordinator.batch_finalized(&batch);
+    assert!(coordinator.admit_item(&item));
+}
+
+#[test]
+fn empty_provider_reconciliation_cannot_erase_newer_notification() {
+    let coordinator = coordinator(true);
+    advertise_all(&coordinator);
+    coordinator.consider_idle();
+    assert!(!coordinator.gate().is_open());
+
+    coordinator
+        .submission_activity
+        .as_ref()
+        .expect("activity")
+        .announce();
+    coordinator.local_submission_pending();
+    coordinator.consider_idle();
+    assert!(coordinator.gate().is_open());
+    assert!(
+        coordinator
+            .state
+            .lock()
+            .expect("mutex poisoned")
+            .local_active
+    );
+}
+
+#[test]
+fn finalizing_old_batch_cannot_erase_newer_notification() {
+    let coordinator = coordinator(true);
+    advertise_all(&coordinator);
+    let old_item = ConsensusItem::Default {
+        variant: 20,
+        bytes: vec![1],
+    };
+    coordinator
+        .submission_activity
+        .as_ref()
+        .expect("activity")
+        .announce();
+    coordinator.local_submission_pending();
+    assert!(coordinator.admit_item(&old_item));
+    let old_items = vec![old_item];
+    let old_batch = UnitData::Batch(old_items.consensus_encode_to_vec());
+    coordinator.batch_created(&old_batch, &old_items);
+
+    coordinator
+        .submission_activity
+        .as_ref()
+        .expect("activity")
+        .announce();
+    coordinator.local_submission_pending();
+    coordinator.batch_finalized(&old_batch);
+    assert!(coordinator.gate().is_open());
+    assert!(
+        coordinator
+            .submission_activity
+            .as_ref()
+            .expect("activity")
+            .has_pending()
+    );
+    assert!(
+        coordinator
+            .state
+            .lock()
+            .expect("mutex poisoned")
+            .local_active
+    );
+}
+
+#[tokio::test]
+async fn enqueue_in_progress_survives_session_observer_initialization() {
+    let coordinator = coordinator(true);
+    advertise_all(&coordinator);
+    coordinator.consider_idle();
+    let activity = coordinator
+        .submission_activity
+        .as_ref()
+        .expect("activity")
+        .clone();
+    let (producer, submissions) = async_channel::bounded(1);
+    let (wake_sender, wake_receiver) = tokio::sync::watch::channel(0);
+    let (control_sender, _control_receiver) = async_channel::unbounded();
+    let connections = RecordingConnections {
+        sent: control_sender,
+    }
+    .into_dyn();
+    let (_shutdown_sender, shutdown) = tokio::sync::watch::channel(None);
+    let (_signature_sender, signature) = tokio::sync::watch::channel(None);
+
+    // Match the forwarder's deliberate ordering: announce first, then let the
+    // new session initialize while the downstream enqueue is still pending.
+    activity.announce();
+    wake_sender.send_modify(|generation| *generation += 1);
+    let mut tasks = IdleSessionTasks::start(
+        coordinator.clone(),
+        submissions.clone(),
+        Some(wake_receiver),
+        connections,
+        shutdown,
+        signature,
+    );
+    tokio::time::timeout(Duration::from_secs(1), async {
+        while !coordinator.gate().is_open() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("pending announcement opens new session");
+    assert!(submissions.is_empty());
+
+    let item = ConsensusItem::Default {
+        variant: 21,
+        bytes: vec![4],
+    };
+    producer
+        .send(item.clone())
+        .await
+        .expect("enqueue completes");
+    let received = submissions.recv().await.expect("data provider receives");
+    assert_eq!(received, item);
+    assert!(coordinator.admit_item(&received));
+    let items = vec![received];
+    let batch = UnitData::Batch(items.consensus_encode_to_vec());
+    coordinator.batch_created(&batch, &items);
+    coordinator.batch_finalized(&batch);
+    assert!(!activity.has_pending());
+    assert!(!coordinator.gate().is_open());
+    tasks.stop().await;
+}
+
+#[test]
+fn recovery_and_lifecycle_fail_open() {
+    let recovery = IdleCoordinator::new(
+        true,
+        true,
+        42,
+        PeerId::from(0),
+        NumPeers::from(4),
+        Some(Arc::new(SubmissionActivity::default())),
+    );
+    assert!(!recovery.enabled());
+
+    let coordinator = coordinator(true);
+    advertise_all(&coordinator);
+    coordinator.fail_open("test lifecycle");
+    coordinator.consider_idle();
+    assert!(coordinator.state.lock().expect("mutex poisoned").gate_open);
+    assert!(coordinator.gate().is_open());
+}
+
+#[test]
+fn recovery_consumption_clears_process_wide_submission_activity() {
+    let activity = Arc::new(SubmissionActivity::default());
+    activity.announce();
+    let recovery = IdleCoordinator::new(
+        true,
+        true,
+        42,
+        PeerId::from(0),
+        NumPeers::from(4),
+        Some(activity.clone()),
+    );
+    let item = ConsensusItem::Default {
+        variant: 22,
+        bytes: vec![5],
+    };
+    assert!(recovery.admit_item(&item));
+    assert!(!activity.has_pending());
+
+    let normal = IdleCoordinator::new(
+        true,
+        false,
+        43,
+        PeerId::from(0),
+        NumPeers::from(4),
+        Some(activity),
+    );
+    for peer in 1..4 {
+        normal.receive(
+            PeerId::from(peer),
+            IdleControlV1::Capability {
+                protocol: 1,
+                session: 43,
+                boot_id: [peer as u8; 16],
+            },
+        );
+    }
+    normal.consider_idle();
+    assert!(!normal.gate().is_open());
+}
+
+#[test]
+fn capability_lease_expiry_fails_open() {
+    let coordinator = coordinator(true);
+    advertise_all(&coordinator);
+    coordinator.consider_idle();
+    coordinator
+        .state
+        .lock()
+        .expect("mutex poisoned")
+        .capabilities
+        .get_mut(&PeerId::from(1))
+        .expect("capability")
+        .1 = Instant::now()
+        .checked_sub(Duration::from_secs(1))
+        .expect("one second fits");
+    coordinator.consider_idle();
+    assert!(coordinator.gate().is_open());
+}
+
+#[test]
+fn default_envelope_roundtrips_through_outer_codec() {
+    let message = P2PMessage::Default {
+        variant: super::ALEPH_IDLE_CONTROL_V1,
+        bytes: IdleCoordinator::encode(&IdleControlV1::Capability {
+            protocol: 1,
+            session: 42,
+            boot_id: [4; 16],
+        }),
+    };
+    assert_eq!(
+        P2PMessage::consensus_decode_whole(
+            &message.consensus_encode_to_vec(),
+            &ModuleRegistry::default(),
+        )
+        .expect("default envelope decodes"),
+        message
+    );
+}
+
+#[tokio::test]
+async fn session_tasks_stop_joined_without_consuming_handoff_items() {
+    let coordinator = coordinator(true);
+    advertise_all(&coordinator);
+    coordinator.consider_idle();
+    assert!(!coordinator.gate().is_open());
+
+    let (source_sender, source) = async_channel::bounded(2);
+    let (wake_sender, wake_receiver) = tokio::sync::watch::channel(0);
+    let (control_sender, control_receiver) = async_channel::unbounded();
+    let connections = RecordingConnections {
+        sent: control_sender,
+    }
+    .into_dyn();
+    let (_shutdown_sender, shutdown) = tokio::sync::watch::channel(None);
+    let (_signature_sender, signature) = tokio::sync::watch::channel(None);
+    let mut tasks = IdleSessionTasks::start(
+        coordinator.clone(),
+        source.clone(),
+        Some(wake_receiver),
+        connections,
+        shutdown,
+        signature,
+    );
+    let first = ConsensusItem::Default {
+        variant: 1,
+        bytes: vec![1],
+    };
+    source_sender
+        .send(first.clone())
+        .await
+        .expect("source open");
+    wake_sender.send_modify(|generation| *generation += 1);
+    tokio::time::timeout(Duration::from_secs(1), async {
+        while !coordinator.gate().is_open() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("observer wakes gate");
+    assert!(coordinator.gate().is_open());
+
+    let second = ConsensusItem::Default {
+        variant: 2,
+        bytes: vec![2],
+    };
+    source_sender
+        .send(second.clone())
+        .await
+        .expect("source open");
+    wake_sender.send_modify(|generation| *generation += 1);
+    tasks.stop().await;
+    assert!(
+        wake_sender.is_closed(),
+        "joined observer dropped its notification receiver"
+    );
+    assert!(
+        control_receiver.is_closed(),
+        "joined control task dropped its connection sender"
+    );
+    assert_eq!(source.recv().await.expect("first item remains"), first);
+    assert_eq!(source.recv().await.expect("second item remains"), second);
+}
+
+#[tokio::test]
+async fn producer_forwarder_notifies_after_lossless_enqueue() {
+    let (producer, source) = async_channel::bounded(2);
+    let (forwarded, consumer) = async_channel::bounded(1);
+    let (notification, mut wake) = tokio::sync::watch::channel(0);
+    let task = spawn(
+        "test idle producer notifier",
+        forward_notified_submissions(
+            source,
+            forwarded,
+            notification,
+            Arc::new(SubmissionActivity::default()),
+        ),
+    );
+    let first = ConsensusItem::Default {
+        variant: 11,
+        bytes: vec![1],
+    };
+    let second = ConsensusItem::Default {
+        variant: 12,
+        bytes: vec![2],
+    };
+    producer.send(first.clone()).await.expect("producer open");
+    producer.send(second.clone()).await.expect("producer open");
+
+    while *wake.borrow_and_update() < 2 {
+        wake.changed().await.expect("announcements remain open");
+    }
+    assert_eq!(consumer.recv().await.expect("first forwarded"), first);
+    assert_eq!(consumer.recv().await.expect("second forwarded"), second);
+    task.abort();
+    assert!(task.await.is_err());
+}
+
+#[tokio::test]
+async fn aleph_joins_before_session_tasks_stop_at_handoff() {
+    let coordinator = coordinator(true);
+    let (producer, submissions) = async_channel::bounded(1);
+    let (wake_sender, wake_receiver) = tokio::sync::watch::channel(0);
+    let (control_sender, control_receiver) = async_channel::unbounded();
+    let connections = RecordingConnections {
+        sent: control_sender,
+    }
+    .into_dyn();
+    let (_shutdown_sender, shutdown) = tokio::sync::watch::channel(None);
+    let (_signature_sender, signature) = tokio::sync::watch::channel(None);
+    let mut tasks = IdleSessionTasks::start(
+        coordinator,
+        submissions.clone(),
+        Some(wake_receiver),
+        connections,
+        shutdown,
+        signature,
+    );
+    let item = ConsensusItem::Default {
+        variant: 13,
+        bytes: vec![3],
+    };
+    producer.send(item.clone()).await.expect("producer open");
+    wake_sender.send_modify(|generation| *generation += 1);
+
+    let (terminator, terminated) = futures::channel::oneshot::channel();
+    let consumer_submissions = submissions.clone();
+    let live_consumer = spawn("test live Aleph consumer", async move {
+        tokio::select! {
+            _ = terminated => {}
+            () = async {
+                while control_receiver.recv().await.is_ok() {}
+            } => {
+                consumer_submissions.recv().await.ok();
+            }
+        }
+    });
+    terminate_aleph_session(terminator, live_consumer, &mut tasks).await;
+    assert_eq!(
+        submissions
+            .try_recv()
+            .expect("successor session retains item"),
+        item
+    );
+}
+
+#[tokio::test]
+async fn wired_provider_and_finalizer_reidle_after_local_batch() {
+    let coordinator = coordinator(true);
+    advertise_all(&coordinator);
+    coordinator.consider_idle();
+
+    let (submission_sender, submission_receiver) = async_channel::bounded(2);
+    let (_signature_sender, signature_receiver) = tokio::sync::watch::channel(None);
+    let (timestamp_sender, _timestamp_receiver) = async_channel::unbounded();
+    let mut provider = DataProvider::new(
+        submission_receiver,
+        signature_receiver,
+        timestamp_sender,
+        false,
+        coordinator.clone(),
+    );
+    let item = ConsensusItem::Default {
+        variant: 3,
+        bytes: vec![3],
+    };
+    submission_sender
+        .send(item.clone())
+        .await
+        .expect("submission queue open");
+    coordinator.local_submission_pending();
+    let data = provider.get_data().await.expect("provider builds batch");
+    assert!(coordinator.gate().is_open());
+    assert_eq!(data, UnitData::Batch(vec![item].consensus_encode_to_vec()));
+
+    let (ordered_sender, ordered_receiver) = async_channel::unbounded();
+    let mut finalizer = FinalizationHandler::new(ordered_sender, coordinator.clone());
+    finalizer.unit_finalized(NodeIndex(0), 1, Some(data.clone()));
+    assert_eq!(
+        ordered_receiver.recv().await.expect("finalized unit").data,
+        Some(data)
+    );
+    assert!(!coordinator.gate().is_open());
+}
+
+#[tokio::test]
+async fn network_dispatches_authenticated_control_and_returns_ack() {
+    let coordinator = coordinator(true);
+    let (local_connections, peer_connections) =
+        make_fake_peer_connection(PeerId::from(0), PeerId::from(1), 4);
+    let (outcome_sender, _outcome_receiver) = async_channel::unbounded();
+    let (signature_sender, _signature_receiver) = async_channel::unbounded();
+    let db: Database = MemDatabase::new().into_database();
+    let mut network = Network::new(
+        local_connections,
+        outcome_sender,
+        signature_sender,
+        db,
+        coordinator.clone(),
+    );
+    let task = spawn("test idle network dispatch", async move {
+        let _ = network.next_event().await;
+    });
+
+    peer_connections.send(
+        Recipient::Peer(PeerId::from(0)),
+        P2PMessage::Default {
+            variant: super::ALEPH_IDLE_CONTROL_V1,
+            bytes: IdleCoordinator::encode(&IdleControlV1::Work {
+                session: 42,
+                boot_id: [1; 16],
+                generation: 7,
+            }),
+        },
+    );
+    let (_, ack) = peer_connections.receive().await.expect("peer receives ACK");
+    assert!(matches!(
+        ack,
+        P2PMessage::Default {
+            variant: super::ALEPH_IDLE_CONTROL_V1,
+            bytes,
+        } if matches!(
+            IdleCoordinator::decode(&bytes),
+            Some(IdleControlV1::Ack { generation: 7, .. })
+        )
+    ));
+    assert!(coordinator.gate().is_open());
+    task.abort();
+    assert!(task.await.is_err());
+}
+
+#[tokio::test]
+async fn control_loop_emits_capability_and_work_but_disabled_mode_is_silent() {
+    let (sent, received) = async_channel::unbounded();
+    let connections = RecordingConnections { sent }.into_dyn();
+    let (_shutdown_sender, shutdown) = tokio::sync::watch::channel(None);
+    let (_signature_sender, signature) = tokio::sync::watch::channel(None);
+    let enabled_coordinator = coordinator(true);
+    let task = spawn("test idle control emission", {
+        let coordinator = enabled_coordinator.clone();
+        let connections = connections.clone();
+        async move {
+            coordinator
+                .run_control_loop(connections, shutdown, signature)
+                .await;
+        }
+    });
+    let (recipient, capability) = received.recv().await.expect("capability emitted");
+    assert_eq!(recipient, Recipient::Everyone);
+    assert!(matches!(
+        capability,
+        P2PMessage::Default {
+            variant: super::ALEPH_IDLE_CONTROL_V1,
+            bytes,
+        } if matches!(
+            IdleCoordinator::decode(&bytes),
+            Some(IdleControlV1::Capability { session: 42, .. })
+        )
+    ));
+
+    enabled_coordinator.local_submission_pending();
+    let (_, work) = tokio::time::timeout(Duration::from_secs(2), received.recv())
+        .await
+        .expect("work refresh deadline")
+        .expect("work emitted");
+    assert!(matches!(
+        work,
+        P2PMessage::Default {
+            variant: super::ALEPH_IDLE_CONTROL_V1,
+            bytes,
+        } if matches!(
+            IdleCoordinator::decode(&bytes),
+            Some(IdleControlV1::Work {
+                session: 42,
+                generation: 1,
+                ..
+            })
+        )
+    ));
+    task.abort();
+    assert!(task.await.is_err());
+
+    let (disabled_sent, disabled_received) = async_channel::unbounded();
+    let disabled_connections = RecordingConnections {
+        sent: disabled_sent,
+    }
+    .into_dyn();
+    let (_shutdown_sender, shutdown) = tokio::sync::watch::channel(None);
+    let (_signature_sender, signature) = tokio::sync::watch::channel(None);
+    coordinator(false)
+        .run_control_loop(disabled_connections, shutdown, signature)
+        .await;
+    assert!(disabled_received.is_empty());
+}

--- a/fedimint-server/src/consensus/aleph_bft/mod.rs
+++ b/fedimint-server/src/consensus/aleph_bft/mod.rs
@@ -1,6 +1,7 @@
 pub mod backup;
 pub mod data_provider;
 pub mod finalization_handler;
+pub mod idle;
 pub mod keychain;
 pub mod network;
 pub mod spawner;

--- a/fedimint-server/src/consensus/aleph_bft/network.rs
+++ b/fedimint-server/src/consensus/aleph_bft/network.rs
@@ -16,6 +16,7 @@ use tracing::{error, trace};
 
 use super::super::db::SignedSessionOutcomeKey;
 use super::data_provider::UnitData;
+use super::idle::{ALEPH_IDLE_CONTROL_V1, IdleCoordinator};
 use super::keychain::Keychain;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -41,6 +42,7 @@ pub struct Network {
     signed_outcomes_sender: Sender<(PeerId, SignedSessionOutcome)>,
     signatures_sender: Sender<(PeerId, schnorr::Signature)>,
     db: Database,
+    idle: IdleCoordinator,
 }
 
 impl Network {
@@ -49,12 +51,14 @@ impl Network {
         signed_outcomes_sender: Sender<(PeerId, SignedSessionOutcome)>,
         signatures_sender: Sender<(PeerId, schnorr::Signature)>,
         db: Database,
+        idle: IdleCoordinator,
     ) -> Self {
         Self {
             connections,
             signed_outcomes_sender,
             signatures_sender,
             db,
+            idle,
         }
     }
 }
@@ -148,6 +152,22 @@ impl aleph_bft::Network<NetworkData> for Network {
                                 "Failed to decode SignedSessionOutcome"
                             );
                         }
+                    }
+                }
+                P2PMessage::Default {
+                    variant: ALEPH_IDLE_CONTROL_V1,
+                    bytes,
+                } => {
+                    if let Some(message) = IdleCoordinator::decode(&bytes)
+                        && let Some(ack) = self.idle.receive(peer_id, message)
+                    {
+                        self.connections.send(
+                            Recipient::Peer(peer_id),
+                            P2PMessage::Default {
+                                variant: ALEPH_IDLE_CONTROL_V1,
+                                bytes: IdleCoordinator::encode(&ack),
+                            },
+                        );
                     }
                 }
                 message => {

--- a/fedimint-server/src/consensus/engine.rs
+++ b/fedimint-server/src/consensus/engine.rs
@@ -16,7 +16,9 @@ use fedimint_core::db::{
 };
 use fedimint_core::encoding::Decodable;
 use fedimint_core::endpoint_constants::AWAIT_SIGNED_SESSION_OUTCOME_ENDPOINT;
-use fedimint_core::envs::is_running_in_test_env;
+use fedimint_core::envs::{
+    FM_EXPERIMENTAL_ALEPH_IDLE_GATE_ENV, is_env_var_set, is_running_in_test_env,
+};
 use fedimint_core::epoch::ConsensusItem;
 use fedimint_core::module::audit::Audit;
 use fedimint_core::module::registry::ModuleDecoderRegistry;
@@ -41,6 +43,7 @@ use crate::config::ServerConfig;
 use crate::consensus::aleph_bft::backup::{BackupReader, BackupWriter};
 use crate::consensus::aleph_bft::data_provider::{DataProvider, UnitData};
 use crate::consensus::aleph_bft::finalization_handler::{FinalizationHandler, OrderedUnit};
+use crate::consensus::aleph_bft::idle::{IdleCoordinator, IdleSessionTasks, SubmissionActivity};
 use crate::consensus::aleph_bft::keychain::Keychain;
 use crate::consensus::aleph_bft::network::Network;
 use crate::consensus::aleph_bft::spawner::Spawner;
@@ -58,6 +61,16 @@ use crate::metrics::{
     CONSENSUS_SESSION_COUNT,
 };
 
+pub(crate) async fn terminate_aleph_session(
+    terminator: futures::channel::oneshot::Sender<()>,
+    aleph_handle: fedimint_core::runtime::JoinHandle<()>,
+    idle_tasks: &mut IdleSessionTasks,
+) {
+    terminator.send(()).ok();
+    aleph_handle.await.ok();
+    idle_tasks.stop().await;
+}
+
 // The name of the directory where the database checkpoints are stored.
 const DB_CHECKPOINTS_DIR: &str = "db_checkpoints";
 
@@ -74,6 +87,8 @@ pub struct ConsensusEngine {
     pub federation_api: DynGlobalApi,
     pub cfg: ServerConfig,
     pub submission_receiver: Receiver<ConsensusItem>,
+    pub submission_wake_receiver: Option<watch::Receiver<u64>>,
+    pub submission_activity: Option<Arc<SubmissionActivity>>,
     pub shutdown_receiver: watch::Receiver<Option<u64>>,
     pub connections: DynP2PConnections<P2PMessage>,
     pub ci_status_senders: BTreeMap<PeerId, watch::Sender<Option<u64>>>,
@@ -280,6 +295,24 @@ impl ConsensusEngine {
         )
         .expect("The exponential slowdown exceeds 10 years");
 
+        let is_recovery = self.is_recovery().await;
+        let idle = IdleCoordinator::new(
+            is_env_var_set(FM_EXPERIMENTAL_ALEPH_IDLE_GATE_ENV),
+            is_recovery,
+            session_index,
+            self.identity(),
+            self.num_peers(),
+            self.submission_activity.clone(),
+        );
+        // The fork's `None` path deliberately preserves the released 0.36.0
+        // creator callpath. Do not install an always-open gate when disabled:
+        // even that would select the experimental scheduling implementation.
+        let config = if idle.enabled() {
+            config.with_unit_creation_gate(idle.gate())
+        } else {
+            config
+        };
+
         // we can use an unbounded channel here since the number and size of units
         // ordered in a single aleph session is bounded as described above
         let (unit_data_sender, unit_data_receiver) = async_channel::unbounded();
@@ -291,6 +324,18 @@ impl ConsensusEngine {
         let (signed_outcomes_sender, signed_outcomes_receiver) = async_channel::unbounded();
         let (signatures_sender, signatures_receiver) = async_channel::unbounded();
 
+        // The upstream gate prevents `DataProvider::get_data` from being polled while
+        // closed. The producer notification wakes a non-consuming observer without
+        // adding idle polling or changing ownership of the shared queue.
+        let mut idle_tasks = IdleSessionTasks::start(
+            idle.clone(),
+            self.submission_receiver.clone(),
+            self.submission_wake_receiver.clone(),
+            connections.clone(),
+            self.shutdown_receiver.clone(),
+            signature_receiver.clone(),
+        );
+
         let aleph_handle = spawn(
             "aleph run session",
             aleph_bft::run_session(
@@ -300,9 +345,10 @@ impl ConsensusEngine {
                         self.submission_receiver.clone(),
                         signature_receiver,
                         timestamp_sender,
-                        self.is_recovery().await,
+                        is_recovery,
+                        idle.clone(),
                     ),
-                    FinalizationHandler::new(unit_data_sender),
+                    FinalizationHandler::new(unit_data_sender, idle.clone()),
                     BackupWriter::new(self.db.clone()).await,
                     BackupReader::new(self.db.clone()),
                 ),
@@ -311,6 +357,7 @@ impl ConsensusEngine {
                     signed_outcomes_sender,
                     signatures_sender,
                     self.db.clone(),
+                    idle,
                 ),
                 Keychain::new(&self.cfg),
                 Spawner::new(self.task_group.make_subgroup()),
@@ -331,7 +378,6 @@ impl ConsensusEngine {
                 connections,
             )
             .await?;
-
         assert!(
             self.validate_signed_session_outcome(&signed_session_outcome, session_index),
             "Our created signed session outcome fails validation"
@@ -341,8 +387,10 @@ impl ConsensusEngine {
 
         // We can terminate the session instead of waiting for other peers to complete
         // it since they can always download the signed session outcome from us
-        terminator_sender.send(()).ok();
-        aleph_handle.await.ok();
+        // Aleph and its data provider must stop before the session observers.
+        // Otherwise awaiting observer teardown gives the still-live data provider
+        // a window to consume work that cannot enter this completed outcome.
+        terminate_aleph_session(terminator_sender, aleph_handle, &mut idle_tasks).await;
 
         // This method removes the backup of the current session from the database
         // and therefore has to be called after we have waited for the session to

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -21,7 +21,7 @@ use fedimint_core::NumPeers;
 use fedimint_core::config::P2PMessage;
 use fedimint_core::core::{ModuleInstanceId, ModuleKind};
 use fedimint_core::db::{Database, apply_migrations_dbtx, verify_module_db_integrity_dbtx};
-use fedimint_core::envs::is_running_in_test_env;
+use fedimint_core::envs::{is_env_var_set, is_running_in_test_env};
 use fedimint_core::epoch::ConsensusItem;
 use fedimint_core::module::registry::ModuleRegistry;
 use fedimint_core::module::{ApiAuth, FEDIMINT_API_ALPN};
@@ -42,6 +42,7 @@ use tracing::{debug, info, warn};
 
 use crate::config::{ServerConfig, ServerConfigLocal};
 use crate::connection_limits::ConnectionLimits;
+use crate::consensus::aleph_bft::idle::{SubmissionActivity, forward_notified_submissions};
 use crate::consensus::api::ConsensusApi;
 use crate::consensus::engine::ConsensusEngine;
 use crate::consensus::iroh_api::{IrohApiState, run_iroh_api, run_iroh_api_next};
@@ -336,7 +337,32 @@ pub async fn run(
 
     let client_cfg = cfg.consensus.to_client_config(&module_init_registry)?;
 
-    let (submission_sender, submission_receiver) = async_channel::bounded(TRANSACTION_BUFFER);
+    let idle_gate_requested =
+        is_env_var_set(fedimint_core::envs::FM_EXPERIMENTAL_ALEPH_IDLE_GATE_ENV);
+    let (submission_sender, submission_receiver, submission_wake_receiver, submission_activity) =
+        if idle_gate_requested {
+            let (submission_sender, source) = async_channel::bounded(TRANSACTION_BUFFER);
+            let (forwarded, submission_receiver) = async_channel::bounded(1);
+            let (notification, receiver) = watch::channel(0);
+            let activity = Arc::new(SubmissionActivity::default());
+            let forward_activity = activity.clone();
+            task_group.spawn(
+                "aleph idle submission notifier",
+                move |_handle| async move {
+                    forward_notified_submissions(source, forwarded, notification, forward_activity)
+                        .await;
+                },
+            );
+            (
+                submission_sender,
+                submission_receiver,
+                Some(receiver),
+                Some(activity),
+            )
+        } else {
+            let (sender, receiver) = async_channel::bounded(TRANSACTION_BUFFER);
+            (sender, receiver, None, None)
+        };
     let (shutdown_sender, shutdown_receiver) = watch::channel(None);
     let (ord_latency_sender, ord_latency_receiver) = watch::channel(None);
 
@@ -486,6 +512,8 @@ pub async fn run(
         ord_latency_sender,
         ci_status_senders,
         submission_receiver,
+        submission_wake_receiver,
+        submission_activity,
         shutdown_receiver,
         modules: module_registry,
         task_group: task_group.clone(),

--- a/fedimint-server/src/metrics.rs
+++ b/fedimint-server/src/metrics.rs
@@ -99,6 +99,59 @@ pub(crate) static CONSENSUS_ORDERING_LATENCY_SECONDS: LazyLock<Histogram> = Lazy
     .unwrap()
 });
 
+pub(crate) static ALEPH_IDLE_GATE_OPEN: LazyLock<IntGauge> = LazyLock::new(|| {
+    register_int_gauge_with_registry!(
+        opts!(
+            "aleph_idle_gate_open",
+            "Whether the experimental local Aleph unit creation gate is open",
+        ),
+        REGISTRY
+    )
+    .unwrap()
+});
+pub(crate) static ALEPH_IDLE_CAPABLE_PEERS: LazyLock<IntGauge> = LazyLock::new(|| {
+    register_int_gauge_with_registry!(
+        opts!(
+            "aleph_idle_capable_peers",
+            "Number of peers with a current experimental idle-gate capability lease",
+        ),
+        REGISTRY
+    )
+    .unwrap()
+});
+pub(crate) static ALEPH_IDLE_OUTSTANDING_BATCHES: LazyLock<IntGauge> = LazyLock::new(|| {
+    register_int_gauge_with_registry!(
+        opts!(
+            "aleph_idle_outstanding_batches",
+            "Number of unfinalized local batches keeping idle activation active",
+        ),
+        REGISTRY
+    )
+    .unwrap()
+});
+pub(crate) static ALEPH_IDLE_CONTROL_MESSAGES: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec_with_registry!(
+        opts!(
+            "aleph_idle_control_messages_total",
+            "Experimental Aleph idle control messages by direction, kind, and result",
+        ),
+        &["direction", "kind", "result"],
+        REGISTRY
+    )
+    .unwrap()
+});
+pub(crate) static ALEPH_IDLE_GATE_TRANSITIONS: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec_with_registry!(
+        opts!(
+            "aleph_idle_gate_transitions_total",
+            "Experimental Aleph unit creation gate transitions",
+        ),
+        &["state", "reason"],
+        REGISTRY
+    )
+    .unwrap()
+});
+
 pub(crate) static IROH_API_CONNECTIONS_ACTIVE: LazyLock<IntGauge> = LazyLock::new(|| {
     register_int_gauge_with_registry!(
         opts!(


### PR DESCRIPTION
*Posted by Tau*

### Summary

Aleph currently creates, backs up, and broadcasts units continuously even when a federation has no consensus work. This experimental, opt-in change lets fully upgraded federations quiesce unit creation while idle, reducing persistent CPU, storage, and network activity. The default path keeps the released Aleph scheduling, submission channel, dependency closure, and wire behavior; operators must explicitly set `FM_EXPERIMENTAL_ALEPH_IDLE_GATE` to accept the liveness and privacy tradeoffs.

### Details

The change pins `fedimint-aleph-bft` to full revision [`320a66f54bd69743a19f443f3564cb13b90e7dfc`](https://github.com/fedimint/AlephBFT/commit/320a66f54bd69743a19f443f3564cb13b90e7dfc), based directly on published 0.36.0. The fork adds an optional unit-creation gate while preserving the original creator callpath when no gate is installed. Its successor manifest uses the same registry sibling dependencies as the published crate, so the disabled dependency closure also stays unchanged.

When enabled, guardians exchange authenticated, session- and boot-scoped Capability and Work messages through the existing generic P2P envelope. The gate closes only after every configured guardian holds a renewable capability lease and no local or peer work remains. Local submissions, any current-session peer Work lease, capability expiry, recovery, signature collection, scheduled shutdown, and one-minute probes reopen or keep open the normal creator. Byzantine messages can restore the normal full-speed rate but cannot increase it.

A process-lifetime, bounded submission path tracks announced and consumed work across Aleph sessions. The data provider remains the sole session consumer; Aleph terminates before session observer tasks stop. This avoids lost wakeups, discarded handoff submissions, and notification/finalization races while keeping state bounded.

The tradeoff is explicit. Quiescence removes continuous Aleph cover traffic: authenticated guardians learn which guardian received new work and how long its work episode lasts, while transport observers, local logs, and metrics can expose related timing. Fail-open paths and probes reduce stall risk but do not prove liveness. `docs/networking.md` and `SECURITY.md` document the operator contract.

### Reviewing

Please focus on:

- equivalence of the disabled path and the fork's `None` gate path;
- process-wide submission accounting and session-boundary ordering;
- capability and Work lease scoping under restart, delay, and Byzantine refreshes;
- fail-open coverage, bounded state, and work-timing privacy leakage;
- whether the experimental flag and documentation set the right deployment boundary.

### Testing

- 19 focused coordinator, codec, lease, producer, P2P, data-provider, finalization, recovery, race, and handoff tests pass.
- `cargo clippy -p fedimint-server --all-targets -- -D warnings` passes.
- `just final-lint` passes.
- `selfci check -c slxvmxuo` passes lint, workspace Clippy, Cargo.lock validation, cargo-crap, and cargo-udeps.
- `just final-check` reached workspace doctests, then the existing `fedimint-testing-core` RocksDB doctest failed to link against the local C++ ABI. Isolated SelfCI passed in a clean environment.

Independent reliability review passed the final stack with no findings after earlier review rounds identified and drove fixes for default-path drift, lossy forwarding, task handoff, dependency provenance, privacy documentation, public API compatibility, and several notification/recovery races.
