### PR TITLE
ci: gate fedimint-bot on the new bot-access team

### DIFF
--- a/.github/workflows/codex-agent.yml
+++ b/.github/workflows/codex-agent.yml
@@ -243,28 +243,28 @@ jobs:
             exit 0
           fi
 
-          reviewer_membership=$(
+          bot_access_membership=$(
             curl --silent --show-error \
               --write-out '%{http_code}' \
-              --output /tmp/fedimint-bot-reviewer-membership.json \
+              --output /tmp/fedimint-bot-access-membership.json \
               -H "Accept: application/vnd.github+json" \
               -H "Authorization: Bearer ${GH_TOKEN}" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
-              "${api_url}/orgs/fedimint/teams/reviewers/memberships/${comment_user}"
+              "${api_url}/orgs/fedimint/teams/bot-access/memberships/${comment_user}"
           )
 
-          if [ "${reviewer_membership}" = "200" ]; then
-            membership_state=$(jq -r '.state // ""' /tmp/fedimint-bot-reviewer-membership.json)
+          if [ "${bot_access_membership}" = "200" ]; then
+            membership_state=$(jq -r '.state // ""' /tmp/fedimint-bot-access-membership.json)
           else
             membership_state=""
           fi
 
-          echo "reviewer_membership_status=${reviewer_membership}"
-          echo "reviewer_membership_state=${membership_state:-<missing>}"
+          echo "bot_access_membership_status=${bot_access_membership}"
+          echo "bot_access_membership_state=${membership_state:-<missing>}"
 
           if [ "${membership_state}" != "active" ]; then
             echo "run=false" >> "${GITHUB_OUTPUT}"
-            echo "Skipping: requester is not an active fedimint/reviewers team member"
+            echo "Skipping: requester is not an active fedimint/bot-access team member"
             exit 0
           fi
 


### PR DESCRIPTION
Bot access was gated on membership of the `fedimint/reviewers` team. That team
is the one that carries `push` (write) permission on `fedimint/fedimint`, so
the gate conflated two decisions that have nothing to do with each other:

- who is trusted to push code and review PRs, and
- who may spend self-hosted CI time driving `@fedimint-bot`.

Handing someone either one currently forces the other. You cannot give a
contributor bot access without also giving them write, and you cannot revoke
bot access from someone without demoting them.

This switches the check in `codex-agent.yml` to a new, dedicated team,
[`fedimint/bot-access`](https://github.com/orgs/fedimint/teams/bot-access). It
holds no repository permissions at all — its only purpose is to answer the
question this workflow asks.

### No one loses access

The team has already been created and seeded with every human currently in
`reviewers`, plus `zeenix`:

`alexlwn123`, `benthecarman`, `douglaz`, `dpc`, `elsirion`, `garyray-k`,
`jkitman`, `joschisan`, `m1sterc001guy`, `maan2003`, `MrImmortal09`,
`okjodom`, `shaurya947`, `zeenix`

`zeenix` is the case that motivated this. They are in the `merge` team, which
also carries `push`, but not in `reviewers` — so today they have write access
and no bot access, and the only way to grant it would be to widen their review
role. That is precisely the coupling this removes.

The `fedimint-bot` account itself is in `reviewers` but was deliberately left
out: every trigger path in this workflow already bails out on
`github.actor == 'fedimint-bot'` before the membership check runs, so its
membership was never load-bearing.

### Notes

- The change is confined to the membership lookup — the URL, the variable
  name, the temp file, and the skip message. The surrounding validation logic
  is untouched.
- `secrets.BACKPORT_TOKEN` performs the lookup. The new team is `closed`, the
  same visibility as `reviewers`, so the token reads it exactly as before.
  Still worth a sanity check on the first `@fedimint-bot` invocation after
  merge: if the token could not see the team, every request would be silently
  skipped with "requester is not an active fedimint/bot-access team member"
  rather than failing loudly.
- A companion PR keeps the other live copy of this workflow in sync:
  fedimint/fedimint-sdk#351.
- `fedimint/fedimint-sdk-ffi` carries a third copy of this workflow, but the
  repo is archived and read-only, so it is left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BQ1tBwGjAGZgDaRdTCE5Nw
