### PR TITLE
chore: bump version to 0.12.1-alpha

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2513,7 +2513,7 @@ dependencies = [
 
 [[package]]
 name = "devimint"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -3078,7 +3078,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fedimint-aead"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "argon2",
@@ -3110,7 +3110,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-api-client"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3137,7 +3137,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-bip39"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "bip39",
  "fedimint-client",
@@ -3148,7 +3148,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-bitcoind"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3163,14 +3163,14 @@ dependencies = [
 
 [[package]]
 name = "fedimint-build"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "fedimint-cli"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3214,7 +3214,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3249,7 +3249,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client-module"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3281,7 +3281,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client-rpc"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3309,7 +3309,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client-wasm"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3328,7 +3328,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-connectors"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "arti-client",
@@ -3363,7 +3363,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-core"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3430,7 +3430,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-cursed-redb"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3450,7 +3450,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-db-locked"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3462,7 +3462,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dbtool"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3498,7 +3498,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-derive"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
@@ -3508,7 +3508,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-derive-secret"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",
@@ -3520,11 +3520,11 @@ dependencies = [
 
 [[package]]
 name = "fedimint-docs"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 
 [[package]]
 name = "fedimint-dummy-client"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3546,7 +3546,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dummy-common"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -3556,7 +3556,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dummy-server"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3572,7 +3572,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-empty-client"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3589,7 +3589,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-empty-common"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -3599,7 +3599,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-empty-server"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3615,7 +3615,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-eventlog"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3634,7 +3634,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-fountain"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3646,7 +3646,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-fuzz"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "fedimint-core",
  "fedimint-ln-common",
@@ -3659,7 +3659,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-client"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "bcrypt",
@@ -3684,7 +3684,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-common"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -3702,7 +3702,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-server"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3786,7 +3786,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-server-db"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -3815,7 +3815,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-ui"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -3847,7 +3847,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gw-client"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3878,7 +3878,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gwv2-client"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3905,7 +3905,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-hkdf"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "bitcoin_hashes",
 ]
@@ -3953,7 +3953,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lightning"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3980,7 +3980,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-client"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -4015,7 +4015,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-common"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4039,7 +4039,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-server"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4065,7 +4065,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-tests"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4094,7 +4094,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnurl"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "bech32",
  "lightning-invoice",
@@ -4106,7 +4106,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-client"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -4138,7 +4138,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-common"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4158,7 +4158,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-server"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4181,7 +4181,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-tests"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4221,7 +4221,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-load-test-tool"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "clap",
@@ -4249,7 +4249,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-logging"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "console-subscriber",
@@ -4262,7 +4262,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-client"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4285,7 +4285,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-common"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -4300,7 +4300,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-server"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4319,7 +4319,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-tests"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "clap",
@@ -4333,7 +4333,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-metrics"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -4345,7 +4345,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-client"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -4388,7 +4388,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-common"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",
@@ -4401,7 +4401,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-server"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4428,7 +4428,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-tests"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4464,7 +4464,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mintv2-client"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -4503,7 +4503,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mintv2-common"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",
@@ -4516,7 +4516,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mintv2-server"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4540,7 +4540,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mintv2-tests"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4574,7 +4574,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-portalloc"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "dirs",
@@ -4588,7 +4588,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-recoverytool"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -4611,7 +4611,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-recurringd"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -4642,7 +4642,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-recurringd-tests"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "devimint",
@@ -4656,7 +4656,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-recurringdv2"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -4677,7 +4677,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-rocksdb"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4694,7 +4694,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -4752,7 +4752,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server-bitcoin-rpc"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4768,7 +4768,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server-core"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4786,7 +4786,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server-tests"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "bitcoin",
  "fedimint-api-client",
@@ -4806,7 +4806,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server-ui"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4833,7 +4833,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-tbs"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "bls12_381",
  "criterion 0.5.1",
@@ -4848,7 +4848,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-testing"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4888,7 +4888,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-testing-core"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -4949,7 +4949,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-tpe"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "bitcoin_hashes",
  "bls12_381",
@@ -4963,7 +4963,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ui-common"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "axum 0.8.9",
  "axum-extra",
@@ -4975,7 +4975,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-unknown-common"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -4985,7 +4985,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-unknown-server"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4999,14 +4999,14 @@ dependencies = [
 
 [[package]]
 name = "fedimint-util-error"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "fedimint-wallet-client"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -5038,7 +5038,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-common"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -5055,7 +5055,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-server"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5082,7 +5082,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-tests"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -5115,7 +5115,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-walletv2-client"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -5143,7 +5143,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-walletv2-common"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -5156,7 +5156,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-walletv2-server"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5178,7 +5178,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-walletv2-tests"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -5209,7 +5209,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wasm-tests"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "fedimint-client",
@@ -5230,7 +5230,7 @@ dependencies = [
 
 [[package]]
 name = "fedimintd"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -5267,7 +5267,7 @@ dependencies = [
 
 [[package]]
 name = "fedimintd-envs"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 
 [[package]]
 name = "ff"
@@ -5589,7 +5589,7 @@ dependencies = [
 
 [[package]]
 name = "gateway-tests"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ keywords = ["bitcoin", "lightning", "chaumian", "e-cash", "federated"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/fedimint/fedimint"
-version = "0.12.0-rc.0"
+version = "0.12.1-alpha"
 
 [workspace.metadata]
 authors = ["The Fedimint Developers"]
@@ -167,7 +167,7 @@ criterion = "0.5.1"
 # We need to pin this arti's `curve25519-dalek` dependency, due to `https://rustsec.org/advisories/RUSTSEC-2024-0344` vulnerability
 # It's been updated by https://gitlab.torproject.org/tpo/core/arti/-/merge_requests/2211, should be removed in next release.
 curve25519-dalek = ">=4.1.3"
-devimint = { path = "./devimint", version = "=0.12.0-rc.0" }
+devimint = { path = "./devimint", version = "=0.12.1-alpha" }
 dirs = "6.0.0"
 erased-serde = "0.4"
 esplora-client = { version = "0.12.3", default-features = false, features = [
@@ -176,70 +176,70 @@ esplora-client = { version = "0.12.3", default-features = false, features = [
     "tokio",
 ] }
 
-fedimint-aead = { path = "./crypto/aead", version = "=0.12.0-rc.0" }
-fedimint-api-client = { path = "./fedimint-api-client", version = "=0.12.0-rc.0" }
-fedimint-bip39 = { path = "./fedimint-bip39", version = "=0.12.0-rc.0" }
-fedimint-bitcoind = { path = "./fedimint-bitcoind", version = "=0.12.0-rc.0" }
-fedimint-build = { path = "./fedimint-build", version = "=0.12.0-rc.0" }
-fedimint-client = { path = "./fedimint-client", version = "=0.12.0-rc.0" }
-fedimint-client-module = { path = "./fedimint-client-module", version = "=0.12.0-rc.0" }
-fedimint-client-rpc = { path = "./fedimint-client-rpc", version = "=0.12.0-rc.0" }
-fedimint-connectors = { path = "./fedimint-connectors", version = "=0.12.0-rc.0" }
-fedimint-core = { path = "./fedimint-core", version = "=0.12.0-rc.0" }
-fedimint-cursed-redb = { path = "./fedimint-cursed-redb", version = "=0.12.0-rc.0" }
-fedimint-db-locked = { path = "./fedimint-db-locked", version = "=0.12.0-rc.0" }
-fedimint-derive = { path = "./fedimint-derive", version = "=0.12.0-rc.0" }
-fedimint-derive-secret = { path = "./crypto/derive-secret", version = "=0.12.0-rc.0" }
-fedimint-dummy-client = { path = "./modules/fedimint-dummy-client", version = "=0.12.0-rc.0" }
-fedimint-dummy-common = { path = "./modules/fedimint-dummy-common", version = "=0.12.0-rc.0" }
-fedimint-dummy-server = { path = "./modules/fedimint-dummy-server", version = "=0.12.0-rc.0" }
-fedimint-empty-common = { path = "./modules/fedimint-empty-common", version = "=0.12.0-rc.0" }
-fedimint-eventlog = { path = "./fedimint-eventlog", version = "=0.12.0-rc.0" }
-fedimint-gateway-common = { package = "fedimint-gateway-common", path = "./gateway/fedimint-gateway-common", version = "=0.12.0-rc.0" }
-fedimint-gateway-server = { package = "fedimint-gateway-server", path = "./gateway/fedimint-gateway-server", version = "=0.12.0-rc.0" }
-fedimint-gateway-server-db = { package = "fedimint-gateway-server-db", path = "./gateway/fedimint-gateway-server-db", version = "=0.12.0-rc.0" }
-fedimint-gateway-ui = { package = "fedimint-gateway-ui", path = "./gateway/fedimint-gateway-ui", version = "=0.12.0-rc.0" }
-fedimint-gw-client = { path = "./modules/fedimint-gw-client", version = "=0.12.0-rc.0" }
-fedimint-gwv2-client = { path = "./modules/fedimint-gwv2-client", version = "=0.12.0-rc.0" }
-fedimint-lightning = { package = "fedimint-lightning", path = "./gateway/fedimint-lightning", version = "=0.12.0-rc.0" }
-fedimint-ln-client = { path = "./modules/fedimint-ln-client", version = "=0.12.0-rc.0" }
-fedimint-ln-common = { path = "./modules/fedimint-ln-common", version = "=0.12.0-rc.0" }
-fedimint-ln-server = { path = "./modules/fedimint-ln-server", version = "=0.12.0-rc.0" }
-fedimint-lnurl = { path = "./fedimint-lnurl", version = "=0.12.0-rc.0" }
-fedimint-lnv2-client = { path = "./modules/fedimint-lnv2-client", version = "=0.12.0-rc.0" }
-fedimint-lnv2-common = { path = "./modules/fedimint-lnv2-common", version = "=0.12.0-rc.0" }
-fedimint-lnv2-server = { path = "./modules/fedimint-lnv2-server", version = "=0.12.0-rc.0" }
-fedimint-logging = { path = "./fedimint-logging", version = "=0.12.0-rc.0" }
-fedimint-meta-client = { path = "./modules/fedimint-meta-client", version = "=0.12.0-rc.0" }
-fedimint-meta-common = { path = "./modules/fedimint-meta-common", version = "=0.12.0-rc.0" }
-fedimint-meta-server = { path = "./modules/fedimint-meta-server", version = "=0.12.0-rc.0" }
-fedimint-metrics = { path = "./fedimint-metrics", version = "=0.12.0-rc.0" }
-fedimint-mint-client = { path = "./modules/fedimint-mint-client", version = "=0.12.0-rc.0" }
-fedimint-mint-common = { path = "./modules/fedimint-mint-common", version = "=0.12.0-rc.0" }
-fedimint-mint-server = { path = "./modules/fedimint-mint-server", version = "=0.12.0-rc.0" }
-fedimint-mintv2-client = { path = "./modules/fedimint-mintv2-client", version = "=0.12.0-rc.0" }
-fedimint-mintv2-common = { path = "./modules/fedimint-mintv2-common", version = "=0.12.0-rc.0" }
-fedimint-mintv2-server = { path = "./modules/fedimint-mintv2-server", version = "=0.12.0-rc.0" }
-fedimint-portalloc = { path = "utils/portalloc", version = "=0.12.0-rc.0" }
-fedimint-rocksdb = { path = "./fedimint-rocksdb", version = "=0.12.0-rc.0" }
-fedimint-server = { path = "./fedimint-server", version = "=0.12.0-rc.0" }
-fedimint-server-bitcoin-rpc = { path = "./fedimint-server-bitcoin-rpc", version = "=0.12.0-rc.0" }
-fedimint-server-core = { path = "./fedimint-server-core", version = "=0.12.0-rc.0" }
-fedimint-server-ui = { path = "./fedimint-server-ui", version = "=0.12.0-rc.0" }
-fedimint-testing = { path = "./fedimint-testing", version = "=0.12.0-rc.0" }
-fedimint-testing-core = { path = "./fedimint-testing-core", version = "=0.12.0-rc.0" }
-fedimint-ui-common = { path = "./fedimint-ui-common", version = "=0.12.0-rc.0" }
-fedimint-unknown-common = { path = "./modules/fedimint-unknown-common", version = "=0.12.0-rc.0" }
-fedimint-unknown-server = { path = "./modules/fedimint-unknown-server", version = "=0.12.0-rc.0" }
-fedimint-util-error = { path = "./fedimint-util-error", version = "=0.12.0-rc.0" }
-fedimint-wallet-client = { path = "./modules/fedimint-wallet-client", version = "=0.12.0-rc.0" }
-fedimint-wallet-common = { path = "./modules/fedimint-wallet-common", version = "=0.12.0-rc.0" }
-fedimint-wallet-server = { path = "./modules/fedimint-wallet-server", version = "=0.12.0-rc.0" }
-fedimint-walletv2-client = { path = "./modules/fedimint-walletv2-client", version = "=0.12.0-rc.0" }
-fedimint-walletv2-common = { path = "./modules/fedimint-walletv2-common", version = "=0.12.0-rc.0" }
-fedimint-walletv2-server = { path = "./modules/fedimint-walletv2-server", version = "=0.12.0-rc.0" }
-fedimintd = { path = "./fedimintd", version = "=0.12.0-rc.0" }
-fedimintd-envs = { path = "./fedimintd-envs", version = "=0.12.0-rc.0" }
+fedimint-aead = { path = "./crypto/aead", version = "=0.12.1-alpha" }
+fedimint-api-client = { path = "./fedimint-api-client", version = "=0.12.1-alpha" }
+fedimint-bip39 = { path = "./fedimint-bip39", version = "=0.12.1-alpha" }
+fedimint-bitcoind = { path = "./fedimint-bitcoind", version = "=0.12.1-alpha" }
+fedimint-build = { path = "./fedimint-build", version = "=0.12.1-alpha" }
+fedimint-client = { path = "./fedimint-client", version = "=0.12.1-alpha" }
+fedimint-client-module = { path = "./fedimint-client-module", version = "=0.12.1-alpha" }
+fedimint-client-rpc = { path = "./fedimint-client-rpc", version = "=0.12.1-alpha" }
+fedimint-connectors = { path = "./fedimint-connectors", version = "=0.12.1-alpha" }
+fedimint-core = { path = "./fedimint-core", version = "=0.12.1-alpha" }
+fedimint-cursed-redb = { path = "./fedimint-cursed-redb", version = "=0.12.1-alpha" }
+fedimint-db-locked = { path = "./fedimint-db-locked", version = "=0.12.1-alpha" }
+fedimint-derive = { path = "./fedimint-derive", version = "=0.12.1-alpha" }
+fedimint-derive-secret = { path = "./crypto/derive-secret", version = "=0.12.1-alpha" }
+fedimint-dummy-client = { path = "./modules/fedimint-dummy-client", version = "=0.12.1-alpha" }
+fedimint-dummy-common = { path = "./modules/fedimint-dummy-common", version = "=0.12.1-alpha" }
+fedimint-dummy-server = { path = "./modules/fedimint-dummy-server", version = "=0.12.1-alpha" }
+fedimint-empty-common = { path = "./modules/fedimint-empty-common", version = "=0.12.1-alpha" }
+fedimint-eventlog = { path = "./fedimint-eventlog", version = "=0.12.1-alpha" }
+fedimint-gateway-common = { package = "fedimint-gateway-common", path = "./gateway/fedimint-gateway-common", version = "=0.12.1-alpha" }
+fedimint-gateway-server = { package = "fedimint-gateway-server", path = "./gateway/fedimint-gateway-server", version = "=0.12.1-alpha" }
+fedimint-gateway-server-db = { package = "fedimint-gateway-server-db", path = "./gateway/fedimint-gateway-server-db", version = "=0.12.1-alpha" }
+fedimint-gateway-ui = { package = "fedimint-gateway-ui", path = "./gateway/fedimint-gateway-ui", version = "=0.12.1-alpha" }
+fedimint-gw-client = { path = "./modules/fedimint-gw-client", version = "=0.12.1-alpha" }
+fedimint-gwv2-client = { path = "./modules/fedimint-gwv2-client", version = "=0.12.1-alpha" }
+fedimint-lightning = { package = "fedimint-lightning", path = "./gateway/fedimint-lightning", version = "=0.12.1-alpha" }
+fedimint-ln-client = { path = "./modules/fedimint-ln-client", version = "=0.12.1-alpha" }
+fedimint-ln-common = { path = "./modules/fedimint-ln-common", version = "=0.12.1-alpha" }
+fedimint-ln-server = { path = "./modules/fedimint-ln-server", version = "=0.12.1-alpha" }
+fedimint-lnurl = { path = "./fedimint-lnurl", version = "=0.12.1-alpha" }
+fedimint-lnv2-client = { path = "./modules/fedimint-lnv2-client", version = "=0.12.1-alpha" }
+fedimint-lnv2-common = { path = "./modules/fedimint-lnv2-common", version = "=0.12.1-alpha" }
+fedimint-lnv2-server = { path = "./modules/fedimint-lnv2-server", version = "=0.12.1-alpha" }
+fedimint-logging = { path = "./fedimint-logging", version = "=0.12.1-alpha" }
+fedimint-meta-client = { path = "./modules/fedimint-meta-client", version = "=0.12.1-alpha" }
+fedimint-meta-common = { path = "./modules/fedimint-meta-common", version = "=0.12.1-alpha" }
+fedimint-meta-server = { path = "./modules/fedimint-meta-server", version = "=0.12.1-alpha" }
+fedimint-metrics = { path = "./fedimint-metrics", version = "=0.12.1-alpha" }
+fedimint-mint-client = { path = "./modules/fedimint-mint-client", version = "=0.12.1-alpha" }
+fedimint-mint-common = { path = "./modules/fedimint-mint-common", version = "=0.12.1-alpha" }
+fedimint-mint-server = { path = "./modules/fedimint-mint-server", version = "=0.12.1-alpha" }
+fedimint-mintv2-client = { path = "./modules/fedimint-mintv2-client", version = "=0.12.1-alpha" }
+fedimint-mintv2-common = { path = "./modules/fedimint-mintv2-common", version = "=0.12.1-alpha" }
+fedimint-mintv2-server = { path = "./modules/fedimint-mintv2-server", version = "=0.12.1-alpha" }
+fedimint-portalloc = { path = "utils/portalloc", version = "=0.12.1-alpha" }
+fedimint-rocksdb = { path = "./fedimint-rocksdb", version = "=0.12.1-alpha" }
+fedimint-server = { path = "./fedimint-server", version = "=0.12.1-alpha" }
+fedimint-server-bitcoin-rpc = { path = "./fedimint-server-bitcoin-rpc", version = "=0.12.1-alpha" }
+fedimint-server-core = { path = "./fedimint-server-core", version = "=0.12.1-alpha" }
+fedimint-server-ui = { path = "./fedimint-server-ui", version = "=0.12.1-alpha" }
+fedimint-testing = { path = "./fedimint-testing", version = "=0.12.1-alpha" }
+fedimint-testing-core = { path = "./fedimint-testing-core", version = "=0.12.1-alpha" }
+fedimint-ui-common = { path = "./fedimint-ui-common", version = "=0.12.1-alpha" }
+fedimint-unknown-common = { path = "./modules/fedimint-unknown-common", version = "=0.12.1-alpha" }
+fedimint-unknown-server = { path = "./modules/fedimint-unknown-server", version = "=0.12.1-alpha" }
+fedimint-util-error = { path = "./fedimint-util-error", version = "=0.12.1-alpha" }
+fedimint-wallet-client = { path = "./modules/fedimint-wallet-client", version = "=0.12.1-alpha" }
+fedimint-wallet-common = { path = "./modules/fedimint-wallet-common", version = "=0.12.1-alpha" }
+fedimint-wallet-server = { path = "./modules/fedimint-wallet-server", version = "=0.12.1-alpha" }
+fedimint-walletv2-client = { path = "./modules/fedimint-walletv2-client", version = "=0.12.1-alpha" }
+fedimint-walletv2-common = { path = "./modules/fedimint-walletv2-common", version = "=0.12.1-alpha" }
+fedimint-walletv2-server = { path = "./modules/fedimint-walletv2-server", version = "=0.12.1-alpha" }
+fedimintd = { path = "./fedimintd", version = "=0.12.1-alpha" }
+fedimintd-envs = { path = "./fedimintd-envs", version = "=0.12.1-alpha" }
 ff = "0.13.1"
 fs-lock = "=0.1.10"
 fs2 = "0.4.3"
@@ -251,7 +251,7 @@ gloo-timers = "0.3.0"
 group = "0.13.0"
 hex = "0.4.3"
 hex-conservative = "1.0.0"
-hkdf = { package = "fedimint-hkdf", path = "./crypto/hkdf", version = "=0.12.0-rc.0" }
+hkdf = { package = "fedimint-hkdf", path = "./crypto/hkdf", version = "=0.12.1-alpha" }
 honggfuzz = { version = "=0.5.60", default-features = false } # needs to be pinned to the same version `cargo-fuzz` binary uses
 hyper = "1.9"
 imbl = "5.0.0"
@@ -330,7 +330,7 @@ substring = "1.4.5"
 subtle = "2.6.1"
 syn = "2.0"
 tar = "0.4.46"
-tbs = { package = "fedimint-tbs", path = "./crypto/tbs", version = "=0.12.0-rc.0" }
+tbs = { package = "fedimint-tbs", path = "./crypto/tbs", version = "=0.12.1-alpha" }
 tempfile = "3.20.0"
 test-log = { version = "0.2", features = ["trace"], default-features = false }
 thiserror = "2.0.18"
@@ -350,7 +350,7 @@ tonic_lnd = { version = "0.4.0", package = "fedimint-tonic-lnd", features = [
 tor-rtcompat = { version = "0.38.0", features = ["tokio", "rustls"] }
 tower = { version = "0.4.13", default-features = false }
 tower-http = { version = "0.6.8", features = ["cors"] }
-tpe = { package = "fedimint-tpe", path = "./crypto/tpe", version = "=0.12.0-rc.0" }
+tpe = { package = "fedimint-tpe", path = "./crypto/tpe", version = "=0.12.1-alpha" }
 tracing = "0.1.44"
 tracing-opentelemetry = "0.29.0"
 tracing-subscriber = "0.3.22"


### PR DESCRIPTION
### Summary

Post-v0.12.0-release housekeeping: bump the `releases/v0.12` branch workspace version from `0.12.0-rc.0` to `0.12.1-alpha` so future backports build with a pre-release version distinct from the published `0.12.0`.

### Details

Generated with `just bump-version 0.12.0-rc.0 0.12.1-alpha`; `Cargo.lock` regenerated via `cargo clippy --workspace --all-targets` (not `cargo update`, to avoid unrelated dependency bumps).

### Testing

Verified the diff only touches workspace crate version strings (symmetric 161/161 insertions/deletions across `Cargo.toml` and `Cargo.lock`); `just final-lint` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AJcaPAX6YXpfrpxQyQ3xvx
