### PR TITLE
chore(core): replace anyhow in fedimint-core's public API with typed errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3416,6 +3416,7 @@ dependencies = [
  "strum 0.27.1",
  "strum_macros 0.27.1",
  "subtle",
+ "tempfile",
  "test-log",
  "thiserror 2.0.18",
  "tokio",

--- a/devimint/src/cli.rs
+++ b/devimint/src/cli.rs
@@ -8,7 +8,7 @@ use anyhow::{Context, Result, anyhow, ensure};
 use clap::builder::BoolishValueParser;
 use clap::{Parser, Subcommand};
 use fedimint_core::task::TaskGroup;
-use fedimint_core::util::{FmtCompactAnyhow as _, write_overwrite_async};
+use fedimint_core::util::{FmtCompact as _, FmtCompactAnyhow as _, write_overwrite_async};
 use fedimint_logging::LOG_DEVIMINT;
 use rand::Rng as _;
 use rand::distributions::Alphanumeric;
@@ -257,13 +257,13 @@ pub async fn cleanup_on_exit(
     let joined = task_group.shutdown_join_all(Duration::from_secs(30)).await;
 
     match (result, joined) {
-        (Ok(()), joined) => joined,
+        (Ok(()), joined) => joined.map_err(anyhow::Error::from),
         (Err(err), Ok(())) => Err(err),
         (Err(err), Err(join_err)) => {
             // The main process error is the one worth reporting.
             warn!(
                 target: LOG_DEVIMINT,
-                err = %join_err.fmt_compact_anyhow(),
+                err = %join_err.fmt_compact(),
                 "Task group did not shut down cleanly"
             );
             Err(err)

--- a/devimint/src/devfed.rs
+++ b/devimint/src/devfed.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use fedimint_core::runtime;
-use fedimint_core::task::jit::{JitTry, JitTryAnyhow};
+use fedimint_core::task::jit::JitTry;
 use fedimint_logging::LOG_DEVIMINT;
 use tokio::join;
 use tracing::{debug, info};
@@ -73,7 +73,7 @@ pub async fn dev_fed(process_mgr: &ProcessManager) -> Result<DevFed> {
         .await
 }
 
-type JitArc<T> = JitTryAnyhow<Arc<T>>;
+type JitArc<T> = JitTry<Arc<T>, anyhow::Error>;
 
 #[derive(Clone)]
 pub struct DevJitFed {
@@ -142,7 +142,7 @@ impl DevJitFed {
                 Ok(Arc::new(lnd))
             }
         });
-        let esplora = JitTryAnyhow::new_try({
+        let esplora = JitTry::new_try({
             let process_mgr = process_mgr.to_owned();
             let bitcoind = bitcoind.clone();
             || async move {
@@ -155,7 +155,7 @@ impl DevJitFed {
             }
         });
 
-        let fed = JitTryAnyhow::new_try({
+        let fed = JitTry::new_try({
             let process_mgr = process_mgr.to_owned();
             let bitcoind = bitcoind.clone();
             move || async move {
@@ -182,7 +182,7 @@ impl DevJitFed {
             }
         });
 
-        let gw_lnd = JitTryAnyhow::new_try({
+        let gw_lnd = JitTry::new_try({
             let process_mgr = process_mgr.to_owned();
             let lnd = lnd.clone();
             || async move {
@@ -194,7 +194,7 @@ impl DevJitFed {
                 Ok(Arc::new(lnd_gw))
             }
         });
-        let gw_lnd_registered = JitTryAnyhow::new_try({
+        let gw_lnd_registered = JitTry::new_try({
             let gw_lnd = gw_lnd.clone();
             let fed = fed.clone();
             move || async move {
@@ -211,7 +211,7 @@ impl DevJitFed {
             }
         });
 
-        let gw_ldk = JitTryAnyhow::new_try({
+        let gw_ldk = JitTry::new_try({
             let process_mgr = process_mgr.to_owned();
             let bitcoind = bitcoind.clone();
             move || async move {
@@ -233,7 +233,7 @@ impl DevJitFed {
                 Ok(Arc::new(ldk_gw))
             }
         });
-        let gw_ldk_second = JitTryAnyhow::new_try({
+        let gw_ldk_second = JitTry::new_try({
             let process_mgr = process_mgr.to_owned();
             let bitcoind = bitcoind.clone();
             move || async move {
@@ -255,7 +255,7 @@ impl DevJitFed {
                 Ok(Arc::new(ldk_gw2))
             }
         });
-        let gw_ldk_connected = JitTryAnyhow::new_try({
+        let gw_ldk_connected = JitTry::new_try({
             let gw_ldk = gw_ldk.clone();
             let fed = fed.clone();
             move || async move {
@@ -275,7 +275,7 @@ impl DevJitFed {
                 Ok(Arc::new(()))
             }
         });
-        let gw_ldk_second_connected = JitTryAnyhow::new_try({
+        let gw_ldk_second_connected = JitTry::new_try({
             let gw_ldk_second = gw_ldk_second.clone();
             let fed = fed.clone();
             move || async move {
@@ -294,7 +294,7 @@ impl DevJitFed {
             }
         });
 
-        let fed_epoch_generated = JitTryAnyhow::new_try({
+        let fed_epoch_generated = JitTry::new_try({
             let fed = fed.clone();
             move || async move {
                 let fed = fed.get_try().await?.deref().clone();
@@ -308,7 +308,7 @@ impl DevJitFed {
             }
         });
 
-        let channel_opened = JitTryAnyhow::new_try({
+        let channel_opened = JitTry::new_try({
             let gw_lnd = gw_lnd.clone();
             let gw_ldk = gw_ldk.clone();
             let gw_ldk_second = gw_ldk_second.clone();
@@ -340,7 +340,7 @@ impl DevJitFed {
             }
         });
 
-        let lnv2_gateways_added = JitTryAnyhow::new_try({
+        let lnv2_gateways_added = JitTry::new_try({
             let fed = fed.clone();
             let gw_lnd = gw_lnd.clone();
             let gw_ldk = gw_ldk.clone();
@@ -375,7 +375,7 @@ impl DevJitFed {
             }
         });
 
-        let recurringd = JitTryAnyhow::new_try({
+        let recurringd = JitTry::new_try({
             let process_mgr = process_mgr.to_owned();
             move || async move {
                 debug!(target: LOG_DEVIMINT, "Starting recurringd...");
@@ -386,7 +386,7 @@ impl DevJitFed {
             }
         });
 
-        let recurringd_connected = JitTryAnyhow::new_try({
+        let recurringd_connected = JitTry::new_try({
             let recurringd = recurringd.clone();
             let fed = fed.clone();
             move || async move {
@@ -403,7 +403,7 @@ impl DevJitFed {
             }
         });
 
-        let recurringdv2 = JitTryAnyhow::new_try({
+        let recurringdv2 = JitTry::new_try({
             let process_mgr = process_mgr.to_owned();
             move || async move {
                 debug!(target: LOG_DEVIMINT, "Starting recurringdv2...");

--- a/devimint/src/external.rs
+++ b/devimint/src/external.rs
@@ -11,7 +11,7 @@ use bitcoincore_rpc::jsonrpc::error::RpcError;
 use bitcoincore_rpc::{Auth, RpcApi};
 use fedimint_core::encoding::Encodable;
 use fedimint_core::rustls::install_crypto_provider;
-use fedimint_core::task::jit::{JitTry, JitTryAnyhow};
+use fedimint_core::task::jit::JitTry;
 use fedimint_core::task::{block_in_place, sleep, timeout};
 use fedimint_core::util::backoff_util::api_networking_backoff;
 use fedimint_core::util::{FmtCompact as _, SafeUrl, retry, write_overwrite_async};
@@ -36,7 +36,7 @@ use crate::{Gatewayd, cmd};
 #[derive(Clone)]
 pub struct Bitcoind {
     pub client: Arc<bitcoincore_rpc::Client>,
-    pub(crate) wallet_client: Arc<JitTryAnyhow<Arc<bitcoincore_rpc::Client>>>,
+    pub(crate) wallet_client: Arc<JitTry<Arc<bitcoincore_rpc::Client>, anyhow::Error>>,
     pub(crate) _process: ProcessHandle,
 }
 

--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -18,7 +18,7 @@ use fedimint_core::module::ModuleCommon;
 use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_core::runtime::block_in_place;
 use fedimint_core::task::block_on;
-use fedimint_core::task::jit::JitTryAnyhow;
+use fedimint_core::task::jit::JitTry;
 use fedimint_core::util::SafeUrl;
 use fedimint_core::{Amount, NumPeers, PeerId};
 use fedimint_gateway_common::WithdrawResponse;
@@ -62,7 +62,7 @@ pub struct Federation {
     pub bitcoind: Bitcoind,
 
     /// Built in [`Client`], already joined
-    client: JitTryAnyhow<Client>,
+    client: JitTry<Client, anyhow::Error>,
     #[allow(dead_code)] // Will need it later, maybe
     connectors: ConnectorRegistry,
 }
@@ -467,7 +467,7 @@ impl Federation {
             }
         }
 
-        let client = JitTryAnyhow::new_try({
+        let client = JitTry::<_, anyhow::Error>::new_try({
             move || async move {
                 let client = Client::open_or_create(federation_name.as_str())?;
                 let invite_code = Self::invite_code_static()?;

--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -567,7 +567,7 @@ impl Federation {
 
     pub fn client_config(&self) -> Result<ClientConfig> {
         let cfg_path = self.vars[&0].FM_DATA_DIR.join("client.json");
-        load_from_file(&cfg_path)
+        Ok(load_from_file(&cfg_path)?)
     }
 
     /// Get the module instance ID for a given module kind

--- a/fedimint-client-module/src/db.rs
+++ b/fedimint-client-module/src/db.rs
@@ -1,7 +1,7 @@
 use std::io::Cursor;
 
 use fedimint_core::core::OperationId;
-use fedimint_core::db::{DatabaseTransaction, DatabaseValue as _};
+use fedimint_core::db::{DatabaseTransaction, DatabaseValue as _, DbMigrationError};
 use fedimint_core::encoding::Decodable;
 use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_core::util::BoxFuture;
@@ -14,12 +14,12 @@ pub type ClientModuleMigrationFn = for<'r, 'tx> fn(
     Vec<(Vec<u8>, OperationId)>, // inactive states
 ) -> BoxFuture<
     'r,
-    anyhow::Result<Option<(Vec<(Vec<u8>, OperationId)>, Vec<(Vec<u8>, OperationId)>)>>,
+    Result<Option<(Vec<(Vec<u8>, OperationId)>, Vec<(Vec<u8>, OperationId)>)>, DbMigrationError>,
 >;
 
 /// Helper function definition for migrating a single state.
 type MigrateStateFn =
-    fn(OperationId, &mut Cursor<&[u8]>) -> anyhow::Result<Option<(Vec<u8>, OperationId)>>;
+    fn(OperationId, &mut Cursor<&[u8]>) -> Result<Option<(Vec<u8>, OperationId)>, DbMigrationError>;
 
 /// Migrates a particular state by looping over all active and inactive states.
 /// If the `migrate` closure returns `None`, this state was not migrated and
@@ -28,7 +28,7 @@ pub fn migrate_state(
     active_states: Vec<(Vec<u8>, OperationId)>,
     inactive_states: Vec<(Vec<u8>, OperationId)>,
     migrate: MigrateStateFn,
-) -> anyhow::Result<Option<(Vec<(Vec<u8>, OperationId)>, Vec<(Vec<u8>, OperationId)>)>> {
+) -> Result<Option<(Vec<(Vec<u8>, OperationId)>, Vec<(Vec<u8>, OperationId)>)>, DbMigrationError> {
     let mut new_active_states = Vec::with_capacity(active_states.len());
     for (active_state, operation_id) in active_states {
         let bytes = active_state.as_slice();

--- a/fedimint-client/src/backup.rs
+++ b/fedimint-client/src/backup.rs
@@ -239,7 +239,7 @@ impl EncryptedClientBackup {
         Ok(client_backup)
     }
 
-    pub fn into_backup_request(self, keypair: &Keypair) -> Result<SignedBackupRequest> {
+    pub fn into_backup_request(self, keypair: &Keypair) -> SignedBackupRequest {
         let request = BackupRequest {
             id: keypair.public_key(),
             timestamp: fedimint_core::time::now(),
@@ -361,7 +361,7 @@ impl Client {
         );
         let backup_request = backup
             .clone()
-            .into_backup_request(&self.get_derived_backup_signing_key())?;
+            .into_backup_request(&self.get_derived_backup_signing_key());
         self.api.upload_backup(&backup_request).await?;
         info!(
             target: LOG_CLIENT_BACKUP,

--- a/fedimint-client/src/client.rs
+++ b/fedimint-client/src/client.rs
@@ -2453,13 +2453,14 @@ impl Client {
             "Fetching guardian public keys",
             backoff_util::background_backoff(),
             || async {
-                Ok(self
-                    .api
-                    .request_current_consensus::<ClientConfig>(
-                        CLIENT_CONFIG_ENDPOINT.to_owned(),
-                        ApiRequestErased::default(),
-                    )
-                    .await?)
+                anyhow::Ok(
+                    self.api
+                        .request_current_consensus::<ClientConfig>(
+                            CLIENT_CONFIG_ENDPOINT.to_owned(),
+                            ApiRequestErased::default(),
+                        )
+                        .await?,
+                )
             },
         )
         .await

--- a/fedimint-client/src/client/builder.rs
+++ b/fedimint-client/src/client/builder.rs
@@ -38,7 +38,7 @@ use fedimint_core::invite_code::InviteCode;
 use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_core::module::{ApiRequestErased, ApiVersion, SupportedApiVersionsSummary};
 use fedimint_core::task::TaskGroup;
-use fedimint_core::task::jit::{Jit, JitTry, JitTryAnyhow};
+use fedimint_core::task::jit::{Jit, JitTry};
 use fedimint_core::util::{FmtCompact as _, FmtCompactAnyhow as _, SafeUrl};
 use fedimint_core::{ChainId, NumPeers, PeerId, fedimint_build_code_version_env};
 use fedimint_derive_secret::DerivableSecret;
@@ -337,9 +337,9 @@ impl ClientBuilder {
         init_mode: InitMode,
         preview_prefetch_api_announcements: Option<Jit<Vec<PeersSignedApiAnnouncements>>>,
         preview_prefetch_api_version_set: Option<
-            JitTryAnyhow<BTreeMap<PeerId, SupportedApiVersionsSummary>>,
+            JitTry<BTreeMap<PeerId, SupportedApiVersionsSummary>, anyhow::Error>,
         >,
-        prefetch_chain_id: Option<JitTryAnyhow<ChainId>>,
+        prefetch_chain_id: Option<JitTry<ChainId, anyhow::Error>>,
     ) -> anyhow::Result<ClientHandle> {
         if Client::is_initialized(&db_no_decoders).await {
             bail!("Client database already initialized")
@@ -559,9 +559,9 @@ impl ClientBuilder {
         stopped: bool,
         preview_prefetch_api_announcements: Option<Jit<Vec<PeersSignedApiAnnouncements>>>,
         preview_prefetch_api_version_set: Option<
-            JitTryAnyhow<BTreeMap<PeerId, SupportedApiVersionsSummary>>,
+            JitTry<BTreeMap<PeerId, SupportedApiVersionsSummary>, anyhow::Error>,
         >,
-        prefetch_chain_id: Option<JitTryAnyhow<ChainId>>,
+        prefetch_chain_id: Option<JitTry<ChainId, anyhow::Error>>,
     ) -> anyhow::Result<ClientHandle> {
         let log_event_added_transient_tx = self.log_event_added_transient_tx.clone();
         let request_hook = self.request_hook.clone();
@@ -604,9 +604,9 @@ impl ClientBuilder {
         request_hook: ApiRequestHook,
         preview_prefetch_api_announcements: Option<Jit<Vec<PeersSignedApiAnnouncements>>>,
         preview_prefetch_api_version_set: Option<
-            JitTryAnyhow<BTreeMap<PeerId, SupportedApiVersionsSummary>>,
+            JitTry<BTreeMap<PeerId, SupportedApiVersionsSummary>, anyhow::Error>,
         >,
-        prefetch_chain_id: Option<JitTryAnyhow<ChainId>>,
+        prefetch_chain_id: Option<JitTry<ChainId, anyhow::Error>>,
     ) -> anyhow::Result<ClientHandle> {
         debug!(
             target: LOG_CLIENT,
@@ -1392,8 +1392,8 @@ pub struct ClientPreview {
     api_secret: Option<String>,
     prefetch_api_announcements: Option<Jit<Vec<PeersSignedApiAnnouncements>>>,
     preview_prefetch_api_version_set:
-        Option<JitTryAnyhow<BTreeMap<PeerId, SupportedApiVersionsSummary>>>,
-    prefetch_chain_id: Option<JitTryAnyhow<ChainId>>,
+        Option<JitTry<BTreeMap<PeerId, SupportedApiVersionsSummary>, anyhow::Error>>,
+    prefetch_chain_id: Option<JitTry<ChainId, anyhow::Error>>,
 }
 
 impl ClientPreview {

--- a/fedimint-client/src/client/handle.rs
+++ b/fedimint-client/src/client/handle.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use anyhow::format_err;
 #[cfg(not(target_family = "wasm"))]
 use fedimint_core::runtime;
-use fedimint_core::util::FmtCompactAnyhow as _;
+use fedimint_core::util::FmtCompact as _;
 use fedimint_logging::LOG_CLIENT;
 #[cfg(not(target_family = "wasm"))]
 use tokio::runtime::{Handle as RuntimeHandle, RuntimeFlavor};
@@ -80,7 +80,7 @@ impl ClientHandle {
             .await
         {
             client_span.in_scope(|| {
-                warn!(target: LOG_CLIENT, err = %err.fmt_compact_anyhow(), "Error waiting for client task group to shut down");
+                warn!(target: LOG_CLIENT, err = %err.fmt_compact(), "Error waiting for client task group to shut down");
             });
         }
 

--- a/fedimint-client/src/db.rs
+++ b/fedimint-client/src/db.rs
@@ -11,7 +11,7 @@ use fedimint_client_module::sm::{ActiveStateMeta, InactiveStateMeta};
 use fedimint_core::config::{ClientConfig, ClientConfigV0, FederationId, GlobalClientConfig};
 use fedimint_core::core::{ModuleInstanceId, OperationId};
 use fedimint_core::db::{
-    Database, DatabaseTransaction, DatabaseVersion, DatabaseVersionKey,
+    Database, DatabaseTransaction, DatabaseVersion, DatabaseVersionKey, DbMigrationError,
     IDatabaseTransactionOpsCore, IDatabaseTransactionOpsCoreTyped, MODULE_GLOBAL_PREFIX,
     apply_migrations_dbtx, create_database_version_dbtx, get_current_database_version,
 };
@@ -772,7 +772,7 @@ pub fn get_core_client_database_migrations()
 pub async fn apply_migrations_core_client_dbtx(
     dbtx: &mut DatabaseTransaction<'_>,
     kind: String,
-) -> Result<(), anyhow::Error> {
+) -> Result<(), DbMigrationError> {
     apply_migrations_dbtx(
         dbtx,
         (),
@@ -798,7 +798,7 @@ pub async fn apply_migrations_client_module(
     kind: String,
     migrations: BTreeMap<DatabaseVersion, ClientModuleMigrationFn>,
     module_instance_id: ModuleInstanceId,
-) -> Result<(), anyhow::Error> {
+) -> Result<(), DbMigrationError> {
     let mut dbtx = db.begin_transaction().await;
     apply_migrations_client_module_dbtx(
         &mut dbtx.to_ref_nc(),
@@ -807,9 +807,7 @@ pub async fn apply_migrations_client_module(
         module_instance_id,
     )
     .await?;
-    dbtx.commit_tx_result()
-        .await
-        .map_err(|e| anyhow::Error::msg(e.to_string()))
+    Ok(dbtx.commit_tx_result().await?)
 }
 
 pub async fn apply_migrations_client_module_dbtx(
@@ -817,7 +815,7 @@ pub async fn apply_migrations_client_module_dbtx(
     kind: String,
     migrations: BTreeMap<DatabaseVersion, ClientModuleMigrationFn>,
     module_instance_id: ModuleInstanceId,
-) -> Result<(), anyhow::Error> {
+) -> Result<(), DbMigrationError> {
     // Newly created databases will not have any data underneath the
     // `MODULE_GLOBAL_PREFIX` since they have just been instantiated.
     let is_new_db = dbtx
@@ -837,7 +835,7 @@ pub async fn apply_migrations_client_module_dbtx(
         kind.clone(),
         is_new_db,
     )
-    .await?;
+    .await;
 
     let current_version = dbtx
         .get_value(&DatabaseVersionKey(module_instance_id))
@@ -857,10 +855,11 @@ pub async fn apply_migrations_client_module_dbtx(
         }
 
         if target_version < current_version {
-            return Err(anyhow!(format!(
-                "On disk database version for module {kind} was higher ({}) than the target database version ({}).",
-                current_version, target_version,
-            )));
+            return Err(DbMigrationError::VersionTooHigh {
+                kind,
+                on_disk: current_version,
+                target: target_version,
+            });
         }
 
         info!(

--- a/fedimint-connectors/src/iroh.rs
+++ b/fedimint-connectors/src/iroh.rs
@@ -147,7 +147,7 @@ impl IrohConnector {
             FM_IROH_CONNECT_OVERRIDES_PLAIN_ENV,
             FM_GW_IROH_CONNECT_OVERRIDES_PLAIN_ENV,
         ] {
-            for (k, v) in parse_kv_list_from_env::<NodeId, SocketAddr>(env_var)? {
+            for (k, v) in parse_kv_list_from_env::<NodeId, SocketAddr>(env_var) {
                 s = s.with_connection_override(k, NodeAddr::new(k).with_direct_addresses([v]));
             }
         }

--- a/fedimint-connectors/src/lib.rs
+++ b/fedimint-connectors/src/lib.rs
@@ -256,7 +256,7 @@ impl ConnectorRegistryBuilder {
     /// Apply overrides from env variables
     pub fn with_env_var_overrides(mut self) -> anyhow::Result<Self> {
         // TODO: read rest of the env
-        for (k, v) in parse_kv_list_from_env::<_, SafeUrl>(FM_WS_API_CONNECT_OVERRIDES_ENV)? {
+        for (k, v) in parse_kv_list_from_env::<_, SafeUrl>(FM_WS_API_CONNECT_OVERRIDES_ENV) {
             self = self.with_connection_override(k, v);
         }
 

--- a/fedimint-core/Cargo.toml
+++ b/fedimint-core/Cargo.toml
@@ -93,6 +93,7 @@ wasm-bindgen-futures = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }
+tempfile = { workspace = true }
 test-log = { workspace = true }
 tokio-test = { workspace = true }
 

--- a/fedimint-core/src/amount.rs
+++ b/fedimint-core/src/amount.rs
@@ -1,7 +1,6 @@
 use std::num::ParseIntError;
 use std::str::FromStr;
 
-use anyhow::bail;
 use bitcoin::Denomination;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -96,14 +95,14 @@ impl Amount {
 
     /// Returns an error if the amount is more precise than satoshis (i.e. if it
     /// has a milli-satoshi remainder). Otherwise, returns `Ok(())`.
-    pub fn ensure_sats_precision(&self) -> anyhow::Result<()> {
+    pub fn ensure_sats_precision(&self) -> Result<(), AmountConversionError> {
         if !self.msats.is_multiple_of(1000) {
-            bail!("Amount is using a precision smaller than satoshi, cannot convert to satoshis");
+            return Err(AmountConversionError::SubSatoshiPrecision { msats: self.msats });
         }
         Ok(())
     }
 
-    pub fn try_into_sats(&self) -> anyhow::Result<u64> {
+    pub fn try_into_sats(&self) -> Result<u64, AmountConversionError> {
         self.ensure_sats_precision()?;
         Ok(self.msats / 1000)
     }
@@ -257,11 +256,21 @@ impl From<bitcoin::Amount> for Amount {
 }
 
 impl TryFrom<Amount> for bitcoin::Amount {
-    type Error = anyhow::Error;
+    type Error = AmountConversionError;
 
-    fn try_from(value: Amount) -> anyhow::Result<Self> {
+    fn try_from(value: Amount) -> Result<Self, Self::Error> {
         value.try_into_sats().map(Self::from_sat)
     }
+}
+
+/// Failure to convert an [`Amount`] to a coarser unit.
+#[derive(Debug, Error, Clone, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum AmountConversionError {
+    /// The amount has a milli-satoshi remainder and cannot be expressed in
+    /// satoshis.
+    #[error("Amount {msats} msat is more precise than a satoshi, cannot convert to satoshis")]
+    SubSatoshiPrecision { msats: u64 },
 }
 
 #[derive(Error, Debug)]

--- a/fedimint-core/src/amount/tests.rs
+++ b/fedimint-core/src/amount/tests.rs
@@ -1,4 +1,4 @@
-use super::{Amount, FromStr};
+use super::{Amount, AmountConversionError, FromStr};
 
 #[test]
 fn amount_multiplication_by_scalar() {
@@ -59,5 +59,26 @@ fn test_amount_parsing() {
     assert_eq!(
         Amount::from_sats(12_345_600_000),
         Amount::from_str("123.456btc").unwrap()
+    );
+}
+
+#[test]
+fn try_into_sats_rejects_sub_satoshi_precision() {
+    assert_eq!(
+        Amount::from_msats(1500).try_into_sats(),
+        Err(AmountConversionError::SubSatoshiPrecision { msats: 1500 })
+    );
+    assert_eq!(Amount::from_msats(2000).try_into_sats(), Ok(2));
+}
+
+#[test]
+fn bitcoin_amount_conversion_rejects_sub_satoshi_precision() {
+    assert_eq!(
+        bitcoin::Amount::try_from(Amount::from_msats(1)),
+        Err(AmountConversionError::SubSatoshiPrecision { msats: 1 })
+    );
+    assert_eq!(
+        bitcoin::Amount::try_from(Amount::from_msats(1000)),
+        Ok(bitcoin::Amount::from_sat(1))
     );
 }

--- a/fedimint-core/src/base32.rs
+++ b/fedimint-core/src/base32.rs
@@ -1,8 +1,8 @@
 use std::collections::BTreeMap;
 
-use anyhow::{Context, ensure};
+use thiserror::Error;
 
-use crate::encoding::{Decodable, Encodable};
+use crate::encoding::{Decodable, DecodeError, Encodable};
 use crate::module::registry::ModuleDecoderRegistry;
 
 /// Lowercase RFC 4648 Base32hex alphabet (32 characters).
@@ -40,7 +40,7 @@ pub fn encode(input: &[u8]) -> String {
 
 /// Decodes a base 32 string back to raw bytes. Returns an error
 /// if any invalid character is encountered.
-pub fn decode(input: &str) -> anyhow::Result<Vec<u8>> {
+pub fn decode(input: &str) -> Result<Vec<u8>, Base32DecodeError> {
     let decode_table = RFC4648
         .iter()
         .enumerate()
@@ -52,11 +52,12 @@ pub fn decode(input: &str) -> anyhow::Result<Vec<u8>> {
     let mut buffer = 0;
     let mut bits = 0;
 
-    for byte in input.as_bytes() {
-        let value = decode_table
-            .get(byte)
-            .copied()
-            .context("Invalid character encountered")?;
+    for (index, ch) in input.char_indices() {
+        let value = ch
+            .is_ascii()
+            .then(|| decode_table.get(&(ch as u8)).copied())
+            .flatten()
+            .ok_or(Base32DecodeError::InvalidCharacter { ch, index })?;
 
         buffer |= value << bits;
         bits += 5;
@@ -80,17 +81,54 @@ pub fn encode_prefixed_bytes(prefix: &str, bytes: &[u8]) -> String {
     format!("{prefix}{}", encode(bytes))
 }
 
-pub fn decode_prefixed<T: Decodable>(prefix: &str, s: &str) -> anyhow::Result<T> {
+pub fn decode_prefixed<T: Decodable>(prefix: &str, s: &str) -> Result<T, PrefixedDecodeError> {
     Ok(T::consensus_decode_whole(
         &decode_prefixed_bytes(prefix, s)?,
         &ModuleDecoderRegistry::default(),
     )?)
 }
 
-pub fn decode_prefixed_bytes(prefix: &str, s: &str) -> anyhow::Result<Vec<u8>> {
+pub fn decode_prefixed_bytes(prefix: &str, s: &str) -> Result<Vec<u8>, PrefixedDecodeError> {
     let s = s.to_lowercase();
-    ensure!(s.starts_with(prefix), "Invalid Prefix");
-    decode(&s[prefix.len()..])
+    if !s.starts_with(prefix) {
+        return Err(PrefixedDecodeError::InvalidPrefix {
+            expected: prefix.to_owned(),
+        });
+    }
+    Ok(decode(&s[prefix.len()..])?)
+}
+
+/// Failure to decode a raw base 32 string.
+#[derive(Debug, Error, Clone, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum Base32DecodeError {
+    /// A character outside the RFC 4648 base32hex alphabet was encountered.
+    ///
+    /// `index` is a byte offset into the string passed to [`decode`]. When the
+    /// error originates in [`decode_prefixed`] or [`decode_prefixed_bytes`],
+    /// that string is the payload after the prefix was stripped and the input
+    /// was lowercased, not the string the caller supplied.
+    #[error("Invalid base32 character {ch:?} at byte index {index}")]
+    InvalidCharacter { ch: char, index: usize },
+}
+
+/// Failure to decode a prefixed base 32 string into a value.
+///
+/// The byte offset in a [`Base32DecodeError::InvalidCharacter`] source refers
+/// to the payload after the prefix was stripped and the input was lowercased,
+/// not to the string the caller supplied.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum PrefixedDecodeError {
+    /// The string does not start with the expected prefix.
+    #[error("Invalid prefix, expected '{expected}'")]
+    InvalidPrefix { expected: String },
+    /// The payload is not valid base 32.
+    #[error("Invalid base32 payload: {0}")]
+    Base32Decode(#[from] Base32DecodeError),
+    /// The decoded bytes are not a valid consensus encoding of the target type.
+    #[error("Invalid consensus encoding in base32 payload: {0}")]
+    ConsensusDecode(#[from] DecodeError),
 }
 
 #[test]
@@ -117,4 +155,34 @@ fn test_base_32_roundtrip() {
             bytes
         );
     }
+}
+
+#[test]
+fn decode_reports_invalid_character_position() {
+    assert_eq!(
+        decode("ab!c"),
+        Err(Base32DecodeError::InvalidCharacter { ch: '!', index: 2 })
+    );
+}
+
+#[test]
+fn decode_escapes_invalid_character_in_message() {
+    let err = decode("a\nb").expect_err("a newline is not in the base32 alphabet");
+
+    assert_eq!(
+        err,
+        Base32DecodeError::InvalidCharacter { ch: '\n', index: 1 }
+    );
+    assert_eq!(
+        err.to_string(),
+        "Invalid base32 character '\\n' at byte index 1"
+    );
+}
+
+#[test]
+fn decode_prefixed_bytes_rejects_wrong_prefix() {
+    assert!(matches!(
+        decode_prefixed_bytes("fed", "xyz00"),
+        Err(PrefixedDecodeError::InvalidPrefix { expected }) if expected == "fed"
+    ));
 }

--- a/fedimint-core/src/config.rs
+++ b/fedimint-core/src/config.rs
@@ -6,7 +6,7 @@ use std::hash::Hash;
 use std::path::Path;
 use std::str::FromStr;
 
-use anyhow::{Context, format_err};
+use anyhow::Context;
 use bitcoin::hashes::sha256::HashEngine;
 use bitcoin::hashes::{Hash as BitcoinHash, hex, sha256};
 use bls12_381::Scalar;
@@ -21,11 +21,12 @@ use secp256k1::PublicKey;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::json;
+use thiserror::Error;
 use threshold_crypto::{G1Projective, G2Projective};
 use tracing::warn;
 
 use crate::core::DynClientConfig;
-use crate::encoding::Decodable;
+use crate::encoding::{Decodable, DecodeError};
 use crate::module::{
     CoreConsensusVersion, DynCommonModuleInit, IDynCommonModuleInit, ModuleConsensusVersion,
     SerdeModuleEncoding,
@@ -310,13 +311,17 @@ impl ClientConfig {
     pub fn meta<V: serde::de::DeserializeOwned + 'static>(
         &self,
         key: &str,
-    ) -> Result<Option<V>, anyhow::Error> {
+    ) -> Result<Option<V>, ModuleConfigError> {
         let Some(str_value) = self.global.meta.get(key) else {
             return Ok(None);
         };
-        let res = serde_json::from_str(str_value)
-            .map(Some)
-            .context(format!("Decoding meta field '{key}' failed"));
+        let res =
+            serde_json::from_str(str_value)
+                .map(Some)
+                .map_err(|source| ModuleConfigError::Meta {
+                    key: key.to_owned(),
+                    source,
+                });
 
         // In the past we encoded some string fields as "just a string" without quotes,
         // this code ensures that old meta values still parse since config is hard to
@@ -489,17 +494,23 @@ impl ClientConfig {
         sha256::Hash::from_engine(engine)
     }
 
-    pub fn get_module<T: Decodable + 'static>(&self, id: ModuleInstanceId) -> anyhow::Result<&T> {
+    pub fn get_module<T: Decodable + 'static>(
+        &self,
+        id: ModuleInstanceId,
+    ) -> Result<&T, ModuleConfigError> {
         self.modules.get(&id).map_or_else(
-            || Err(format_err!("Client config for module id {id} not found")),
+            || Err(ModuleConfigError::ModuleNotFound { id }),
             |client_cfg| client_cfg.cast(),
         )
     }
 
     // TODO: rename this and one above
-    pub fn get_module_cfg(&self, id: ModuleInstanceId) -> anyhow::Result<ClientModuleConfig> {
+    pub fn get_module_cfg(
+        &self,
+        id: ModuleInstanceId,
+    ) -> Result<ClientModuleConfig, ModuleConfigError> {
         self.modules.get(&id).map_or_else(
-            || Err(format_err!("Client config for module id {id} not found")),
+            || Err(ModuleConfigError::ModuleNotFound { id }),
             |client_cfg| Ok(client_cfg.clone()),
         )
     }
@@ -514,10 +525,10 @@ impl ClientConfig {
     pub fn get_first_module_by_kind<T: Decodable + 'static>(
         &self,
         kind: impl Into<ModuleKind>,
-    ) -> anyhow::Result<(ModuleInstanceId, &T)> {
+    ) -> Result<(ModuleInstanceId, &T), ModuleConfigError> {
         let kind: ModuleKind = kind.into();
         let Some((id, module_cfg)) = self.modules.iter().find(|(_, v)| v.is_kind(&kind)) else {
-            anyhow::bail!("Module kind {kind} not found")
+            return Err(ModuleConfigError::KindNotFound { kind });
         };
         Ok((*id, module_cfg.cast()?))
     }
@@ -526,13 +537,13 @@ impl ClientConfig {
     pub fn get_first_module_by_kind_cfg(
         &self,
         kind: impl Into<ModuleKind>,
-    ) -> anyhow::Result<(ModuleInstanceId, ClientModuleConfig)> {
+    ) -> Result<(ModuleInstanceId, ClientModuleConfig), ModuleConfigError> {
         let kind: ModuleKind = kind.into();
         self.modules
             .iter()
             .find(|(_, v)| v.is_kind(&kind))
             .map(|(id, v)| (*id, v.clone()))
-            .ok_or_else(|| anyhow::format_err!("Module kind {kind} not found"))
+            .ok_or(ModuleConfigError::KindNotFound { kind })
     }
 }
 
@@ -645,7 +656,7 @@ where
     pub fn decoders<'a>(
         &self,
         modules: impl Iterator<Item = (ModuleInstanceId, &'a ModuleKind)>,
-    ) -> anyhow::Result<ModuleDecoderRegistry> {
+    ) -> Result<ModuleDecoderRegistry, ModuleConfigError> {
         self.decoders_strict(modules)
     }
 
@@ -653,13 +664,14 @@ where
     pub fn decoders_strict<'a>(
         &self,
         modules: impl Iterator<Item = (ModuleInstanceId, &'a ModuleKind)>,
-    ) -> anyhow::Result<ModuleDecoderRegistry> {
+    ) -> Result<ModuleDecoderRegistry, ModuleConfigError> {
         let mut decoders = BTreeMap::new();
         for (id, kind) in modules {
             let Some(init) = self.0.get(kind) else {
-                anyhow::bail!(
-                    "Detected configuration for unsupported module id: {id}, kind: {kind}"
-                )
+                return Err(ModuleConfigError::UnsupportedModule {
+                    id,
+                    kind: kind.clone(),
+                });
             };
 
             decoders.insert(id, (kind.clone(), init.as_ref().decoder()));
@@ -760,15 +772,27 @@ impl ClientModuleConfig {
 }
 
 impl ClientModuleConfig {
-    pub fn cast<T>(&self) -> anyhow::Result<&T>
+    pub fn cast<T>(&self) -> Result<&T, ModuleConfigError>
     where
         T: 'static,
     {
-        self.config
-            .expect_decoded_ref()
-            .as_any()
-            .downcast_ref::<T>()
-            .context("can't convert client module config to desired type")
+        match &self.config {
+            DynRawFallback::Decoded(config) => {
+                config
+                    .as_any()
+                    .downcast_ref::<T>()
+                    .ok_or_else(|| ModuleConfigError::WrongType {
+                        kind: self.kind.clone(),
+                        expected: std::any::type_name::<T>(),
+                    })
+            }
+            DynRawFallback::Raw {
+                module_instance_id, ..
+            } => Err(ModuleConfigError::NotDecoded {
+                id: *module_instance_id,
+                kind: self.kind.clone(),
+            }),
+        }
     }
 }
 
@@ -786,7 +810,7 @@ impl ServerModuleConfig {
         Self { private, consensus }
     }
 
-    pub fn to_typed<T: TypedServerModuleConfig>(&self) -> anyhow::Result<T> {
+    pub fn to_typed<T: TypedServerModuleConfig>(&self) -> Result<T, ModuleConfigError> {
         let private = serde_json::from_value(self.private.value().clone())?;
         let consensus = <T::Consensus>::consensus_decode_whole(
             &self.consensus.config[..],
@@ -805,7 +829,7 @@ pub trait TypedServerModuleConsensusConfig:
 
     fn version(&self) -> ModuleConsensusVersion;
 
-    fn from_erased(erased: &ServerModuleConsensusConfig) -> anyhow::Result<Self> {
+    fn from_erased(erased: &ServerModuleConsensusConfig) -> Result<Self, ModuleConfigError> {
         Ok(Self::consensus_decode_whole(
             &erased.config[..],
             &ModuleRegistry::default(),
@@ -931,6 +955,51 @@ pub const META_FEDERATION_NAME_KEY: &str = "federation_name";
 pub fn load_from_file<T: DeserializeOwned>(path: &Path) -> Result<T, anyhow::Error> {
     let file = std::fs::File::open(path)?;
     Ok(serde_json::from_reader(file)?)
+}
+
+/// Failure to look up or cast a module configuration.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum ModuleConfigError {
+    /// No module with this instance id exists in the config.
+    #[error("Client config for module id {id} not found")]
+    ModuleNotFound { id: ModuleInstanceId },
+    /// No module of this kind exists in the config.
+    #[error("Module kind {kind} not found")]
+    KindNotFound { kind: ModuleKind },
+    /// The decoded module config is not of the requested type.
+    #[error("Client module config of kind {kind} is not a {expected}")]
+    WrongType {
+        kind: ModuleKind,
+        expected: &'static str,
+    },
+    /// The module config is still in its raw, undecoded form because no
+    /// decoder for its kind was available; see
+    /// [`ClientModuleConfig::redecode_raw`].
+    #[error("Client module config for module id {id} of kind {kind} has not been decoded")]
+    NotDecoded {
+        id: ModuleInstanceId,
+        kind: ModuleKind,
+    },
+    /// The config references a module kind this build has no support for.
+    #[error("Detected configuration for unsupported module id: {id}, kind: {kind}")]
+    UnsupportedModule {
+        id: ModuleInstanceId,
+        kind: ModuleKind,
+    },
+    /// A meta field exists but does not deserialize to the requested type.
+    #[error("Decoding meta field '{key}' failed")]
+    Meta {
+        key: String,
+        #[source]
+        source: serde_json::Error,
+    },
+    /// A JSON part of the config failed to (de)serialize.
+    #[error("Invalid JSON in module config")]
+    Json(#[from] serde_json::Error),
+    /// A consensus-encoded part of the config failed to decode.
+    #[error("Invalid consensus encoding in module config")]
+    Decode(#[from] DecodeError),
 }
 
 #[cfg(test)]

--- a/fedimint-core/src/config.rs
+++ b/fedimint-core/src/config.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::{Debug, Display};
 use std::hash::Hash;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use anyhow::Context;
@@ -952,9 +952,16 @@ impl<'de> Deserialize<'de> for DkgMessageG2 {
 /// of the config
 pub const META_FEDERATION_NAME_KEY: &str = "federation_name";
 
-pub fn load_from_file<T: DeserializeOwned>(path: &Path) -> Result<T, anyhow::Error> {
-    let file = std::fs::File::open(path)?;
-    Ok(serde_json::from_reader(file)?)
+pub fn load_from_file<T: DeserializeOwned>(path: &Path) -> Result<T, ConfigFileError> {
+    let contents = std::fs::read(path).map_err(|source| ConfigFileError::Io {
+        path: path.to_owned(),
+        source,
+    })?;
+
+    serde_json::from_slice(&contents).map_err(|source| ConfigFileError::Json {
+        path: path.to_owned(),
+        source,
+    })
 }
 
 /// Failure to look up or cast a module configuration.
@@ -1000,6 +1007,26 @@ pub enum ModuleConfigError {
     /// A consensus-encoded part of the config failed to decode.
     #[error("Invalid consensus encoding in module config")]
     Decode(#[from] DecodeError),
+}
+
+/// Failure to load a JSON config file.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum ConfigFileError {
+    /// The file could not be opened or read.
+    #[error("Failed to read config file {}", path.display())]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    /// The file is not valid JSON for the requested type.
+    #[error("Invalid JSON in config file {}", path.display())]
+    Json {
+        path: PathBuf,
+        #[source]
+        source: serde_json::Error,
+    },
 }
 
 #[cfg(test)]

--- a/fedimint-core/src/config.rs
+++ b/fedimint-core/src/config.rs
@@ -683,7 +683,7 @@ where
     pub fn available_decoders<'a>(
         &self,
         modules: impl Iterator<Item = (ModuleInstanceId, &'a ModuleKind)>,
-    ) -> anyhow::Result<ModuleDecoderRegistry> {
+    ) -> ModuleDecoderRegistry {
         let mut decoders = BTreeMap::new();
         for (id, kind) in modules {
             let Some(init) = self.0.get(kind) else {
@@ -693,7 +693,7 @@ where
 
             decoders.insert(id, (kind.clone(), init.as_ref().decoder()));
         }
-        Ok(ModuleDecoderRegistry::from(decoders))
+        ModuleDecoderRegistry::from(decoders)
     }
 }
 
@@ -743,13 +743,13 @@ impl ClientModuleConfig {
         kind: ModuleKind,
         version: ModuleConsensusVersion,
         value: T,
-    ) -> anyhow::Result<Self> {
-        Ok(Self {
+    ) -> Self {
+        Self {
             kind,
             version,
             config: fedimint_core::core::DynClientConfig::from_typed(module_instance_id, value)
                 .into(),
-        })
+        }
     }
 
     pub fn redecode_raw(

--- a/fedimint-core/src/config.rs
+++ b/fedimint-core/src/config.rs
@@ -426,7 +426,7 @@ impl Display for FederationId {
 }
 
 impl FromStr for FederationIdPrefix {
-    type Err = anyhow::Error;
+    type Err = hex::HexToArrayError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(Self(<[u8; 4]>::from_hex(s)?))
@@ -466,14 +466,14 @@ impl FederationId {
     pub fn to_fake_ln_pub_key(
         &self,
         secp: &bitcoin::secp256k1::Secp256k1<bitcoin::secp256k1::All>,
-    ) -> anyhow::Result<bitcoin::secp256k1::PublicKey> {
+    ) -> Result<bitcoin::secp256k1::PublicKey, bitcoin::secp256k1::Error> {
         let sk = bitcoin::secp256k1::SecretKey::from_slice(&self.0.to_byte_array())?;
         Ok(bitcoin::secp256k1::PublicKey::from_secret_key(secp, &sk))
     }
 }
 
 impl FromStr for FederationId {
-    type Err = anyhow::Error;
+    type Err = hex::HexToArrayError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(Self::from_byte_array(<[u8; 32]>::from_hex(s)?))

--- a/fedimint-core/src/config/tests.rs
+++ b/fedimint-core/src/config/tests.rs
@@ -188,3 +188,49 @@ fn cast_to_the_wrong_type_names_kind_and_type() {
         "Client module config of kind test is not a u64"
     );
 }
+
+#[cfg(unix)]
+#[test]
+fn load_from_file_reports_a_read_failure_as_io() {
+    use crate::config::{ConfigFileError, load_from_file};
+
+    // A directory opens successfully but fails to read with `EISDIR`.
+    let dir = tempfile::tempdir().expect("creating a temporary directory failed");
+
+    assert!(matches!(
+        load_from_file::<serde_json::Value>(dir.path()),
+        Err(ConfigFileError::Io { path, .. }) if path == dir.path()
+    ));
+}
+
+#[test]
+fn load_from_file_reports_invalid_json() {
+    use std::io::Write;
+
+    use crate::config::{ConfigFileError, load_from_file};
+
+    let mut file = tempfile::NamedTempFile::new().expect("creating a temporary file failed");
+    file.write_all(b"{ not json")
+        .expect("writing the temporary file failed");
+
+    assert!(matches!(
+        load_from_file::<serde_json::Value>(file.path()),
+        Err(ConfigFileError::Json { path, .. }) if path == file.path()
+    ));
+}
+
+#[test]
+fn load_from_file_reads_valid_json() {
+    use std::io::Write;
+
+    use crate::config::load_from_file;
+
+    let mut file = tempfile::NamedTempFile::new().expect("creating a temporary file failed");
+    file.write_all(br#"{"answer": 42}"#)
+        .expect("writing the temporary file failed");
+
+    assert_eq!(
+        load_from_file::<serde_json::Value>(file.path()).expect("the file holds valid JSON"),
+        serde_json::json!({ "answer": 42 })
+    );
+}

--- a/fedimint-core/src/config/tests.rs
+++ b/fedimint-core/src/config/tests.rs
@@ -4,9 +4,8 @@ use fedimint_core::config::{ClientConfig, GlobalClientConfig};
 
 use crate::module::CoreConsensusVersion;
 
-#[test]
-fn test_dcode_meta() {
-    let config = ClientConfig {
+fn test_config() -> ClientConfig {
+    ClientConfig {
         global: GlobalClientConfig {
             api_endpoints: BTreeMap::new(),
             broadcast_public_keys: None,
@@ -20,7 +19,12 @@ fn test_dcode_meta() {
             .collect(),
         },
         modules: BTreeMap::new(),
-    };
+    }
+}
+
+#[test]
+fn test_dcode_meta() {
+    let config = test_config();
 
     assert_eq!(
         config
@@ -46,5 +50,141 @@ fn test_dcode_meta() {
             .meta::<String>("arr")
             .expect("parsing via legacy fallback failed"),
         Some("[\"1\", \"2\"]".to_string())
+    );
+}
+
+#[test]
+fn module_lookups_return_typed_errors() {
+    use fedimint_core::core::ModuleKind;
+
+    use crate::config::ModuleConfigError;
+
+    let config = test_config();
+
+    assert!(matches!(
+        config.get_module_cfg(7),
+        Err(ModuleConfigError::ModuleNotFound { id: 7 })
+    ));
+    assert!(matches!(
+        config.get_first_module_by_kind_cfg(ModuleKind::from_static_str("nope")),
+        Err(ModuleConfigError::KindNotFound { kind }) if kind.as_str() == "nope"
+    ));
+}
+
+#[test]
+fn meta_decode_failure_names_the_key() {
+    use crate::config::ModuleConfigError;
+
+    let config = test_config();
+
+    // "foo" holds the legacy unquoted string "bar", which is not a number.
+    assert!(matches!(
+        config.meta::<u32>("foo"),
+        Err(ModuleConfigError::Meta { key, .. }) if key == "foo"
+    ));
+}
+
+#[test]
+fn cast_reports_an_undecoded_config() {
+    use fedimint_core::core::ModuleKind;
+
+    use crate::config::{ClientModuleConfig, ModuleConfigError};
+    use crate::encoding::DynRawFallback;
+    use crate::module::ModuleConsensusVersion;
+
+    let cfg = ClientModuleConfig {
+        kind: ModuleKind::from_static_str("test"),
+        version: ModuleConsensusVersion::new(0, 0),
+        config: DynRawFallback::Raw {
+            module_instance_id: 3,
+            raw: vec![],
+        },
+    };
+
+    assert!(matches!(
+        cfg.cast::<()>(),
+        Err(ModuleConfigError::NotDecoded { id: 3, kind }) if kind.as_str() == "test"
+    ));
+}
+
+#[test]
+fn get_module_reports_an_undecoded_config() {
+    use fedimint_core::core::ModuleKind;
+
+    use crate::config::{ClientModuleConfig, ModuleConfigError};
+    use crate::encoding::DynRawFallback;
+    use crate::module::ModuleConsensusVersion;
+
+    let mut config = test_config();
+    config.modules.insert(
+        3,
+        ClientModuleConfig {
+            kind: ModuleKind::from_static_str("test"),
+            version: ModuleConsensusVersion::new(0, 0),
+            config: DynRawFallback::Raw {
+                module_instance_id: 3,
+                raw: vec![],
+            },
+        },
+    );
+
+    assert!(matches!(
+        config.get_module::<()>(3),
+        Err(ModuleConfigError::NotDecoded { id: 3, kind }) if kind.as_str() == "test"
+    ));
+}
+
+#[test]
+fn cast_to_the_wrong_type_names_kind_and_type() {
+    use std::fmt;
+
+    use fedimint_core::core::{DynClientConfig, ModuleInstanceId, ModuleKind};
+    use serde::{Deserialize, Serialize};
+
+    use crate::config::{ClientModuleConfig, ModuleConfigError};
+    use crate::encoding::{Decodable, Encodable};
+    use crate::module::ModuleConsensusVersion;
+
+    #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Encodable, Decodable)]
+    struct TestClientConfig {
+        value: u64,
+    }
+
+    impl fmt::Display for TestClientConfig {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "TestClientConfig({})", self.value)
+        }
+    }
+
+    impl fedimint_core::core::ClientConfig for TestClientConfig {
+        const KIND: ModuleKind = ModuleKind::from_static_str("test");
+    }
+
+    impl fedimint_core::core::IntoDynInstance for TestClientConfig {
+        type DynType = DynClientConfig;
+
+        fn into_dyn(self, instance_id: ModuleInstanceId) -> Self::DynType {
+            DynClientConfig::from_typed(instance_id, self)
+        }
+    }
+
+    let cfg = ClientModuleConfig {
+        kind: ModuleKind::from_static_str("test"),
+        version: ModuleConsensusVersion::new(0, 0),
+        config: DynClientConfig::from_typed(3, TestClientConfig { value: 1 }).into(),
+    };
+
+    assert!(cfg.cast::<TestClientConfig>().is_ok());
+
+    let err = cfg.cast::<u64>().expect_err("the config is not a u64");
+
+    assert!(matches!(
+        &err,
+        ModuleConfigError::WrongType { kind, expected }
+            if kind.as_str() == "test" && *expected == "u64"
+    ));
+    assert_eq!(
+        err.to_string(),
+        "Client module config of kind test is not a u64"
     );
 }

--- a/fedimint-core/src/core.rs
+++ b/fedimint-core/src/core.rs
@@ -109,7 +109,7 @@ impl Debug for OperationId {
 }
 
 impl FromStr for OperationId {
-    type Err = anyhow::Error;
+    type Err = hex::FromHexError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let bytes: [u8; 32] = hex::FromHex::from_hex(s)?;

--- a/fedimint-core/src/core/backup.rs
+++ b/fedimint-core/src/core/backup.rs
@@ -63,14 +63,14 @@ impl BackupRequest {
         self.consensus_hash()
     }
 
-    pub fn sign(self, keypair: &Keypair) -> anyhow::Result<SignedBackupRequest> {
+    pub fn sign(self, keypair: &Keypair) -> SignedBackupRequest {
         let signature = secp256k1::SECP256K1
             .sign_schnorr(&Message::from_digest(*self.hash().as_ref()), keypair);
 
-        Ok(SignedBackupRequest {
+        SignedBackupRequest {
             request: self,
             signature,
-        })
+        }
     }
 }
 

--- a/fedimint-core/src/db/mod.rs
+++ b/fedimint-core/src/db/mod.rs
@@ -1572,7 +1572,7 @@ fn decode_value_expect<V: DatabaseValue>(
         panic!(
             "Unrecoverable decoding DatabaseValue as {}; err={}, key_bytes={}, val_bytes={}",
             any::type_name::<V>(),
-            err,
+            err.fmt_compact(),
             AbbreviateHexBytes(key_bytes),
             AbbreviateHexBytes(value_bytes),
         )
@@ -1589,7 +1589,7 @@ fn decode_key_expect<K: DatabaseKey>(key_bytes: &[u8], decoders: &ModuleDecoderR
         panic!(
             "Unrecoverable decoding DatabaseKey as {}; err={}; bytes={}",
             any::type_name::<K>(),
-            err,
+            err.fmt_compact(),
             AbbreviateHexBytes(key_bytes)
         )
     })
@@ -1946,7 +1946,7 @@ where
         }
 
         <Self as crate::encoding::Decodable>::consensus_decode_whole(&data[1..], modules)
-            .map_err(|decode_error| DecodingError::Other(decode_error.0))
+            .map_err(|decode_error| DecodingError::Other(decode_error.0.into()))
     }
 }
 
@@ -1958,7 +1958,7 @@ where
         data: &[u8],
         modules: &ModuleDecoderRegistry,
     ) -> std::result::Result<Self, DecodingError> {
-        T::consensus_decode_whole(data, modules).map_err(|e| DecodingError::Other(e.0))
+        T::consensus_decode_whole(data, modules).map_err(|e| DecodingError::Other(e.0.into()))
     }
 
     fn to_bytes(&self) -> Vec<u8> {
@@ -2108,18 +2108,19 @@ pub enum DbKeyPrefix {
 }
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum DecodingError {
     #[error("Key had a wrong prefix, expected {expected} but got {found}")]
     WrongPrefix { expected: u8, found: u8 },
     #[error("Key had a wrong length, expected {expected} but got {found}")]
     WrongLength { expected: usize, found: usize },
-    #[error("Other decoding error: {0:#}")]
-    Other(anyhow::Error),
+    #[error("Other decoding error")]
+    Other(#[source] Box<dyn Error + Send + Sync>),
 }
 
 impl DecodingError {
     pub fn other<E: Error + Send + Sync + 'static>(error: E) -> Self {
-        Self::Other(anyhow::Error::from(error))
+        Self::Other(Box::new(error))
     }
 
     pub fn wrong_prefix(expected: u8, found: u8) -> Self {

--- a/fedimint-core/src/db/mod.rs
+++ b/fedimint-core/src/db/mod.rs
@@ -126,7 +126,7 @@ use thiserror::Error;
 use tracing::{debug, info, instrument, trace, warn};
 
 use crate::core::{ModuleInstanceId, ModuleKind};
-use crate::encoding::{Decodable, Encodable};
+use crate::encoding::{Decodable, DecodeError, Encodable};
 use crate::fmt_utils::AbbreviateHexBytes;
 use crate::task::{MaybeSend, MaybeSync};
 use crate::{async_trait_maybe_send, maybe_add_send, maybe_add_send_sync, timing};
@@ -2314,10 +2314,46 @@ pub type DbMigrationFn<C> = Box<
         dyn for<'tx> Fn(
             DbMigrationFnContext<'tx, C>,
         ) -> Pin<
-            Box<maybe_add_send!(dyn futures::Future<Output = anyhow::Result<()>> + 'tx)>,
+            Box<maybe_add_send!(dyn futures::Future<Output = Result<(), DbMigrationError>> + 'tx)>,
         >
     ),
 >;
+
+/// Failure while applying database migrations.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum DbMigrationError {
+    /// The database itself failed.
+    #[error("Database error")]
+    Database(#[from] DatabaseError),
+    /// A stored value is not a valid consensus encoding.
+    #[error("Failed to consensus-decode a database entry")]
+    Decode(#[from] DecodeError),
+    /// The database was written by newer code than the one applying migrations.
+    #[error(
+        "On disk database version {on_disk} for module {kind} is higher than the code \
+         database version {target}"
+    )]
+    VersionTooHigh {
+        kind: String,
+        on_disk: DatabaseVersion,
+        target: DatabaseVersion,
+    },
+    /// A migration failed for a reason specific to it.
+    #[error("Migration failed")]
+    Other(#[source] Box<dyn Error + Send + Sync>),
+}
+
+impl DbMigrationError {
+    /// Wraps a migration-specific error; accepts anything convertible into a
+    /// boxed error, an `anyhow::Error` included.
+    pub fn other<E>(error: E) -> Self
+    where
+        E: Into<Box<dyn Error + Send + Sync>>,
+    {
+        Self::Other(error.into())
+    }
+}
 
 /// Verifies that all database migrations are defined contiguously and returns
 /// the "current" database version, which is one greater than the last key in
@@ -2350,7 +2386,7 @@ pub async fn apply_migrations<C>(
     // When used in client side context, we can/should ignore keys that external app
     // is allowed to use, and but since this function is shared, we make it optional argument
     external_prefixes_above: Option<u8>,
-) -> std::result::Result<(), anyhow::Error>
+) -> Result<(), DbMigrationError>
 where
     C: Clone,
 {
@@ -2365,9 +2401,7 @@ where
     )
     .await?;
 
-    dbtx.commit_tx_result()
-        .await
-        .map_err(|e| anyhow::Error::msg(e.to_string()))
+    Ok(dbtx.commit_tx_result().await?)
 }
 /// `apply_migrations` iterates from the on disk database version for the
 /// module.
@@ -2389,7 +2423,7 @@ pub async fn apply_migrations_dbtx<C>(
     // When used in client side context, we can/should ignore keys that external app
     // is allowed to use, and but since this function is shared, we make it optional argument
     external_prefixes_above: Option<u8>,
-) -> std::result::Result<(), anyhow::Error>
+) -> Result<(), DbMigrationError>
 where
     C: Clone,
 {
@@ -2419,7 +2453,7 @@ where
         kind.clone(),
         is_new_db,
     )
-    .await?;
+    .await;
 
     let module_instance_id_key = module_instance_id_or_global(module_instance_id);
 
@@ -2431,9 +2465,11 @@ where
         let mut current_db_version = disk_version;
 
         if current_db_version > target_db_version {
-            return Err(anyhow::anyhow!(format!(
-                "On disk database version {current_db_version} for module {kind} was higher than the code database version {target_db_version}."
-            )));
+            return Err(DbMigrationError::VersionTooHigh {
+                kind,
+                on_disk: current_db_version,
+                target: target_db_version,
+            });
         }
 
         while current_db_version < target_db_version {
@@ -2474,7 +2510,7 @@ pub async fn create_database_version(
     module_instance_id: Option<ModuleInstanceId>,
     kind: String,
     is_new_db: bool,
-) -> std::result::Result<(), anyhow::Error> {
+) -> Result<(), DbMigrationError> {
     let mut dbtx = db.begin_transaction().await;
 
     create_database_version_dbtx(
@@ -2484,7 +2520,7 @@ pub async fn create_database_version(
         kind,
         is_new_db,
     )
-    .await?;
+    .await;
 
     dbtx.commit_tx_result().await?;
     Ok(())
@@ -2499,7 +2535,7 @@ pub async fn create_database_version_dbtx(
     module_instance_id: Option<ModuleInstanceId>,
     kind: String,
     is_new_db: bool,
-) -> std::result::Result<(), anyhow::Error> {
+) {
     let key_module_instance_id = module_instance_id_or_global(module_instance_id);
 
     // First check if the module has a `DatabaseVersion` written to
@@ -2546,8 +2582,6 @@ pub async fn create_database_version_dbtx(
             )
             .await;
     }
-
-    Ok(())
 }
 
 /// Removes `DatabaseVersion` from `DatabaseVersionKeyV0` if it exists and
@@ -2589,7 +2623,8 @@ mod test_utils {
 
     use super::{
         Database, DatabaseTransaction, DatabaseVersion, DatabaseVersionKey, DatabaseVersionKeyV0,
-        DbMigrationFn, apply_migrations,
+        DbMigrationError, DbMigrationFn, apply_migrations, apply_migrations_dbtx,
+        create_database_version_dbtx,
     };
     use crate::core::ModuleKind;
     use crate::db::mem_impl::MemDatabase;
@@ -3329,10 +3364,60 @@ mod test_utils {
         }
     }
 
+    #[cfg(test)]
+    #[tokio::test]
+    async fn apply_migrations_rejects_newer_on_disk_version() {
+        let db = Database::new(MemDatabase::new(), ModuleDecoderRegistry::default());
+        let mut dbtx = db.begin_transaction().await;
+
+        // Pretend the code that wrote this database was at version 5.
+        create_database_version_dbtx(
+            &mut dbtx.to_ref_nc(),
+            DatabaseVersion(5),
+            None,
+            "test".to_owned(),
+            true,
+        )
+        .await;
+
+        // This code knows no migrations at all, i.e. it is at version 0.
+        let err = apply_migrations_dbtx(
+            &mut dbtx.to_ref_nc(),
+            (),
+            "test".to_owned(),
+            BTreeMap::new(),
+            None,
+            None,
+        )
+        .await
+        .expect_err("on-disk version 5 must not be accepted by code at version 0");
+
+        assert!(matches!(
+            err,
+            DbMigrationError::VersionTooHigh {
+                on_disk: DatabaseVersion(5),
+                target: DatabaseVersion(0),
+                ..
+            }
+        ));
+    }
+
+    #[cfg(test)]
+    #[test]
+    fn db_migration_error_other_accepts_anyhow() {
+        let err = DbMigrationError::other(anyhow::anyhow!("legacy"));
+
+        assert!(matches!(
+            &err,
+            DbMigrationError::Other(source) if source.to_string() == "legacy"
+        ));
+        assert!(std::error::Error::source(&err).is_some());
+    }
+
     #[allow(dead_code)]
     async fn migrate_test_db_version_0(
         mut ctx: DbMigrationFnContext<'_, ()>,
-    ) -> std::result::Result<(), anyhow::Error> {
+    ) -> Result<(), DbMigrationError> {
         let mut dbtx = ctx.dbtx();
         let example_keys_v0 = dbtx
             .find_by_prefix(&DbPrefixTestPrefixV0)

--- a/fedimint-core/src/db/mod.rs
+++ b/fedimint-core/src/db/mod.rs
@@ -487,9 +487,7 @@ impl Database {
     /// `Err` if [`Self::is_global`] is not true
     pub fn ensure_global(&self) -> DatabaseResult<()> {
         if !self.is_global() {
-            return Err(DatabaseError::Other(anyhow::anyhow!(
-                "Database instance not global"
-            )));
+            return Err(DatabaseError::NotGlobal);
         }
 
         Ok(())
@@ -498,9 +496,7 @@ impl Database {
     /// `Err` if [`Self::is_global`] is true
     pub fn ensure_isolated(&self) -> DatabaseResult<()> {
         if self.is_global() {
-            return Err(DatabaseError::Other(anyhow::anyhow!(
-                "Database instance not isolated"
-            )));
+            return Err(DatabaseError::NotIsolated);
         }
 
         Ok(())
@@ -1746,9 +1742,7 @@ impl<'tx, Cap> DatabaseTransaction<'tx, Cap> {
     /// `Err` if [`Self::is_global`] is not true
     pub fn ensure_global(&self) -> DatabaseResult<()> {
         if !self.is_global() {
-            return Err(DatabaseError::Other(anyhow::anyhow!(
-                "Database instance not global"
-            )));
+            return Err(DatabaseError::NotGlobal);
         }
 
         Ok(())
@@ -1757,9 +1751,7 @@ impl<'tx, Cap> DatabaseTransaction<'tx, Cap> {
     /// `Err` if [`Self::is_global`] is true
     pub fn ensure_isolated(&self) -> DatabaseResult<()> {
         if self.is_global() {
-            return Err(DatabaseError::Other(anyhow::anyhow!(
-                "Database instance not isolated"
-            )));
+            return Err(DatabaseError::NotIsolated);
         }
 
         Ok(())
@@ -2134,6 +2126,7 @@ impl DecodingError {
 
 /// Error type for database operations
 #[derive(Debug, Error)]
+#[non_exhaustive]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Error))]
 #[cfg_attr(feature = "uniffi", uniffi(flat_error))]
 pub enum DatabaseError {
@@ -2165,17 +2158,16 @@ pub enum DatabaseError {
     #[error("Database backend error: {0}")]
     DatabaseBackend(#[from] Box<dyn Error + Send + Sync>),
 
-    /// Other database error
-    #[error("Database error: {0:#}")]
-    Other(anyhow::Error),
+    /// The operation requires a global (non module-isolated) database instance.
+    #[error("Database instance is not global")]
+    NotGlobal,
+
+    /// The operation requires a module-isolated database instance.
+    #[error("Database instance is not isolated")]
+    NotIsolated,
 }
 
 impl DatabaseError {
-    /// Create a DatabaseError from any error type
-    pub fn other<E: Error + Send + Sync + 'static>(error: E) -> Self {
-        Self::Other(anyhow::Error::from(error))
-    }
-
     /// Create a DatabaseBackend error from any error type
     pub fn backend<E: Error + Send + Sync + 'static>(error: E) -> Self {
         Self::DatabaseBackend(Box::new(error))
@@ -2184,12 +2176,6 @@ impl DatabaseError {
     /// Create a `SnapshotTooOld` error, preserving the backend's own error
     pub fn snapshot_too_old<E: Error + Send + Sync + 'static>(error: E) -> Self {
         Self::SnapshotTooOld(Box::new(error))
-    }
-}
-
-impl From<anyhow::Error> for DatabaseError {
-    fn from(error: anyhow::Error) -> Self {
-        Self::Other(error)
     }
 }
 
@@ -3440,7 +3426,6 @@ mod test_utils {
         use std::ops::Range;
         use std::path::Path;
 
-        use anyhow::anyhow;
         use async_trait::async_trait;
 
         use crate::ModuleDecoderRegistry;
@@ -3519,7 +3504,9 @@ mod test_utils {
             async fn commit_tx(self) -> DatabaseResult<()> {
                 use crate::db::DatabaseError;
 
-                Err(DatabaseError::Other(anyhow::anyhow!("Can't commit!")))
+                Err(DatabaseError::backend(std::io::Error::other(
+                    "Can't commit!",
+                )))
             }
         }
 

--- a/fedimint-core/src/envs.rs
+++ b/fedimint-core/src/envs.rs
@@ -349,7 +349,7 @@ pub enum EnvParseError {
     },
 }
 
-pub fn parse_kv_list_from_env<K, V>(env: &str) -> anyhow::Result<BTreeMap<K, V>>
+pub fn parse_kv_list_from_env<K, V>(env: &str) -> BTreeMap<K, V>
 where
     K: FromStr + cmp::Ord,
     <K as FromStr>::Err: std::error::Error,
@@ -358,7 +358,7 @@ where
 {
     let mut map = BTreeMap::new();
     let Ok(env_value) = std::env::var(env) else {
-        return Ok(BTreeMap::new());
+        return BTreeMap::new();
     };
     for kv in env_value.split(',') {
         let kv = kv.trim();
@@ -397,7 +397,7 @@ where
         }
     }
 
-    Ok(map)
+    map
 }
 
 #[cfg(test)]

--- a/fedimint-core/src/envs.rs
+++ b/fedimint-core/src/envs.rs
@@ -1,13 +1,14 @@
 use std::collections::BTreeMap;
+use std::ffi::OsString;
 use std::str::FromStr;
 use std::{cmp, env};
 
-use anyhow::Context;
 use fedimint_core::util::SafeUrl;
 use fedimint_derive::{Decodable, Encodable};
 use fedimint_logging::LOG_CORE;
 use jsonrpsee_core::Serialize;
 use serde::Deserialize;
+use thiserror::Error;
 use tracing::warn;
 
 use crate::util::FmtCompact as _;
@@ -228,42 +229,124 @@ pub struct BitcoinRpcConfig {
 }
 
 impl BitcoinRpcConfig {
-    pub fn get_defaults_from_env_vars() -> anyhow::Result<Self> {
-        Ok(Self {
-        kind: env::var(FM_FORCE_BITCOIN_RPC_KIND_ENV)
-            .or_else(|_| env::var(FM_DEFAULT_BITCOIN_RPC_KIND_ENV))
-            .or_else(|_| env::var(FM_BITCOIN_RPC_KIND_ENV).inspect(|_v| {
-                warn!(target: LOG_CORE, "{FM_BITCOIN_RPC_KIND_ENV} is obsolete, use {FM_DEFAULT_BITCOIN_RPC_KIND_ENV} instead");
-            }))
-            .or_else(|_| env::var(FM_FORCE_BITCOIN_RPC_KIND_BAD_ENV).inspect(|_v| {
-                warn!(target: LOG_CORE, "{FM_FORCE_BITCOIN_RPC_KIND_BAD_ENV} is obsolete, use {FM_FORCE_BITCOIN_RPC_KIND_ENV} instead");
-            }))
-            .or_else(|_| env::var(FM_DEFAULT_BITCOIN_RPC_KIND_BAD_ENV).inspect(|_v| {
-                warn!(target: LOG_CORE, "{FM_DEFAULT_BITCOIN_RPC_KIND_BAD_ENV} is obsolete, use {FM_DEFAULT_BITCOIN_RPC_KIND_ENV} instead");
-            }))
-            .with_context(|| {
-                anyhow::anyhow!("failure looking up env var for Bitcoin RPC kind")
-            })?,
-        url: env::var(FM_FORCE_BITCOIN_RPC_URL_ENV)
-            .or_else(|_| env::var(FM_DEFAULT_BITCOIN_RPC_URL_ENV))
-            .or_else(|_| env::var(FM_BITCOIN_RPC_URL_ENV).inspect(|_v| {
-                warn!(target: LOG_CORE, "{FM_BITCOIN_RPC_URL_ENV} is obsolete, use {FM_DEFAULT_BITCOIN_RPC_URL_ENV} instead");
-            }))
-            .or_else(|_| env::var(FM_FORCE_BITCOIN_RPC_URL_BAD_ENV).inspect(|_v| {
-                warn!(target: LOG_CORE, "{FM_FORCE_BITCOIN_RPC_URL_BAD_ENV} is obsolete, use {FM_FORCE_BITCOIN_RPC_URL_ENV} instead");
-            }))
-            .or_else(|_| env::var(FM_DEFAULT_BITCOIN_RPC_URL_BAD_ENV).inspect(|_v| {
-                warn!(target: LOG_CORE, "{FM_DEFAULT_BITCOIN_RPC_URL_BAD_ENV} is obsolete, use {FM_DEFAULT_BITCOIN_RPC_URL_ENV} instead");
-            }))
-            .with_context(|| {
-                anyhow::anyhow!("failure looking up env var for Bitcoin RPC URL")
-            })?
-            .parse()
-            .with_context(|| {
-                anyhow::anyhow!("failure parsing Bitcoin RPC URL")
-            })?,
-    })
+    pub fn get_defaults_from_env_vars() -> Result<Self, EnvParseError> {
+        Self::defaults_from_lookup(&|var: &str| env::var_os(var))
     }
+
+    /// The defaults, reading the variables through `lookup` rather than from
+    /// the process environment.
+    fn defaults_from_lookup<L>(lookup: &L) -> Result<Self, EnvParseError>
+    where
+        L: Fn(&str) -> Option<OsString>,
+    {
+        let (_, kind) = first_env_var_set(
+            BITCOIN_RPC_KIND_ENVS,
+            FM_DEFAULT_BITCOIN_RPC_KIND_ENV,
+            lookup,
+        )?;
+        let (url_var, url) =
+            first_env_var_set(BITCOIN_RPC_URL_ENVS, FM_DEFAULT_BITCOIN_RPC_URL_ENV, lookup)?;
+
+        Ok(Self {
+            kind,
+            url: url.parse().map_err(|source| EnvParseError::InvalidUrl {
+                var: url_var,
+                source,
+            })?,
+        })
+    }
+}
+
+/// The environment variables holding the Bitcoin RPC kind, in lookup order,
+/// each paired with the variable that replaces it if it is deprecated.
+const BITCOIN_RPC_KIND_ENVS: &[(&str, Option<&str>)] = &[
+    (FM_FORCE_BITCOIN_RPC_KIND_ENV, None),
+    (FM_DEFAULT_BITCOIN_RPC_KIND_ENV, None),
+    (
+        FM_BITCOIN_RPC_KIND_ENV,
+        Some(FM_DEFAULT_BITCOIN_RPC_KIND_ENV),
+    ),
+    (
+        FM_FORCE_BITCOIN_RPC_KIND_BAD_ENV,
+        Some(FM_FORCE_BITCOIN_RPC_KIND_ENV),
+    ),
+    (
+        FM_DEFAULT_BITCOIN_RPC_KIND_BAD_ENV,
+        Some(FM_DEFAULT_BITCOIN_RPC_KIND_ENV),
+    ),
+];
+
+/// The environment variables holding the Bitcoin RPC URL, in lookup order,
+/// each paired with the variable that replaces it if it is deprecated.
+const BITCOIN_RPC_URL_ENVS: &[(&str, Option<&str>)] = &[
+    (FM_FORCE_BITCOIN_RPC_URL_ENV, None),
+    (FM_DEFAULT_BITCOIN_RPC_URL_ENV, None),
+    (FM_BITCOIN_RPC_URL_ENV, Some(FM_DEFAULT_BITCOIN_RPC_URL_ENV)),
+    (
+        FM_FORCE_BITCOIN_RPC_URL_BAD_ENV,
+        Some(FM_FORCE_BITCOIN_RPC_URL_ENV),
+    ),
+    (
+        FM_DEFAULT_BITCOIN_RPC_URL_BAD_ENV,
+        Some(FM_DEFAULT_BITCOIN_RPC_URL_ENV),
+    ),
+];
+
+/// The value of the first variable of `vars` that `lookup` finds, together
+/// with the name of that variable, warning about the deprecated ones on the
+/// way.
+///
+/// `canonical` is the variable a user should set, reported when none of them
+/// is.
+///
+/// A variable that is set but does not hold valid Unicode fails even when a
+/// lower-priority variable holds a usable value, because silently ignoring a
+/// variable the user did set would surprise them.
+fn first_env_var_set<L>(
+    vars: &[(&'static str, Option<&'static str>)],
+    canonical: &'static str,
+    lookup: &L,
+) -> Result<(&'static str, String), EnvParseError>
+where
+    L: Fn(&str) -> Option<OsString>,
+{
+    for &(var, replacement) in vars {
+        let Some(value) = lookup(var) else {
+            continue;
+        };
+        let Ok(value) = value.into_string() else {
+            return Err(EnvParseError::NotUnicode { var });
+        };
+
+        if let Some(replacement) = replacement {
+            warn!(target: LOG_CORE, "{var} is obsolete, use {replacement} instead");
+        }
+
+        return Ok((var, value));
+    }
+
+    Err(EnvParseError::NotSet { var: canonical })
+}
+
+/// Failure to build a configuration value from environment variables.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum EnvParseError {
+    /// None of the accepted variables is set; `var` is the canonical one to
+    /// set.
+    #[error("Environment variable {var} (or one of its aliases) is not set")]
+    NotSet { var: &'static str },
+    /// The variable is set but its value is not valid Unicode. A lower-priority
+    /// alias is not consulted once a variable is set.
+    #[error("Environment variable {var} is not valid Unicode")]
+    NotUnicode { var: &'static str },
+    /// The variable is set but is not a valid URL.
+    #[error("Environment variable {var} is not a valid URL")]
+    InvalidUrl {
+        var: &'static str,
+        #[source]
+        source: url::ParseError,
+    },
 }
 
 pub fn parse_kv_list_from_env<K, V>(env: &str) -> anyhow::Result<BTreeMap<K, V>>
@@ -316,3 +399,6 @@ where
 
     Ok(map)
 }
+
+#[cfg(test)]
+mod tests;

--- a/fedimint-core/src/envs/tests.rs
+++ b/fedimint-core/src/envs/tests.rs
@@ -1,0 +1,140 @@
+use std::collections::BTreeMap;
+use std::ffi::OsString;
+
+use super::{
+    BITCOIN_RPC_KIND_ENVS, BitcoinRpcConfig, EnvParseError, FM_BITCOIN_RPC_KIND_ENV,
+    FM_BITCOIN_RPC_URL_ENV, FM_DEFAULT_BITCOIN_RPC_KIND_ENV, FM_DEFAULT_BITCOIN_RPC_URL_ENV,
+    FM_FORCE_BITCOIN_RPC_KIND_ENV, first_env_var_set,
+};
+
+/// A lookup over a fixed set of variables, standing in for the process
+/// environment.
+fn lookup(vars: Vec<(&'static str, OsString)>) -> impl Fn(&str) -> Option<OsString> {
+    let vars: BTreeMap<&'static str, OsString> = vars.into_iter().collect();
+
+    move |var: &str| vars.get(var).cloned()
+}
+
+#[test]
+fn first_env_var_set_prefers_the_highest_priority_variable() {
+    let all = lookup(vec![
+        (FM_FORCE_BITCOIN_RPC_KIND_ENV, "forced".into()),
+        (FM_DEFAULT_BITCOIN_RPC_KIND_ENV, "default".into()),
+        (FM_BITCOIN_RPC_KIND_ENV, "obsolete".into()),
+    ]);
+
+    assert_eq!(
+        first_env_var_set(BITCOIN_RPC_KIND_ENVS, FM_DEFAULT_BITCOIN_RPC_KIND_ENV, &all)
+            .expect("the forced variable is set"),
+        (FM_FORCE_BITCOIN_RPC_KIND_ENV, "forced".to_owned())
+    );
+
+    let without_force = lookup(vec![
+        (FM_DEFAULT_BITCOIN_RPC_KIND_ENV, "default".into()),
+        (FM_BITCOIN_RPC_KIND_ENV, "obsolete".into()),
+    ]);
+
+    assert_eq!(
+        first_env_var_set(
+            BITCOIN_RPC_KIND_ENVS,
+            FM_DEFAULT_BITCOIN_RPC_KIND_ENV,
+            &without_force
+        )
+        .expect("the default variable is set"),
+        (FM_DEFAULT_BITCOIN_RPC_KIND_ENV, "default".to_owned())
+    );
+
+    // The obsolete variable is still honoured, and reported under its own name
+    // so that a later `InvalidUrl` names the variable the user actually set.
+    let only_obsolete = lookup(vec![(FM_BITCOIN_RPC_KIND_ENV, "obsolete".into())]);
+
+    assert_eq!(
+        first_env_var_set(
+            BITCOIN_RPC_KIND_ENVS,
+            FM_DEFAULT_BITCOIN_RPC_KIND_ENV,
+            &only_obsolete
+        )
+        .expect("the obsolete variable is set"),
+        (FM_BITCOIN_RPC_KIND_ENV, "obsolete".to_owned())
+    );
+}
+
+#[test]
+fn first_env_var_set_reports_the_canonical_variable_when_unset() {
+    let empty = lookup(vec![]);
+
+    assert!(matches!(
+        first_env_var_set(
+            BITCOIN_RPC_KIND_ENVS,
+            FM_DEFAULT_BITCOIN_RPC_KIND_ENV,
+            &empty
+        ),
+        Err(EnvParseError::NotSet {
+            var: FM_DEFAULT_BITCOIN_RPC_KIND_ENV
+        })
+    ));
+}
+
+/// A set but non-Unicode variable fails instead of falling through to a
+/// lower-priority alias.
+#[cfg(unix)]
+#[test]
+fn first_env_var_set_rejects_a_non_unicode_value() {
+    use std::os::unix::ffi::OsStringExt as _;
+
+    let vars = lookup(vec![
+        (
+            FM_FORCE_BITCOIN_RPC_KIND_ENV,
+            OsString::from_vec(vec![0xff]),
+        ),
+        (FM_DEFAULT_BITCOIN_RPC_KIND_ENV, "default".into()),
+    ]);
+
+    assert!(matches!(
+        first_env_var_set(
+            BITCOIN_RPC_KIND_ENVS,
+            FM_DEFAULT_BITCOIN_RPC_KIND_ENV,
+            &vars
+        ),
+        Err(EnvParseError::NotUnicode {
+            var: FM_FORCE_BITCOIN_RPC_KIND_ENV
+        })
+    ));
+}
+
+#[test]
+fn defaults_from_lookup_names_the_variable_holding_an_invalid_url() {
+    let vars = lookup(vec![
+        (FM_DEFAULT_BITCOIN_RPC_KIND_ENV, "bitcoind".into()),
+        (FM_BITCOIN_RPC_URL_ENV, "not a url".into()),
+    ]);
+
+    assert!(matches!(
+        BitcoinRpcConfig::defaults_from_lookup(&vars),
+        Err(EnvParseError::InvalidUrl {
+            var: FM_BITCOIN_RPC_URL_ENV,
+            ..
+        })
+    ));
+}
+
+#[test]
+fn defaults_from_lookup_builds_the_config() {
+    let vars = lookup(vec![
+        (FM_DEFAULT_BITCOIN_RPC_KIND_ENV, "bitcoind".into()),
+        (
+            FM_DEFAULT_BITCOIN_RPC_URL_ENV,
+            "http://localhost:38332".into(),
+        ),
+    ]);
+
+    assert_eq!(
+        BitcoinRpcConfig::defaults_from_lookup(&vars).expect("both variables are set"),
+        BitcoinRpcConfig {
+            kind: "bitcoind".to_owned(),
+            url: "http://localhost:38332"
+                .parse()
+                .expect("the URL is well-formed"),
+        }
+    );
+}

--- a/fedimint-core/src/invite_code.rs
+++ b/fedimint-core/src/invite_code.rs
@@ -5,11 +5,11 @@ use std::fmt::{Display, Formatter};
 use std::io::Read;
 use std::str::FromStr;
 
-use anyhow::ensure;
 use bech32::{Bech32m, Hrp};
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
-use crate::base32::FEDIMINT_PREFIX;
+use crate::base32::{FEDIMINT_PREFIX, PrefixedDecodeError};
 use crate::config::FederationId;
 use crate::encoding::{Decodable, DecodeError, Encodable};
 use crate::module::registry::{ModuleDecoderRegistry, ModuleRegistry};
@@ -30,7 +30,7 @@ pub struct InviteCode(Vec<InviteCodePart>);
 #[cfg(feature = "uniffi")]
 uniffi::custom_type!(InviteCode, String, {
     lower: |i| i.to_string(),
-    try_lift: |s| s.parse().map_err(|e: anyhow::Error| e),
+    try_lift: |s| s.parse::<InviteCode>().map_err(anyhow::Error::from),
 });
 
 impl Decodable for InviteCode {
@@ -218,21 +218,50 @@ enum InviteCodePart {
 const BECH32_HRP: Hrp = Hrp::parse_unchecked("fed1");
 
 impl FromStr for InviteCode {
-    type Err = anyhow::Error;
+    type Err = InviteCodeParseError;
 
     fn from_str(encoded: &str) -> Result<Self, Self::Err> {
-        if let Ok(invite_code) = crate::base32::decode_prefixed(FEDIMINT_PREFIX, encoded) {
-            return Ok(invite_code);
+        // The prefix is ASCII, so a case-insensitive match here agrees with the
+        // lowercasing `decode_prefixed` does before comparing the prefix.
+        if encoded
+            .get(..FEDIMINT_PREFIX.len())
+            .is_some_and(|prefix| prefix.eq_ignore_ascii_case(FEDIMINT_PREFIX))
+        {
+            return Ok(crate::base32::decode_prefixed(FEDIMINT_PREFIX, encoded)?);
         }
 
         let (hrp, data) = bech32::decode(encoded)?;
 
-        ensure!(hrp == BECH32_HRP, "Invalid HRP in bech32 encoding");
+        if hrp != BECH32_HRP {
+            return Err(InviteCodeParseError::InvalidHrp { hrp });
+        }
 
         let invite = Self::consensus_decode_whole(&data, &ModuleRegistry::default())?;
 
         Ok(invite)
     }
+}
+
+/// Failure to parse an [`InviteCode`] from its string form.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum InviteCodeParseError {
+    /// The string is not a valid bech32m encoding.
+    #[error("Invalid bech32 encoding: {0}")]
+    Bech32(#[from] bech32::DecodeError),
+    /// The bech32 human-readable part is not the invite code HRP.
+    #[error(
+        "Invalid bech32 human-readable part '{hrp}', expected '{}'",
+        BECH32_HRP
+    )]
+    InvalidHrp { hrp: bech32::Hrp },
+    /// The payload is not a valid consensus encoding of an invite code.
+    #[error("Invalid invite code payload: {0}")]
+    Decode(#[from] DecodeError),
+    /// The string carries the [`FEDIMINT_PREFIX`] but its base 32 payload does
+    /// not decode into an invite code.
+    #[error("Invalid prefixed base32 invite code: {0}")]
+    Base32(#[from] PrefixedDecodeError),
 }
 
 /// Parses the invite code from a bech32 string
@@ -270,6 +299,7 @@ mod tests {
     use fedimint_core::PeerId;
     use fedimint_core::base32::FEDIMINT_PREFIX;
 
+    use super::InviteCodeParseError;
     use crate::config::FederationId;
     use crate::invite_code::InviteCode;
 
@@ -300,5 +330,31 @@ mod tests {
                 ))
             ]
         );
+    }
+
+    #[test]
+    fn from_str_rejects_wrong_hrp() {
+        let other_hrp = bech32::Hrp::parse("abcd").expect("valid hrp");
+        let encoded = bech32::encode::<bech32::Bech32m>(other_hrp, &[0u8; 8]).expect("encodes");
+        assert!(matches!(
+            InviteCode::from_str(&encoded),
+            Err(InviteCodeParseError::InvalidHrp { hrp }) if hrp == other_hrp
+        ));
+    }
+
+    #[test]
+    fn from_str_rejects_non_bech32() {
+        assert!(matches!(
+            InviteCode::from_str("definitely not bech32"),
+            Err(InviteCodeParseError::Bech32(_))
+        ));
+    }
+
+    #[test]
+    fn from_str_reports_corrupt_prefixed_base32() {
+        assert!(matches!(
+            InviteCode::from_str(&format!("{FEDIMINT_PREFIX}not!base32")),
+            Err(InviteCodeParseError::Base32(_))
+        ));
     }
 }

--- a/fedimint-core/src/lib.rs
+++ b/fedimint-core/src/lib.rs
@@ -272,7 +272,7 @@ impl std::fmt::Display for BitcoinAmountOrAll {
 }
 
 impl FromStr for BitcoinAmountOrAll {
-    type Err = anyhow::Error;
+    type Err = ParseBitcoinAmountOrAllError;
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         if s.eq_ignore_ascii_case("all") {
@@ -282,6 +282,18 @@ impl FromStr for BitcoinAmountOrAll {
             Ok(Self::Amount(amount.try_into()?))
         }
     }
+}
+
+/// Failure to parse a [`BitcoinAmountOrAll`] from its string form.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum ParseBitcoinAmountOrAllError {
+    /// The string is neither `all` nor a valid amount.
+    #[error("Invalid amount: {0}")]
+    Amount(#[from] ParseAmountError),
+    /// The amount is valid but has sub-satoshi precision.
+    #[error("Amount cannot be expressed in satoshis: {0}")]
+    Precision(#[from] AmountConversionError),
 }
 
 // Custom serde to handle both "all" and numbers/strings

--- a/fedimint-core/src/net/iroh.rs
+++ b/fedimint-core/src/net/iroh.rs
@@ -1,7 +1,6 @@
 use std::net::SocketAddr;
 use std::time::Duration;
 
-use anyhow::Context;
 use fedimint_core::util::SafeUrl;
 use fedimint_logging::LOG_NET_IROH;
 use iroh::defaults::DEFAULT_STUN_PORT;
@@ -9,6 +8,7 @@ use iroh::discovery::pkarr::{PkarrPublisher, PkarrResolver};
 use iroh::endpoint::{Builder, TransportConfig};
 use iroh::{Endpoint, RelayMode, RelayNode, RelayUrl, SecretKey};
 use iroh_relay::RelayQuicConfig;
+use thiserror::Error;
 use tracing::{debug, info, warn};
 use url::Url;
 
@@ -35,7 +35,7 @@ pub async fn build_iroh_endpoint(
     iroh_dns: Option<SafeUrl>,
     iroh_relays: Vec<SafeUrl>,
     alpn: &[u8],
-) -> Result<Endpoint, anyhow::Error> {
+) -> Result<Endpoint, IrohEndpointError> {
     let relay_mode = if !is_env_var_set_opt(FM_IROH_RELAYS_ENABLE_ENV).unwrap_or(true) {
         warn!(
             target: LOG_NET_IROH,
@@ -127,7 +127,7 @@ pub async fn build_iroh_endpoint(
 
     let endpoint = Box::pin(builder.bind())
         .await
-        .context("Failed to bind Iroh endpoint")?;
+        .map_err(|e| IrohEndpointError::Bind(e.into()))?;
 
     info!(
         target: LOG_NET_IROH,
@@ -138,6 +138,15 @@ pub async fn build_iroh_endpoint(
     );
 
     Ok(endpoint)
+}
+
+/// Failure to set up an iroh endpoint.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum IrohEndpointError {
+    /// The endpoint could not bind its socket or reach its relays.
+    #[error("Failed to bind Iroh endpoint")]
+    Bind(#[source] Box<dyn std::error::Error + Send + Sync>),
 }
 
 fn relay_node_from_url(url: Url) -> RelayNode {

--- a/fedimint-core/src/task.rs
+++ b/fedimint-core/src/task.rs
@@ -11,7 +11,6 @@ use std::pin::{Pin, pin};
 use std::sync::Arc;
 use std::time::SystemTime;
 
-use anyhow::bail;
 use fedimint_core::time::now;
 use fedimint_logging::{LOG_TASK, LOG_TEST};
 use futures::future::{self, Either};
@@ -84,7 +83,7 @@ impl TaskGroup {
     pub async fn shutdown_join_all(
         self,
         join_timeout: impl Into<Option<Duration>>,
-    ) -> Result<(), anyhow::Error> {
+    ) -> Result<(), JoinAllError> {
         self.shutdown();
         self.join_all(join_timeout.into()).await
     }
@@ -310,7 +309,7 @@ impl TaskGroup {
         })
     }
 
-    pub async fn join_all(self, timeout: Option<Duration>) -> Result<(), anyhow::Error> {
+    pub async fn join_all(self, timeout: Option<Duration>) -> Result<(), JoinAllError> {
         let deadline = timeout.map(|timeout| now() + timeout);
         let mut errors = vec![];
 
@@ -319,8 +318,7 @@ impl TaskGroup {
         if errors.is_empty() {
             Ok(())
         } else {
-            let num_errors = errors.len();
-            bail!("{num_errors} tasks did not finish cleanly: {errors:?}")
+            Err(JoinAllError { errors })
         }
     }
 
@@ -365,6 +363,17 @@ pub struct TaskHandle {
 #[error("Task group is shutting down")]
 #[non_exhaustive]
 pub struct ShuttingDownError {}
+
+/// One or more tasks of a [`TaskGroup`] did not finish cleanly.
+#[derive(Debug, Error)]
+#[error("{} tasks did not finish cleanly: {errors:?}", .errors.len())]
+#[non_exhaustive]
+pub struct JoinAllError {
+    /// The join failures collected for tasks that were still registered with
+    /// the group when joining; a task that had already finished or panicked
+    /// before the join is not included.
+    pub errors: Vec<JoinError>,
+}
 
 impl TaskHandle {
     /// Is task group shutting down?

--- a/fedimint-core/src/task/jit.rs
+++ b/fedimint-core/src/task/jit.rs
@@ -15,7 +15,6 @@ use crate::util::FmtCompact;
 
 pub type Jit<T> = JitCore<T, Infallible>;
 pub type JitTry<T, E> = JitCore<T, E>;
-pub type JitTryAnyhow<T> = JitCore<T, anyhow::Error>;
 
 /// Error that could have been returned before
 ///
@@ -24,7 +23,7 @@ pub type JitTryAnyhow<T> = JitCore<T, anyhow::Error>;
 #[derive(Debug)]
 pub enum OneTimeError<E> {
     Original(E),
-    Copy(anyhow::Error),
+    Copy(String),
 }
 
 impl<E> std::error::Error for OneTimeError<E>
@@ -48,7 +47,7 @@ where
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Original(o) => o.fmt(f),
-            Self::Copy(c) => c.fmt(f),
+            Self::Copy(c) => f.write_str(c),
         }
     }
 }
@@ -142,7 +141,7 @@ where
         }
         value
             .as_ref()
-            .map_err(|err_str| OneTimeError::Copy(anyhow::Error::msg(err_str.to_owned())))
+            .map_err(|err_str| OneTimeError::Copy(err_str.to_owned()))
     }
 }
 impl<T> JitCore<T, Infallible>

--- a/fedimint-core/src/task/jit/tests.rs
+++ b/fedimint-core/src/task/jit/tests.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use anyhow::bail;
 
-use super::{Jit, JitTry, JitTryAnyhow};
+use super::{Jit, JitTry};
 
 #[test_log::test(tokio::test)]
 async fn sanity_jit() {
@@ -18,7 +18,7 @@ async fn sanity_jit() {
 
 #[test_log::test(tokio::test)]
 async fn sanity_jit_try_ok() {
-    let v = JitTryAnyhow::new_try(|| async {
+    let v = JitTry::<_, anyhow::Error>::new_try(|| async {
         fedimint_core::runtime::sleep(Duration::from_millis(0)).await;
         Ok(3)
     });

--- a/fedimint-core/src/task/tests.rs
+++ b/fedimint-core/src/task/tests.rs
@@ -1,4 +1,4 @@
-use super::{Duration, TaskGroup, sleep};
+use super::{Duration, JoinAllError, TaskGroup, sleep};
 
 #[test_log::test(tokio::test)]
 async fn shutdown_task_group_after() -> anyhow::Result<()> {
@@ -44,4 +44,24 @@ async fn shutdown_task_subgroup_before() -> anyhow::Result<()> {
         });
     tg.shutdown_join_all(None).await?;
     Ok(())
+}
+
+#[test_log::test(tokio::test)]
+async fn join_all_reports_tasks_that_did_not_finish_cleanly() {
+    let tg = TaskGroup::new();
+    tg.spawn("panics", |_handle| async { panic!("boom") });
+    // Join immediately: a task that has already finished (or panicked) removes its
+    // own join handle from the group, so it must still be pending when
+    // `join_all` collects. `#[tokio::test]` runs single-threaded and `join_all`
+    // drains the handle map before its first await, so the panicking task is
+    // still registered.
+    let err: JoinAllError = tg
+        .join_all(None)
+        .await
+        .expect_err("a panicked task is not a clean finish");
+    assert_eq!(err.errors.len(), 1);
+    assert!(
+        err.to_string()
+            .starts_with("1 tasks did not finish cleanly")
+    );
 }

--- a/fedimint-core/src/tests.rs
+++ b/fedimint-core/src/tests.rs
@@ -48,3 +48,40 @@ fn test_deserialize_amount_or_all() {
     let amount_parsed = BitcoinAmountOrAll::from_str(&amount_string).unwrap();
     assert_eq!(amount, amount_parsed);
 }
+
+#[test]
+fn bitcoin_amount_or_all_parse_errors_are_typed() {
+    use std::str::FromStr;
+
+    use crate::{BitcoinAmountOrAll, ParseBitcoinAmountOrAllError};
+
+    assert_eq!(
+        BitcoinAmountOrAll::from_str("ALL").expect("parses"),
+        BitcoinAmountOrAll::All
+    );
+    assert!(matches!(
+        BitcoinAmountOrAll::from_str("1msat"),
+        Err(ParseBitcoinAmountOrAllError::Precision(_))
+    ));
+    assert!(matches!(
+        BitcoinAmountOrAll::from_str("not a number"),
+        Err(ParseBitcoinAmountOrAllError::Amount(_))
+    ));
+}
+
+#[test]
+fn operation_id_parse_error_is_typed() {
+    use std::str::FromStr;
+
+    use crate::core::OperationId;
+
+    // 64 hex digits (32 bytes) with one invalid character: `hex` 0.4 checks the
+    // length before the characters, so a short input would report
+    // `InvalidStringLength` instead.
+    let input = format!("z{}", "0".repeat(63));
+    let err: hex::FromHexError = OperationId::from_str(&input).expect_err("not hex");
+    assert!(matches!(
+        err,
+        hex::FromHexError::InvalidHexCharacter { c: 'z', index: 0 }
+    ));
+}

--- a/fedimint-core/src/util/mod.rs
+++ b/fedimint-core/src/util/mod.rs
@@ -16,7 +16,6 @@ use std::str::FromStr;
 use std::sync::LazyLock;
 use std::{fs, io};
 
-use anyhow::format_err;
 use fedimint_logging::LOG_CORE;
 pub use fedimint_util_error::*;
 use futures::StreamExt;
@@ -35,13 +34,18 @@ pub type BoxFuture<'a, T> = Pin<Box<maybe_add_send!(dyn Future<Output = T> + 'a)
 /// Stream that is `Send` unless targeting WASM
 pub type BoxStream<'a, T> = Pin<Box<maybe_add_send!(dyn futures::Stream<Item = T> + 'a)>>;
 
+/// The stream ended while an item was still expected.
+#[derive(Debug, thiserror::Error, Clone, Copy, Eq, PartialEq)]
+#[error("Stream was unexpectedly closed")]
+pub struct StreamEndedError;
+
 #[apply(async_trait_maybe_send!)]
 pub trait NextOrPending {
     type Output;
 
     async fn next_or_pending(&mut self) -> Self::Output;
 
-    async fn ok(&mut self) -> anyhow::Result<Self::Output>;
+    async fn ok(&mut self) -> Result<Self::Output, StreamEndedError>;
 }
 
 #[apply(async_trait_maybe_send!)]
@@ -54,10 +58,8 @@ where
 
     /// Waits for the next item in a stream. If the stream is closed while
     /// waiting, returns an error.  Useful when expecting a stream to progress.
-    async fn ok(&mut self) -> anyhow::Result<Self::Output> {
-        self.next()
-            .await
-            .map_or_else(|| Err(format_err!("Stream was unexpectedly closed")), Ok)
+    async fn ok(&mut self) -> Result<Self::Output, StreamEndedError> {
+        self.next().await.ok_or(StreamEndedError)
     }
 
     /// Waits for the next item in a stream. If the stream is closed while

--- a/fedimint-core/src/util/mod.rs
+++ b/fedimint-core/src/util/mod.rs
@@ -413,7 +413,7 @@ pub fn handle_version_hash_command(version_hash: &str) {
 ///     backoff_util::background_backoff(),
 ///     || async {
 ///         // Fallible network calls …
-///         Ok(())
+///         anyhow::Ok(())
 ///     },
 /// )
 /// .await
@@ -425,15 +425,16 @@ pub fn handle_version_hash_command(version_hash: &str) {
 ///
 /// - If the closure runs successfully, the result is immediately returned
 /// - If the closure did not run successfully for `max_attempts` times, the
-///   error of the closure is returned
-pub async fn retry<F, Fut, T>(
+///   closure's error is returned
+pub async fn retry<F, Fut, T, E>(
     op_name: impl Into<String>,
     strategy: impl backoff_util::Backoff,
     op_fn: F,
-) -> Result<T, anyhow::Error>
+) -> Result<T, E>
 where
     F: Fn() -> Fut,
-    Fut: Future<Output = Result<T, anyhow::Error>>,
+    Fut: Future<Output = Result<T, E>>,
+    E: Display,
 {
     let mut strategy = strategy;
     let op_name = op_name.into();
@@ -447,7 +448,7 @@ where
                     // run closure op_fn again
                     debug!(
                         target: LOG_CORE,
-                        err = %err.fmt_compact_anyhow(),
+                        err = %format_args!("{err:#}"),
                         %attempts,
                         interval = interval.as_secs(),
                         "{} failed, retrying",
@@ -457,7 +458,7 @@ where
                 } else {
                     warn!(
                         target: LOG_CORE,
-                        err = %err.fmt_compact_anyhow(),
+                        err = %format_args!("{err:#}"),
                         %attempts,
                         "{} failed",
                         op_name,

--- a/fedimint-core/src/util/tests.rs
+++ b/fedimint-core/src/util/tests.rs
@@ -88,7 +88,7 @@ async fn retry_succeed_with_one_attempt() {
     let closure = || async {
         counter.fetch_add(1, Ordering::SeqCst);
         // Always return a success.
-        Ok(42)
+        anyhow::Ok(42)
     };
 
     let _ = retry(
@@ -119,4 +119,19 @@ async fn retry_fail_with_three_attempts() {
     .await;
 
     assert_eq!(counter.load(Ordering::SeqCst), 3);
+}
+
+#[tokio::test]
+async fn retry_keeps_the_closure_error_type() {
+    #[derive(Debug, PartialEq, thiserror::Error)]
+    #[error("Nope")]
+    struct Nope;
+
+    let result: Result<(), Nope> = retry(
+        "always fails",
+        backoff_util::immediate_backoff(Some(2)),
+        || async { Err(Nope) },
+    )
+    .await;
+    assert_eq!(result, Err(Nope));
 }

--- a/fedimint-core/src/util/tests.rs
+++ b/fedimint-core/src/util/tests.rs
@@ -122,6 +122,13 @@ async fn retry_fail_with_three_attempts() {
 }
 
 #[tokio::test]
+async fn ok_reports_closed_stream_with_typed_error() {
+    let mut stream = futures::stream::iter(vec![1]);
+    assert_eq!(stream.ok().await, Ok(1));
+    assert_eq!(stream.ok().await, Err(super::StreamEndedError));
+}
+
+#[tokio::test]
 async fn retry_keeps_the_closure_error_type() {
     #[derive(Debug, PartialEq, thiserror::Error)]
     #[error("Nope")]

--- a/fedimint-dbtool/src/dump.rs
+++ b/fedimint-dbtool/src/dump.rs
@@ -84,7 +84,6 @@ impl DatabaseDump {
             // db
             let decoders = module_inits
                 .available_decoders(cfg.iter_module_instances())
-                .unwrap()
                 .with_fallback();
             (Some(cfg), None, decoders)
         } else {
@@ -100,7 +99,6 @@ impl DatabaseDump {
                     let kinds = client_cfg.modules.iter().map(|(k, v)| (*k, &v.kind));
                     let decoders = client_module_inits
                         .available_decoders(kinds)
-                        .unwrap()
                         .with_fallback();
                     let client_cfg = client_cfg.redecode_raw(&decoders)?;
                     (None, Some(client_cfg), decoders)

--- a/fedimint-server-core/src/init.rs
+++ b/fedimint-server-core/src/init.rs
@@ -318,12 +318,12 @@ where
         module_instance_id: ModuleInstanceId,
         config: &ServerModuleConsensusConfig,
     ) -> anyhow::Result<ClientModuleConfig> {
-        ClientModuleConfig::from_typed(
+        Ok(ClientModuleConfig::from_typed(
             module_instance_id,
             <Self as ServerModuleInit>::kind(),
             config.version,
             <Self as ServerModuleInit>::get_client_config(self, config)?,
-        )
+        ))
     }
     fn get_database_migrations(&self) -> BTreeMap<DatabaseVersion, DynServerDbMigrationFn> {
         <Self as ServerModuleInit>::get_database_migrations(self)

--- a/fedimint-server-core/src/migration.rs
+++ b/fedimint-server-core/src/migration.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use fedimint_core::core::{DynInput, DynModuleConsensusItem, DynOutput, ModuleInstanceId};
 use fedimint_core::db::{
-    Database, DatabaseTransaction, DatabaseVersion, DbMigrationFn, DbMigrationFnContext,
-    apply_migrations_dbtx,
+    Database, DatabaseTransaction, DatabaseVersion, DbMigrationError, DbMigrationFn,
+    DbMigrationFnContext, apply_migrations_dbtx,
 };
 use fedimint_core::module::ModuleCommon;
 use fedimint_core::util::BoxStream;
@@ -153,14 +153,11 @@ pub async fn apply_migrations_server(
     db: &Database,
     kind: String,
     migrations: BTreeMap<DatabaseVersion, DynServerDbMigrationFn>,
-) -> Result<(), anyhow::Error> {
+) -> Result<(), DbMigrationError> {
     let mut global_dbtx = db.begin_transaction().await;
     global_dbtx.ensure_global()?;
     apply_migrations_server_dbtx(&mut global_dbtx.to_ref_nc(), ctx, kind, migrations).await?;
-    global_dbtx
-        .commit_tx_result()
-        .await
-        .map_err(|e| anyhow::Error::msg(e.to_string()))
+    Ok(global_dbtx.commit_tx_result().await?)
 }
 
 /// Applies the database migrations to a non-isolated database.
@@ -169,7 +166,7 @@ pub async fn apply_migrations_server_dbtx(
     ctx: DynServerDbMigrationContext,
     kind: String,
     migrations: BTreeMap<DatabaseVersion, DynServerDbMigrationFn>,
-) -> Result<(), anyhow::Error> {
+) -> Result<(), DbMigrationError> {
     global_dbtx.ensure_global()?;
     apply_migrations_dbtx(global_dbtx, ctx, kind, migrations, None, None).await
 }

--- a/fedimint-server/src/config/mod.rs
+++ b/fedimint-server/src/config/mod.rs
@@ -392,7 +392,7 @@ impl ServerConfig {
             .clone();
         let module = ServerModuleConfig::from(private, consensus);
 
-        module.to_typed()
+        Ok(module.to_typed()?)
     }
     pub fn get_module_id_by_kind(
         &self,

--- a/fedimint-server/src/net/p2p_connector/iroh.rs
+++ b/fedimint-server/src/net/p2p_connector/iroh.rs
@@ -72,7 +72,7 @@ impl IrohConnector {
         // read the `NodeTicket`-format
         // `FM_IROH_CONNECT_OVERRIDES` instead; devimint emits both side by side.
         for (k, v) in
-            parse_kv_list_from_env::<EndpointId, SocketAddr>(FM_IROH_CONNECT_OVERRIDES_PLAIN_ENV)?
+            parse_kv_list_from_env::<EndpointId, SocketAddr>(FM_IROH_CONNECT_OVERRIDES_PLAIN_ENV)
         {
             s.connection_overrides
                 .insert(k, EndpointAddr::from_parts(k, [TransportAddr::Ip(v)]));

--- a/fedimint-testing/src/federation.rs
+++ b/fedimint-testing/src/federation.rs
@@ -345,7 +345,7 @@ impl FederationTestBuilder {
             }
 
             let instances = cfg.consensus.iter_module_instances();
-            let decoders = self.server_init.available_decoders(instances).unwrap();
+            let decoders = self.server_init.available_decoders(instances);
             let db = Database::new(MemDatabase::new(), decoders);
             let module_init_registry = self.server_init.clone();
             let subgroup = task_group.make_subgroup();

--- a/fedimint-testing/src/fixtures.rs
+++ b/fedimint-testing/src/fixtures.rs
@@ -207,8 +207,7 @@ impl Fixtures {
             .collect();
         let decoders = self
             .servers
-            .available_decoders(module_kinds.iter().map(|(id, kind)| (*id, kind)))
-            .unwrap();
+            .available_decoders(module_kinds.iter().map(|(id, kind)| (*id, kind)));
         let gateway_db = Database::new(MemDatabase::new(), decoders.clone());
 
         let mnemonic = Bip39RootSecretStrategy::<12>::random(&mut OsRng);

--- a/fedimintd/src/lib.rs
+++ b/fedimintd/src/lib.rs
@@ -29,7 +29,9 @@ use fedimint_core::module::{ApiAuth, CORE_CONSENSUS_VERSION};
 use fedimint_core::rustls::install_crypto_provider;
 use fedimint_core::task::TaskGroup;
 use fedimint_core::timing;
-use fedimint_core::util::{FmtCompactAnyhow as _, SafeUrl, handle_version_hash_command};
+use fedimint_core::util::{
+    FmtCompact as _, FmtCompactAnyhow as _, SafeUrl, handle_version_hash_command,
+};
 use fedimint_ln_server::LightningInit;
 use fedimint_logging::{LOG_CORE, LOG_SERVER, TracingSetup};
 use fedimint_meta_server::MetaInit;
@@ -527,7 +529,7 @@ pub async fn run(
     debug!(target: LOG_CORE, "Terminating main task");
 
     if let Err(err) = root_task_group.join_all(Some(SHUTDOWN_TIMEOUT)).await {
-        error!(target: LOG_CORE, err = %err.fmt_compact_anyhow(), "Error while shutting down task group");
+        error!(target: LOG_CORE, err = %err.fmt_compact(), "Error while shutting down task group");
     }
 
     debug!(target: LOG_CORE, "Shutdown complete");

--- a/gateway/fedimint-gateway-server-db/src/lib.rs
+++ b/gateway/fedimint-gateway-server-db/src/lib.rs
@@ -6,7 +6,7 @@ use bitcoin::hashes::{Hash, sha256};
 use fedimint_core::config::FederationId;
 use fedimint_core::core::OperationId;
 use fedimint_core::db::{
-    Database, DatabaseTransaction, DatabaseVersion, GeneralDbMigrationFn,
+    Database, DatabaseTransaction, DatabaseVersion, DbMigrationError, GeneralDbMigrationFn,
     GeneralDbMigrationFnContext, IDatabaseTransactionOpsCore, IDatabaseTransactionOpsCoreTyped,
 };
 use fedimint_core::encoding::btc::NetworkLegacyEncodingWrapper;
@@ -655,7 +655,7 @@ pub fn get_gatewayd_database_migrations() -> BTreeMap<DatabaseVersion, GeneralDb
     migrations
 }
 
-async fn migrate_to_v1(mut ctx: GeneralDbMigrationFnContext<'_>) -> Result<(), anyhow::Error> {
+async fn migrate_to_v1(mut ctx: GeneralDbMigrationFnContext<'_>) -> Result<(), DbMigrationError> {
     /// Creates a password hash by appending a 4 byte salt to the plaintext
     /// password.
     fn hash_password(plaintext_password: &str, salt: [u8; 16]) -> sha256::Hash {
@@ -685,7 +685,7 @@ async fn migrate_to_v1(mut ctx: GeneralDbMigrationFnContext<'_>) -> Result<(), a
     Ok(())
 }
 
-async fn migrate_to_v2(mut ctx: GeneralDbMigrationFnContext<'_>) -> Result<(), anyhow::Error> {
+async fn migrate_to_v2(mut ctx: GeneralDbMigrationFnContext<'_>) -> Result<(), DbMigrationError> {
     let mut dbtx = ctx.dbtx();
 
     // If there is no old federation configuration, there is nothing to do.
@@ -712,7 +712,7 @@ async fn migrate_to_v2(mut ctx: GeneralDbMigrationFnContext<'_>) -> Result<(), a
     Ok(())
 }
 
-async fn migrate_to_v3(mut ctx: GeneralDbMigrationFnContext<'_>) -> Result<(), anyhow::Error> {
+async fn migrate_to_v3(mut ctx: GeneralDbMigrationFnContext<'_>) -> Result<(), DbMigrationError> {
     let mut dbtx = ctx.dbtx();
 
     // If there is no old gateway configuration, there is nothing to do.
@@ -729,7 +729,7 @@ async fn migrate_to_v3(mut ctx: GeneralDbMigrationFnContext<'_>) -> Result<(), a
     Ok(())
 }
 
-async fn migrate_to_v4(mut ctx: GeneralDbMigrationFnContext<'_>) -> Result<(), anyhow::Error> {
+async fn migrate_to_v4(mut ctx: GeneralDbMigrationFnContext<'_>) -> Result<(), DbMigrationError> {
     let mut dbtx = ctx.dbtx();
 
     dbtx.remove_entry(&GatewayConfigurationKeyV2).await;
@@ -760,14 +760,14 @@ async fn migrate_to_v4(mut ctx: GeneralDbMigrationFnContext<'_>) -> Result<(), a
 /// record and the isolated databases used for each client. We must migrate the
 /// isolated databases to be behind the `ClientDatabase` prefix to allow the
 /// gateway to properly read the federation configs.
-async fn migrate_to_v5(mut ctx: GeneralDbMigrationFnContext<'_>) -> Result<(), anyhow::Error> {
+async fn migrate_to_v5(mut ctx: GeneralDbMigrationFnContext<'_>) -> Result<(), DbMigrationError> {
     let mut dbtx = ctx.dbtx();
     migrate_federation_configs(&mut dbtx).await
 }
 
 async fn migrate_federation_configs(
     dbtx: &mut DatabaseTransaction<'_>,
-) -> Result<(), anyhow::Error> {
+) -> Result<(), DbMigrationError> {
     // We need to migrate all isolated database entries to be behind the 0x10
     // prefix. The problem is, if there is a `FederationId` that starts with
     // 0x04, we cannot read the `FederationId` because the database will be confused
@@ -828,7 +828,7 @@ async fn migrate_federation_configs(
     Ok(())
 }
 
-async fn migrate_to_v6(mut ctx: GeneralDbMigrationFnContext<'_>) -> Result<(), anyhow::Error> {
+async fn migrate_to_v6(mut ctx: GeneralDbMigrationFnContext<'_>) -> Result<(), DbMigrationError> {
     let mut dbtx = ctx.dbtx();
 
     let configs = dbtx
@@ -848,7 +848,7 @@ async fn migrate_to_v6(mut ctx: GeneralDbMigrationFnContext<'_>) -> Result<(), a
     Ok(())
 }
 
-async fn migrate_to_v7(mut ctx: GeneralDbMigrationFnContext<'_>) -> anyhow::Result<()> {
+async fn migrate_to_v7(mut ctx: GeneralDbMigrationFnContext<'_>) -> Result<(), DbMigrationError> {
     let mut dbtx = ctx.dbtx();
 
     let gateway_keypair = dbtx.remove_entry(&GatewayPublicKeyV0).await;
@@ -867,14 +867,14 @@ async fn migrate_to_v7(mut ctx: GeneralDbMigrationFnContext<'_>) -> anyhow::Resu
 
 /// Adds the invoice expiry to registered incoming contract records so stale
 /// records can be pruned.
-async fn migrate_to_v8(mut ctx: GeneralDbMigrationFnContext<'_>) -> anyhow::Result<()> {
+async fn migrate_to_v8(mut ctx: GeneralDbMigrationFnContext<'_>) -> Result<(), DbMigrationError> {
     let mut dbtx = ctx.dbtx();
     migrate_registered_incoming_contracts(&mut dbtx).await
 }
 
 async fn migrate_registered_incoming_contracts(
     dbtx: &mut DatabaseTransaction<'_>,
-) -> anyhow::Result<()> {
+) -> Result<(), DbMigrationError> {
     // Existing records predate the invoice expiry, so backfill it as if their
     // invoice had just been created with the maximum allowed expiry; they are
     // retained conservatively and eventually pruned.

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -1000,7 +1000,7 @@ impl Gateway {
                             // could cause it to cancel real HTLCs after `gateway_receiver`
                             // is dropped.
                             if let Err(err) = payment_stream_task_group.shutdown_join_all(None).await {
-                                crit!(target: LOG_GATEWAY, err = %err.fmt_compact_anyhow(), "Lightning payment stream task group shutdown");
+                                crit!(target: LOG_GATEWAY, err = %err.fmt_compact(), "Lightning payment stream task group shutdown");
                             }
                             sleep(Duration::from_secs(PAYMENT_STREAM_RETRY_SECONDS)).await;
                             continue
@@ -1016,7 +1016,7 @@ impl Gateway {
 
                     self_copy.set_gateway_state(GatewayState::Disconnected).await;
                     if let Err(err) = payment_stream_task_group.shutdown_join_all(None).await {
-                        crit!(target: LOG_GATEWAY, err = %err.fmt_compact_anyhow(), "Lightning payment stream task group shutdown");
+                        crit!(target: LOG_GATEWAY, err = %err.fmt_compact(), "Lightning payment stream task group shutdown");
                     }
 
                     self_copy.unannounce_from_all_federations().await;
@@ -2924,7 +2924,7 @@ impl IAdminGateway for Gateway {
         let tg = task_group.clone();
         tg.spawn("Kill Gateway", |_task_handle| async {
             if let Err(err) = task_group.shutdown_join_all(Duration::from_mins(3)).await {
-                warn!(target: LOG_GATEWAY, err = %err.fmt_compact_anyhow(), "Error shutting down gateway");
+                warn!(target: LOG_GATEWAY, err = %err.fmt_compact(), "Error shutting down gateway");
             }
         });
         Ok(())

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -2057,7 +2057,7 @@ impl Gateway {
 
         // Verify the LNv1 network if present
         if let Some(cfg) = lnv1_cfg {
-            let ln_cfg: &LightningClientConfig = cfg.cast()?;
+            let ln_cfg: &LightningClientConfig = cfg.cast().map_err(anyhow::Error::from)?;
 
             if ln_cfg.network.0 != network {
                 crit!(
@@ -2075,7 +2075,8 @@ impl Gateway {
 
         // Verify the LNv2 network if present
         if let Some(cfg) = lnv2_cfg {
-            let ln_cfg: &fedimint_lnv2_common::config::LightningClientConfig = cfg.cast()?;
+            let ln_cfg: &fedimint_lnv2_common::config::LightningClientConfig =
+                cfg.cast().map_err(anyhow::Error::from)?;
 
             if ln_cfg.network != network {
                 crit!(

--- a/modules/fedimint-ln-client/src/db.rs
+++ b/modules/fedimint-ln-client/src/db.rs
@@ -2,6 +2,7 @@ use std::io::Cursor;
 
 use bitcoin::hashes::sha256;
 use fedimint_core::core::OperationId;
+use fedimint_core::db::DbMigrationError;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_core::secp256k1::{Keypair, PublicKey};
@@ -127,7 +128,7 @@ impl_db_lookup!(
 pub(crate) fn get_v1_migrated_state(
     operation_id: OperationId,
     cursor: &mut Cursor<&[u8]>,
-) -> anyhow::Result<Option<(Vec<u8>, OperationId)>> {
+) -> Result<Option<(Vec<u8>, OperationId)>, DbMigrationError> {
     #[derive(Debug, Clone, Decodable)]
     pub struct LightningReceiveConfirmedInvoiceV0 {
         invoice: Bolt11Invoice,
@@ -189,7 +190,7 @@ pub(crate) fn get_v1_migrated_state(
 pub(crate) fn get_v2_migrated_state(
     operation_id: OperationId,
     cursor: &mut Cursor<&[u8]>,
-) -> anyhow::Result<Option<(Vec<u8>, OperationId)>> {
+) -> Result<Option<(Vec<u8>, OperationId)>, DbMigrationError> {
     let decoders = ModuleDecoderRegistry::default();
     let ln_sm_variant = u16::consensus_decode_partial(cursor, &decoders)?;
 
@@ -222,7 +223,7 @@ pub(crate) fn get_v2_migrated_state(
 pub(crate) fn get_v3_migrated_state(
     operation_id: OperationId,
     cursor: &mut Cursor<&[u8]>,
-) -> anyhow::Result<Option<(Vec<u8>, OperationId)>> {
+) -> Result<Option<(Vec<u8>, OperationId)>, DbMigrationError> {
     let decoders = ModuleDecoderRegistry::default();
     let ln_sm_variant = u16::consensus_decode_partial(cursor, &decoders)?;
 

--- a/modules/fedimint-lnv2-server/src/db.rs
+++ b/modules/fedimint-lnv2-server/src/db.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use fedimint_core::db::IDatabaseTransactionOpsCoreTyped;
+use fedimint_core::db::{DbMigrationError, IDatabaseTransactionOpsCoreTyped};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::util::SafeUrl;
 use fedimint_core::{OutPoint, PeerId, impl_db_lookup, impl_db_record};
@@ -229,7 +229,7 @@ impl_db_lookup!(
 
 pub(crate) async fn migrate_to_v1(
     mut ctx: ServerModuleDbMigrationFnContext<'_, Lightning>,
-) -> Result<(), anyhow::Error> {
+) -> Result<(), DbMigrationError> {
     let mut contracts = BTreeMap::new();
     let mut stream_index = 0;
 

--- a/modules/fedimint-meta-client/src/lib.rs
+++ b/modules/fedimint-meta-client/src/lib.rs
@@ -325,7 +325,7 @@ async fn get_meta_module_value(
             let meta_api = api.with_module(instance_id);
 
             let overrides_res = retry("fetch_meta_values", backoff, || async {
-                Ok(meta_api.get_consensus(DEFAULT_META_KEY).await?)
+                anyhow::Ok(meta_api.get_consensus(DEFAULT_META_KEY).await?)
             })
             .await;
 

--- a/modules/fedimint-mint-client/src/client_db.rs
+++ b/modules/fedimint-mint-client/src/client_db.rs
@@ -3,7 +3,9 @@ use std::io::Cursor;
 use fedimint_client_module::module::init::recovery::RecoveryFromHistoryCommon;
 use fedimint_client_module::module::{IdxRange, OutPointRange};
 use fedimint_core::core::OperationId;
-use fedimint_core::db::{DatabaseRecord, DatabaseTransaction, IDatabaseTransactionOpsCore};
+use fedimint_core::db::{
+    DatabaseRecord, DatabaseTransaction, DbMigrationError, IDatabaseTransactionOpsCore,
+};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_core::{Amount, impl_db_lookup, impl_db_record};
@@ -138,7 +140,7 @@ impl_db_record!(
 
 pub async fn migrate_to_v1(
     dbtx: &mut DatabaseTransaction<'_>,
-) -> anyhow::Result<Option<(Vec<(Vec<u8>, OperationId)>, Vec<(Vec<u8>, OperationId)>)>> {
+) -> Result<Option<(Vec<(Vec<u8>, OperationId)>, Vec<(Vec<u8>, OperationId)>)>, DbMigrationError> {
     dbtx.ensure_isolated().expect("Must be in our database");
     // between v0 and v1, we changed the format of `MintRecoveryState`, and instead
     // of migrating it, we can just delete it, so the recovery will just start
@@ -159,7 +161,7 @@ pub async fn migrate_to_v1(
 pub(crate) fn migrate_state_to_v2(
     operation_id: OperationId,
     cursor: &mut Cursor<&[u8]>,
-) -> anyhow::Result<Option<(Vec<u8>, OperationId)>> {
+) -> Result<Option<(Vec<u8>, OperationId)>, DbMigrationError> {
     let decoders = ModuleDecoderRegistry::default();
 
     let mint_client_state_machine_variant = u16::consensus_decode_partial(cursor, &decoders)?;

--- a/modules/fedimint-mint-client/src/repair_wallet.rs
+++ b/modules/fedimint-mint-client/src/repair_wallet.rs
@@ -120,7 +120,7 @@ impl MintClientModule {
                 let module_api_inner = module_api.clone();
                 async move {
                     let spent = retry("fetch e-cash spentness", aggressive_backoff(), || async {
-                        Ok(module_api_inner.check_note_spent(key.nonce).await?)
+                        anyhow::Ok(module_api_inner.check_note_spent(key.nonce).await?)
                     })
                     .await?;
                     anyhow::Ok(if spent { Some(key) } else { None })
@@ -195,7 +195,7 @@ impl MintClientModule {
             let nonce_used = retry(
                 "checking if blind nonce was already used",
                 aggressive_backoff(),
-                || async { Ok(module_api.check_blind_nonce_used(blind_nonce).await?) },
+                || async { anyhow::Ok(module_api.check_blind_nonce_used(blind_nonce).await?) },
             )
             .await?;
             if nonce_used {

--- a/modules/fedimint-mint-server/src/lib.rs
+++ b/modules/fedimint-mint-server/src/lib.rs
@@ -17,7 +17,7 @@ use fedimint_core::config::{
 };
 use fedimint_core::core::ModuleInstanceId;
 use fedimint_core::db::{
-    DatabaseTransaction, DatabaseVersion, IDatabaseTransactionOpsCore,
+    DatabaseTransaction, DatabaseVersion, DbMigrationError, IDatabaseTransactionOpsCore,
     IDatabaseTransactionOpsCoreTyped,
 };
 use fedimint_core::encoding::Encodable;
@@ -380,7 +380,7 @@ impl ServerModuleInit for MintInit {
 
 async fn migrate_db_v0(
     mut migration_context: ServerModuleDbMigrationFnContext<'_, Mint>,
-) -> anyhow::Result<()> {
+) -> Result<(), DbMigrationError> {
     let blind_nonces = migration_context
         .get_typed_module_history_stream()
         .await
@@ -430,7 +430,7 @@ async fn migrate_db_v0(
 // Remove now unused ECash backups from DB. Backup functionality moved to core.
 async fn migrate_db_v1(
     mut migration_context: ServerModuleDbMigrationFnContext<'_, Mint>,
-) -> anyhow::Result<()> {
+) -> Result<(), DbMigrationError> {
     migration_context
         .dbtx()
         .raw_remove_by_prefix(&[0x15])
@@ -440,7 +440,9 @@ async fn migrate_db_v1(
 }
 
 // Backfill RecoveryItem and RecoveryBlindNonceOutpoint from module history
-async fn migrate_db_v2(mut ctx: ServerModuleDbMigrationFnContext<'_, Mint>) -> anyhow::Result<()> {
+async fn migrate_db_v2(
+    mut ctx: ServerModuleDbMigrationFnContext<'_, Mint>,
+) -> Result<(), DbMigrationError> {
     let mut recovery_items = Vec::new();
     let mut blind_nonce_outpoints = Vec::new();
     let mut stream = ctx.get_typed_module_history_stream().await;

--- a/modules/fedimint-mint-server/src/test.rs
+++ b/modules/fedimint-mint-server/src/test.rs
@@ -29,8 +29,7 @@ fn build_configs() -> (Vec<ServerModuleConfig>, ClientModuleConfig) {
         MintInit
             .get_client_config(&mint_cfg[&PeerId::from(0)].consensus)
             .unwrap(),
-    )
-    .unwrap();
+    );
 
     (mint_cfg.into_values().collect(), client_cfg)
 }

--- a/modules/fedimint-mintv2-server/src/lib.rs
+++ b/modules/fedimint-mintv2-server/src/lib.rs
@@ -168,10 +168,10 @@ impl ServerModuleInit for MintInit {
         MINT_REDEEMED_ECASH_SATS.get_sample_count();
         MINT_REDEEMED_ECASH_FEES_SATS.get_sample_count();
 
-        args.cfg().to_typed().map(|cfg| Mint {
+        Ok(args.cfg().to_typed().map(|cfg| Mint {
             cfg,
             db: args.db().clone(),
-        })
+        })?)
     }
 
     fn trusted_dealer_gen(

--- a/modules/fedimint-wallet-server/src/db.rs
+++ b/modules/fedimint-wallet-server/src/db.rs
@@ -1,6 +1,6 @@
 use bitcoin::secp256k1::ecdsa::Signature;
 use bitcoin::{BlockHash, OutPoint, TxOut, Txid};
-use fedimint_core::db::IDatabaseTransactionOpsCoreTyped;
+use fedimint_core::db::{DbMigrationError, IDatabaseTransactionOpsCoreTyped};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::ModuleConsensusVersion;
 use fedimint_core::{PeerId, impl_db_lookup, impl_db_record};
@@ -231,7 +231,7 @@ impl_db_lookup!(
 /// Migrate to v1, backfilling all previously pegged-in outpoints
 pub async fn migrate_to_v1(
     mut ctx: ServerModuleDbMigrationFnContext<'_, Wallet>,
-) -> Result<(), anyhow::Error> {
+) -> Result<(), DbMigrationError> {
     let outpoints = ctx
         .get_typed_module_history_stream()
         .await
@@ -306,7 +306,7 @@ impl_db_lookup!(key = RecoveryItemKey, query_prefix = RecoveryItemKeyPrefix);
 /// Migrate to v2, backfilling recovery items from module history
 pub async fn migrate_to_v2(
     mut ctx: ServerModuleDbMigrationFnContext<'_, Wallet>,
-) -> Result<(), anyhow::Error> {
+) -> Result<(), DbMigrationError> {
     let mut recovery_items = Vec::new();
     let mut stream = ctx.get_typed_module_history_stream().await;
 
@@ -344,7 +344,7 @@ pub async fn migrate_to_v2(
 /// recoverable in full.
 pub async fn migrate_to_v3(
     mut ctx: ServerModuleDbMigrationFnContext<'_, Wallet>,
-) -> Result<(), anyhow::Error> {
+) -> Result<(), DbMigrationError> {
     let mut dbtx = ctx.dbtx();
 
     let change_outpoints = dbtx

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -1978,7 +1978,7 @@ fn build_wallet_server_configs() -> anyhow::Result<(
             &WalletInit,
             &wallet_cfg[&PeerId::from(0)].consensus,
         )?,
-    )?;
+    );
     Ok((wallet_cfg.into_values().collect(), client_cfg))
 }
 


### PR DESCRIPTION
## Summary

First PR of the #8821 series (client-facing crates first, one commit per error type, stacked in dependency order). This one covers `fedimint-core`: amount conversion, base32/prefixed decoding, the `FromStr` impls, module config lookups, env-derived config, database migrations, task-group joins and the `retry`/stream/iroh utilities. Functions that could not fail lose their `Result`. Callers across the workspace adapt mechanically; binaries, tests and devimint keep `anyhow` and `?`.

Deliberately left for the next PR (A2), which reworks `DecodeError`'s internals together with the derive macro: `pub use anyhow` in `fedimint-core`, `DecodeError::new_custom(anyhow::Error)` / `From<anyhow::Error> for DecodeError`, and the documented FFI stringify conversion `From<anyhow::Error> for UniffiError`.

## Details

- New enums are `#[non_exhaustive]`, carry structured data (`OperationAlreadyExists`-style variants come in the client PR; here: `ModuleNotFound { id }`, `KindNotFound { kind }`, `VersionTooHigh { kind, on_disk, target }`, `InvalidCharacter { ch, index }`, …), and box opaque third-party causes as `Box<dyn Error + Send + Sync>` — never `anyhow`.
- Display convention: a variant with a `#[source]` does not repeat it in its message and `fmt_compact` prints the chain — except for types whose `Display` is the text a consumer sees (`FromStr::Err` types, which clap prints as-is; errors serialized into RPC/HTTP strings; uniffi `flat_error` enums): `InviteCodeParseError`, `ParseBitcoinAmountOrAllError` and `PrefixedDecodeError` interpolate their source.
- `DatabaseError::Other(anyhow)` and `From<anyhow::Error> for DatabaseError` are gone; `NotGlobal`/`NotIsolated` replace the two message producers and are appended after `DatabaseBackend` so the uniffi `flat_error` discriminants of existing variants are unchanged; the enum is now `#[non_exhaustive]`, as is `DecodingError`. `DbMigrationError` is the output of every migration closure (mechanical: their real failures were already `DatabaseError`/`DecodeError`).
- `util::retry` is generic over the closure error (`E: Display`, because `anyhow::Error` is not `std::error::Error` and the remaining `anyhow` callers are allowed to stay); its retry log prints `{err:#}`, which is the cause chain for `anyhow` and plain `Display` for typed errors. Six call sites pin `anyhow::Ok` for inference.
- `InviteCode::from_str` now reports the prefixed-base32 attempt when the input carries the `fedimint` prefix instead of falling through to a bech32 error.
- `ClientModuleConfig::cast` (and `ClientConfig::get_module*` through it) returns `ModuleConfigError::NotDecoded { id, kind }` for a config that is still raw instead of panicking; `WrongType` names the kind and the requested type. `DbMigrationError::other` accepts anything convertible into a boxed error, `anyhow::Error` included, so out-of-tree migrations adapt with a `map_err`.
- `BitcoinRpcConfig::get_defaults_from_env_vars` names the variable that actually supplied a value (deprecated aliases included); a variable that is set but not valid Unicode is now an error rather than being skipped in favour of a lower-priority alias. `load_from_file` reads the file before parsing so read failures are `ConfigFileError::Io`.
- No wire or DB format changes; no error type that derives `Encodable` is touched.

## Breaking changes

- `FromStr::Err` of `FederationId`, `FederationIdPrefix` (`hex::HexToArrayError`), `OperationId` (`hex::FromHexError`), `InviteCode` (`InviteCodeParseError`), `BitcoinAmountOrAll` (`ParseBitcoinAmountOrAllError`).
- No longer return `Result`: `ModuleInitRegistry::available_decoders`, `ClientModuleConfig::from_typed`, `envs::parse_kv_list_from_env`, `BackupRequest::sign`, `ClientBackup::into_backup_request`, `db::create_database_version_dbtx`.
- `DatabaseError` and `DecodingError` variant changes are FFI-visible through `uniffi(flat_error)` (no in-tree non-Rust consumer matches on the removed variant).
- `JitTryAnyhow` removed — spell `JitTry<T, anyhow::Error>`; `OneTimeError::Copy` holds a `String`.
- `DbMigrationFn`, `ClientModuleMigrationFn` and every `apply_migrations*` produce `DbMigrationError`; `TaskGroup::{join_all, shutdown_join_all}` produce `JoinAllError`; `load_from_file` produces `ConfigFileError`.

## Known and left alone

- `BitcoinAmountOrAll` reads a bare number as milli-satoshis via `FromStr` but as satoshis via `Deserialize` (pre-existing; the new test uses an explicit denomination).
- A task that panics and finishes before `TaskGroup::join_all` runs is not part of the join set (pre-existing; `JoinAllError` documents it).
- The gateway's `cast().map_err(anyhow::Error::from)?` shim keeps `AdminGatewayError` unchanged; extending it is gateway-phase work. `ConnectorRegistryBuilder::with_env_var_overrides` is infallible in body but not yet in signature (PR B). The server-only `build_iroh_endpoint` twin in `fedimint-server` keeps `anyhow` (server side is out of scope for the series).

## Reviewing

Commit by commit, one logical change each; every commit passes `cargo check --workspace --all-targets` on its own. Behavioural changes to look at: the six functions that became infallible, `create_database_version_dbtx` included; `cast` on a raw config; the env lookup's Unicode handling; `retry`'s log line; `InviteCode::from_str`'s base32 branch. Everything else is a signature change.

## Testing

- [x] `cargo check --workspace --all-targets`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo check -p fedimint-core --features uniffi`, `cargo doc --no-deps` (core, client, client-module), the `check-wasm` package set, pre-commit hook (semgrep, typos, formatting)
- [x] `cargo test -p fedimint-core` (lib + doc), client crates' unit tests, `fedimint-server-tests` migration test
- [x] every commit passes `cargo check --workspace --all-targets` in isolation

Part of #8821.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

