### PR TITLE
chore(ci): test against v0.12.0

### DIFF
--- a/.github/workflows/ci-backwards-compatibility.yml
+++ b/.github/workflows/ci-backwards-compatibility.yml
@@ -53,14 +53,14 @@ jobs:
           # run a slimmed down back-compat test for PR push or each major version for merge queue
           if [[ "${{ github.event_name }}" == "merge_group" ]]; then
             PERFIT_METRIC="90S3yoXDQ-SXB0UbXG4qHQ"
-            VERSIONS_TO_TEST="v0.9.1 v0.10.1 v0.11.2"
+            VERSIONS_TO_TEST="v0.10.1 v0.11.2 v0.12.0"
             # Run only a random sample of tests to keep merge queue fast.
             # With multiple versions x multiple test combos, 25% still
             # gives good coverage for catching version-specific regressions.
             export FM_BACKCOMPAT_TEST_SAMPLE_PERCENT=25
           else
             PERFIT_METRIC="aPuCAjrFT7uE5Oax_T4sMw"
-            VERSIONS_TO_TEST="v0.10.1"
+            VERSIONS_TO_TEST="v0.11.2"
             # PRs only test one version (vs three in merge queue), but the
             # full test matrix is still ~37 combos and takes ~23 min.
             # Since the merge queue will re-run these tests anyway, sample

--- a/.github/workflows/upgrade-tests.yml
+++ b/.github/workflows/upgrade-tests.yml
@@ -60,7 +60,7 @@ jobs:
           # read versions from manually triggered workflows
           # default needed for cron or manual workflow without params
           VERSIONS="${{ github.event.inputs.versions }}"
-          VERSIONS=${VERSIONS:="v0.9.1 current, v0.10.1 current, v0.11.2 current"}
+          VERSIONS=${VERSIONS:="v0.10.1 current, v0.11.2 current, v0.12.0 current"}
 
           # if empty, defaults to all test kinds within script
           export TEST_KINDS="${{ github.event.inputs.test_kinds }}"

--- a/justfile.fedimint.just
+++ b/justfile.fedimint.just
@@ -22,13 +22,13 @@ test-ci-all:
 test-count:
   ./scripts/tests/test-cov.sh
 
-test-compatibility *VERSIONS="v0.9.1 v0.10.1 v0.11.2":
+test-compatibility *VERSIONS="v0.10.1 v0.11.2 v0.12.0":
   ./scripts/tests/test-ci-all-backcompat.sh {{VERSIONS}}
 
 test-full-compatibility *VERSIONS="v0.4.4":
   env FM_FULL_VERSION_MATRIX=1 ./scripts/tests/test-ci-all-backcompat.sh {{VERSIONS}}
 
-test-upgrades *VERSIONS="v0.9.1 current, v0.10.1 current, v0.11.2 current":
+test-upgrades *VERSIONS="v0.10.1 current, v0.11.2 current, v0.12.0 current":
   ./scripts/tests/upgrade-test.sh {{VERSIONS}}
 
 # `cargo udeps` check


### PR DESCRIPTION
### Summary

Post-v0.12.0-release housekeeping: add the freshly tagged `v0.12.0` release to the backwards-compatibility and upgrade test matrices on master.

### Details

Follows the pattern of the previous matrix updates (d605aa55d6c after v0.11.2, 0844b55a11c after v0.11.0): the merge-queue back-compat list and the upgrade-test/justfile defaults keep the three most recent releases, so `v0.12.0` is added and `v0.9.1` is dropped. The single-version PR back-compat run advances to the second-newest release, `v0.11.2`.

### Testing

CI itself exercises these lists; `just final-lint` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AJcaPAX6YXpfrpxQyQ3xvx
