### PR TITLE
fix(client-wasm): install a panic hook so panics keep their message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1737,6 +1737,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2283,7 +2293,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2396,7 +2406,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357422a457ccb850dc8f1c1680e0670079560feaad6c2e247e3f345c4fab8a3f"
 dependencies = [
  "heck 0.5.0",
- "indexmap 1.9.3",
+ "indexmap 2.9.0",
  "itertools 0.14.0",
  "proc-macro-crate",
  "proc-macro2",
@@ -2414,7 +2424,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caef6056a5788d05d173cdc3c562ac28ae093828f851f69378b74e4e3d578e41"
 dependencies = [
  "heck 0.5.0",
- "indexmap 1.9.3",
+ "indexmap 2.9.0",
  "itertools 0.14.0",
  "proc-macro-crate",
  "proc-macro2",
@@ -2995,7 +3005,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3303,6 +3313,7 @@ version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
+ "console_error_panic_hook",
  "fedimint-client-rpc",
  "fedimint-connectors",
  "fedimint-core",
@@ -7039,7 +7050,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7142,7 +7153,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7482,7 +7493,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -8444,7 +8455,7 @@ dependencies = [
  "pin-project-lite",
  "rustc-hash",
  "rustls 0.23.38",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -8487,7 +8498,7 @@ checksum = "bde7a5d5102f1cff03d482240f0ed20551661f63663620f4b26112ed751165e9"
 dependencies = [
  "cfg_aliases",
  "libc",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -9928,7 +9939,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10463,7 +10474,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10476,7 +10487,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10556,7 +10567,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10784,7 +10795,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11642,7 +11653,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.7",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13946,7 +13957,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/fedimint-client-wasm/Cargo.toml
+++ b/fedimint-client-wasm/Cargo.toml
@@ -20,6 +20,7 @@ path = "src/lib.rs"
 [target.'cfg(target_family = "wasm")'.dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
+console_error_panic_hook = { workspace = true }
 fedimint-client-rpc = { workspace = true }
 fedimint-connectors = { workspace = true }
 fedimint-core = { workspace = true }

--- a/fedimint-client-wasm/Cargo.toml
+++ b/fedimint-client-wasm/Cargo.toml
@@ -33,6 +33,7 @@ wasm-bindgen-futures = { workspace = true }
 web-sys = { version = "0.3", features = [
     "FileSystemSyncAccessHandle",
     "FileSystemReadWriteOptions",
+    "console",
 ] }
 
 [lints]

--- a/fedimint-client-wasm/src/lib.rs
+++ b/fedimint-client-wasm/src/lib.rs
@@ -42,18 +42,21 @@ struct RpcHandler {
 #[wasm_bindgen]
 impl RpcHandler {
     #[wasm_bindgen(constructor)]
-    pub async fn new(sync_handle: FileSystemSyncAccessHandle) -> Self {
-        // Create the database directly
-        let cursed_db = MemAndRedb::new(sync_handle).unwrap();
+    pub async fn new(sync_handle: FileSystemSyncAccessHandle) -> Result<RpcHandler, JsError> {
+        // Return errors instead of panicking: a panic in an async export
+        // leaves the returned `Promise` unsettled forever, so the caller
+        // would hang instead of getting a rejection it can catch.
+        let cursed_db = MemAndRedb::new(sync_handle)
+            .map_err(|err| JsError::new(&format!("Failed to open client database: {err:#}")))?;
         let database = Database::new(cursed_db, Default::default());
         let connectors = fedimint_connectors::ConnectorRegistry::build_from_client_defaults()
             .bind()
             .await
-            .unwrap();
+            .map_err(|err| JsError::new(&format!("Failed to bind client connectors: {err:#}")))?;
 
         let state = Arc::new(RpcGlobalState::new(connectors, database));
 
-        Self { state }
+        Ok(Self { state })
     }
 
     #[wasm_bindgen]

--- a/fedimint-client-wasm/src/lib.rs
+++ b/fedimint-client-wasm/src/lib.rs
@@ -8,6 +8,21 @@ use fedimint_cursed_redb::MemAndRedb;
 use wasm_bindgen::prelude::{JsError, JsValue, wasm_bindgen};
 use web_sys::FileSystemSyncAccessHandle;
 
+/// Runs automatically when the wasm module is instantiated, before any
+/// exported function can be called; calling it again is harmless.
+///
+/// Without a hook, a panic anywhere in the module (including the RPC tasks
+/// spawned via `wasm_bindgen_futures::spawn_local`) traps with a message-less
+/// `RuntimeError: unreachable executed` and the panic message and Rust
+/// location are lost. Log them to the console instead.
+///
+/// When triaging, trust the first logged panic: after it, the executor's
+/// poisoned state may log an unrelated `BorrowMutError` panic as well.
+#[wasm_bindgen(start)]
+fn install_panic_hook() {
+    console_error_panic_hook::set_once();
+}
+
 struct JsFunctionWrapper(js_sys::Function);
 
 impl RpcResponseHandler for JsFunctionWrapper {

--- a/fedimint-client-wasm/src/lib.rs
+++ b/fedimint-client-wasm/src/lib.rs
@@ -27,10 +27,18 @@ struct JsFunctionWrapper(js_sys::Function);
 
 impl RpcResponseHandler for JsFunctionWrapper {
     fn handle_response(&self, response: RpcResponse) {
-        let _ = self.0.call1(
-            &JsValue::null(),
-            &JsValue::from_str(&serde_json::to_string(&response).unwrap()),
+        let response = serde_json::to_string(&response).expect(
+            "RpcResponse is numbers, strings and serde_json::Value; serialization cannot fail",
         );
+        if let Err(err) = self
+            .0
+            .call1(&JsValue::null(), &JsValue::from_str(&response))
+        {
+            // There is no tracing subscriber in the wasm client, so log
+            // straight to the console; swallowing this leaves the request
+            // hanging with zero diagnostics.
+            web_sys::console::error_2(&JsValue::from_str("RPC response callback threw"), &err);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Make `fedimint-client-wasm` failures diagnosable and catchable: install `console_error_panic_hook` from a `#[wasm_bindgen(start)]` function so any panic logs its message and Rust location before trapping, make `RpcHandler::new` return a rejection instead of panicking on its genuinely fallible steps, and log JS callback exceptions instead of swallowing them.

## Details

The crate installed no panic hook, so a client panic inside a task handed to `wasm_bindgen_futures::spawn_local` surfaced in the worker as an unhandled rejection carrying only `RuntimeError: unreachable executed` — the panic message and location never existed anywhere, and the request that triggered it got no response. That made a real crash in fedimint-sdk's CI effectively undiagnosable (fedimint/fedimint-sdk#330 showed up as two bare `null` lines and a silent timeout).

`console_error_panic_hook` was already pinned in the workspace dependencies (unused until now). The `#[wasm_bindgen(start)]` function runs on module instantiation, before any export can be called, so the hook also covers panics outside `RpcHandler` and nothing has to remember to install it per entry point.

Second commit: `RpcHandler::new` now returns `Result<RpcHandler, JsError>`. Opening the database and binding connectors are genuinely fallible (corrupt redb, OPFS I/O error, quota), and a panic in an async wasm-bindgen export leaves the returned `Promise` unsettled forever — even with the hook, the caller would hang with no rejection to catch. (wasm-bindgen's pre-existing deprecation warning about async constructors remains; fixing it means replacing the constructor with a static factory, which changes the JS API and is follow-up material.)

Third commit: `handle_response` no longer drops the `Result` of calling the JS callback — a throwing callback is the same silent-hang class on the JS side, where the panic hook cannot help — and the response-serialization `unwrap()` became an `expect()` saying why it cannot fail. There is no tracing subscriber in the wasm client, so the callback error goes straight to `web_sys::console`.

The hook stays in release builds deliberately: the crate optimizes for size (`wasm-opt = -Oz`), but production panic diagnostics are the point of this change — the SDK consumes the release bundle. Measured cost: 309 bytes after `wasm-opt -Oz --strip-debug` on the ~16.9 MB release module (~16 KiB pre-opt on the unstripped build) — the panic-formatting machinery is already linked regardless.

The Cargo.lock diff beyond the new package is cargo re-pinning existing duplicate-version edges (`syn`, `indexmap`, `windows-sys`, `socket2` — all versions already in the lock, none added or bumped). Recent lock commits on master flip the same edges back and forth (e.g. 3c9241505d0 flipped them the other way), and any cargo invocation regenerates them, so they are left as generated.

## Testing

- `cargo check --locked --target wasm32-unknown-unknown -p fedimint-client-wasm` under the nix toolchain, for the head and for each intermediate commit (bisectable). The only remaining crate warning is the pre-existing async-constructor deprecation noted above.
- Workspace clippy (`--locked --offline --all-targets -- -D warnings`) under the nix toolchain, also validating the re-pinned lock edges.
- The hook's effect (panic message on the console instead of a bare `unreachable executed`) is the documented behaviour of `console_error_panic_hook`; there is no wasm test harness for this crate to assert console output in-repo. A max-effort review flagged the lack of behavioural coverage — a browser-test harness for this crate would be a separate piece of infrastructure, so I left it out; happy to file a follow-up issue if wanted.
- The `#[wasm_bindgen(start)]` function is unavoidably also emitted as a JS export, so it is named `install_panic_hook` and documented as auto-run and idempotent.

Fixes #9045.

Generated by Claude Fable 5.
