### PR TITLE
fix(devimint): tear down daemons explicitly after a failed user command

### DIFF
--- a/devimint/src/cli.rs
+++ b/devimint/src/cli.rs
@@ -220,28 +220,50 @@ pub async fn cleanup_on_exit<T>(
     main_process: impl futures::Future<Output = Result<T>>,
     task_group: TaskGroup,
 ) -> Result<Option<T>> {
-    match task_group
+    let result = task_group
         .make_handle()
         .cancel_on_shutdown(main_process)
-        .await
-    {
+        .await;
+
+    match &result {
         Err(_) => {
-            info!("Received shutdown signal before finishing main process, exiting early");
+            info!(target: LOG_DEVIMINT, "Received shutdown signal before finishing main process, exiting early");
+        }
+        Ok(Ok(_)) => {
+            debug!(target: LOG_DEVIMINT, "Main process finished successfully, shutting down task group");
+        }
+        Ok(Err(err)) => {
+            warn!(target: LOG_DEVIMINT, err = %err.fmt_compact_anyhow(), "Main process failed, will shutdown");
+        }
+    }
+
+    // Join the task group on every exit path, so that tasks still holding
+    // daemons finish inside the runtime instead of being dropped by its
+    // shutdown, and the caller's teardown owns the last references.
+    let joined = task_group.shutdown_join_all(Duration::from_secs(30)).await;
+
+    match result {
+        Err(_) => {
+            warn_on_join_error(joined);
             Ok(None)
         }
         Ok(Ok(v)) => {
-            debug!(target: LOG_DEVIMINT, "Main process finished successfully, shutting down task group");
-            task_group
-                .shutdown_join_all(Duration::from_secs(30))
-                .await?;
+            joined?;
 
             // the caller can drop the v after shutdown
             Ok(Some(v))
         }
         Ok(Err(err)) => {
-            warn!(target: LOG_DEVIMINT, err = %err.fmt_compact_anyhow(), "Main process failed, will shutdown");
+            // The main process error is the one worth reporting.
+            warn_on_join_error(joined);
             Err(err)
         }
+    }
+}
+
+fn warn_on_join_error(joined: Result<()>) {
+    if let Err(err) = joined {
+        warn!(target: LOG_DEVIMINT, err = %err.fmt_compact_anyhow(), "Task group did not shut down cleanly");
     }
 }
 
@@ -288,12 +310,11 @@ async fn handle_dev_fed_command(
         "dev-fed-pre-restore cannot be combined with skip-setup or pre-dkg"
     );
     let (process_mgr, task_group) = setup(common_args).await?;
+    let dev_fed = DevJitFed::new_with_pre_restore(&process_mgr, skip_setup, pre_dkg, pre_restore)?;
     let main = {
         let task_group = task_group.clone();
+        let dev_fed = dev_fed.clone();
         async move {
-            let dev_fed =
-                DevJitFed::new_with_pre_restore(&process_mgr, skip_setup, pre_dkg, pre_restore)?;
-
             let pegin_start_time = Instant::now();
             debug!(target: LOG_DEVIMINT, "Peging in client and gateways");
 
@@ -410,7 +431,7 @@ async fn handle_dev_fed_command(
                 dev_fed.finalize(&process_mgr).await?;
             }
 
-            let daemons = write_ready_file(&process_mgr.globals, Ok(dev_fed)).await?;
+            write_ready_file(&process_mgr.globals, Ok(())).await?;
 
             info!(
                 target: LOG_DEVIMINT,
@@ -421,18 +442,19 @@ async fn handle_dev_fed_command(
             if let Some(exec) = exec {
                 debug!(target: LOG_DEVIMINT, "Starting exec command");
                 exec_user_command(exec).await?;
-                task_group.shutdown();
+            } else {
+                debug!(target: LOG_DEVIMINT, "Waiting for group task shutdown");
+                task_group.make_handle().make_shutdown_rx().await;
             }
 
-            debug!(target: LOG_DEVIMINT, "Waiting for group task shutdown");
-            task_group.make_handle().make_shutdown_rx().await;
-
-            Ok::<_, anyhow::Error>(daemons)
+            Ok::<_, anyhow::Error>(())
         }
     };
-    if let Some(fed) = cleanup_on_exit(main, task_group).await? {
-        fed.fast_terminate().await;
-    }
+    let result = cleanup_on_exit(main, task_group).await;
+    // Explicit teardown in async context on every exit path, cancellation
+    // included; `cleanup_on_exit` has joined the task group by now.
+    dev_fed.fast_terminate().await;
+    result?;
 
     Ok(())
 }

--- a/devimint/src/faucet.rs
+++ b/devimint/src/faucet.rs
@@ -9,56 +9,48 @@ use fedimint_ln_server::common::lightning_invoice::Bolt11Invoice;
 use tokio::net::TcpListener;
 use tower_http::cors::CorsLayer;
 
-use crate::federation::Federation;
-use crate::{DevFed, Gatewayd};
+use crate::DevFed;
+use crate::gatewayd::GatewayClient;
 
 #[derive(Clone)]
 pub struct Faucet {
-    gw_ldk: Gatewayd,
-    fed: Federation,
+    gw_ldk: GatewayClient,
+    invite_code: String,
 }
 
 impl Faucet {
-    pub fn new(dev_fed: &DevFed) -> Self {
-        let gw_ldk = dev_fed.gw_ldk.clone();
-        let fed = dev_fed.fed.clone();
-        Faucet { gw_ldk, fed }
+    /// Captures what the faucet serves, so that it does not have to hold on
+    /// to the daemons themselves.
+    pub fn new(dev_fed: &DevFed) -> anyhow::Result<Self> {
+        Ok(Faucet {
+            gw_ldk: dev_fed.gw_ldk.client(),
+            invite_code: dev_fed.fed.invite_code()?,
+        })
     }
 
     async fn pay_invoice(&self, invoice: String) -> anyhow::Result<()> {
         self.gw_ldk
-            .client()
             .pay_invoice(Bolt11Invoice::from_str(&invoice).expect("Could not parse invoice"))
             .await?;
         Ok(())
     }
 
     async fn generate_invoice(&self, amount: u64) -> anyhow::Result<String> {
-        Ok(self
-            .gw_ldk
-            .client()
-            .create_invoice(amount)
-            .await?
-            .to_string())
+        Ok(self.gw_ldk.create_invoice(amount).await?.to_string())
     }
 
-    fn get_invite_code(&self) -> anyhow::Result<String> {
-        self.fed.invite_code()
+    fn invite_code(&self) -> String {
+        self.invite_code.clone()
     }
 }
 
 /// Serves the faucet API on the already bound `listener` until the task is
 /// cancelled.
-pub async fn run(dev_fed: &DevFed, listener: TcpListener, gw_lnd_port: u16) -> anyhow::Result<()> {
-    let faucet = Faucet::new(dev_fed);
+pub async fn run(faucet: Faucet, listener: TcpListener, gw_lnd_port: u16) -> anyhow::Result<()> {
     let router = Router::new()
         .route(
             "/connect-string",
-            get(|State(faucet): State<Faucet>| async move {
-                faucet
-                    .get_invite_code()
-                    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("{e:?}")))
-            }),
+            get(|State(faucet): State<Faucet>| async move { faucet.invite_code() }),
         )
         .route(
             "/pay",

--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -2876,28 +2876,28 @@ pub async fn handle_command(cmd: TestCmd, common_args: CommonArgs) -> Result<()>
     match cmd {
         TestCmd::WasmTestSetup { exec } => {
             let (process_mgr, task_group) = setup(common_args).await?;
+            // Bind before bringing up the federation, and outside the faucet
+            // task, so that a port clash fails the setup right away instead of
+            // leaving the test suite talking to whatever else is listening on
+            // that port. Holding the socket from here on also keeps other port
+            // allocators off it.
+            let faucet_bind_addr = process_mgr.globals.FM_FAUCET_BIND_ADDR.clone();
+            let faucet_listener = TcpListener::bind(&faucet_bind_addr)
+                .await
+                .with_context(|| format!("binding faucet to {faucet_bind_addr}"))?;
+            let gw_lnd_port = process_mgr.globals.FM_PORT_GW_LND;
+            let dev_fed = dev_fed(&process_mgr).await?;
             let main = {
                 let task_group = task_group.clone();
+                let dev_fed = dev_fed.clone();
                 async move {
-                    // Bind before bringing up the federation, and outside the
-                    // faucet task, so that a port clash fails the setup right
-                    // away instead of leaving the test suite talking to whatever
-                    // else is listening on that port. Holding the socket from here
-                    // on also keeps other port allocators off it.
-                    let faucet_bind_addr = &process_mgr.globals.FM_FAUCET_BIND_ADDR;
-                    let faucet_listener = TcpListener::bind(faucet_bind_addr)
-                        .await
-                        .with_context(|| format!("binding faucet to {faucet_bind_addr}"))?;
-                    let dev_fed = dev_fed(&process_mgr).await?;
-                    let gw_lnd = dev_fed.gw_lnd.clone();
-                    let fed = dev_fed.fed.clone();
-                    gw_lnd
+                    dev_fed
+                        .gw_lnd
                         .client()
                         .set_federation_routing_fee(dev_fed.fed.calculate_federation_id(), 0, 0)
                         .await?;
-                    info!(addr = %faucet_bind_addr, "Faucet listening");
-                    let gw_lnd_port = process_mgr.globals.FM_PORT_GW_LND;
                     let faucet = crate::faucet::Faucet::new(&dev_fed)?;
+                    info!(addr = %faucet_bind_addr, "Faucet listening");
                     task_group.spawn_cancellable("faucet", async move {
                         if let Err(err) =
                             crate::faucet::run(faucet, faucet_listener, gw_lnd_port).await
@@ -2905,15 +2905,24 @@ pub async fn handle_command(cmd: TestCmd, common_args: CommonArgs) -> Result<()>
                             error!(err = %err.fmt_compact_anyhow(), "Faucet failed");
                         }
                     });
-                    fed.pegin_gateways(30_000, vec![&gw_lnd]).await?;
+                    dev_fed
+                        .fed
+                        .pegin_gateways(30_000, vec![&dev_fed.gw_lnd])
+                        .await?;
                     if let Some(exec) = exec {
                         exec_user_command(exec).await?;
-                        task_group.shutdown();
+                    } else {
+                        task_group.make_handle().make_shutdown_rx().await;
                     }
                     Ok::<_, anyhow::Error>(())
                 }
             };
-            cleanup_on_exit(main, task_group).await?;
+            let result = cleanup_on_exit(main, task_group).await;
+            // Explicit teardown in async context on every exit path,
+            // cancellation included; `cleanup_on_exit` has joined the task
+            // group by now.
+            dev_fed.fast_terminate().await;
+            result?;
         }
         TestCmd::LatencyTests { r#type, iterations } => {
             let (process_mgr, _) = setup(common_args).await?;

--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -2897,9 +2897,10 @@ pub async fn handle_command(cmd: TestCmd, common_args: CommonArgs) -> Result<()>
                         .await?;
                     info!(addr = %faucet_bind_addr, "Faucet listening");
                     let gw_lnd_port = process_mgr.globals.FM_PORT_GW_LND;
+                    let faucet = crate::faucet::Faucet::new(&dev_fed)?;
                     task_group.spawn_cancellable("faucet", async move {
                         if let Err(err) =
-                            crate::faucet::run(&dev_fed, faucet_listener, gw_lnd_port).await
+                            crate::faucet::run(faucet, faucet_listener, gw_lnd_port).await
                         {
                             error!(err = %err.fmt_compact_anyhow(), "Faucet failed");
                         }

--- a/scripts/tests/devimint-exec-failure-test.sh
+++ b/scripts/tests/devimint-exec-failure-test.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# A failing user command must still tear down every daemon devimint started and
+# exit non-zero, instead of leaving them to whatever the tokio runtime shutdown
+# makes of them (see #9065).
+
+set -euo pipefail
+export RUST_LOG="${RUST_LOG:-info}"
+
+source scripts/_common.sh
+build_workspace
+add_target_dir_to_path
+make_fm_test_marker
+
+test_dir="$(mktemp -d)"
+
+# Daemons started by a run carry its FM_TEST_DIR in their environment.
+function orphans() {
+  local name pid
+  for name in fedimintd gatewayd bitcoind lnd esplora; do
+    for pid in $(pgrep -x "$name" || true); do
+      if tr '\0' '\n' < "/proc/$pid/environ" 2>/dev/null | grep -qx "FM_TEST_DIR=$FM_TEST_DIR"; then
+        echo "$name ($pid)"
+      fi
+    done
+  done
+}
+
+for cmd in dev-fed wasm-test-setup; do
+  >&2 echo "Testing that $cmd tears down after a failed user command"
+  export FM_TEST_DIR="$test_dir/$cmd"
+  mkdir -p "$FM_TEST_DIR"
+
+  if devimint "$@" "$cmd" --exec false; then
+    >&2 echo "devimint $cmd --exec false succeeded, expected it to fail"
+    exit 1
+  fi
+
+  leftovers="$(orphans)"
+  if [ -n "$leftovers" ]; then
+    >&2 echo "devimint $cmd --exec false left daemons running:"
+    >&2 echo "$leftovers"
+    exit 1
+  fi
+done

--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -408,6 +408,11 @@ function large_setup_test() {
 }
 export -f large_setup_test
 
+function devimint_exec_failure_test() {
+  fm-run-test "${FUNCNAME[0]}" ./scripts/tests/devimint-exec-failure-test.sh
+}
+export -f devimint_exec_failure_test
+
 # allows versions to be passed in as either a single string or multiple params
 # e.g. `"v0.3.0 v0.4.0"` is the same as `v0.3.0 v0.4.0`
 if [ "$#" -eq 1 ]; then
@@ -508,6 +513,7 @@ tests_to_run_in_parallel+=(
   "mint_recovery_v1"
   "mint_recovery_v2"
   "recurringd_test"
+  "devimint_exec_failure_test"
   "large_setup_test"
 )
 done


### PR DESCRIPTION
### Summary

devimint tore its daemons down explicitly only on the success path of `dev-fed --exec`, and never for `wasm-test-setup --exec`: on a failed user command the `DevFed` was owned by the faucet task, and `cleanup_on_exit` returned the error without joining the task group, so the daemons were dropped by that cancelled task during tokio runtime shutdown. `cleanup_on_exit` now joins the task group on every exit path, both commands build their daemons outside the cancellable main future and call `fast_terminate().await` after it unconditionally (the shape `run_devfed_test` already uses), and the faucet no longer holds a `DevFed` at all. Fixes #9065.

### Details

This is the destructor behind the fedimint-sdk CI teardown aborts (fedimint-sdk#330), and the ownership above is why it ran at the worst possible moment. In the SDK's devimint **v0.10.0**, `ProcessHandleInner::drop` nested a second `block_in_place` + `block_on` inside `Federation::drop`'s; when `JoinSet::spawn` on the shutting-down runtime dropped a member future inside tokio's `with_current` borrow, the inner `block_on` hit `set_current`'s `borrow_mut` ("RefCell already borrowed"), then "closure claimed permanent executor", then the abort that orphaned a dozen daemons per failed run. Master no longer panics there because the process reaper (`7428c88d175`, first in `v0.12.0-beta.4`) made the member drop synchronous — on master `wasm-test-setup --exec false` exits 1 cleanly — but the teardown still happened at runtime shutdown rather than explicitly. `dev-fed --exec` was better off (it dropped its `DevJitFed` inline on the main thread), but it too skipped `fast_terminate` on failure, and neither command tore down explicitly when a shutdown signal cancelled it.

Commits:

1. `refactor(devimint): let the faucet own only what it serves` — `Faucet` captures the LDK gateway client and the invite code instead of a `Federation` and a `Gatewayd`, and the faucet task owns just that. That removes the one reason a task-group task ever co-owned the `fedimintd` handles (and the per-request `Federation` deep clone through the axum state, whose blocking `Drop` ran inside the handler).
2. `fix(devimint): tear down daemons explicitly on every exit path` — `cleanup_on_exit` joins the task group in all three arms (the main future's own error stays the reported one; a join error is only logged next to it). `dev-fed` builds its `DevJitFed` and `wasm-test-setup` its `DevFed` before the cancellable main future, clone it in, and call `fast_terminate().await` after `cleanup_on_exit` regardless of outcome, then propagate the result. `wasm-test-setup` without `--exec` now waits for a shutdown signal like `dev-fed` does instead of tearing down right after the peg-ins.
3. `test(devimint): cover teardown after a failed user command` — new `devimint_exec_failure_test` in `test-ci-all`: runs both commands with `--exec false`, requires a non-zero exit and no surviving daemon from the run (matched by the run's `FM_TEST_DIR` in `/proc/<pid>/environ`, so parallel tests don't interfere). Until now CI only ever exercised the success paths, which is how #9065 stayed hidden.

Deliberately not done: the `Drop` fallback and shared "can I block here" helper the issue text suggests. `Federation::drop` stays as it is — the fallback, no longer the plan.

For fedimint-sdk, the aborts stop with a devimint bump to at least `v0.12.0-beta.4`; this PR makes the teardown explicit regardless of runtime state.

### Reviewing

- Building the daemons outside the cancellable future means a shutdown signal during bring-up is only honoured once bring-up finishes (same trade-off `run_devfed_test` makes); the signal still cancels the user command and the wait promptly.
- Join on the cancelled/failed arms uses the same 30 s timeout as the success arm; a timeout there is logged and the run still proceeds to `fast_terminate`.
- Follow-ups, pre-existing and out of scope: `DevJitFed::fast_terminate` only aborts jits that are still pending (matters for `dev-fed-pre-restore` and for failures during bring-up, where those jits hold daemon clones until the aborted futures are dropped); `external-daemons --exec` still has the old inline shape without `cleanup_on_exit`.

### Testing

E2E with the rebuilt devimint, `RUST_LOG=info,fm::devimint=debug`: on master, `wasm-test-setup --exec false` logs `Main process failed, will shutdown` *before* the first `killing child process`, i.e. the daemons die during runtime teardown. With this PR: `dev-fed --exec false` and `wasm-test-setup --exec false` (the new CI script) exit 1 with the kills inside `fast_terminate` and no daemon of the run left alive; `dev-fed --exec true` and `wasm-test-setup --exec true` exit 0 with `Main process finished successfully, shutting down task group` followed by the kills; `dev-fed` and `wasm-test-setup` without `--exec` wait and, on SIGINT, log `Received shutdown signal before finishing main process` followed by the kills, exit 0, nothing left running.

Also: clippy with `-D warnings` on devimint and the pre-commit hook (rustfmt/semgrep/typos/shellcheck).
