### PR TITLE
fix(devimint): allocate the faucet port, fail fast if it cannot bind

### DIFF
--- a/devimint/src/envs.rs
+++ b/devimint/src/envs.rs
@@ -41,6 +41,9 @@ pub const FM_FEDERATIONS_BASE_PORT_ENV: &str = "FM_FEDERATIONS_BASE_PORT";
 // Fix base port for gateway (gatewayd) port range
 pub const FM_GATEWAY_BASE_PORT_ENV: &str = "FM_GATEWAY_BASE_PORT";
 
+// Fix the port of the faucet spawned by `wasm-test-setup`
+pub const FM_FAUCET_PORT_ENV: &str = "FM_FAUCET_PORT";
+
 // Env variable to set a federation's invite code
 pub const FM_INVITE_CODE_ENV: &str = "FM_INVITE_CODE";
 

--- a/devimint/src/faucet.rs
+++ b/devimint/src/faucet.rs
@@ -47,11 +47,9 @@ impl Faucet {
     }
 }
 
-pub async fn run(
-    dev_fed: &DevFed,
-    fauct_bind_addr: String,
-    gw_lnd_port: u16,
-) -> anyhow::Result<()> {
+/// Serves the faucet API on the already bound `listener` until the task is
+/// cancelled.
+pub async fn run(dev_fed: &DevFed, listener: TcpListener, gw_lnd_port: u16) -> anyhow::Result<()> {
     let faucet = Faucet::new(dev_fed);
     let router = Router::new()
         .route(
@@ -90,7 +88,6 @@ pub async fn run(
         .layer(CorsLayer::permissive())
         .with_state(faucet);
 
-    let listener = TcpListener::bind(fauct_bind_addr).await?;
     axum::serve(listener, router.into_make_service()).await?;
     Ok(())
 }

--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -20,7 +20,7 @@ use fedimint_core::module::registry::ModuleRegistry;
 use fedimint_core::net::api_announcement::SignedApiAnnouncement;
 use fedimint_core::task::block_in_place;
 use fedimint_core::util::backoff_util::aggressive_backoff;
-use fedimint_core::util::{retry, write_overwrite_async};
+use fedimint_core::util::{FmtCompactAnyhow, retry, write_overwrite_async};
 use fedimint_core::{Amount, PeerId};
 use fedimint_ln_client::LightningPaymentOutcome;
 use fedimint_ln_client::cli::LnInvoiceResponse;
@@ -31,7 +31,7 @@ use fedimint_testing_core::node_type::LightningNodeType;
 use futures::future::try_join_all;
 use serde_json::json;
 use substring::Substring;
-use tokio::net::TcpStream;
+use tokio::net::TcpListener;
 use tokio::{fs, try_join};
 use tracing::{debug, error, info};
 
@@ -2879,6 +2879,15 @@ pub async fn handle_command(cmd: TestCmd, common_args: CommonArgs) -> Result<()>
             let main = {
                 let task_group = task_group.clone();
                 async move {
+                    // Bind before bringing up the federation, and outside the
+                    // faucet task, so that a port clash fails the setup right
+                    // away instead of leaving the test suite talking to whatever
+                    // else is listening on that port. Holding the socket from here
+                    // on also keeps other port allocators off it.
+                    let faucet_bind_addr = &process_mgr.globals.FM_FAUCET_BIND_ADDR;
+                    let faucet_listener = TcpListener::bind(faucet_bind_addr)
+                        .await
+                        .with_context(|| format!("binding faucet to {faucet_bind_addr}"))?;
                     let dev_fed = dev_fed(&process_mgr).await?;
                     let gw_lnd = dev_fed.gw_lnd.clone();
                     let fed = dev_fed.fed.clone();
@@ -2886,30 +2895,16 @@ pub async fn handle_command(cmd: TestCmd, common_args: CommonArgs) -> Result<()>
                         .client()
                         .set_federation_routing_fee(dev_fed.fed.calculate_federation_id(), 0, 0)
                         .await?;
+                    info!(addr = %faucet_bind_addr, "Faucet listening");
+                    let gw_lnd_port = process_mgr.globals.FM_PORT_GW_LND;
                     task_group.spawn_cancellable("faucet", async move {
-                        if let Err(err) = crate::faucet::run(
-                            &dev_fed,
-                            format!("0.0.0.0:{}", process_mgr.globals.FM_PORT_FAUCET),
-                            process_mgr.globals.FM_PORT_GW_LND,
-                        )
-                        .await
+                        if let Err(err) =
+                            crate::faucet::run(&dev_fed, faucet_listener, gw_lnd_port).await
                         {
-                            error!("Error spawning faucet: {err}");
+                            error!(err = %err.fmt_compact_anyhow(), "Faucet failed");
                         }
                     });
-                    try_join!(fed.pegin_gateways(30_000, vec![&gw_lnd]), async {
-                        poll("waiting for faucet startup", || async {
-                            TcpStream::connect(format!(
-                                "127.0.0.1:{}",
-                                process_mgr.globals.FM_PORT_FAUCET
-                            ))
-                            .await
-                            .context("connect to faucet")
-                            .map_err(ControlFlow::Continue)
-                        })
-                        .await?;
-                        Ok(())
-                    },)?;
+                    fed.pegin_gateways(30_000, vec![&gw_lnd]).await?;
                     if let Some(exec) = exec {
                         exec_user_command(exec).await?;
                         task_group.shutdown();

--- a/devimint/src/vars.rs
+++ b/devimint/src/vars.rs
@@ -3,6 +3,8 @@
 mod net_overrides;
 use std::path::{Path, PathBuf};
 use std::str::FromStr as _;
+
+use anyhow::Context as _;
 pub trait ToEnvVar {
     fn to_env_value(&self) -> Option<String> {
         panic!("Must implement one of the two ToEnvVar methods");
@@ -108,6 +110,7 @@ use fedimintd_envs::FM_FORCE_API_SECRETS_ENV;
 use format as f;
 use net_overrides::{FederationsNetOverrides, FedimintdPeerOverrides};
 
+use crate::envs::FM_FAUCET_PORT_ENV;
 use crate::federation::{
     FEDIMINTD_METRICS_PORT_OFFSET, FEDIMINTD_UI_PORT_OFFSET, PORTS_PER_FEDIMINTD,
 };
@@ -183,7 +186,10 @@ declare_vars! {
             Some(b) => b + GATEWAY_PORT_OFFSET_LDK2_METRICS,
             None => port_alloc(1)?,
         }; env: "FM_PORT_GW_LDK2_METRICS";
-        FM_PORT_FAUCET: u16 = port_alloc(1)?; env: "FM_PORT_FAUCET";
+        FM_PORT_FAUCET: u16 = match std::env::var(FM_FAUCET_PORT_ENV) {
+            Ok(port) => port.parse().with_context(|| f!("parsing {FM_FAUCET_PORT_ENV}={port}"))?,
+            Err(_) => port_alloc(1)?,
+        }; env: "FM_PORT_FAUCET";
         FM_PORT_RECURRINGD: u16 = port_alloc(1)?; env: "FM_PORT_RECURRINGD";
         FM_PORT_RECURRINGDV2: u16 = port_alloc(1)?; env: "FM_PORT_RECURRINGDV2";
 

--- a/devimint/src/vars.rs
+++ b/devimint/src/vars.rs
@@ -183,7 +183,7 @@ declare_vars! {
             Some(b) => b + GATEWAY_PORT_OFFSET_LDK2_METRICS,
             None => port_alloc(1)?,
         }; env: "FM_PORT_GW_LDK2_METRICS";
-        FM_PORT_FAUCET: u16 = 15243u16; env: "FM_PORT_FAUCET";
+        FM_PORT_FAUCET: u16 = port_alloc(1)?; env: "FM_PORT_FAUCET";
         FM_PORT_RECURRINGD: u16 = port_alloc(1)?; env: "FM_PORT_RECURRINGD";
         FM_PORT_RECURRINGDV2: u16 = port_alloc(1)?; env: "FM_PORT_RECURRINGDV2";
 

--- a/fedimint-wasm-tests/src/lib.rs
+++ b/fedimint-wasm-tests/src/lib.rs
@@ -64,8 +64,10 @@ async fn client(invite_code: &InviteCode) -> Result<fedimint_client::ClientHandl
 }
 
 mod faucet {
+    use anyhow::Context;
+
     pub async fn invite_code() -> anyhow::Result<String> {
-        let resp = gloo_net::http::Request::get("http://localhost:15243/connect-string")
+        let resp = gloo_net::http::Request::get(&url("/connect-string")?)
             .send()
             .await?;
         if resp.ok() {
@@ -76,7 +78,7 @@ mod faucet {
     }
 
     pub async fn pay_invoice(invoice: &str) -> anyhow::Result<()> {
-        let resp = gloo_net::http::Request::post("http://localhost:15243/pay")
+        let resp = gloo_net::http::Request::post(&url("/pay")?)
             .body(invoice)?
             .send()
             .await?;
@@ -88,7 +90,7 @@ mod faucet {
     }
 
     pub async fn gateway_api() -> anyhow::Result<String> {
-        let resp = gloo_net::http::Request::get("http://localhost:15243/gateway-api")
+        let resp = gloo_net::http::Request::get(&url("/gateway-api")?)
             .send()
             .await?;
         if resp.ok() {
@@ -99,7 +101,7 @@ mod faucet {
     }
 
     pub async fn generate_invoice(amt: u64) -> anyhow::Result<String> {
-        let resp = gloo_net::http::Request::post("http://localhost:15243/invoice")
+        let resp = gloo_net::http::Request::post(&url("/invoice")?)
             .body(amt)?
             .send()
             .await?;
@@ -108,6 +110,28 @@ mod faucet {
         } else {
             anyhow::bail!(resp.text().await?);
         }
+    }
+
+    /// Devimint allocates the faucet port when it starts and exports it as
+    /// `FM_PORT_FAUCET` to the command run via `wasm-test-setup --exec`, which
+    /// is how it reaches this build. Browser tests have no other way to learn
+    /// it at runtime.
+    ///
+    /// Only the wasm build captures it. This crate is also compiled natively
+    /// as part of `--workspace` builds, frequently from inside a devimint
+    /// environment, and must not go stale every time devimint hands out a
+    /// different port.
+    #[cfg(target_arch = "wasm32")]
+    const PORT: Option<&str> = option_env!("FM_PORT_FAUCET");
+    #[cfg(not(target_arch = "wasm32"))]
+    const PORT: Option<&str> = None;
+
+    fn url(path: &str) -> anyhow::Result<String> {
+        let port = PORT.context(
+            "FM_PORT_FAUCET was not set when fedimint-wasm-tests was built; \
+             run the tests via `devimint wasm-test-setup --exec`",
+        )?;
+        Ok(format!("http://localhost:{port}{path}"))
     }
 }
 

--- a/scripts/tests/wasm-test.sh
+++ b/scripts/tests/wasm-test.sh
@@ -34,6 +34,9 @@ function run_tests() {
   export CARGO_BUILD_TARGET_DIR
   CARGO_BUILD_TARGET_DIR="${CARGO_BUILD_TARGET_DIR:-${PWD}/target}"
   CARGO_BUILD_TARGET_DIR="${CARGO_BUILD_TARGET_DIR}/pkgs/fedimint-wasm-tests"
+
+  # The tests capture `FM_PORT_FAUCET` at build time, so they get rebuilt
+  # whenever devimint hands out a different faucet port.
   WASM_BINDGEN_TEST_TIMEOUT=300 wasm-pack test --firefox --headless fedimint-wasm-tests ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} -- --nocapture
 }
 export -f run_tests


### PR DESCRIPTION
## Summary

Allocate devimint's faucet port through `port_alloc` like every other port, and make `wasm-test-setup` fail fast when the faucet cannot bind instead of logging the error and letting a plain connect-probe succeed against whatever foreign process holds the port.

## Details

The faucet was the only service on a hard-coded port (`FM_PORT_FAUCET = 15243`), so two devimint instances on one host always collided on it, and the failure mode was nasty: the faucet task only `error!`'d on a bind failure, and the "waiting for faucet startup" probe was a `TcpStream::connect`, which succeeds against any listener. The `--exec`'d suite then happily fetched invite codes from another federation (or from a process mid-teardown), producing dozens of confusing cross-federation failures instead of one clear error (see fedimint/fedimint-sdk#340).

- `FM_PORT_FAUCET` is now `port_alloc(1)?` and is exported to the `--exec`'d command as before; `FM_FAUCET_BIND_ADDR` follows it.
- `wasm-test-setup` binds the listener itself right after the ports are allocated — before the federation is brought up — and hands it to the serve task once `dev_fed` is ready (logging `Faucet listening addr=...` at that point). A clash therefore fails the setup within milliseconds with `binding faucet to 0.0.0.0:<port>: Address already in use`, before a single daemon is spawned. Holding the socket from then on also closes the window between allocation and bind (portalloc only probes ports and its reservation expires after 120 s). The connect-probe is gone.
- Second commit: an opt-in `FM_FAUCET_PORT` environment variable pins the port, for consumers that cannot read `FM_PORT_FAUCET` (e.g. to keep `15243` during a transition). It follows the other env-driven overrides in `Global` (`FM_USE_UNKNOWN_MODULE`, `FM_API_SECRET`); the input name deliberately differs from the exported `FM_PORT_FAUCET` so a sourced devimint env file cannot accidentally pin a nested run to a port that is already taken.
- `fedimint-wasm-tests` runs in a browser and has no runtime channel to learn the port, so it captures `FM_PORT_FAUCET` via `option_env!` at build time (it is set in the `--exec` environment, which is where `wasm-pack test` runs). Cargo tracks `option_env!` in dep-info, so the crate is rebuilt whenever the port changes, and it errors out with a clear message if it was built outside `devimint wasm-test-setup`. The capture is gated on `target_arch = "wasm32"`: the crate is also compiled natively by every `--workspace` build, often from inside a devimint environment (`backend-test.sh` runs `cargo nextest run --workspace` under `devimint external-daemons --exec`, with `CARGO_DENY_COMPILATION=1` in `test-ci-all.sh`), and must not go stale there.

External consumers of `wasm-test-setup` (e.g. fedimint-sdk) should read `FM_PORT_FAUCET` from the environment instead of assuming 15243.

## Reviewing

The one design decision worth an opinion is the compile-time capture in `fedimint-wasm-tests`. In nix CI the wasm test artifacts are pre-built without `FM_PORT_FAUCET`, so the `wasmTest` derivation now recompiles the leaf `fedimint-wasm-tests` crate once when `wasm-pack test` runs under devimint (about 3 s in the CI log; its dependencies stay cached). The runtime alternative I found is that the wasm-bindgen test runner also serves static files from the test's cwd, so `wasm-test.sh` could write the port into a gitignored file under `fedimint-wasm-tests/` and the tests could fetch it same-origin; that avoids the rebuild but relies on an undocumented runner behaviour and a file in the source tree. I went with the compile-time capture; happy to switch if you prefer the other trade-off.

The `FM_FAUCET_PORT` pin is a separate commit and easy to drop if you would rather keep the port purely dynamic.

## Testing

- `cargo check`, clippy (`--no-deps -D warnings`) and rustfmt on `devimint` and `fedimint-wasm-tests` under the nix toolchain; the pre-commit lint hook passes.
- End-to-end in the nix dev shell:
  - `devimint wasm-test-setup --exec bash -c '...'`: `FM_PORT_FAUCET` is allocated (14267 in my run) and exported, `ss` shows devimint listening on it, `/connect-string` returns an invite code and `/gateway-api` the LND gateway URL, nothing listens on 15243.
  - Fail-fast: with `python3 -m http.server 15243` already running and `FM_FAUCET_PORT=15243`, devimint exited 1 after 0.3 s with `Error: binding faucet to 0.0.0.0:15243` / `Caused by: Address already in use (os error 98)`, spawned no daemons and never ran the `--exec` command. (An earlier variant that grabbed the allocated port from `$FM_TEST_DIR/env` as soon as it appeared now loses the race to devimint's own bind, which is the point of binding early.)
  - Pin: `FM_FAUCET_PORT=15243 devimint wasm-test-setup --exec ...` exports `FM_PORT_FAUCET=15243` and the faucet answers there.
  - A small experiment confirming cargo rebuilds a crate when an `option_env!` variable changes and stays fresh when it does not.
- CI's `wasmTest` job exercises the `option_env!` path for real: its log shows devimint's `Faucet listening addr=0.0.0.0:10033`, a ~3 s `Compiling fedimint-wasm-tests` under `wasm-pack test`, and all 6 browser tests passing.
- Native staleness check in the dev shell: `FM_PORT_FAUCET=... cargo build -p fedimint-wasm-tests` stays `Finished` (no recompile) and passes with `CARGO_DENY_COMPILATION=1`; before the `cfg` gate it recompiled and the deny wrapper failed the build.

Fixes #9044.

Generated by Claude Fable 5.
