### PR TITLE
fix(wallet-client): tolerate races when storing the safe-deposit marker

### DIFF
--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -54,7 +54,8 @@ use fedimint_client_module::transaction::{
 use fedimint_client_module::{DynGlobalClientContext, sm_enum_variant_translation};
 use fedimint_core::core::{Decoder, IntoDynInstance, ModuleInstanceId, ModuleKind, OperationId};
 use fedimint_core::db::{
-    AutocommitError, Database, DatabaseTransaction, IDatabaseTransactionOpsCoreTyped,
+    AutocommitError, Committable, Database, DatabaseError, DatabaseTransaction,
+    IDatabaseTransactionOpsCoreTyped,
 };
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::envs::{BitcoinRpcConfig, is_running_in_test_env};
@@ -64,7 +65,7 @@ use fedimint_core::module::{
 };
 use fedimint_core::task::{MaybeSend, MaybeSync, TaskGroup, sleep};
 use fedimint_core::util::backoff_util::background_backoff;
-use fedimint_core::util::{BoxStream, backoff_util, retry};
+use fedimint_core::util::{BoxStream, FmtCompact as _, backoff_util, retry};
 use fedimint_core::{
     BitcoinHash, OutPoint, TransactionId, apply, async_trait_maybe_send, push_db_pair_items,
     runtime, secp256k1,
@@ -81,7 +82,7 @@ use secp256k1::Keypair;
 use serde::{Deserialize, Serialize};
 use strum::IntoEnumIterator;
 use tokio::sync::watch;
-use tracing::{debug, instrument};
+use tracing::{debug, instrument, warn};
 
 use crate::api::WalletFederationApi;
 use crate::backup::{FEDERATION_RECOVER_MAX_GAP, RecoveryStateV2, WalletRecovery};
@@ -1098,27 +1099,13 @@ impl WalletClientModule {
     /// verified the version, it must be online to fetch the latest wallet
     /// module consensus version.
     pub async fn supports_safe_deposit(&self) -> bool {
-        let mut dbtx = self.db.begin_transaction().await;
-
-        let already_verified_supports_safe_deposit =
-            dbtx.get_value(&SupportsSafeDepositKey).await.is_some();
-
-        already_verified_supports_safe_deposit || {
-            match self.module_api.module_consensus_version().await {
-                Ok(module_consensus_version) => {
-                    let supported_version =
-                        SAFE_DEPOSIT_MODULE_CONSENSUS_VERSION <= module_consensus_version;
-
-                    if supported_version {
-                        dbtx.insert_new_entry(&SupportsSafeDepositKey, &()).await;
-                        dbtx.commit_tx().await;
-                    }
-
-                    supported_version
-                }
-                Err(_) => false,
-            }
+        if supports_safe_deposit_verified(&self.db).await {
+            return true;
         }
+
+        verify_supports_safe_deposit(&self.db, &self.module_api)
+            .await
+            .unwrap_or(false)
     }
 
     /// Allocates a deposit address controlled by the federation, guaranteeing
@@ -1137,7 +1124,7 @@ impl WalletClientModule {
     {
         ensure!(
             self.supports_safe_deposit().await,
-            "Wallet module consensus version doesn't support safe deposits",
+            "Could not verify that the wallet module consensus version supports safe deposits",
         );
 
         self.allocate_deposit_address_expert_only(extra_meta).await
@@ -2042,29 +2029,91 @@ impl WalletClientModule {
 /// supports safe deposits, saving the result in the db once it does.
 async fn poll_supports_safe_deposit_version(db: Database, module_api: DynModuleApi) {
     loop {
-        let mut dbtx = db.begin_transaction().await;
-
-        if dbtx.get_value(&SupportsSafeDepositKey).await.is_some() {
+        if supports_safe_deposit_verified(&db).await {
             break;
         }
 
         module_api.wait_for_initialized_connections().await;
 
-        if let Ok(module_consensus_version) = module_api.module_consensus_version().await
-            && SAFE_DEPOSIT_MODULE_CONSENSUS_VERSION <= module_consensus_version
-        {
-            dbtx.insert_new_entry(&SupportsSafeDepositKey, &()).await;
-            dbtx.commit_tx().await;
+        if verify_supports_safe_deposit(&db, &module_api).await == Some(true) {
             break;
         }
-
-        drop(dbtx);
 
         if is_running_in_test_env() {
             // Even in tests we don't want to spam the federation with requests about it
             sleep(Duration::from_secs(10)).await;
         } else {
             sleep(Duration::from_hours(1)).await;
+        }
+    }
+}
+
+/// Whether the federation's wallet module consensus version was already
+/// verified to support safe deposits.
+async fn supports_safe_deposit_verified(db: &Database) -> bool {
+    db.begin_transaction_nc()
+        .await
+        .get_value(&SupportsSafeDepositKey)
+        .await
+        .is_some()
+}
+
+/// Fetches the federation's wallet module consensus version and records the
+/// marker if it supports safe deposits.
+///
+/// Returns `None` if the version could not be fetched, e.g. while offline.
+async fn verify_supports_safe_deposit(db: &Database, module_api: &DynModuleApi) -> Option<bool> {
+    let module_consensus_version = match module_api.module_consensus_version().await {
+        Ok(module_consensus_version) => module_consensus_version,
+        Err(err) => {
+            debug!(
+                target: LOG_CLIENT_MODULE_WALLET,
+                err = %err.fmt_compact(),
+                "Could not fetch the wallet module consensus version"
+            );
+            return None;
+        }
+    };
+
+    let supported_version = SAFE_DEPOSIT_MODULE_CONSENSUS_VERSION <= module_consensus_version;
+
+    if supported_version {
+        store_supports_safe_deposit(db.begin_transaction().await).await;
+    }
+
+    Some(supported_version)
+}
+
+/// Records in `dbtx` that the federation's wallet module consensus version
+/// was verified to support safe deposits, and commits it.
+///
+/// The marker is written by both the background version poller and
+/// [`WalletClientModule::supports_safe_deposit`], which race right after
+/// joining a federation. The loser's commit fails with a write conflict, but
+/// the winner stored the very same marker and nothing ever removes it, so the
+/// conflict is treated as success. That is only sound for a fresh `dbtx` whose
+/// sole write is the marker: any other write in it would be lost as well.
+///
+/// Any other commit error is logged rather than escalated: the marker only
+/// lets future checks skip re-verifying the version, callers already have
+/// their answer, and the next verification simply writes it again — an
+/// optional write is not worth crashing over.
+async fn store_supports_safe_deposit(mut dbtx: DatabaseTransaction<'_, Committable>) {
+    if dbtx.get_value(&SupportsSafeDepositKey).await.is_some() {
+        // The other writer won before this transaction started.
+        return;
+    }
+
+    dbtx.insert_entry(&SupportsSafeDepositKey, &()).await;
+
+    match dbtx.commit_tx_result().await {
+        Ok(()) | Err(DatabaseError::WriteConflict) => {}
+        Err(err) => {
+            warn!(
+                target: LOG_CLIENT_MODULE_WALLET,
+                err = %err.fmt_compact(),
+                "Failed to store the safe-deposit marker"
+            );
         }
     }
 }
@@ -2130,6 +2179,9 @@ impl State for WalletClientStates {
 mod tests {
     use std::collections::BTreeSet;
     use std::sync::atomic::{AtomicBool, Ordering};
+
+    use fedimint_core::db::mem_impl::MemDatabase;
+    use fedimint_core::module::registry::ModuleDecoderRegistry;
 
     use super::*;
     use crate::backup::{
@@ -2286,5 +2338,34 @@ mod tests {
                 tweak_idxes_with_pegins: BTreeSet::from([TweakIdx(15)])
             }
         );
+    }
+
+    #[tokio::test]
+    async fn store_supports_safe_deposit_tolerates_a_lost_race() {
+        let db = Database::new(MemDatabase::new(), ModuleDecoderRegistry::default());
+
+        // Both opened before the competing write below, so committing either
+        // of them must run into a write conflict.
+        let racing_dbtx = db.begin_transaction().await;
+        let mut sibling_dbtx = db.begin_transaction().await;
+
+        let mut competing_dbtx = db.begin_transaction().await;
+        competing_dbtx
+            .insert_entry(&SupportsSafeDepositKey, &())
+            .await;
+        competing_dbtx.commit_tx().await;
+
+        // Proves the setup: a plain commit of the stale sibling is rejected.
+        sibling_dbtx
+            .insert_entry(&SupportsSafeDepositKey, &())
+            .await;
+        assert!(matches!(
+            sibling_dbtx.commit_tx_result().await,
+            Err(DatabaseError::WriteConflict)
+        ));
+
+        store_supports_safe_deposit(racing_dbtx).await;
+
+        assert!(supports_safe_deposit_verified(&db).await);
     }
 }

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -11,7 +11,9 @@ use fedimint_client::ClientHandleArc;
 use fedimint_client::secret::{PlainRootSecretStrategy, RootSecretStrategy};
 use fedimint_connectors::ConnectorRegistry;
 use fedimint_core::db::mem_impl::MemDatabase;
-use fedimint_core::db::{DatabaseTransaction, IDatabaseTransactionOpsCoreTyped, IRawDatabaseExt};
+use fedimint_core::db::{
+    DatabaseError, DatabaseTransaction, IDatabaseTransactionOpsCoreTyped, IRawDatabaseExt,
+};
 use fedimint_core::module::{AmountUnit, serde_json};
 use fedimint_core::task::{TaskGroup, sleep_in_test};
 use fedimint_core::util::{BoxStream, NextOrPending, SafeUrl, retry};
@@ -26,6 +28,7 @@ use fedimint_testing::federation::FederationTest;
 use fedimint_testing::fixtures::Fixtures;
 use fedimint_testing_core::config::API_AUTH;
 use fedimint_wallet_client::api::WalletFederationApi;
+use fedimint_wallet_client::client_db::SupportsSafeDepositKey;
 use fedimint_wallet_client::{
     AllocateDepositOutcome, DepositStateV2, MaybeNewAddress, WalletClientInit, WalletClientModule,
     WithdrawState,
@@ -1512,6 +1515,53 @@ async fn allocate_deposit_address_pooled_used_address_shrinks_gap() -> anyhow::R
     assert_ne!(
         deposit_address.address, used_addr,
         "fresh allocation must not collide with the used address"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn concurrent_supports_safe_deposit_checks_succeed() -> anyhow::Result<()> {
+    skip_if_not_wallet_test_group!("2");
+    let fixtures = fixtures();
+    let fed = fixtures.new_fed_degraded().await;
+    let client = fed.new_client().await;
+    await_consensus_upgrade(&client, &fed).await?;
+
+    let wallet_module = client.get_first_module::<WalletClientModule>()?;
+
+    // The module's background version poller may have stored the marker while
+    // the upgrade was in flight; drop it so both checks below have to store it.
+    // If the poller is storing it right now instead, this removal loses a write
+    // conflict and the checks below simply find the marker in place.
+    let mut dbtx = wallet_module.db.begin_transaction().await;
+    dbtx.remove_entry(&SupportsSafeDepositKey).await;
+    if let Err(err) = dbtx.commit_tx_result().await {
+        assert!(matches!(err, DatabaseError::WriteConflict), "{err}");
+    }
+
+    // Two checks in one task: each queries the federation before storing the
+    // marker, so neither may keep a write transaction open across that round
+    // trip. The old code did and panicked on the second commit; this is the
+    // race a peg-in issued right after joining has with the background poller.
+    let (first, second) = tokio::join!(
+        wallet_module.supports_safe_deposit(),
+        wallet_module.supports_safe_deposit()
+    );
+    assert!(
+        first && second,
+        "safe deposits must be reported as supported"
+    );
+
+    let marker = wallet_module
+        .db
+        .begin_transaction_nc()
+        .await
+        .get_value(&SupportsSafeDepositKey)
+        .await;
+    assert!(
+        marker.is_some(),
+        "the verified consensus version must be recorded"
     );
 
     Ok(())


### PR DESCRIPTION
### Summary

`WalletClientModule::supports_safe_deposit()` and the module's background consensus-version poller both store the `SupportsSafeDepositKey` marker with `insert_new_entry` + `commit_tx()` (the panicking commit), and both keep that transaction open across the network round trip that fetches the consensus version. Right after `join_federation` they run concurrently, so whichever commits second panics on a routine `WriteConflict`. This is the crash behind #9046 (native backtrace in the issue comment): in wasm it surfaced as a bare `RuntimeError: unreachable` (named since #9052), under `panic = "abort"` it takes the host app down, and on the poller side it trips `TaskPanicGuard`, which shuts down the client's whole task group. Fixes #9046.

### Details

Both writers now share one `store_supports_safe_deposit` helper that opens the write transaction only once the version is known and commits with `commit_tx_result()`, treating `WriteConflict` as success: the other writer stored the very same marker and nothing ever removes it, so the lost race changes nothing. Any other commit error is logged at warn level and swallowed (review feedback — the write is optional: callers already have their answer and the next verification rewrites the marker, while a genuinely broken backend still fails loudly on the next essential commit). The read side gets a matching `supports_safe_deposit_verified` helper, the fetch/compare/store sequence is shared by the RPC path and the poller (`verify_supports_safe_deposit`) so both log the API error behind an "unsupported" answer at debug level instead of dropping it, and `safe_allocate_deposit_address`'s error no longer claims the federation's version is too old when the client merely could not verify it.

The first version of this PR used `db.autocommit(.., None)`; the independent review pointed out that this retries *every* commit error forever (a full disk would turn the old panic into a silent hang of `peg_in` and of the poller task) and logs a WARN on the designed-in conflict. The narrow form above avoids both.

This should let fedimint-sdk drop the 100 ms sleep it carries between `join_federation` and the first wallet RPC (fedimint-sdk#330).

### Reviewing

- Treating `WriteConflict` as success is the whole fix. It is only sound because the marker is a constant `()` that is never deleted; if the marker ever carries data (e.g. the verified version), this must become a real retry.
- Two other bare `commit_tx()` calls remain in this file (recovery finalization and the withdraw event-log write). They are different writers with different conflict surfaces and are out of scope; flagging so nobody assumes this PR audited them.
- Follow-up outside this PR: the same shape (non-committable read, network round trip, fresh write transaction, bare `commit_tx()` of a cache value) exists in `fedimint-client` for `ChainIdKey`, `CachedApiVersionSetKey` and `PeerLastApiVersionsSummaryKey`. Only the commit-duration window overlaps there today, so it is not a blocker, but a shared conflict-tolerant helper in core would fix the class.
- Possible follow-up in core: `DatabaseTransaction::commit_tx()` labels a retriable `WriteConflict` "Unrecoverable error occurred while committing to the database", which is how this class of bug keeps getting reported (#3553, #8077, #8040, this one). Naming the write-write race and pointing at `autocommit`/`commit_tx_result` in that message would make the next one self-diagnosing.

### Testing

- Unit test `store_supports_safe_deposit_tolerates_a_lost_race` (`fedimint-wallet-client`): hands the helper a transaction whose snapshot predates a competing commit of the marker, so the commit runs into a `WriteConflict` deterministically (a sibling stale transaction first proves the setup does conflict). With a plain `commit_tx()` in the helper it panics (`Unrecoverable error occurred while committing to the database.: WriteConflict`); with the fix it passes and the marker is stored.
- Integration test `concurrent_supports_safe_deposit_checks_succeed` (`fedimint-wallet-tests`): after the consensus upgrade it deletes the marker (the background poller may already have stored it), runs two `supports_safe_deposit()` calls in one `tokio::join!`, and asserts both succeed and the marker is stored. Against upstream master's `lib.rs` it fails with the `WriteConflict` panic because the old code held its write transaction across the network round trip; with the fix the write transaction is opened after the reply, so the two calls no longer conflict at all.
- Note for local runs: under plain `cargo test` the poller sleeps its production interval (1 h) and `verify_auto_consensus_voting` times out, because `is_running_in_test_env()` is only true under nextest/devimint; CI runs nextest.

Also ran locally with the nix toolchain on the rebased branch: clippy with `-D warnings` for the touched crates and the whole workspace, the wallet-client unit tests, the full `fedimint_wallet_tests` target under `NEXTEST=1` (24/24), and the pre-commit hook (rustfmt/semgrep/typos).

