### PR TITLE
fix(server): report bitcoind status without a feerate while syncing

### DIFF
--- a/fedimint-server-core/src/bitcoin_rpc.rs
+++ b/fedimint-server-core/src/bitcoin_rpc.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
-use anyhow::{Context, Result, ensure};
+use anyhow::{Result, ensure};
 use fedimint_core::bitcoin::{Block, BlockHash, Network, Transaction};
 use fedimint_core::envs::BitcoinRpcConfig;
 use fedimint_core::task::TaskGroup;
@@ -103,9 +103,9 @@ impl ServerBitcoinRpcMonitor {
         let sync_progress = rpc.get_sync_progress().await?;
 
         let fee_rate = if network == Network::Regtest {
-            Feerate { sats_per_kvb: 1000 }
+            Some(Feerate { sats_per_kvb: 1000 })
         } else {
-            rpc.get_feerate().await?.context("Feerate not available")?
+            rpc.get_feerate().await?
         };
 
         Ok(ServerBitcoinRpcStatus {

--- a/fedimint-server-core/src/dashboard_ui.rs
+++ b/fedimint-server-core/src/dashboard_ui.rs
@@ -122,6 +122,9 @@ impl DashboardApiModuleExt for DynDashboardApi {
 pub struct ServerBitcoinRpcStatus {
     pub network: Network,
     pub block_count: u64,
-    pub fee_rate: Feerate,
+    /// `None` while the backend cannot estimate fees yet — a node in initial
+    /// block download has no fee data until it reaches the tip, and consensus
+    /// does not start before then.
+    pub fee_rate: Option<Feerate>,
     pub sync_progress: Option<f64>,
 }

--- a/fedimint-server-ui/src/dashboard/bitcoin.rs
+++ b/fedimint-server-ui/src/dashboard/bitcoin.rs
@@ -22,9 +22,11 @@ pub fn render(url: SafeUrl, status: &Option<ServerBitcoinRpcStatus>) -> Markup {
                                 th { "Block Count" }
                                 td { (status.block_count) }
                             }
-                            tr {
-                                th { "Fee Rate" }
-                                td { (format!("{} sats/vB", status.fee_rate.sats_per_kvb / 1000)) }
+                            @if let Some(fee_rate) = status.fee_rate {
+                                tr {
+                                    th { "Fee Rate" }
+                                    td { (format!("{} sats/vB", fee_rate.sats_per_kvb / 1000)) }
+                                }
                             }
                             @if let Some(sync) = status.sync_progress {
                                 tr {

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -455,7 +455,11 @@ pub async fn run(
                         break;
                     }
 
-                    info!(target: LOG_CONSENSUS, "Waiting for bitcoin backend to sync... {progress:.1}%");
+                    info!(
+                        target: LOG_CONSENSUS,
+                        "Waiting for bitcoin backend to sync... {:.1}%",
+                        progress * 100.0
+                    );
                 } else {
                     break;
                 }

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -1415,7 +1415,8 @@ impl Wallet {
             sats_per_kvb: ((self
                 .btc_rpc
                 .status()
-                .map_or(self.cfg.consensus.default_fee, |status| status.fee_rate)
+                .and_then(|status| status.fee_rate)
+                .unwrap_or(self.cfg.consensus.default_fee)
                 .sats_per_kvb as f64
                 * get_feerate_multiplier())
             .round()) as u64,

--- a/modules/fedimint-walletv2-server/src/lib.rs
+++ b/modules/fedimint-walletv2-server/src/lib.rs
@@ -464,12 +464,13 @@ impl ServerModule for Wallet {
 
             items.push(WalletConsensusItem::BlockCount(block_count_vote));
 
+            // `None` retracts our vote while the backend cannot estimate
+            // fees yet, e.g. while it is still syncing.
             let feerate_vote = status
                 .fee_rate
-                .sats_per_kvb
-                .max(MIN_FEERATE_VOTE_SATS_PER_KVB);
+                .map(|fee_rate| fee_rate.sats_per_kvb.max(MIN_FEERATE_VOTE_SATS_PER_KVB));
 
-            items.push(WalletConsensusItem::Feerate(Some(feerate_vote)));
+            items.push(WalletConsensusItem::Feerate(feerate_vote));
         } else {
             // Bitcoin backend not connected, retract fee rate vote
             items.push(WalletConsensusItem::Feerate(None));


### PR DESCRIPTION
Every fresh guardian backed by a syncing bitcoind spends its entire initial block download with logs saying `Waiting to connect to bitcoin backend...` and a disconnected dashboard — while the backend is reachable and syncing fine. Diagnosed live on a mainnet node at 0.5% sync: the RPC answered `getblockcount`/`getblockchaininfo` normally, and the monitor logged `Bitcoin status update failed err=Feerate not available` once per interval.

Root cause: `fetch_status` requires `get_feerate()` to return a value on non-regtest networks, but Bitcoin Core's fee estimator has no data until the node reaches the tip — so the whole `ServerBitcoinRpcStatus` collapses to `None`. The honest `Waiting for bitcoin backend to sync... X%` branch (and the dashboard's sync-progress row) are unreachable during exactly the period they exist for.

- `ServerBitcoinRpcStatus.fee_rate` becomes `Option<Feerate>` — the status now succeeds during IBD (chain id, block count and `verification_progress` all work mid-sync). Regtest still pins `Some(1000)`.
- walletv2 maps a missing estimate to `WalletConsensusItem::Feerate(None)`, the same vote-retraction path used for a down backend. Safe because consensus doesn't start before `sync_progress >= 0.999`, at which point fee estimation has data.
- The legacy wallet's `get_fee_rate_opt` falls back to `default_fee` exactly as it did when the status was `None`.
- The dashboard hides the fee-rate row while unavailable instead of rendering the whole panel as disconnected.
- Drive-by: the sync wait-loop logged the raw 0..1 fraction (`Waiting for bitcoin backend to sync... 0.0%` for hours); it now multiplies by 100 like the dashboard does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)