### PR TITLE
feat(ci): publish fedimintd:latest on stable releases

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -457,6 +457,18 @@ jobs:
               docker manifest annotate "$image:${GITHUB_REF_NAME}" "$image:${GITHUB_REF_NAME}-x86_64-linux" --arch amd64
               docker manifest annotate "$image:${GITHUB_REF_NAME}" "$image:${GITHUB_REF_NAME}-aarch64-linux" --arch arm64
               docker manifest push "$image:${GITHUB_REF_NAME}"
+
+              # Point `latest` at fedimintd stable releases only. The strict vX.Y.Z match
+              # excludes pre-releases (v0.12.0-rc.0) and custom tags (v0.11.0-fedi2) alike.
+              if [ "$container" = "fedimintd" ] && [[ "$GITHUB_REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                echo "Creating manifest for $image:latest"
+                docker manifest create "$image:latest" \
+                  "$image:${GITHUB_REF_NAME}-x86_64-linux" \
+                  "$image:${GITHUB_REF_NAME}-aarch64-linux"
+                docker manifest annotate "$image:latest" "$image:${GITHUB_REF_NAME}-x86_64-linux" --arch amd64
+                docker manifest annotate "$image:latest" "$image:${GITHUB_REF_NAME}-aarch64-linux" --arch arm64
+                docker manifest push "$image:latest"
+              fi
             elif [[ "$GITHUB_REF" =~ ^refs/heads/releases/ ]]; then
               # Extract the version from branch name (e.g., releases/v0.8 -> releases-v0.8)
               BRANCH_NAME="${GITHUB_REF#refs/heads/}"


### PR DESCRIPTION
`fedimint/fedimintd` has no `latest` tag, so downstream consumers have to pin an explicit version. This points `latest` at the multi-arch manifest whenever a stable release is tagged.

The strict `vX.Y.Z` guard keeps pre-releases and custom tags (`v0.12.0-rc.0`, `v0.11.0-fedi2`) from moving `latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)