### PR TITLE
fix(recurringd): use jemalloc as the global allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4637,6 +4637,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
+ "tikv-jemallocator",
  "tokio",
  "tower-http",
  "tracing",

--- a/fedimint-recurringd/Cargo.toml
+++ b/fedimint-recurringd/Cargo.toml
@@ -9,6 +9,10 @@ readme = { workspace = true }
 repository = { workspace = true }
 version = { workspace = true }
 
+[features]
+default = ["jemalloc"]
+jemalloc = ["dep:tikv-jemallocator", "fedimint-rocksdb/jemalloc"]
+
 [[bin]]
 name = "fedimint-recurringd"
 path = "src/main.rs"
@@ -36,6 +40,7 @@ lightning-invoice = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+tikv-jemallocator = { workspace = true, optional = true }
 tokio = { workspace = true }
 tower-http = { workspace = true }
 tracing = { workspace = true }

--- a/fedimint-recurringd/src/main.rs
+++ b/fedimint-recurringd/src/main.rs
@@ -25,10 +25,17 @@ use fedimint_recurringd::{LNURLPayInvoice, PaymentCodeInvoice, RecurringInvoiceS
 use fedimint_rocksdb::RocksDb;
 use lightning_invoice::Bolt11Invoice;
 use serde_json::json;
+#[cfg(feature = "jemalloc")]
+use tikv_jemallocator::Jemalloc;
 use tokio::net::TcpListener;
 use tower_http::cors;
 use tower_http::cors::CorsLayer;
 use tracing::{debug, info};
+
+#[cfg(feature = "jemalloc")]
+#[global_allocator]
+// rocksdb suffers from memory fragmentation when using standard allocator
+static GLOBAL: Jemalloc = Jemalloc;
 
 #[derive(Debug, Parser)]
 struct CliOpts {


### PR DESCRIPTION
### Summary

Make `fedimint-recurringd` use jemalloc as its global allocator via a default-on `jemalloc` feature, mirroring the existing setup in `fedimintd` and `fedimint-cli`. This is the likely fix for the unbounded linear memory growth reported in #8876.

### Details

recurringd embeds one RocksDB-backed fedimint client per served federation, yet it was the only long-running daemon in the workspace still running on the default allocator. The project has already diagnosed this failure mode elsewhere: `fedimintd` warns at startup that "rocksdb is prone to memory fragmentation with the default allocator" and defaults to jemalloc, as do `fedimint-cli` and `gatewayd`.

glibc arena fragmentation matches every observation in #8876: growth that is linear and never plateaus (freed memory returns to per-thread arena free lists, not the OS), is decoupled from *logged* activity (recurringd's silent steady state still performs tens of thousands of guardian API calls and RocksDB write transactions per hour across its background loops), shows the same signature on v0.10 and v0.11 (both glibc builds), and resets to a small working set on restart before climbing at the identical slope. Containers make it worse: glibc sizes its arena count from visible host cores, not the cgroup CPU limit.

The change copies fedimintd's wiring verbatim: a `jemalloc` default feature enabling `tikv-jemallocator` as `#[global_allocator]` plus `fedimint-rocksdb/jemalloc`.

### Reviewing

The feature is default-on, matching fedimintd/fedimint-cli; anyone who needs the old behavior can build with `--no-default-features`. The workspace `tikv-jemallocator` dependency already enables the `profiling` feature, so if a residual leak remains after this change, heap profiles can name it directly.

### Testing

`just final-lint` passes (pre-commit hook, workspace clippy with `-D warnings`, cargo-sort). The change is allocator wiring only, so behavior is otherwise unchanged; confirmation of the fix itself is operational (deploy and compare the memory slope, or equivalently set `MALLOC_ARENA_MAX=2` on a current build to approximate it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SPuVW9y3XofMUFG9GFCXAf
