### PR TITLE
fix(client): don't panic in ClientHandle::drop outside a tokio runtime

### DIFF
--- a/fedimint-client/src/client/handle.rs
+++ b/fedimint-client/src/client/handle.rs
@@ -164,20 +164,31 @@ impl Drop for ClientHandle {
             return;
         }
 
-        // We can't use block_on in single-threaded mode or wasm
+        // We can't use block_on in single-threaded mode, on wasm, or on a thread
+        // without a runtime context, e.g. when the last handle is dropped while
+        // unwinding from a panic. Destructors must never panic, so all these
+        // cases fall back to a non-blocking partial shutdown.
+        #[cfg(not(target_family = "wasm"))]
+        let runtime_handle = RuntimeHandle::try_current();
         #[cfg(target_family = "wasm")]
         let can_block = false;
         #[cfg(not(target_family = "wasm"))]
-        // nosemgrep: ban-raw-block-on
-        let can_block = RuntimeHandle::current().runtime_flavor() != RuntimeFlavor::CurrentThread;
+        let can_block = runtime_handle
+            .as_ref()
+            .is_ok_and(|handle| handle.runtime_flavor() != RuntimeFlavor::CurrentThread);
         if !can_block {
             let inner = self.inner.take().expect("Must have inner client set");
             inner.executor.stop_executor();
-            if cfg!(target_family = "wasm") {
-                error!(target: LOG_CLIENT, "Automatic client shutdown is not possible on wasm, call ClientHandle::shutdown manually.");
+            #[cfg(target_family = "wasm")]
+            let reason = "on wasm";
+            #[cfg(not(target_family = "wasm"))]
+            // `can_block` is false, so an existing runtime must be current-thread flavored.
+            let reason = if runtime_handle.is_ok() {
+                "on current thread runtime"
             } else {
-                error!(target: LOG_CLIENT, "Automatic client shutdown is not possible on current thread runtime, call ClientHandle::shutdown manually.");
-            }
+                "without a runtime"
+            };
+            error!(target: LOG_CLIENT, "Automatic client shutdown is not possible {reason}, call ClientHandle::shutdown manually.");
             return;
         }
 

--- a/fedimint-client/src/client/tests.rs
+++ b/fedimint-client/src/client/tests.rs
@@ -30,6 +30,7 @@ use tokio::sync::{broadcast, oneshot, watch};
 use tokio::task::yield_now;
 
 use super::{Client, ModuleRecoveryFuture, RecoveryStatus};
+use crate::ClientHandle;
 use crate::db::ClientModuleRecovery;
 use crate::meta::MetaService;
 use crate::oplog::OperationLog;
@@ -826,4 +827,21 @@ async fn wait_for_module_kind_recovery_reports_failure_despite_other_kind_failin
         error.contains(&format!("module_instance_id={FAILING_MODULE_INSTANCE_ID}")),
         "{error}"
     );
+}
+
+/// The last [`ClientHandle`] may get dropped on a thread without a tokio
+/// runtime context, e.g. while unwinding from a panic on a plain thread. The
+/// drop impl must fall back to a non-blocking shutdown instead of panicking,
+/// which during unwind would abort the process.
+///
+/// <https://github.com/fedimint/fedimint/issues/9053>
+#[tokio::test]
+async fn client_handle_drop_outside_runtime_does_not_panic() {
+    let (_status_sender, status_receiver) = watch::channel(BTreeMap::new());
+    let client = client_for_recovery_test(status_receiver, BTreeMap::new()).await;
+    let handle = ClientHandle::new(Arc::new(client));
+
+    std::thread::spawn(move || drop(handle))
+        .join()
+        .expect("Dropping a ClientHandle outside a runtime must not panic");
 }

--- a/fedimint-client/src/sm/executor.rs
+++ b/fedimint-client/src/sm/executor.rs
@@ -913,7 +913,13 @@ impl ExecutorInner {
 impl ExecutorInner {
     /// See [`Executor::stop_executor`].
     fn stop_executor(&self) -> Option<()> {
-        let mut state = self.state.write().expect("Locking can't fail");
+        // This runs from destructors, which must never panic, so recover from a lock
+        // poisoned by a panic elsewhere. `ExecutorState` is always left in a coherent
+        // variant, so the poison can be ignored safely.
+        let mut state = self
+            .state
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
 
         state.stop()
     }

--- a/fedimint-client/src/sm/executor/tests.rs
+++ b/fedimint-client/src/sm/executor/tests.rs
@@ -207,3 +207,26 @@ async fn test_executor() {
         "State was written to DB and waits for broadcast"
     );
 }
+
+/// A panic while the executor state write lock is held, e.g. from a panicking
+/// tracing subscriber, poisons the lock. `stop_executor` runs from destructors,
+/// which must never panic, so it has to tolerate the poison instead of
+/// panicking on it.
+#[tokio::test]
+async fn stop_executor_tolerates_poisoned_state_lock() {
+    let (executor, _sender, _db) = get_executor();
+
+    let executor_clone = executor.clone();
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+        let _guard = executor_clone
+            .inner
+            .state
+            .write()
+            .expect("Not poisoned yet");
+        panic!("Poison the executor state lock");
+    }))
+    .expect_err("Must have panicked to poison the lock");
+
+    assert!(executor.inner.state.is_poisoned());
+    executor.stop_executor();
+}


### PR DESCRIPTION
### Summary

`ClientHandle`'s `Drop` impl called `tokio::runtime::Handle::current()`, which panics when the
last handle is dropped on a thread without a live runtime context. Because this fires inside a
destructor, it commonly happens while already unwinding from another panic and escalates to a
process abort (SIGABRT), e.g. devimint dying mid-teardown and orphaning its child daemons. The
drop now uses `Handle::try_current()` and takes the existing non-blocking shutdown fallback when
no runtime is available.

Fixes #9053.

### Details

Destructors must never panic, so the no-runtime case is treated the same as the current-thread
runtime and wasm cases that already existed: take the inner client, stop the executor
(`stop_executor` is purely synchronous, so it is safe without a runtime) and log that only a
partial shutdown was performed. Behavior on a multi-thread runtime is unchanged: drop still
performs the full blocking shutdown. The three near-identical log messages were deduplicated
into a single `error!` with a per-case reason; the two pre-existing messages stay byte-identical.

While verifying that the fallback path can never panic, a second destructor-reachable panic
turned up: `stop_executor()` did `state.write().expect(...)`, which panics if the lock was
poisoned by a panic elsewhere (e.g. a panicking tracing subscriber inside the executor state's
critical sections) — the same unwind-into-abort failure class. `ExecutorState` is only mutated
via `mem::replace` and is coherent at every possible panic point, so the poison is now safely
ignored via `PoisonError::into_inner`.

Each fix is preceded by a commit adding a regression test that fails at that commit; this
repro-first ordering is deliberate.

The `// nosemgrep: ban-raw-block-on` suppression was dropped because the rule's patterns match
`Handle::current` but not `Handle::try_current`.

Known related issues left as follow-ups: `devimint`'s `Federation::drop` has the same
`block_on`-in-drop hazard, and the `try_current` + flavor-check idiom now exists in two places
(here and `devimint/src/process_reaper.rs`, with slightly different flavor semantics) and could
move into a shared `fedimint_core::runtime` helper.

### Reviewing

The wasm/non-wasm `cfg` split in `Drop` is the main thing to eyeball: `runtime_handle` only
exists on non-wasm, and every use of it is behind the same `cfg`. `just check-wasm` passes.

### Testing

Two new regression tests: `client_handle_drop_outside_runtime_does_not_panic` drops a
`ClientHandle` on a plain `std::thread` and joins it; `stop_executor_tolerates_poisoned_state_lock`
poisons the executor state lock via `catch_unwind` and then calls `stop_executor`. Both fail on
their preceding commit and pass at HEAD. `cargo test -p fedimint-client --lib` (35 tests),
workspace clippy via `just final-lint`, and `just check-wasm` all pass.

Generated by Claude Fable 5.
