### PR TITLE
fix(nix): scrub C toolchain refs from binaries' debug info

### DIFF
--- a/nix/flakebox.nix
+++ b/nix/flakebox.nix
@@ -329,6 +329,45 @@ let
       >&2 echo "Removing references to $rust_toolchain_pkg"
 
       find "$out" -type f -executable -exec remove-references-to -t $rust_toolchain_pkg '{}' +
+
+      # C/C++ code compiled by build scripts (e.g. vendored rocksdb) records
+      # the absolute include paths of the C toolchain (clang's resource dir,
+      # gcc's libstdc++ headers, glibc's dev headers) in DWARF debug info,
+      # which we keep (see `dontStrip` above). The debug sections are
+      # zstd-compressed, which usually mangles these store paths beyond
+      # recognition, but zstd stores hard-to-compress chunks verbatim, so
+      # individual references can survive intact. When that happens Nix's
+      # reference scanner picks them up and drags the whole C toolchain
+      # (~1.8 GB) into the runtime closure, and thus into the container
+      # images; see https://github.com/fedimint/fedimint/issues/9075
+      #
+      # Scrub references to the C compiler wrapper and to every package its
+      # compile flags point at. Linker flags are deliberately not included:
+      # they point at runtime libs (glibc, gcc's libs) we depend on.
+      if [ -n "''${NIX_CC:-}" ]; then
+        c_toolchain_pkgs=$(
+          {
+            echo "$NIX_CC"
+            # the vendored crate sources are referenced from DWARF the same
+            # way (tens of thousands of times), so guard against the same
+            # failure mode pulling the whole vendor dir into the closure
+            case "''${cargoVendorDir:-}" in
+              /nix/store/*) echo "$cargoVendorDir" ;;
+            esac
+            cat "$NIX_CC/nix-support/cc-cflags" \
+              "$NIX_CC/nix-support/libc-cflags" \
+              "$NIX_CC/nix-support/libcxx-cxxflags" 2>/dev/null |
+              grep -oE '/nix/store/[a-z0-9]{32}-[^ /]+' || true
+          } | sort -u
+        )
+        c_toolchain_args=()
+        for c_toolchain_pkg in $c_toolchain_pkgs; do
+          c_toolchain_args+=(-t "$c_toolchain_pkg")
+        done
+        >&2 echo "Removing references to C toolchain packages:" $c_toolchain_pkgs
+
+        find "$out" -type f -executable -exec remove-references-to "''${c_toolchain_args[@]}" '{}' +
+      fi
     '';
   };
 


### PR DESCRIPTION
Fixes #9075

### Summary

The linux/arm64 `fedimint/fedimintd:v0.12.0` image is 2.51 GB (vs 607 MB for amd64) because ~1.8 GB of C build toolchain (clang-lib 883M, llvm-lib 545M, gcc 251M, clang 52M, binutils, compiler-rt, linux-headers, glibc-dev, ...) ended up in the runtime closure. This PR scrubs the C toolchain references from the built binaries in the existing `postFixup` pass, the same way the Rust toolchain reference is already scrubbed.

### Details

Root cause, established by extracting both published v0.12.0 images and scanning them:

1. C/C++ code compiled by build scripts during the workspace build (e.g. vendored rocksdb, compiled with the flake's clang 20.1.8 toolchain) records absolute include paths in its DWARF `.debug_line` directory tables: the clang wrapper's `resource-root`, gcc's libstdc++ headers (`.../gcc-15.2.0/include/c++/...`), and glibc's dev headers (`.../glibc-2.42-67-dev/include`). We keep debug info on purpose (`dontStrip = true`), so these tables ship in the release binaries on **both** architectures.
2. The debug sections are zstd-compressed (`-Wl,--compress-debug-sections=zstd` via the wild linker config), which *usually* mangles the store-path strings beyond recognition, so Nix's reference scanner doesn't see them. But zstd emits hard-to-compress chunks as verbatim literal runs, so whether a given 32-char store hash survives intact in the on-disk bytes is essentially a compression accident.
3. In the aarch64-linux v0.12.0 build that accident happened: `fedimint-pkgs/bin/fedimint-cli` and `bin/fedimint-recoverytool` contain literal `5f7v95…-clang-wrapper-20.1.8`, `qk7y9z…-gcc-15.2.0` and `9gj6jd…-glibc-2.42-67-dev` byte sequences inside their compressed `.debug_line` sections. The scanner retained them, and their transitive closure (clang → clang-lib → llvm-lib, gcc → binutils/isl/mpfr/…) is the ~1.8 GB delta. The amd64 build has the same strings in its (decompressed) DWARF but got lucky: no hash survived compression verbatim, so its closure stayed clean. In other words this is not an arm64-specific build path — amd64 could regress the same way on any rebuild.

The fix extends the existing `postFixup` (which already runs `remove-references-to` for the Rust toolchain) to also remove references to `$NIX_CC` and every store path mentioned in its `nix-support/{cc-cflags,libc-cflags,libcxx-cxxflags}` (clang wrapper, unwrapped gcc, glibc-dev, clang-lib). The target list is derived from the build environment at build time, so it tracks future toolchain bumps automatically. Linker-flag paths (`cc-ldflags`) are deliberately **not** scrubbed: they point at runtime libraries (glibc, gcc-lib) that the binaries legitimately reference.

Byte-patching hashes inside a zstd stream is safe here: the linker emits zstd frames without content checksums (`zstd -lv` → `Check: None`), and `remove-references-to` only rewrites hash bytes that sit in verbatim literal runs (compressed occurrences don't match the raw-byte pattern, but they are also invisible to Nix's scanner, so they don't affect the closure).

### Reviewing

- The scrub applies to all crane-built outputs via `commonArgs`, so amd64 (and darwin) derivation hashes change too; their *contents* only change where a toolchain hash actually survived in the raw bytes (none observed in the amd64 v0.12.0 binaries).
- The decompressed DWARF also contains tens of thousands of references to the cargo vendor dir (`vendor-cargo-deps`, ~1 GB+), which the existing scrubbing did not cover — the exact same compression accident could pull it into the closure on any build. The scrub therefore also includes `$cargoVendorDir` when it is a store path.
- Note that these scrubs can only rewrite hashes that survive in raw bytes — which is exactly the set the reference scanner can see, so the closure is protected either way.

### Testing

Verified against the actual published v0.12.0 arm64 image (mechanism verification; a full local aarch64 rebuild was not feasible — it would require many hours under qemu):

- Extracted the arm64 image filesystem and confirmed the only files referencing the toolchain paths are `fedimint-cli` and `fedimint-recoverytool`, with the references located inside the zstd-compressed `.debug_line` section (decompressed it to confirm they are DWARF include-directory entries).
- Ran the exact scrub (`remove-references-to -t <clang-wrapper> -t <gcc> -t <glibc-dev>`) on those binaries: all three hashes disappear from the raw files, and the `.debug_line` section still decompresses to the exact same length afterwards, differing only in the substituted hash bytes.
- Dry-ran the new target-list derivation against both the x86_64 and the aarch64 clang wrappers: it selects exactly {clang-wrapper, gcc, clang-lib, glibc-dev} and nothing needed at runtime.
- `nix build --dry-run .#container.fedimintd` and `.#legacyPackages.aarch64-linux.container.fedimintd` both evaluate.
- Compared the x86_64 `fedimint-pkgs` derivation before/after: no new input derivations; only the fixup script changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ucvfzwgyt5fga6P5PF5Jzq
