### PR TITLE
fix(server): don't hold overlapping watch guards in status endpoint

### DIFF
--- a/fedimint-server/src/consensus/api.rs
+++ b/fedimint-server/src/consensus/api.rs
@@ -78,7 +78,7 @@ use crate::consensus::transaction::{TxProcessingMode, process_transaction_with_d
 use crate::metrics::{BACKUP_WRITE_SIZE_BYTES, STORED_BACKUPS_COUNT};
 use crate::net::api::HasApiContext;
 use crate::net::api::announcement::{ApiAnnouncementKey, ApiAnnouncementPrefix, get_api_urls};
-use crate::net::p2p::P2PStatusReceivers;
+use crate::net::p2p::{P2PConnectionState, P2PStatusReceivers};
 
 /// Maximum number of output outcomes a single `await_outputs_outcomes` request
 /// may ask for. The endpoint is public and unauthenticated and the requested
@@ -117,6 +117,38 @@ fn checked_outputs_outcomes_count(outpoint_range: OutPointRange) -> Result<usize
     );
 
     Ok(count)
+}
+
+/// Status of a single peer, read from the p2p and consensus-item watch
+/// channels it is tracked by.
+///
+/// Each channel is read exactly once, into a local. `watch::Receiver::borrow`
+/// returns a guard over a `parking_lot::RwLock`, and Rust drops temporaries at
+/// the end of the enclosing *statement* rather than the sub-expression, so
+/// borrowing inline in a struct literal would keep several guards alive at
+/// once. That deadlocks the whole process: `parking_lot`'s `RwLock` is
+/// write-preferring, so a second `borrow()` of a channel this thread already
+/// holds a guard on blocks behind any writer that queued in between, and that
+/// writer can never drain because the first guard is still held. These are
+/// blocking waits, so every stuck request burns a tokio worker until the
+/// runtime has none left to poll the reactor with.
+fn legacy_peer_status(
+    p2p_receiver: &watch::Receiver<P2PConnectionState>,
+    ci_receiver: &watch::Receiver<Option<u64>>,
+    session_count: u64,
+) -> LegacyPeerStatus {
+    let p2p_connected = p2p_receiver.borrow().connected.is_some();
+    let last_contribution = *ci_receiver.borrow();
+
+    LegacyPeerStatus {
+        connection_status: if p2p_connected {
+            LegacyP2PConnectionStatus::Connected
+        } else {
+            LegacyP2PConnectionStatus::Disconnected
+        },
+        last_contribution,
+        flagged: last_contribution.unwrap_or(0) + 1 < session_count,
+    }
 }
 
 #[derive(Clone)]
@@ -380,16 +412,10 @@ impl ConsensusApi {
             .map(|(peer, p2p_receiver)| {
                 let ci_receiver = self.ci_status_receivers.get(peer).unwrap();
 
-                let consensus_status = LegacyPeerStatus {
-                    connection_status: match p2p_receiver.borrow().connected {
-                        Some(..) => LegacyP2PConnectionStatus::Connected,
-                        None => LegacyP2PConnectionStatus::Disconnected,
-                    },
-                    last_contribution: *ci_receiver.borrow(),
-                    flagged: ci_receiver.borrow().unwrap_or(0) + 1 < session_count,
-                };
-
-                (*peer, consensus_status)
+                (
+                    *peer,
+                    legacy_peer_status(p2p_receiver, ci_receiver, session_count),
+                )
             })
             .collect::<BTreeMap<_, _>>();
 
@@ -1219,6 +1245,12 @@ pub(crate) async fn backup_statistics_static(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::Ordering::Relaxed;
+    use std::sync::atomic::{AtomicBool, AtomicUsize};
+    use std::thread;
+    use std::time::Instant;
+
     use fedimint_core::db::IRawDatabaseExt as _;
     use fedimint_core::db::mem_impl::MemDatabase;
     use fedimint_core::net::guardian_metadata::GuardianMetadata;
@@ -1254,6 +1286,144 @@ mod tests {
                 "{rejected:?} must be rejected"
             );
         }
+    }
+
+    /// `legacy_peer_status` must never hold two guards on the same watch
+    /// channel at once. `parking_lot`'s `RwLock` is write-preferring, so the
+    /// second `borrow()` would block behind a queued writer that can never
+    /// drain past the first guard, wedging a guardian permanently.
+    ///
+    /// Hitting the window between two guards is a race, so this hammers it:
+    /// with the guards overlapping, a writer lands in that window and the
+    /// reader threads stop making progress long before the deadline.
+    #[test]
+    fn legacy_peer_status_does_not_deadlock_against_a_writer() {
+        const READERS: usize = 8;
+        const READS_PER_THREAD: u64 = 100_000;
+
+        let (p2p_sender, p2p_receiver) = watch::channel(P2PConnectionState {
+            connected: None,
+            last_error: None,
+        });
+        let (ci_sender, ci_receiver) = watch::channel(None);
+        let stop = Arc::new(AtomicBool::new(false));
+
+        let writers = [
+            {
+                // The p2p writer is the one observed wedged in production: the
+                // connection task calls `send_replace` on every state change.
+                let stop = stop.clone();
+                thread::spawn(move || {
+                    let mut connected = false;
+                    while !stop.load(Relaxed) {
+                        connected = !connected;
+                        p2p_sender.send_replace(P2PConnectionState {
+                            connected: connected.then_some(P2PConnectionStatus {
+                                conn_type: None,
+                                rtt: None,
+                            }),
+                            last_error: None,
+                        });
+                    }
+                })
+            },
+            {
+                let stop = stop.clone();
+                thread::spawn(move || {
+                    let mut session = 0;
+                    while !stop.load(Relaxed) {
+                        session += 1;
+                        ci_sender.send_replace(Some(session));
+                    }
+                })
+            },
+        ];
+
+        let finished_readers = Arc::new(AtomicUsize::new(0));
+
+        for _ in 0..READERS {
+            let p2p_receiver = p2p_receiver.clone();
+            let ci_receiver = ci_receiver.clone();
+            let finished_readers = finished_readers.clone();
+
+            thread::spawn(move || {
+                for _ in 0..READS_PER_THREAD {
+                    legacy_peer_status(&p2p_receiver, &ci_receiver, u64::MAX);
+                }
+
+                finished_readers.fetch_add(1, Relaxed);
+            });
+        }
+
+        // Deadlocked readers never return, so wait on a counter rather than
+        // joining them: this has to fail the test, not hang the suite.
+        let deadline = Instant::now() + Duration::from_secs(60);
+        while finished_readers.load(Relaxed) < READERS {
+            if Instant::now() >= deadline {
+                // Stop the writers before failing. The wedged readers can
+                // never be joined, so a writer still spinning here would burn
+                // a core for the rest of the test binary and slow every test
+                // that runs after this one.
+                stop.store(true, Relaxed);
+
+                panic!(
+                    "only {} of {READERS} reader threads finished before the deadline, \
+                     which means peer status reads are wedged behind a writer",
+                    finished_readers.load(Relaxed)
+                );
+            }
+
+            thread::sleep(Duration::from_millis(10));
+        }
+
+        stop.store(true, Relaxed);
+        for writer in writers {
+            writer.join().expect("writer thread panicked");
+        }
+    }
+
+    /// The two watch channels are read once each, and `flagged` is derived
+    /// from the same `last_contribution` that is reported.
+    #[test]
+    fn legacy_peer_status_flags_peers_lagging_the_session_count() {
+        let peer_status = |connected: bool, last_contribution, session_count| {
+            let (_p2p_sender, p2p_receiver) = watch::channel(P2PConnectionState {
+                connected: connected.then_some(P2PConnectionStatus {
+                    conn_type: None,
+                    rtt: None,
+                }),
+                last_error: None,
+            });
+            let (_ci_sender, ci_receiver) = watch::channel(last_contribution);
+
+            legacy_peer_status(&p2p_receiver, &ci_receiver, session_count)
+        };
+
+        let current = peer_status(true, Some(9), 10);
+        assert_eq!(
+            current.connection_status,
+            LegacyP2PConnectionStatus::Connected
+        );
+        assert_eq!(current.last_contribution, Some(9));
+        assert!(!current.flagged, "a peer one behind the session is current");
+
+        assert!(
+            peer_status(true, Some(8), 10).flagged,
+            "a peer two behind the session is flagged"
+        );
+        assert!(
+            peer_status(true, None, 10).flagged,
+            "a peer that has never contributed is flagged"
+        );
+        assert!(
+            !peer_status(true, None, 1).flagged,
+            "no peer has contributed to the first session yet"
+        );
+
+        assert_eq!(
+            peer_status(false, Some(9), 10).connection_status,
+            LegacyP2PConnectionStatus::Disconnected
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

A guardian can wedge permanently — process alive, p2p socket `ESTABLISHED`, peers still reporting it `online`, but no consensus contributions and an API that never answers. No panic, no OOM, no crash-loop; only a restart clears it. The cause is `get_federation_status()` holding two `parking_lot` read guards on the same `tokio::sync::watch` channel at once, which deadlocks against the p2p task's `send_replace` writer and then drains the tokio worker pool one stuck `status` request at a time.

Observed in production on one guardian of a 4-guardian mainnet federation, wedged for ~22h before it was noticed, and diagnosed from a symbolized core dump of the live wedged process. The same code is on `master` and in `v0.12.0-beta.3`.

## Details

### Root cause

`get_federation_status()` built its `LegacyPeerStatus` literal by borrowing three watch channels inline — two of them the same channel:

```rust
let consensus_status = LegacyPeerStatus {
    connection_status: match p2p_receiver.borrow().connected {       // guard A (p2p chan)
        Some(..) => LegacyP2PConnectionStatus::Connected,
        None => LegacyP2PConnectionStatus::Disconnected,
    },
    last_contribution: *ci_receiver.borrow(),                        // guard B (ci chan)
    flagged: ci_receiver.borrow().unwrap_or(0) + 1 < session_count,  // guard C — SAME chan as B
};
```

Rust drops temporaries at the end of the enclosing **statement**, not the sub-expression, so guards A, B and C are all alive until the `let` completes.

`tokio::sync::watch` uses a `parking_lot::RwLock` internally, and `parking_lot`'s `RwLock` is **write-preferring**: once a writer queues, new readers block rather than barging, and `read()` is explicitly not recursive (`read_recursive()` exists for this case). So a thread that already holds a read guard and then takes a *second* read on the same lock blocks forever if a writer queued in between — while still holding the first guard, so the writer can never drain either.

The writer is the p2p connection task calling `send_replace` on every connection state change.

### Why one stuck request takes down the whole process

These are **blocking** `parking_lot` waits, not async waits, so each stuck `status` request consumes a tokio worker for good. The guardian dashboard polls `status` on an interval, so requests accumulate. Tokio spawns replacement workers, which are consumed in turn. Once every worker is blocked, nothing polls the I/O reactor and the process goes fully silent.

The core dump of the wedged process (139 threads) shows exactly that:

- **130 threads** blocked in `lock_shared_slow` → `borrow` → the `fold`/`collect` inside the `status` handler.
- **2 threads** (the p2p connection task) blocked in `wait_for_readers` → `lock_exclusive_slow` → `send_replace`, on the same watch channel.

Measured against two healthy nodes running the identical binary:

| | healthy A | healthy B | wedged |
|---|---:|---:|---:|
| threads | 62 | 72 | **139** |
| threads in `epoll_wait` | 2 | 1 | **0** |
| untimed futex waits | ~3 | ~5 | **138** |
| CPU | normal | normal | **0.00%** |

The reactor stayed healthy for ~31 minutes after consensus stopped — new connections accepted, DB reads served, outbound HTTP and timers firing — and only went silent once the worker pool was exhausted. 58 threads were created in the 15 minutes before that, tokio replacing workers as they were consumed.

### The fix

Read each watch channel exactly once into a local, so no two guards are ever alive at the same time. This also drops the redundant third borrow, since `flagged` can reuse `last_contribution`.

That removes a latent correctness wart as well: the old code's second borrow could observe a *newer* consensus-item value than the first, so a response could report `last_contribution: Some(n)` with `flagged` computed from `Some(n + k)` — unflagged while the reported contribution implies lagging. The status a peer reports is now a self-consistent snapshot.

`read_recursive()` would paper over the deadlock, but not holding two guards is the better fix.

The per-peer computation moves into a `legacy_peer_status` free function, which is what makes it testable without standing up a full `ConsensusApi`.

## Reviewing

- **The lifetime argument is the crux.** Worth confirming for yourself that each `borrow()` temporary in the new helper really does drop at its own semicolon, and that no path leaves a guard alive across the second acquisition.
- **The `flagged` behavior change is intentional but is a change.** `flagged` is now derived from the same `last_contribution` that gets reported, rather than from an independent re-read. Per observed value the mapping is identical; what changes is that the two fields can no longer disagree.
- **Completeness.** Every `watch::Receiver::borrow()` site in the workspace was audited for the same pattern and none has the fatal same-lock double borrow. Two near-misses were checked and are safe: `config/mod.rs:564` calls `Receiver::clone` while holding a read guard (clone is an `Arc::clone` plus a relaxed `fetch_add`, it never touches the `RwLock`), and `engine.rs:413` holds a match-scrutinee guard that drops before the following `send_replace`. The latter is safe today but is one refactor away from a self-deadlock; `send_modify` would be structurally immune. Happy to send that as a separate change if reviewers want it.
- **Test cost.** The regression test spins 8 reader threads and 2 writer threads. It finishes in ~0.14s on the happy path and only reaches its 60s deadline when the bug is present.

## Testing

- `legacy_peer_status_does_not_deadlock_against_a_writer` — 8 reader threads hammer the helper while writers replace both channels. It waits on a completion counter rather than joining, so a regression fails the test instead of hanging the suite.

  This was verified to actually catch the bug rather than merely to pass: with the original overlapping-guard pattern restored, it deadlocks with 0 of 8 readers finishing and fails at the deadline. With the fix it completes in 0.14s — 0.07–0.10s even pinned to a single CPU, roughly 600x headroom under the deadline.

- `legacy_peer_status_flags_peers_lagging_the_session_count` — pins the reported connection status and the `flagged` derivation, including the never-contributed and first-session edge cases.

- `just final-lint` passes locally.

To reproduce the deadlock yourself, restore the struct-literal form of `legacy_peer_status` and run `cargo test -p fedimint-server --lib legacy_peer_status`.

## Breaking changes

None. The `status` response is unchanged.
