### PR TITLE
fix: Fail when Guardians cannot agree on peg out fees

### DIFF
--- a/fedimint-api-client/src/api/mod.rs
+++ b/fedimint-api-client/src/api/mod.rs
@@ -235,6 +235,15 @@ pub trait FederationApiExt: IRawFederationApi {
                 },
                 Err(e) => {
                     e.report_if_unusual(peer, "RequestWithStrategy");
+
+                    // A strategy that tracks which peers are still outstanding
+                    // needs to see failures too, otherwise it cannot tell a slow
+                    // peer from one that will never answer. Defaults to
+                    // `Continue`, so other strategies are unaffected.
+                    if let QueryStep::Success(response) = strategy.process_error(peer, &e) {
+                        return Ok(response);
+                    }
+
                     peer_errors.insert(peer, e);
                 }
             }

--- a/fedimint-api-client/src/query.rs
+++ b/fedimint-api-client/src/query.rs
@@ -15,6 +15,16 @@ use fedimint_core::{NumPeers, PeerId, maybe_add_send_sync};
 /// of each specific strategy for the generic client Api code.
 pub trait QueryStrategy<IR, OR = IR> {
     fn process(&mut self, peer_id: PeerId, response: IR) -> QueryStep<OR>;
+
+    /// Called when a peer's request fails, so a strategy can tell "still
+    /// waiting" apart from "will never answer".
+    ///
+    /// Defaults to [`QueryStep::Continue`], leaving failed peers entirely to
+    /// the caller's error accounting, which is what every strategy other than
+    /// [`ThresholdAgreement`] wants.
+    fn process_error(&mut self, _peer_id: PeerId, _error: &ServerError) -> QueryStep<OR> {
+        QueryStep::Continue
+    }
 }
 
 /// Results from the strategy handling a response from a peer
@@ -132,6 +142,155 @@ impl<R: Eq + Clone> QueryStrategy<R> for ThresholdConsensus<R> {
         } else {
             QueryStep::Continue
         }
+    }
+}
+
+#[cfg(test)]
+fn dead_peer() -> ServerError {
+    ServerError::Connection(anyhow::anyhow!("peer is unreachable"))
+}
+
+#[test]
+fn threshold_agreement_counts_every_peer() {
+    use assert_matches::assert_matches;
+
+    // The case `FilterMapThreshold` gets wrong: peer 0 lags, and the agreement
+    // among 1, 2 and 3 only becomes visible once the fourth answer lands. A
+    // strategy that stopped at `threshold` responses would have reported a
+    // divergence that does not exist.
+    let mut agreement = ThresholdAgreement::<u64>::new(NumPeers::from(4));
+
+    assert_matches!(agreement.process(PeerId::from(0), 0), QueryStep::Continue);
+    assert_matches!(agreement.process(PeerId::from(1), 1), QueryStep::Continue);
+    assert_matches!(agreement.process(PeerId::from(3), 1), QueryStep::Continue);
+    assert_matches!(
+        agreement.process(PeerId::from(2), 1),
+        QueryStep::Success(Ok(1))
+    );
+}
+
+#[test]
+fn threshold_agreement_reports_divergence_once_every_peer_has_answered() {
+    use assert_matches::assert_matches;
+
+    let mut agreement = ThresholdAgreement::<u64>::new(NumPeers::from(4));
+
+    assert_matches!(agreement.process(PeerId::from(0), 0), QueryStep::Continue);
+    assert_matches!(agreement.process(PeerId::from(1), 1), QueryStep::Continue);
+    assert_matches!(agreement.process(PeerId::from(2), 2), QueryStep::Continue);
+
+    let QueryStep::Success(Err(responses)) = agreement.process(PeerId::from(3), 3) else {
+        panic!("expected a divergence carrying every response");
+    };
+    assert_eq!(responses.len(), 4);
+}
+
+#[test]
+fn threshold_agreement_does_not_wait_on_a_peer_that_errored() {
+    use assert_matches::assert_matches;
+
+    // A failed peer completes the picture just as a response does, so the
+    // divergence is reported rather than waiting on an answer that is never
+    // coming - the hang this strategy exists to avoid.
+    let mut agreement = ThresholdAgreement::<u64>::new(NumPeers::from(4));
+
+    assert_matches!(agreement.process(PeerId::from(0), 0), QueryStep::Continue);
+    assert_matches!(agreement.process(PeerId::from(1), 1), QueryStep::Continue);
+    assert_matches!(agreement.process(PeerId::from(2), 1), QueryStep::Continue);
+
+    let QueryStep::Success(Err(responses)) = agreement.process_error(PeerId::from(3), &dead_peer())
+    else {
+        panic!("expected a divergence once every peer has answered");
+    };
+    assert_eq!(responses.len(), 3);
+}
+
+#[test]
+fn threshold_agreement_defers_to_peer_errors_when_too_few_answered() {
+    use assert_matches::assert_matches;
+
+    // Two of four unreachable leaves fewer responses than the threshold. The
+    // useful complaint is that peers are down, which the caller reports from
+    // its own error accounting, so stay quiet.
+    let mut agreement = ThresholdAgreement::<u64>::new(NumPeers::from(4));
+
+    assert_matches!(agreement.process(PeerId::from(0), 0), QueryStep::Continue);
+    assert_matches!(agreement.process(PeerId::from(1), 1), QueryStep::Continue);
+    assert_matches!(
+        agreement.process_error(PeerId::from(2), &dead_peer()),
+        QueryStep::Continue
+    );
+    assert_matches!(
+        agreement.process_error(PeerId::from(3), &dead_peer()),
+        QueryStep::Continue
+    );
+}
+
+/// Returns the response a threshold of peers agree on, or - when they do not
+/// converge - every answer received, as `Err`.
+///
+/// Like [`ThresholdConsensus`] it counts identical responses across *all*
+/// peers rather than the first `threshold` to reply, so one lagging peer
+/// cannot mask an agreement that exists among the others.
+///
+/// Unlike it, a disagreement is never retried. Values worth querying this way
+/// are a pure function of the ordered consensus log, so a peer that has fallen
+/// behind never converges, and re-requesting it renews the transport timeout
+/// indefinitely. Asking each peer exactly once is what bounds the call.
+pub struct ThresholdAgreement<R> {
+    responses: BTreeMap<PeerId, R>,
+    errors: usize,
+    threshold: usize,
+    total: usize,
+}
+
+impl<R> ThresholdAgreement<R> {
+    pub fn new(num_peers: NumPeers) -> Self {
+        Self {
+            responses: BTreeMap::new(),
+            errors: 0,
+            threshold: num_peers.threshold(),
+            total: num_peers.total(),
+        }
+    }
+
+    /// Every peer has answered one way or the other without any value reaching
+    /// a threshold, so waiting longer cannot help.
+    fn diverged(&mut self) -> Option<QueryStep<Result<R, BTreeMap<PeerId, R>>>> {
+        if self.responses.len() + self.errors < self.total {
+            return None;
+        }
+
+        // Below a threshold of responses the useful complaint is that too few
+        // peers answered, not that they disagreed. Stay quiet and let the
+        // caller report the peer errors it collected.
+        if self.responses.len() < self.threshold {
+            return None;
+        }
+
+        Some(QueryStep::Success(Err(mem::take(&mut self.responses))))
+    }
+}
+
+impl<R: Eq + Clone> QueryStrategy<R, Result<R, BTreeMap<PeerId, R>>> for ThresholdAgreement<R> {
+    fn process(&mut self, peer: PeerId, response: R) -> QueryStep<Result<R, BTreeMap<PeerId, R>>> {
+        self.responses.insert(peer, response.clone());
+
+        if self.responses.values().filter(|r| **r == response).count() == self.threshold {
+            return QueryStep::Success(Ok(response));
+        }
+
+        self.diverged().unwrap_or(QueryStep::Continue)
+    }
+
+    fn process_error(
+        &mut self,
+        _peer: PeerId,
+        _error: &ServerError,
+    ) -> QueryStep<Result<R, BTreeMap<PeerId, R>>> {
+        self.errors += 1;
+
+        self.diverged().unwrap_or(QueryStep::Continue)
     }
 }
 

--- a/modules/fedimint-wallet-client/src/api.rs
+++ b/modules/fedimint-wallet-client/src/api.rs
@@ -3,7 +3,7 @@ use bitcoin::{Address, Amount};
 use fedimint_api_client::api::{
     FederationApiExt, FederationError, FederationResult, IModuleFederationApi, ServerResult,
 };
-use fedimint_api_client::query::FilterMapThreshold;
+use fedimint_api_client::query::{FilterMapThreshold, ThresholdAgreement};
 use fedimint_core::envs::BitcoinRpcConfig;
 use fedimint_core::module::{ApiAuth, ApiRequestErased, ModuleConsensusVersion};
 use fedimint_core::task::{MaybeSend, MaybeSync};
@@ -132,11 +132,46 @@ where
         address: &Address,
         amount: Amount,
     ) -> FederationResult<Option<PegOutFees>> {
-        self.request_current_consensus(
+        let params = ApiRequestErased::new((address, amount.to_sat()));
+
+        // Deliberately not `request_current_consensus`. The quote is a pure
+        // function of the ordered consensus log, so peers in sync always agree;
+        // one that has fallen behind never converges, and `ThresholdConsensus`
+        // would re-request it forever while logging nothing at all.
+        let quotes = match self
+            .request_with_strategy(
+                ThresholdAgreement::new(self.all_peers().to_num_peers()),
+                PEG_OUT_FEES_ENDPOINT.to_string(),
+                params.clone(),
+            )
+            .await?
+        {
+            Ok(fees) => return Ok(fees),
+            Err(quotes) => quotes,
+        };
+
+        let detail = quotes
+            .iter()
+            .map(|(peer, quote)| match quote {
+                Some(fees) => format!(
+                    "peer {peer}: {} sats/kvb, weight {}",
+                    fees.fee_rate.sats_per_kvb, fees.total_weight
+                ),
+                None => format!("peer {peer}: no quote"),
+            })
+            .collect::<Vec<_>>()
+            .join("; ");
+
+        Err(FederationError::general(
             PEG_OUT_FEES_ENDPOINT.to_string(),
-            ApiRequestErased::new((address, amount.to_sat())),
-        )
-        .await
+            params,
+            anyhow!(
+                "Guardians disagree on peg-out fees ({detail}). The quote is consensus \
+                 state, so a guardian returning a different value has diverged - most \
+                 often because its Bitcoin backend is lagging. The same rate validates \
+                 the peg-out, so it cannot be accepted until the federation agrees."
+            ),
+        ))
     }
 
     async fn fetch_bitcoin_rpc_kind(&self, peer_id: PeerId) -> FederationResult<String> {

--- a/modules/fedimint-walletv2-client/src/api.rs
+++ b/modules/fedimint-walletv2-client/src/api.rs
@@ -1,13 +1,31 @@
-use fedimint_api_client::api::{FederationApiExt, FederationResult, IModuleFederationApi};
+use std::collections::BTreeMap;
+
+use anyhow::anyhow;
+use fedimint_api_client::api::{
+    FederationApiExt, FederationError, FederationResult, IModuleFederationApi,
+};
+use fedimint_api_client::query::ThresholdAgreement;
 use fedimint_core::module::ApiRequestErased;
 use fedimint_core::task::{MaybeSend, MaybeSync};
-use fedimint_core::{OutPoint, apply, async_trait_maybe_send};
+use fedimint_core::{NumPeersExt, OutPoint, PeerId, apply, async_trait_maybe_send};
 use fedimint_walletv2_common::endpoint_constants::{
     CONSENSUS_BLOCK_COUNT_ENDPOINT, CONSENSUS_FEERATE_ENDPOINT, FEDERATION_WALLET_ENDPOINT,
     OUTPUT_INFO_SLICE_ENDPOINT, PENDING_TRANSACTION_CHAIN_ENDPOINT, RECEIVE_FEE_ENDPOINT,
     SEND_FEE_ENDPOINT, TRANSACTION_CHAIN_ENDPOINT, TRANSACTION_ID_ENDPOINT,
 };
 use fedimint_walletv2_common::{FederationWallet, OutputInfo, TxInfo};
+
+/// Renders each peer's fee answer so a divergence error names the odd one out.
+fn describe_fee_quotes(quotes: &BTreeMap<PeerId, Option<bitcoin::Amount>>) -> String {
+    quotes
+        .iter()
+        .map(|(peer, fee)| match fee {
+            Some(fee) => format!("peer {peer}: {} sats", fee.to_sat()),
+            None => format!("peer {peer}: no quote"),
+        })
+        .collect::<Vec<_>>()
+        .join("; ")
+}
 
 #[apply(async_trait_maybe_send!)]
 pub trait WalletFederationApi {
@@ -64,13 +82,68 @@ where
     }
 
     async fn send_fee(&self) -> FederationResult<Option<bitcoin::Amount>> {
-        self.request_current_consensus(SEND_FEE_ENDPOINT.to_string(), ApiRequestErased::new(()))
-            .await
+        // Deliberately not `request_current_consensus`; see the same reasoning in
+        // wallet v1's `fetch_peg_out_fees`. walletv2 is if anything more exposed:
+        // this single amount folds together the consensus feerate, a floor that
+        // doubles with every pending federation transaction, and the fees already
+        // paid by that pending stack, so any one of them diverging is enough to
+        // stop a threshold ever agreeing and hang the caller forever.
+        let quotes = match self
+            .request_with_strategy(
+                ThresholdAgreement::new(self.all_peers().to_num_peers()),
+                SEND_FEE_ENDPOINT.to_string(),
+                ApiRequestErased::new(()),
+            )
+            .await?
+        {
+            Ok(fee) => return Ok(fee),
+            Err(quotes) => quotes,
+        };
+
+        Err(FederationError::general(
+            SEND_FEE_ENDPOINT.to_string(),
+            ApiRequestErased::new(()),
+            anyhow!(
+                "Guardians disagree on the onchain send fee ({}). The fee is \
+                 consensus state, so a guardian returning a different value has \
+                 diverged - because its Bitcoin backend is lagging, or because its \
+                 view of the pending transaction stack differs. The same fee \
+                 validates the send, so it cannot be accepted until they agree.",
+                describe_fee_quotes(&quotes)
+            ),
+        ))
     }
 
     async fn receive_fee(&self) -> FederationResult<Option<bitcoin::Amount>> {
-        self.request_current_consensus(RECEIVE_FEE_ENDPOINT.to_string(), ApiRequestErased::new(()))
-            .await
+        // Same reasoning as `send_fee`. The caller here is the background
+        // output-scanner, which loops with a `warn!` and a sleep, so returning
+        // an error is how this waits for consensus *visibly*: it keeps retrying
+        // for as long as the divergence lasts and resumes on its own, instead of
+        // wedging the scanner inside a request that never returns.
+        let quotes = match self
+            .request_with_strategy(
+                ThresholdAgreement::new(self.all_peers().to_num_peers()),
+                RECEIVE_FEE_ENDPOINT.to_string(),
+                ApiRequestErased::new(()),
+            )
+            .await?
+        {
+            Ok(fee) => return Ok(fee),
+            Err(quotes) => quotes,
+        };
+
+        Err(FederationError::general(
+            RECEIVE_FEE_ENDPOINT.to_string(),
+            ApiRequestErased::new(()),
+            anyhow!(
+                "Guardians disagree on the onchain receive fee ({}). The fee is \
+                 consensus state, so a guardian returning a different value has \
+                 diverged - because its Bitcoin backend is lagging, or because its \
+                 view of the pending transaction stack differs. The same fee \
+                 validates the claim, so it cannot be accepted until they agree.",
+                describe_fee_quotes(&quotes)
+            ),
+        ))
     }
 
     async fn pending_tx_chain(&self) -> FederationResult<Vec<TxInfo>> {

--- a/skills/gateway-liquidity/SKILL.md
+++ b/skills/gateway-liquidity/SKILL.md
@@ -131,6 +131,20 @@ Amount can be a raw number (millisats), a value with unit (e.g. "1000 sats"), or
 $GW ecash pegout-to-onchain --federation-id <FEDERATION_ID> --amount <AMOUNT_OR_ALL>
 ```
 
+If this fails with "Guardians disagree on peg-out fees" (or, on walletv2,
+"Guardians disagree on the onchain send fee"), **the federation has a problem —
+this is not something to work around from the CLI.**
+
+The quote is consensus state: every guardian derives it from the same ordered
+log, so guardians that are in sync always return the same value. A guardian
+returning a different number has diverged, usually because its Bitcoin backend
+is lagging or unreachable. The error lists each guardian's quote, so the odd one
+out names the broken guardian.
+
+Since the same consensus fee rate is what validates the peg-out, a federation
+that cannot agree on the quote will not accept the withdrawal either. Report the
+divergent guardian to the federation operators rather than retrying.
+
 ### On-chain
 
 **Get the LN node's on-chain deposit address:**


### PR DESCRIPTION
We currently have a bug where if a threshold of the guardians do not agree, the peg-out request actually stalls the client (both CLI and gateway) because it uses `ThresholdConsensus` and it makes it very difficult to figure out what's going on.

The peg out fees request is already the consensus fee rate. This means that if the guardians do not return a unified agreement on the consensus fee rate, then the federation is not in consensus. This means it is not safe to do a peg out.

If the guardians do not have consensus on the fee rate, it means the federation has stalled and pegout requests should not succeed.

This PR turns this into a hard error rather than stalling.
