### PR TITLE
devimint: teardown follow-ups from the #9068 review

### DIFF
--- a/devimint/src/cli.rs
+++ b/devimint/src/cli.rs
@@ -216,54 +216,74 @@ pub async fn update_test_dir_link(
     Ok(())
 }
 
-pub async fn cleanup_on_exit<T>(
-    main_process: impl futures::Future<Output = Result<T>>,
+/// Runs `main_process` until it finishes or the task group is told to shut
+/// down, then shuts the task group down and joins it on every exit path, so
+/// that tasks still holding daemons finish inside the runtime instead of
+/// being dropped by its shutdown. Callers tear their daemons down explicitly
+/// afterwards.
+pub async fn cleanup_on_exit(
+    main_process: impl futures::Future<Output = Result<()>>,
     task_group: TaskGroup,
-) -> Result<Option<T>> {
-    let result = task_group
+) -> Result<()> {
+    let result = match task_group
         .make_handle()
         .cancel_on_shutdown(main_process)
-        .await;
-
-    match &result {
+        .await
+    {
         Err(_) => {
-            info!(target: LOG_DEVIMINT, "Received shutdown signal before finishing main process, exiting early");
+            info!(
+                target: LOG_DEVIMINT,
+                "Received shutdown signal before finishing main process, exiting early"
+            );
+            Ok(())
         }
-        Ok(Ok(_)) => {
-            debug!(target: LOG_DEVIMINT, "Main process finished successfully, shutting down task group");
+        Ok(Ok(())) => {
+            debug!(
+                target: LOG_DEVIMINT,
+                "Main process finished successfully, shutting down task group"
+            );
+            Ok(())
         }
         Ok(Err(err)) => {
-            warn!(target: LOG_DEVIMINT, err = %err.fmt_compact_anyhow(), "Main process failed, will shutdown");
+            warn!(
+                target: LOG_DEVIMINT,
+                err = %err.fmt_compact_anyhow(),
+                "Main process failed, will shutdown"
+            );
+            Err(err)
         }
-    }
+    };
 
-    // Join the task group on every exit path, so that tasks still holding
-    // daemons finish inside the runtime instead of being dropped by its
-    // shutdown, and the caller's teardown owns the last references.
     let joined = task_group.shutdown_join_all(Duration::from_secs(30)).await;
 
-    match result {
-        Err(_) => {
-            warn_on_join_error(joined);
-            Ok(None)
-        }
-        Ok(Ok(v)) => {
-            joined?;
-
-            // the caller can drop the v after shutdown
-            Ok(Some(v))
-        }
-        Ok(Err(err)) => {
+    match (result, joined) {
+        (Ok(()), joined) => joined,
+        (Err(err), Ok(())) => Err(err),
+        (Err(err), Err(join_err)) => {
             // The main process error is the one worth reporting.
-            warn_on_join_error(joined);
+            warn!(
+                target: LOG_DEVIMINT,
+                err = %join_err.fmt_compact_anyhow(),
+                "Task group did not shut down cleanly"
+            );
             Err(err)
         }
     }
 }
 
-fn warn_on_join_error(joined: Result<()>) {
-    if let Err(err) = joined {
-        warn!(target: LOG_DEVIMINT, err = %err.fmt_compact_anyhow(), "Task group did not shut down cleanly");
+/// Runs the user command if there is one, otherwise waits for the task group
+/// to be told to shut down, e.g. by a signal.
+pub async fn exec_or_wait_for_shutdown(
+    exec: Option<Vec<ffi::OsString>>,
+    task_group: &TaskGroup,
+) -> Result<()> {
+    if let Some(exec) = exec {
+        debug!(target: LOG_DEVIMINT, "Starting exec command");
+        exec_user_command(exec).await
+    } else {
+        debug!(target: LOG_DEVIMINT, "Waiting for group task shutdown");
+        task_group.make_handle().make_shutdown_rx().await;
+        Ok(())
     }
 }
 
@@ -439,24 +459,14 @@ async fn handle_dev_fed_command(
                 path = %process_mgr.globals.FM_DATA_DIR.display(),
                 "Devfed ready"
             );
-            if let Some(exec) = exec {
-                debug!(target: LOG_DEVIMINT, "Starting exec command");
-                exec_user_command(exec).await?;
-            } else {
-                debug!(target: LOG_DEVIMINT, "Waiting for group task shutdown");
-                task_group.make_handle().make_shutdown_rx().await;
-            }
-
-            Ok::<_, anyhow::Error>(())
+            exec_or_wait_for_shutdown(exec, &task_group).await
         }
     };
     let result = cleanup_on_exit(main, task_group).await;
-    // Explicit teardown in async context on every exit path, cancellation
-    // included; `cleanup_on_exit` has joined the task group by now.
+    // Explicit teardown in async context; `cleanup_on_exit` has joined the
+    // task group by now.
     dev_fed.fast_terminate().await;
-    result?;
-
-    Ok(())
+    result
 }
 
 pub async fn exec_user_command(path: Vec<ffi::OsString>) -> Result<(), anyhow::Error> {

--- a/devimint/src/faucet.rs
+++ b/devimint/src/faucet.rs
@@ -28,10 +28,8 @@ impl Faucet {
         })
     }
 
-    async fn pay_invoice(&self, invoice: String) -> anyhow::Result<()> {
-        self.gw_ldk
-            .pay_invoice(Bolt11Invoice::from_str(&invoice).expect("Could not parse invoice"))
-            .await?;
+    async fn pay_invoice(&self, invoice: Bolt11Invoice) -> anyhow::Result<()> {
+        self.gw_ldk.pay_invoice(invoice).await?;
         Ok(())
     }
 
@@ -55,6 +53,8 @@ pub async fn run(faucet: Faucet, listener: TcpListener, gw_lnd_port: u16) -> any
         .route(
             "/pay",
             post(|State(faucet): State<Faucet>, invoice: String| async move {
+                let invoice = Bolt11Invoice::from_str(&invoice)
+                    .map_err(|e| (StatusCode::BAD_REQUEST, format!("{e:?}")))?;
                 faucet
                     .pay_invoice(invoice)
                     .await

--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -35,7 +35,8 @@ use tokio::net::TcpListener;
 use tokio::{fs, try_join};
 use tracing::{debug, error, info};
 
-use crate::cli::{CommonArgs, cleanup_on_exit, exec_user_command, setup};
+use crate::cli::{CommonArgs, cleanup_on_exit, exec_or_wait_for_shutdown, setup};
+use crate::devfed::DevJitFed;
 use crate::envs::{FM_DATA_DIR_ENV, FM_DEVIMINT_RUN_DEPRECATED_TESTS_ENV};
 use crate::federation::Client;
 use crate::util::{LoadTestTool, ProcessManager, almost_equal, poll};
@@ -2886,11 +2887,12 @@ pub async fn handle_command(cmd: TestCmd, common_args: CommonArgs) -> Result<()>
                 .await
                 .with_context(|| format!("binding faucet to {faucet_bind_addr}"))?;
             let gw_lnd_port = process_mgr.globals.FM_PORT_GW_LND;
-            let dev_fed = dev_fed(&process_mgr).await?;
+            let dev_fed = DevJitFed::new(&process_mgr, false, false)?;
             let main = {
                 let task_group = task_group.clone();
                 let dev_fed = dev_fed.clone();
                 async move {
+                    let dev_fed = dev_fed.to_dev_fed(&process_mgr).await?;
                     dev_fed
                         .gw_lnd
                         .client()
@@ -2909,18 +2911,12 @@ pub async fn handle_command(cmd: TestCmd, common_args: CommonArgs) -> Result<()>
                         .fed
                         .pegin_gateways(30_000, vec![&dev_fed.gw_lnd])
                         .await?;
-                    if let Some(exec) = exec {
-                        exec_user_command(exec).await?;
-                    } else {
-                        task_group.make_handle().make_shutdown_rx().await;
-                    }
-                    Ok::<_, anyhow::Error>(())
+                    exec_or_wait_for_shutdown(exec, &task_group).await
                 }
             };
             let result = cleanup_on_exit(main, task_group).await;
-            // Explicit teardown in async context on every exit path,
-            // cancellation included; `cleanup_on_exit` has joined the task
-            // group by now.
+            // Explicit teardown in async context; `cleanup_on_exit` has joined
+            // the task group by now.
             dev_fed.fast_terminate().await;
             result?;
         }

--- a/scripts/tests/devimint-exec-failure-test.sh
+++ b/scripts/tests/devimint-exec-failure-test.sh
@@ -11,34 +11,38 @@ build_workspace
 add_target_dir_to_path
 make_fm_test_marker
 
-test_dir="$(mktemp -d)"
-
-# Daemons started by a run carry its FM_TEST_DIR in their environment.
-function orphans() {
-  local name pid
-  for name in fedimintd gatewayd bitcoind lnd esplora; do
-    for pid in $(pgrep -x "$name" || true); do
-      if tr '\0' '\n' < "/proc/$pid/environ" 2>/dev/null | grep -qx "FM_TEST_DIR=$FM_TEST_DIR"; then
-        echo "$name ($pid)"
-      fi
-    done
+# Processes started by a run carry its FM_TEST_DIR in their environment.
+function leaked_processes() {
+  local pid
+  for pid in $(pgrep -u "$(id -u)"); do
+    if [ "$pid" != "$$" ] && grep -qzxF "FM_TEST_DIR=$FM_TEST_DIR" "/proc/$pid/environ" 2>/dev/null; then
+      echo "$pid $(cat "/proc/$pid/comm" 2>/dev/null)"
+    fi
   done
 }
 
 for cmd in dev-fed wasm-test-setup; do
   >&2 echo "Testing that $cmd tears down after a failed user command"
-  export FM_TEST_DIR="$test_dir/$cmd"
-  mkdir -p "$FM_TEST_DIR"
+  # Under the per-test TMPDIR and named like devimint's own directories, so
+  # that fm-run-test finds the daemon logs on failure.
+  FM_TEST_DIR="$(mktemp -d --tmpdir "devimint-$cmd-XXXXXX")"
+  export FM_TEST_DIR
+  marker="$FM_TEST_DIR/user-command-ran"
 
-  if devimint "$@" "$cmd" --exec false; then
-    >&2 echo "devimint $cmd --exec false succeeded, expected it to fail"
+  if devimint "$@" "$cmd" --exec sh -c "touch '$marker' && exit 1"; then
+    >&2 echo "devimint $cmd with a failing user command succeeded, expected it to fail"
+    exit 1
+  fi
+  if [ ! -e "$marker" ]; then
+    >&2 echo "devimint $cmd failed before running the user command"
     exit 1
   fi
 
-  leftovers="$(orphans)"
-  if [ -n "$leftovers" ]; then
-    >&2 echo "devimint $cmd --exec false left daemons running:"
-    >&2 echo "$leftovers"
+  leaked="$(leaked_processes)"
+  if [ -n "$leaked" ]; then
+    >&2 echo "devimint $cmd left processes running, killing them:"
+    >&2 echo "$leaked"
+    echo "$leaked" | awk '{ print $1 }' | xargs -r kill
     exit 1
   fi
 done

--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -409,7 +409,10 @@ function large_setup_test() {
 export -f large_setup_test
 
 function devimint_exec_failure_test() {
-  fm-run-test "${FUNCNAME[0]}" ./scripts/tests/devimint-exec-failure-test.sh
+  # only devimint's own code is under test, so we skip for backwards-compatibility tests
+  if [ -z "${FM_BACKWARDS_COMPATIBILITY_TEST:-}" ]; then
+    fm-run-test "${FUNCNAME[0]}" ./scripts/tests/devimint-exec-failure-test.sh
+  fi
 }
 export -f devimint_exec_failure_test
 


### PR DESCRIPTION
### Summary

Follow-up to #9068 with the refinements from its last review round that could not be pushed once the PR was queued: `cleanup_on_exit` shrinks to `Result<()>` with a documented contract and one match, the run-or-wait step is shared as `exec_or_wait_for_shutdown`, `wasm-test-setup`'s bring-up is cancellable again, a malformed faucet `/pay` gets a 400 instead of a panic, and the new `devimint_exec_failure_test` can no longer pass vacuously. Refs #9065.

### Details

- `refactor(devimint): tidy up the explicit teardown` — every caller of `cleanup_on_exit` now discards its value (daemons are no longer handed back through the cancellable future, which was the ownership shape behind #9065), so it returns `Result<()>`, says in its doc that it joins the task group on every exit path, and decides the join-error policy in one place: the main future's own error wins, a join error next to it is only logged. `dev-fed` and `wasm-test-setup` share `exec_or_wait_for_shutdown`. `wasm-test-setup` built its whole `DevFed` outside the cancellable future, so a shutdown signal during bring-up was only honoured once bring-up had finished; it now builds the `DevJitFed` outside like `dev-fed` does and finalizes it inside, so the signal cancels bring-up promptly while the outer handle still tears everything down afterwards. The teardown comments no longer claim more than `fast_terminate` delivers for jits that are still pending, and the log calls that had grown past 100 columns are split.
- `fix(devimint): answer a malformed faucet /pay with 400` — `pay_invoice` parsed the request body with `expect`; parse in the handler and map to 400 like `/invoice`.
- `test(devimint): harden the failed-user-command teardown test` — the user command now leaves a marker the test requires, so a failed bring-up cannot pass it; survivors are found by the run's `FM_TEST_DIR` in `/proc/<pid>/environ` across all own processes (the name list missed `fedimint-recurringd` and `pgrep -x` could not have matched it anyway), with `grep -zxF` instead of a `tr | grep` pipe that `pipefail` turns into a false negative on large environments; survivors are killed after being reported; run directories use devimint's naming under the per-test TMPDIR so `fm-run-test` finds the daemon logs on failure; skipped on the backwards-compatibility matrix since only devimint's own code is under test.

Still open and unchanged here: `DevJitFed::fast_terminate` only aborts pending jits (matters for `dev-fed-pre-restore` and for failures during bring-up), and `external-daemons --exec` keeps the old inline shape.

### Reviewing

- `cleanup_on_exit`'s signature change is API-visible for the devimint crate, which has no reverse dependencies; all in-tree callers used `T = ()`.
- Only the synchronous `DevJitFed::new` happens outside the cancellable future now; a task that overruns the 30 s join timeout is detached by tokio rather than aborted, as before — nothing in tree does that today.

### Testing

E2E with the rebuilt devimint on this branch: the negative CI script passes for both commands; `wasm-test-setup` interrupted with SIGINT 8 s into bring-up exits 0 with nothing of the run left running. The earlier full set (`--exec true` for both commands, SIGINT after "ready" for both) was run on the same content before the rebase onto master. Also: clippy with `-D warnings` on devimint and the pre-commit hook (rustfmt/semgrep/typos/shellcheck).
