### PR TITLE
feat(connectors): add WebSocket redirect control

### DIFF
--- a/fedimint-connectors/src/lib.rs
+++ b/fedimint-connectors/src/lib.rs
@@ -103,6 +103,8 @@ pub struct ConnectorRegistryBuilder {
     /// Enable Websocket API handling at all?
     ws_enable: bool,
     ws_force_tor: bool,
+    #[cfg(not(target_family = "wasm"))]
+    ws_follow_redirects: bool,
 
     // Enable HTTP
     http_enable: bool,
@@ -202,7 +204,12 @@ impl ConnectorRegistryBuilder {
                 Ok(Arc::new(TorConnector::bootstrap().await?) as DynConnector)
             }
 
-            false => Ok(Arc::new(WebsocketConnector::new()) as DynConnector),
+            false => {
+                let connector = WebsocketConnector::new();
+                #[cfg(not(target_family = "wasm"))]
+                let connector = connector.follow_redirects(self.ws_follow_redirects);
+                Ok(Arc::new(connector) as DynConnector)
+            }
             #[allow(unreachable_patterns)]
             _ => bail!("Tor requested, but not support not compiled in"),
         }
@@ -235,6 +242,20 @@ impl ConnectorRegistryBuilder {
     pub fn ws_force_tor(self, enable: bool) -> Self {
         Self {
             ws_force_tor: enable,
+            ..self
+        }
+    }
+
+    /// Configure whether the native WebSocket client follows redirects.
+    ///
+    /// For an IP-literal URL, disabling redirects prevents a connection to a
+    /// redirect target. The underlying client may still resolve a hostname in
+    /// the redirect response. See [`WebsocketConnector::follow_redirects`] for
+    /// the full boundary.
+    #[cfg(not(target_family = "wasm"))]
+    pub fn ws_follow_redirects(self, enable: bool) -> Self {
+        Self {
+            ws_follow_redirects: enable,
             ..self
         }
     }
@@ -345,6 +366,8 @@ impl ConnectorRegistry {
             iroh_next: true,
             ws_enable: true,
             ws_force_tor: false,
+            #[cfg(not(target_family = "wasm"))]
+            ws_follow_redirects: true,
             http_enable: true,
 
             connection_overrides: BTreeMap::default(),
@@ -361,6 +384,8 @@ impl ConnectorRegistry {
             iroh_next: true,
             ws_enable: true,
             ws_force_tor: false,
+            #[cfg(not(target_family = "wasm"))]
+            ws_follow_redirects: true,
             http_enable: false,
 
             connection_overrides: BTreeMap::default(),
@@ -377,6 +402,8 @@ impl ConnectorRegistry {
             iroh_next: false,
             ws_enable: true,
             ws_force_tor: false,
+            #[cfg(not(target_family = "wasm"))]
+            ws_follow_redirects: true,
             http_enable: true,
 
             connection_overrides: BTreeMap::default(),

--- a/fedimint-connectors/src/ws.rs
+++ b/fedimint-connectors/src/ws.rs
@@ -27,18 +27,47 @@ use crate::{
     ServerError, ServerResult,
 };
 
+/// Connector for WebSocket federation APIs.
 #[derive(Debug, Clone)]
 pub struct WebsocketConnector {}
 
+#[cfg(not(target_family = "wasm"))]
+#[derive(Debug)]
+struct ConfiguredWebsocketConnector {
+    inner: WebsocketConnector,
+    follow_redirects: bool,
+}
+
 impl WebsocketConnector {
+    /// Create a WebSocket connector with redirects enabled.
     pub fn new() -> Self {
         Self {}
+    }
+
+    /// Configure whether the native WebSocket client follows redirects.
+    ///
+    /// For an IP-literal URL, disabling redirects dials the supplied endpoint
+    /// once and does not connect to a redirect target. jsonrpsee still parses
+    /// an absolute `Location` and may resolve its hostname before returning.
+    ///
+    /// A hostname may resolve to multiple original addresses, and jsonrpsee
+    /// can apply redirected request metadata to a remaining original address.
+    /// Redirect rejection therefore does not provide a hostname destination
+    /// guarantee. It also does not pin routing, TLS, or SNI; callers must
+    /// separately validate and pass the exact IP-literal URL.
+    #[cfg(not(target_family = "wasm"))]
+    pub fn follow_redirects(self, follow_redirects: bool) -> impl Connector {
+        ConfiguredWebsocketConnector {
+            inner: self,
+            follow_redirects,
+        }
     }
 
     async fn make_new_connection(
         &self,
         url: &SafeUrl,
         api_secret: Option<&str>,
+        _follow_redirects: bool,
     ) -> ServerResult<Arc<WsClient>> {
         trace!(target: LOG_NET_WS, %url, "Creating new websocket connection");
 
@@ -56,9 +85,18 @@ impl WebsocketConnector {
                 .with_root_certificates(root_certs)
                 .with_no_client_auth();
 
-            WsClientBuilder::default()
+            let client = WsClientBuilder::default()
                 .max_concurrent_requests(u16::MAX as usize)
-                .with_custom_cert_store(tls_cfg)
+                .with_custom_cert_store(tls_cfg);
+
+            if _follow_redirects {
+                client
+            } else {
+                // jsonrpsee counts the initial connection attempt against this
+                // budget. For an IP-literal URL, one attempt dials the supplied
+                // endpoint and stops before dialing a redirect target.
+                client.max_redirections(1)
+            }
         };
 
         #[cfg(target_family = "wasm")]
@@ -112,6 +150,186 @@ impl WebsocketConnector {
     }
 }
 
+#[cfg(all(test, not(target_family = "wasm")))]
+mod tests {
+    use std::future::Future;
+    use std::io::ErrorKind;
+    use std::time::Duration;
+
+    use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+    use tokio::net::TcpListener;
+    use tokio::time::timeout;
+
+    use super::*;
+    use crate::{ConnectorRegistry, DynGuaridianConnection};
+
+    async fn assert_redirect_rejected<F, Fut>(connect: F)
+    where
+        F: FnOnce(SafeUrl) -> Fut,
+        Fut: Future<Output = ServerResult<DynGuaridianConnection>>,
+    {
+        timeout(
+            Duration::from_secs(10),
+            assert_redirect_rejected_inner(connect),
+        )
+        .await
+        .expect("redirect rejection test timed out");
+    }
+
+    async fn assert_redirect_rejected_inner<F, Fut>(connect: F)
+    where
+        F: FnOnce(SafeUrl) -> Fut,
+        Fut: Future<Output = ServerResult<DynGuaridianConnection>>,
+    {
+        let redirect_target =
+            std::net::TcpListener::bind("127.0.0.1:0").expect("bind redirect target");
+        redirect_target
+            .set_nonblocking(true)
+            .expect("make redirect target nonblocking");
+        let redirect_target_addr = redirect_target
+            .local_addr()
+            .expect("read redirect target address");
+        let original_endpoint = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind original endpoint");
+        let original_endpoint_addr = original_endpoint
+            .local_addr()
+            .expect("read original endpoint address");
+
+        let original_endpoint_task =
+            fedimint_core::runtime::spawn("WebSocket redirect original endpoint", async move {
+                let (mut stream, _) = original_endpoint
+                    .accept()
+                    .await
+                    .expect("accept initial connection");
+                let mut request = Vec::new();
+                loop {
+                    let mut buffer = [0; 1024];
+                    let bytes_read = stream.read(&mut buffer).await.expect("read handshake");
+                    assert_ne!(bytes_read, 0, "client closed before sending handshake");
+                    request.extend_from_slice(&buffer[..bytes_read]);
+                    if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                        break;
+                    }
+                }
+
+                stream
+                    .write_all(
+                        format!(
+                            "HTTP/1.1 302 Found\r\nLocation: ws://{redirect_target_addr}/\r\n\
+                         Content-Length: 0\r\n\r\n"
+                        )
+                        .as_bytes(),
+                    )
+                    .await
+                    .expect("send redirect");
+                request
+            });
+
+        let url = SafeUrl::parse(&format!("ws://{original_endpoint_addr}/"))
+            .expect("parse original endpoint URL");
+        connect(url).await.expect_err("redirect must be rejected");
+
+        let request = original_endpoint_task
+            .await
+            .expect("original endpoint task completed");
+        assert!(
+            request.starts_with(b"GET / HTTP/1.1\r\n"),
+            "original endpoint did not receive a WebSocket handshake"
+        );
+        assert!(
+            matches!(redirect_target.accept(), Err(error) if error.kind() == ErrorKind::WouldBlock),
+            "redirect target received a connection"
+        );
+    }
+
+    #[tokio::test]
+    async fn websocket_connector_can_disable_redirects() {
+        assert_redirect_rejected(|url| async move {
+            WebsocketConnector::new()
+                .follow_redirects(false)
+                .connect_guardian(&url, None)
+                .await
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn registry_propagates_disabled_websocket_redirects() {
+        let registry = ConnectorRegistry::build_from_testing_defaults()
+            .ws_follow_redirects(false)
+            .bind()
+            .await
+            .expect("build connector registry");
+
+        assert_redirect_rejected(|url| async move { registry.connect_guardian(&url, None).await })
+            .await;
+    }
+
+    #[tokio::test]
+    async fn websocket_redirects_are_enabled_by_default() {
+        let redirect_target = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind redirect target");
+        let redirect_target_addr = redirect_target
+            .local_addr()
+            .expect("read redirect target address");
+        let original_endpoint = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind original endpoint");
+        let original_endpoint_addr = original_endpoint
+            .local_addr()
+            .expect("read original endpoint address");
+
+        let original_endpoint_task =
+            fedimint_core::runtime::spawn("WebSocket redirect original endpoint", async move {
+                let (mut stream, _) = original_endpoint
+                    .accept()
+                    .await
+                    .expect("accept initial connection");
+                let mut request = [0; 4096];
+                let bytes_read = stream.read(&mut request).await.expect("read handshake");
+                assert_ne!(bytes_read, 0, "client closed before sending handshake");
+                stream
+                    .write_all(
+                        format!(
+                            "HTTP/1.1 302 Found\r\nLocation: ws://{redirect_target_addr}/\r\n\
+                         Content-Length: 0\r\n\r\n"
+                        )
+                        .as_bytes(),
+                    )
+                    .await
+                    .expect("send redirect");
+            });
+        let redirect_target_task =
+            fedimint_core::runtime::spawn("WebSocket redirect target", async move {
+                redirect_target
+                    .accept()
+                    .await
+                    .expect("default connector should dial redirect target");
+            });
+        let url = SafeUrl::parse(&format!("ws://{original_endpoint_addr}/"))
+            .expect("parse original endpoint URL");
+
+        timeout(Duration::from_secs(10), async {
+            let registry = ConnectorRegistry::build_from_testing_defaults()
+                .bind()
+                .await
+                .expect("build connector registry");
+            let connection = registry.connect_guardian(&url, None).await;
+            assert!(connection.is_err(), "closed redirect target must fail");
+            original_endpoint_task
+                .await
+                .expect("original endpoint task completed");
+            redirect_target_task
+                .await
+                .expect("redirect target task completed");
+        })
+        .await
+        .expect("redirect test timed out");
+    }
+}
+
 impl Default for WebsocketConnector {
     fn default() -> Self {
         Self::new()
@@ -125,7 +343,31 @@ impl Connector for WebsocketConnector {
         url: &SafeUrl,
         api_secret: Option<&str>,
     ) -> ServerResult<DynGuaridianConnection> {
-        let client = self.make_new_connection(url, api_secret).await?;
+        let client = self.make_new_connection(url, api_secret, true).await?;
+        Ok(client.into_dyn())
+    }
+
+    async fn connect_gateway(&self, _url: &SafeUrl) -> anyhow::Result<DynGatewayConnection> {
+        Err(anyhow!("Unsupported transport method"))
+    }
+
+    fn connectivity(&self, _url: &SafeUrl) -> Connectivity {
+        Connectivity::Direct
+    }
+}
+
+#[cfg(not(target_family = "wasm"))]
+#[async_trait::async_trait]
+impl Connector for ConfiguredWebsocketConnector {
+    async fn connect_guardian(
+        &self,
+        url: &SafeUrl,
+        api_secret: Option<&str>,
+    ) -> ServerResult<DynGuaridianConnection> {
+        let client = self
+            .inner
+            .make_new_connection(url, api_secret, self.follow_redirects)
+            .await?;
         Ok(client.into_dyn())
     }
 


### PR DESCRIPTION
*Posted by Tau*

### Summary

Fedimint's native WebSocket connector follows redirects by default, so a caller checking an exact IP-literal federation endpoint cannot currently prevent a connection to the redirect target. This adds opt-in redirect control to `WebsocketConnector` and `ConnectorRegistryBuilder` while preserving the existing redirect-following default. It gives callers a narrow primitive for exact checked literal `ws` and IPv4-literal `wss` URLs; URL validation and broader destination policy remain the caller's responsibility.

### Details

jsonrpsee 0.24.9 names its setting `max_redirections`, but the value is actually the total connection-attempt-loop budget. Redirects-disabled therefore maps to `1`, not `0`: the original single-address endpoint is dialed and receives the WebSocket handshake, then the loop ends before a redirect target is contacted. The public API exposes `follow_redirects(bool)` / `ws_follow_redirects(bool)` rather than the dependency-specific numeric budget. It is native-only because browser WebSocket redirects cannot be controlled, and an opaque configured wrapper preserves existing `WebsocketConnector {}` construction.

This is deliberately not a generic redirect-preprocessing or hostname-safety guarantee. jsonrpsee still parses an absolute `Location` and may resolve its hostname before its attempt loop ends. If the original hostname resolves to multiple addresses, redirected Host/TLS metadata can also be applied to another original address. The intended boundary therefore requires a caller to validate and pass the exact single-address IP-literal URL without changing it.

This PR does not add URL policy, hostname DNS/address pinning, proxy or routing control, TLS/SNI pinning, bracket normalization, connection-override policy, IPv6-literal `wss` support, or Manifold integration. Hostname `wss` and IPv6-literal `wss` remain explicitly out of scope, and the change has no dependency on #9015.

### Reviewing

Please pay particular attention to jsonrpsee's budget-`1` semantics, the residual `Location` parsing/DNS behavior, and the exact single-address guarantee boundary.

### Testing

Native regression tests use real local listeners through both the direct connector and registry paths. They prove that disabling redirects still sends the initial WebSocket handshake, never connects to the absolute cross-origin redirect target, and fails within a bounded timeout. A default-registry regression proves existing behavior still connects to the redirect target. The crate also continues to compile for `wasm32-unknown-unknown`, where the redirect-control methods are intentionally absent.
