### PR TITLE
feat(client): five accounts per federation

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -9,7 +9,10 @@ slow-timeout = { period = "30s", terminate-after = 4 }
 [profile.dev]
 
 [profile.ci]
-slow-timeout = { period = "30s", terminate-after = 3 }
+# One period longer than it was, and level with every other profile: the
+# walletv2 module tests spin up a federation and a bitcoind and were landing
+# just under the old 90s ceiling, so a busy runner tipped them over.
+slow-timeout = { period = "30s", terminate-after = 4 }
 
 # ccov seems MUCH slower, especially in Nix sandbox
 # possibly due to writing to a shared tracing file(?)

--- a/fedimint-cli/src/client.rs
+++ b/fedimint-cli/src/client.rs
@@ -11,7 +11,7 @@ use fedimint_bip39::Mnemonic;
 use fedimint_client::backup::Metadata;
 use fedimint_client::{Client, ClientHandleArc};
 use fedimint_core::config::{ClientModuleConfig, FederationId};
-use fedimint_core::core::{ModuleInstanceId, ModuleKind, OperationId};
+use fedimint_core::core::{Account, ModuleInstanceId, ModuleKind, OperationId};
 use fedimint_core::encoding::Encodable;
 use fedimint_core::{Amount, BitcoinAmountOrAll, TieredCounts, TieredMulti};
 use fedimint_ln_client::cli::LnInvoiceResponse;
@@ -585,7 +585,7 @@ pub async fn handle_command(
                 // federation's per-note fees. The returned fees are quoted at
                 // the returned amount, so they must be used together.
                 BitcoinAmountOrAll::All => {
-                    let balance = client.get_balance_for_btc().await?;
+                    let balance = client.get_balance_for_btc(Account::Primary).await?;
                     wallet_module
                         .max_withdrawable_amount(&address, balance)
                         .await?
@@ -709,7 +709,9 @@ async fn get_note_summary(client: &ClientHandleArc) -> anyhow::Result<serde_json
     } else if let Ok(mintv2_client) =
         client.get_first_module::<fedimint_mintv2_client::MintClientModule>()
     {
-        let counts = mintv2_client.get_count_by_denomination().await;
+        let counts = mintv2_client
+            .get_count_by_denomination(Account::Primary)
+            .await;
         let mut summary = TieredCounts::default();
         #[allow(clippy::cast_possible_truncation)]
         for (denomination, count) in counts {

--- a/fedimint-client-module/src/lib.rs
+++ b/fedimint-client-module/src/lib.rs
@@ -20,7 +20,9 @@ use std::sync::Arc;
 
 use fedimint_api_client::api::{DynGlobalApi, DynModuleApi};
 use fedimint_core::config::ClientConfig;
-pub use fedimint_core::core::{IInput, IOutput, ModuleInstanceId, ModuleKind, OperationId};
+pub use fedimint_core::core::{
+    Account, IInput, IOutput, ModuleInstanceId, ModuleKind, OperationId,
+};
 use fedimint_core::db::Database;
 use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_core::module::{ApiAuth, ApiVersion};
@@ -71,6 +73,15 @@ pub mod api_version_discovery;
 pub struct TxCreatedEvent {
     pub txid: TransactionId,
     pub operation_id: OperationId,
+    /// Balance the primary module funded the transaction from and credits its
+    /// change to. Tagged here because not every transaction belongs to an
+    /// operation that emits an account-tagged module event: an internal
+    /// reissue runs under its own operation id and emits none. The later
+    /// tx-accepted and tx-rejected events share this event's txid, so they
+    /// need no tag of their own. Defaulted so entries written before accounts
+    /// existed still decode.
+    #[serde(default = "Account::primary")]
+    pub account: Account,
 }
 
 impl Event for TxCreatedEvent {
@@ -232,6 +243,13 @@ pub trait IGlobalClientContext: Debug + MaybeSend + MaybeSync + 'static {
 
     fn decoders(&self) -> &ModuleDecoderRegistry;
 
+    /// The account the state machine's operation acts on: the balance the
+    /// primary module funds its transactions from and credits its change,
+    /// claims and refunds to. Read from the operation's record rather than
+    /// carried by the state machine, so no machine's persisted shape depends
+    /// on it.
+    async fn account(&self, dbtx: &mut ClientSMDatabaseTransaction<'_, '_>) -> Account;
+
     /// This function is mostly meant for internal use, you are probably looking
     /// for [`DynGlobalClientContext::claim_inputs`].
     /// Returns transaction id of the funding transaction and an optional
@@ -303,6 +321,10 @@ impl IGlobalClientContext for () {
     }
 
     fn decoders(&self) -> &ModuleDecoderRegistry {
+        unimplemented!("fake implementation, only for tests");
+    }
+
+    async fn account(&self, _dbtx: &mut ClientSMDatabaseTransaction<'_, '_>) -> Account {
         unimplemented!("fake implementation, only for tests");
     }
 
@@ -388,6 +410,8 @@ impl DynGlobalClientContext {
             .await
     }
 
+    /// The claim is credited to the operation's account, and any change the
+    /// primary module adds comes back to the same one.
     pub async fn claim_inputs<I, S>(
         &self,
         dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
@@ -409,6 +433,7 @@ impl DynGlobalClientContext {
     /// for the funding inputs are generated automatically. The caller is
     /// responsible for the output's state machines, should there be any
     /// required.
+    /// The primary module funds the output from the operation's account.
     pub async fn fund_output<O, S>(
         &self,
         dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,

--- a/fedimint-client-module/src/module/mod.rs
+++ b/fedimint-client-module/src/module/mod.rs
@@ -11,7 +11,7 @@ use bitcoin::secp256k1::PublicKey;
 use fedimint_api_client::api::{DynGlobalApi, DynModuleApi};
 use fedimint_core::config::ClientConfig;
 use fedimint_core::core::{
-    Decoder, DynInput, DynOutput, IInput, IntoDynInstance, ModuleInstanceId, ModuleKind,
+    Account, Decoder, DynInput, DynOutput, IInput, IntoDynInstance, ModuleInstanceId, ModuleKind,
     OperationId,
 };
 use fedimint_core::db::{Database, DatabaseTransaction, GlobalDBTxAccessToken, NonCommittable};
@@ -97,7 +97,31 @@ pub trait ClientContextIface: MaybeSend + MaybeSync {
 
     /// The client's balance for `unit`, held by the primary module. See
     /// `Client::get_balance_for_unit`.
-    async fn get_balance_for_unit(&self, unit: AmountUnit) -> anyhow::Result<Amount>;
+    async fn get_balance_for_unit(
+        &self,
+        unit: AmountUnit,
+        account: Account,
+    ) -> anyhow::Result<Amount>;
+
+    /// Whether the primary module for `unit` can hold a balance for
+    /// `account`. See `Client::supports_account`.
+    fn supports_account(&self, unit: AmountUnit, account: Account) -> bool;
+
+    /// The account `operation_id` acts on. See
+    /// `Client::operation_account_dbtx`.
+    async fn operation_account_dbtx(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        operation_id: OperationId,
+    ) -> Account;
+
+    /// See `Client::set_operation_account_dbtx`.
+    async fn set_operation_account_dbtx(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        operation_id: OperationId,
+        account: Account,
+    );
 
     async fn transaction_updates(&self, operation_id: OperationId) -> TransactionUpdates;
 
@@ -439,13 +463,21 @@ where
         self.client.get().fee_quote(operation_id, request).await
     }
 
-    /// The client's Bitcoin balance, held by the primary module. See
+    /// The account's Bitcoin balance, held by the primary module. See
     /// `Client::get_balance_for_btc`.
-    pub async fn get_balance_for_btc(&self) -> anyhow::Result<Amount> {
+    pub async fn get_balance_for_btc(&self, account: Account) -> anyhow::Result<Amount> {
         self.client
             .get()
-            .get_balance_for_unit(AmountUnit::BITCOIN)
+            .get_balance_for_unit(AmountUnit::BITCOIN, account)
             .await
+    }
+
+    /// Whether the primary module for `unit` can hold a balance for
+    /// `account`. A module handing out account-bound receive keys or addresses
+    /// checks this first, so that nothing is ever paid into an account the
+    /// primary module cannot fund a claim for.
+    pub fn supports_account(&self, unit: AmountUnit, account: Account) -> bool {
+        self.client.get().supports_account(unit, account)
     }
 
     pub async fn transaction_updates(&self, operation_id: OperationId) -> TransactionUpdates {
@@ -630,6 +662,7 @@ where
     pub async fn manual_operation_start(
         &self,
         operation_id: OperationId,
+        account: Account,
         op_type: &str,
         operation_meta: impl serde::Serialize + Debug,
         sms: Vec<DynState>,
@@ -642,6 +675,7 @@ where
             self.manual_operation_start_inner(
                 &mut dbtx.to_ref_nc(),
                 operation_id,
+                account,
                 op_type,
                 operation_meta,
                 sms,
@@ -663,6 +697,7 @@ where
         &self,
         dbtx: &mut DatabaseTransaction<'_>,
         operation_id: OperationId,
+        account: Account,
         op_type: &str,
         operation_meta: impl serde::Serialize + Debug,
         sms: Vec<DynState>,
@@ -670,6 +705,7 @@ where
         self.manual_operation_start_inner(
             &mut dbtx.global_dbtx(self.global_dbtx_access_token),
             operation_id,
+            account,
             op_type,
             operation_meta,
             sms,
@@ -683,6 +719,7 @@ where
         &self,
         dbtx: &mut DatabaseTransaction<'_>,
         operation_id: OperationId,
+        account: Account,
         op_type: &str,
         operation_meta: impl serde::Serialize + Debug,
         sms: Vec<DynState>,
@@ -710,6 +747,7 @@ where
             .add_operation_log_entry_dbtx(
                 &mut dbtx.to_ref_nc(),
                 operation_id,
+                account,
                 op_type,
                 serde_json::to_value(operation_meta).expect("Can't fail"),
             )
@@ -797,6 +835,8 @@ where
         ))
     }
 
+    /// The claim is credited to the operation's account, and any change the
+    /// primary module adds comes back to the same one.
     pub async fn claim_inputs<I, S>(
         &self,
         dbtx: &mut DatabaseTransaction<'_>,
@@ -817,17 +857,40 @@ where
         inputs: InstancelessDynClientInputBundle,
         operation_id: OperationId,
     ) -> anyhow::Result<OutPointRange> {
+        let dbtx = &mut dbtx.global_dbtx(self.global_dbtx_access_token);
+
+        let account = self
+            .client
+            .get()
+            .operation_account_dbtx(&mut dbtx.to_ref_nc(), operation_id)
+            .await;
+
         let tx_builder =
-            TransactionBuilder::new().with_inputs(inputs.into_dyn(self.module_instance_id));
+            TransactionBuilder::new(account).with_inputs(inputs.into_dyn(self.module_instance_id));
 
         self.client
             .get()
-            .finalize_and_submit_transaction_inner(
+            .finalize_and_submit_transaction_inner(dbtx, operation_id, tx_builder)
+            .await
+    }
+
+    /// Records the account for an operation started without an operation log
+    /// entry, such as the state machines a recovery adds. See
+    /// `Client::set_operation_account_dbtx`.
+    pub async fn set_operation_account_dbtx(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        operation_id: OperationId,
+        account: Account,
+    ) {
+        self.client
+            .get()
+            .set_operation_account_dbtx(
                 &mut dbtx.global_dbtx(self.global_dbtx_access_token),
                 operation_id,
-                tx_builder,
+                account,
             )
-            .await
+            .await;
     }
 
     pub async fn add_state_machines_dbtx(
@@ -866,6 +929,7 @@ where
         &self,
         dbtx: &mut DatabaseTransaction<'_>,
         operation_id: OperationId,
+        account: Account,
         operation_type: &str,
         operation_meta: impl serde::Serialize,
     ) {
@@ -875,6 +939,7 @@ where
             .add_operation_log_entry_dbtx(
                 &mut dbtx.global_dbtx(self.global_dbtx_access_token),
                 operation_id,
+                account,
                 operation_type,
                 serde_json::to_value(operation_meta).expect("Can't fail"),
             )
@@ -923,11 +988,15 @@ impl PrimaryModulePriority {
 /// Which amount units this module supports being primary for
 pub enum PrimaryModuleSupport {
     /// Potentially any unit
-    Any { priority: PrimaryModulePriority },
+    Any {
+        priority: PrimaryModulePriority,
+        accounts: AccountSupport,
+    },
     /// Some units supported by the module
     Selected {
         priority: PrimaryModulePriority,
         units: BTreeSet<AmountUnit>,
+        accounts: AccountSupport,
     },
     /// None
     None,
@@ -937,10 +1006,36 @@ impl PrimaryModuleSupport {
     pub fn selected<const N: usize>(
         priority: PrimaryModulePriority,
         units: [AmountUnit; N],
+        accounts: AccountSupport,
     ) -> Self {
         Self::Selected {
             priority,
             units: BTreeSet::from(units),
+            accounts,
+        }
+    }
+}
+
+/// Which of the client's accounts a primary module can hold a balance for.
+///
+/// Advertised rather than discovered: a module that gives out account-bound
+/// receive keys or addresses has to know before anyone pays into them whether
+/// the primary module will be able to fund the claim, since by the time
+/// balancing fails the payer's money has already moved.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AccountSupport {
+    /// The module keeps a single balance and refuses to fund any other
+    /// account.
+    PrimaryOnly,
+    /// Every [`Account`] has its own balance in the module.
+    All,
+}
+
+impl AccountSupport {
+    pub fn supports(self, account: Account) -> bool {
+        match self {
+            Self::PrimaryOnly => account == Account::Primary,
+            Self::All => true,
         }
     }
 }
@@ -1076,6 +1171,7 @@ pub trait ClientModule: Debug + MaybeSend + MaybeSync + 'static {
         _unit: AmountUnit,
         _input_amount: Amount,
         _output_amount: Amount,
+        _account: Account,
     ) -> anyhow::Result<(
         ClientInputBundle<<Self::Common as ModuleCommon>::Input, Self::States>,
         ClientOutputBundle<<Self::Common as ModuleCommon>::Output, Self::States>,
@@ -1097,7 +1193,12 @@ pub trait ClientModule: Debug + MaybeSend + MaybeSync + 'static {
 
     /// Returns the balance held by this module and available for funding
     /// transactions.
-    async fn get_balance(&self, _dbtx: &mut DatabaseTransaction<'_>, _unit: AmountUnit) -> Amount {
+    async fn get_balance(
+        &self,
+        _dbtx: &mut DatabaseTransaction<'_>,
+        _unit: AmountUnit,
+        _account: Account,
+    ) -> Amount {
         unimplemented!()
     }
 
@@ -1206,6 +1307,7 @@ pub trait IClientModule: Debug {
 
     fn supports_being_primary(&self) -> PrimaryModuleSupport;
 
+    #[allow(clippy::too_many_arguments)]
     async fn create_final_inputs_and_outputs(
         &self,
         module_instance: ModuleInstanceId,
@@ -1214,6 +1316,7 @@ pub trait IClientModule: Debug {
         unit: AmountUnit,
         input_amount: Amount,
         output_amount: Amount,
+        account: Account,
     ) -> anyhow::Result<(ClientInputBundle, ClientOutputBundle)>;
 
     async fn await_primary_module_output(
@@ -1227,6 +1330,7 @@ pub trait IClientModule: Debug {
         module_instance: ModuleInstanceId,
         dbtx: &mut DatabaseTransaction<'_>,
         unit: AmountUnit,
+        account: Account,
     ) -> Amount;
 
     async fn subscribe_balance_changes(&self) -> BoxStream<'static, ()>;
@@ -1320,6 +1424,7 @@ where
         unit: AmountUnit,
         input_amount: Amount,
         output_amount: Amount,
+        account: Account,
     ) -> anyhow::Result<(ClientInputBundle, ClientOutputBundle)> {
         let (inputs, outputs) = <T as ClientModule>::create_final_inputs_and_outputs(
             self,
@@ -1328,6 +1433,7 @@ where
             unit,
             input_amount,
             output_amount,
+            account,
         )
         .await?;
 
@@ -1351,11 +1457,13 @@ where
         module_instance: ModuleInstanceId,
         dbtx: &mut DatabaseTransaction<'_>,
         unit: AmountUnit,
+        account: Account,
     ) -> Amount {
         <T as ClientModule>::get_balance(
             self,
             &mut dbtx.to_ref_with_prefix_module_id(module_instance).0,
             unit,
+            account,
         )
         .await
     }

--- a/fedimint-client-module/src/oplog.rs
+++ b/fedimint-client-module/src/oplog.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 use std::future;
 use std::time::SystemTime;
 
-use fedimint_core::core::OperationId;
+use fedimint_core::core::{Account, OperationId};
 use fedimint_core::db::DatabaseTransaction;
 use fedimint_core::encoding::{
     Decodable, DecodeError, Encodable, decode_field_from_finite_reader,
@@ -62,6 +62,7 @@ pub trait IOperationLog {
         &self,
         dbtx: &mut DatabaseTransaction<'_>,
         operation_id: OperationId,
+        account: Account,
         operation_type: &str,
         operation_meta: serde_json::Value,
     );

--- a/fedimint-client-module/src/secret.rs
+++ b/fedimint-client-module/src/secret.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 use std::io::{Read, Write};
 
 use fedimint_core::config::FederationId;
-use fedimint_core::core::ModuleInstanceId;
+use fedimint_core::core::{Account, ModuleInstanceId};
 use fedimint_core::encoding::{Decodable, DecodeError, Encodable};
 use fedimint_core::module::registry::ModuleRegistry;
 use fedimint_derive_secret::{ChildId, DerivableSecret};
@@ -15,10 +15,20 @@ const TYPE_PRE_ROOT_SECRET_HASH: ChildId = ChildId(0);
 const TYPE_MODULE: ChildId = ChildId(0);
 const TYPE_BACKUP: ChildId = ChildId(1);
 
+// Derived from a module-root-secret, to namespace the non-primary accounts.
+//
+// Sits far above anything a module derives at that level, so an account
+// subtree can never collide with a module's own children: mintv2 derives
+// `ChildId(denomination)` with denomination a `u8`, lnv2 derives `ChildId(0)`
+// and `ChildId(1)`, and walletv2 derives `ChildId(address_index)` counting up
+// from zero one address at a time.
+const TYPE_ACCOUNT: ChildId = ChildId(0xACC0_0000_0000_0000);
+
 pub trait DeriveableSecretClientExt {
     fn derive_module_secret(&self, module_instance_id: ModuleInstanceId) -> DerivableSecret;
     fn derive_backup_secret(&self) -> DerivableSecret;
     fn derive_pre_root_secret_hash(&self) -> [u8; 8];
+    fn derive_account_secret(&self, account: Account) -> DerivableSecret;
 }
 
 impl DeriveableSecretClientExt for DerivableSecret {
@@ -31,6 +41,22 @@ impl DeriveableSecretClientExt for DerivableSecret {
     fn derive_backup_secret(&self) -> DerivableSecret {
         assert_eq!(self.level(), 0);
         self.child_key(TYPE_BACKUP)
+    }
+
+    /// Account-scoped root, to be called on a module root secret.
+    ///
+    /// [`Account::Primary`] returns the module root unchanged, so every path a
+    /// released client has already derived stays bit-for-bit what it was and
+    /// no existing wallet's money moves. That costs the tree its uniformity —
+    /// this is a `match` where every other hop is just a hop — and the
+    /// alternative was to re-key every client in the field.
+    fn derive_account_secret(&self, account: Account) -> DerivableSecret {
+        if account == Account::Primary {
+            return self.clone();
+        }
+
+        self.child_key(TYPE_ACCOUNT)
+            .child_key(ChildId(u64::from(account.index())))
     }
 
     fn derive_pre_root_secret_hash(&self) -> [u8; 8] {

--- a/fedimint-client-module/src/transaction/builder.rs
+++ b/fedimint-client-module/src/transaction/builder.rs
@@ -7,7 +7,7 @@ use bitcoin::key::Keypair;
 use bitcoin::secp256k1;
 use fedimint_core::Amount;
 use fedimint_core::core::{
-    DynInput, DynOutput, IInput, IOutput, IntoDynInstance, ModuleInstanceId,
+    Account, DynInput, DynOutput, IInput, IOutput, IntoDynInstance, ModuleInstanceId,
 };
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::Amounts;
@@ -434,6 +434,10 @@ pub struct FeeQuoteRequest {
     pub input_fee: Amounts,
     /// Federation fees charged on the operation's explicit outputs, per unit.
     pub output_fee: Amounts,
+    /// Balance the primary module would fund the operation from. The quote
+    /// runs the real balancing against that account's inventory, so it moves
+    /// with the account it names.
+    pub account: Account,
 }
 
 /// Breakdown of the fee finalizing a transaction would incur, as computed by
@@ -644,15 +648,32 @@ where
     }
 }
 
-#[derive(Default, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub struct TransactionBuilder {
     inputs: Vec<ClientInputBundle>,
     outputs: Vec<ClientOutputBundle>,
+    account: Account,
 }
 
 impl TransactionBuilder {
-    pub fn new() -> Self {
-        Self::default()
+    /// A transaction acting on `account`: the primary module funds it from
+    /// that account's balance and credits its change back to the same one.
+    ///
+    /// Taken rather than defaulted, so a module that forgets to thread an
+    /// account through fails to compile instead of quietly spending the
+    /// primary balance.
+    pub fn new(account: Account) -> Self {
+        Self {
+            inputs: Vec::new(),
+            outputs: Vec::new(),
+            account,
+        }
+    }
+
+    /// The account the primary module funds this transaction from and credits
+    /// its change to.
+    pub fn account(&self) -> Account {
+        self.account
     }
 
     pub fn with_inputs(mut self, inputs: ClientInputBundle) -> Self {

--- a/fedimint-client-module/src/transaction/builder/tests.rs
+++ b/fedimint-client-module/src/transaction/builder/tests.rs
@@ -5,7 +5,7 @@ use std::sync::{Arc, Mutex};
 
 use bitcoin::key::Secp256k1;
 use fedimint_core::Amount;
-use fedimint_core::core::{Input, IntoDynInstance, ModuleKind, Output};
+use fedimint_core::core::{Account, Input, IntoDynInstance, ModuleKind, Output};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::Amounts;
 
@@ -110,7 +110,7 @@ fn tx_builder_empty_bundles() {
 
     // This is ugly due to repetition, but the more manual, the better, and in real
     // code some of these conversions are hidden in the generics. Oh well.
-    TransactionBuilder::new()
+    TransactionBuilder::new(Account::Primary)
         .with_inputs(
             ClientInputBundle::<NoopInput>::new(vec![], vec![no_call_input_sm.clone()])
                 .into_instanceless()

--- a/fedimint-client/src/client.rs
+++ b/fedimint-client/src/client.rs
@@ -19,7 +19,7 @@ use fedimint_bitcoind::DynBitcoindRpc;
 use fedimint_client_module::module::recovery::RecoveryProgress;
 use fedimint_client_module::module::{
     ClientContextIface, ClientModule, ClientModuleRegistry, DynClientModule, FinalClientIface,
-    IClientModule, IdxRange, OutPointRange, PrimaryModulePriority,
+    IClientModule, IdxRange, OutPointRange, PrimaryModulePriority, PrimaryModuleSupport,
 };
 use fedimint_client_module::oplog::IOperationLog;
 use fedimint_client_module::secret::{PlainRootSecretStrategy, RootSecretStrategy as _};
@@ -37,7 +37,9 @@ use fedimint_connectors::{ConnectorRegistry, PeerStatus};
 use fedimint_core::config::{
     ClientConfig, FederationId, GlobalClientConfig, JsonClientConfig, ModuleInitRegistry,
 };
-use fedimint_core::core::{DynInput, DynOutput, ModuleInstanceId, ModuleKind, OperationId};
+use fedimint_core::core::{
+    Account, DynInput, DynOutput, ModuleInstanceId, ModuleKind, OperationId,
+};
 use fedimint_core::db::{
     AutocommitError, Database, DatabaseRecord, DatabaseTransaction,
     IDatabaseTransactionOpsCore as _, IDatabaseTransactionOpsCoreTyped as _, NonCommittable,
@@ -86,9 +88,10 @@ use crate::client::event_log::DefaultApplicationEventLogKey;
 use crate::db::{
     ApiSecretKey, CachedApiVersionSet, CachedApiVersionSetKey, ChainIdKey,
     ChronologicalOperationLogKey, ClientConfigKey, ClientMetadataKey, ClientModuleRecovery,
-    ClientModuleRecoveryState, EncodedClientSecretKey, OperationLogKey, PeerLastApiVersionsSummary,
-    PeerLastApiVersionsSummaryKey, PendingClientConfigKey, TransactionFeesKey,
-    apply_migrations_core_client_dbtx, get_decoded_client_secret, verify_client_db_integrity_dbtx,
+    ClientModuleRecoveryState, EncodedClientSecretKey, OperationAccountKey, OperationLogKey,
+    PeerLastApiVersionsSummary, PeerLastApiVersionsSummaryKey, PendingClientConfigKey,
+    TransactionFeesKey, apply_migrations_core_client_dbtx, get_decoded_client_secret,
+    verify_client_db_integrity_dbtx,
 };
 use crate::meta::MetaService;
 use crate::module_init::{ClientModuleInitRegistry, DynClientModuleInit, IClientModuleInit};
@@ -292,10 +295,27 @@ pub struct GetOperationIdRequest {
     operation_id: OperationId,
 }
 
+/// Which balance `get_balance` and `subscribe_balance_changes` are asking
+/// about. Both fields default, so a caller that predates either the multi-unit
+/// or the multi-account world can keep sending what it always sent.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct GetBalanceChangesRequest {
+pub struct BalanceRequest {
     #[serde(default = "AmountUnit::bitcoin")]
     unit: AmountUnit,
+    #[serde(default = "Account::primary")]
+    account: Account,
+}
+
+/// Spelt out rather than derived, since [`Account`] has no `Default` on
+/// purpose. What is defaulted here is one RPC's legacy wire shape, not an
+/// account-scoped write.
+impl Default for BalanceRequest {
+    fn default() -> Self {
+        Self {
+            unit: AmountUnit::bitcoin(),
+            account: Account::primary(),
+        }
+    }
 }
 
 impl Client {
@@ -768,6 +788,14 @@ impl Client {
                 bail!("No module to balance a partial transaction (affected unit: {unit:?}");
             };
 
+            let account = partial_transaction.account();
+
+            if !Self::module_supports_account(module, account) {
+                bail!(
+                    "The primary module for {unit:?} only holds a balance for the primary account"
+                );
+            }
+
             let (added_input_bundle, added_output_bundle) = module
                 .create_final_inputs_and_outputs(
                     module_id,
@@ -776,6 +804,7 @@ impl Client {
                     *unit,
                     input_amount,
                     output_amount,
+                    account,
                 )
                 .await?;
 
@@ -872,6 +901,7 @@ impl Client {
             output_amount,
             input_fee,
             output_fee,
+            account,
         } = request;
 
         // Start the totals from the explicit side; the change the primary
@@ -911,6 +941,12 @@ impl Client {
                 bail!("No module to balance a partial transaction (affected unit: {unit:?}");
             };
 
+            if !Self::module_supports_account(module, account) {
+                bail!(
+                    "The primary module for {unit:?} only holds a balance for the primary account"
+                );
+            }
+
             let (change_input, change_output) = module
                 .create_final_inputs_and_outputs(
                     module_id,
@@ -919,6 +955,7 @@ impl Client {
                     *unit,
                     balance_input_amount,
                     balance_output_amount,
+                    account,
                 )
                 .await?;
 
@@ -1066,6 +1103,8 @@ impl Client {
             bail!("There already exists an operation with id {operation_id:?}")
         }
 
+        let account = tx_builder.account();
+
         let out_point_range = self
             .finalize_and_submit_transaction_inner(dbtx, operation_id, tx_builder)
             .await?;
@@ -1074,6 +1113,7 @@ impl Client {
             .add_operation_log_entry_dbtx(
                 dbtx,
                 operation_id,
+                account,
                 operation_type,
                 operation_meta_gen(out_point_range),
             )
@@ -1088,6 +1128,8 @@ impl Client {
         operation_id: OperationId,
         tx_builder: TransactionBuilder,
     ) -> anyhow::Result<OutPointRange> {
+        let account = tx_builder.account();
+
         let FinalizedTransaction {
             transaction,
             mut states,
@@ -1145,8 +1187,16 @@ impl Client {
         dbtx.insert_new_entry(&TransactionFeesKey(txid), &fees)
             .await;
 
-        self.log_event_dbtx(dbtx, None, TxCreatedEvent { txid, operation_id })
-            .await;
+        self.log_event_dbtx(
+            dbtx,
+            None,
+            TxCreatedEvent {
+                txid,
+                operation_id,
+                account,
+            },
+        )
+        .await;
 
         Ok(OutPointRange::new(txid, IdxRange::from(change_range)))
     }
@@ -1169,6 +1219,33 @@ impl Client {
         let mut dbtx = self.db().begin_transaction_nc().await;
 
         Client::operation_exists_dbtx(&mut dbtx, operation_id).await
+    }
+
+    /// The account `operation_id` acts on. See [`OperationAccountKey`] for
+    /// why an absent row is primary.
+    pub async fn operation_account_dbtx(
+        dbtx: &mut DatabaseTransaction<'_>,
+        operation_id: OperationId,
+    ) -> Account {
+        dbtx.get_value(&OperationAccountKey(operation_id))
+            .await
+            .unwrap_or(Account::Primary)
+    }
+
+    /// Records the account an operation acts on. The operation log calls
+    /// this as it writes an entry; a module that starts state machines
+    /// without one, as a recovery does, calls it directly. Idempotent, so an
+    /// operation recorded here and then started through the log is fine.
+    /// Absent reads as primary, see [`OperationAccountKey`].
+    pub async fn set_operation_account_dbtx(
+        dbtx: &mut DatabaseTransaction<'_>,
+        operation_id: OperationId,
+        account: Account,
+    ) {
+        if account != Account::Primary {
+            dbtx.insert_entry(&OperationAccountKey(operation_id), &account)
+                .await;
+        }
     }
 
     pub async fn operation_exists_dbtx(
@@ -1387,27 +1464,46 @@ impl Client {
     #[doc(hidden)]
     /// Like [`Self::get_balance`] but returns an error if primary module is not
     /// available
-    pub async fn get_balance_for_btc(&self) -> anyhow::Result<Amount> {
-        self.get_balance_for_unit(AmountUnit::BITCOIN).await
+    pub async fn get_balance_for_btc(&self, account: Account) -> anyhow::Result<Amount> {
+        self.get_balance_for_unit(AmountUnit::BITCOIN, account)
+            .await
     }
 
-    pub async fn get_balance_for_unit(&self, unit: AmountUnit) -> anyhow::Result<Amount> {
+    pub async fn get_balance_for_unit(
+        &self,
+        unit: AmountUnit,
+        account: Account,
+    ) -> anyhow::Result<Amount> {
         let (id, module) = self
             .primary_module_for_unit(unit)
             .ok_or_else(|| anyhow!("Primary module not available"))?;
+
+        if !Self::module_supports_account(module, account) {
+            return Ok(Amount::ZERO);
+        }
+
         Ok(module
-            .get_balance(id, &mut self.db().begin_transaction_nc().await, unit)
+            .get_balance(
+                id,
+                &mut self.db().begin_transaction_nc().await,
+                unit,
+                account,
+            )
             .await)
     }
 
     /// Returns a stream that yields the current client balance every time it
     /// changes.
-    pub async fn subscribe_balance_changes(&self, unit: AmountUnit) -> BoxStream<'static, Amount> {
+    pub async fn subscribe_balance_changes(
+        &self,
+        unit: AmountUnit,
+        account: Account,
+    ) -> BoxStream<'static, Amount> {
         let primary_module_things =
             if let Some((primary_module_id, primary_module)) = self.primary_module_for_unit(unit) {
                 let balance_changes = primary_module.subscribe_balance_changes().await;
                 let initial_balance = self
-                    .get_balance_for_unit(unit)
+                    .get_balance_for_unit(unit, account)
                     .await
                     .expect("Primary is present");
 
@@ -1435,7 +1531,7 @@ impl Client {
             while let Some(()) = balance_changes.next().await {
                 let mut dbtx = db.begin_transaction_nc().await;
                 let balance = primary_module
-                     .get_balance(primary_module_id, &mut dbtx, unit)
+                     .get_balance(primary_module_id, &mut dbtx, unit, account)
                     .await;
 
                 // Deduplicate in case modules cannot always tell if the balance actually changed
@@ -2493,12 +2589,21 @@ impl Client {
         Box::pin(try_stream! {
             match method.as_str() {
                 "get_balance" => {
-                    let balance = self.get_balance_for_btc().await.unwrap_or_default();
+                    // Callers that predate accounts send no params at all.
+                    let req: BalanceRequest = if params.is_null() {
+                        BalanceRequest::default()
+                    } else {
+                        serde_json::from_value(params)?
+                    };
+                    let balance = self
+                        .get_balance_for_unit(req.unit, req.account)
+                        .await
+                        .unwrap_or_default();
                     yield serde_json::to_value(balance)?;
                 }
                 "subscribe_balance_changes" => {
-                    let req: GetBalanceChangesRequest= serde_json::from_value(params)?;
-                    let mut stream = self.subscribe_balance_changes(req.unit).await;
+                    let req: BalanceRequest = serde_json::from_value(params)?;
+                    let mut stream = self.subscribe_balance_changes(req.unit, req.account).await;
                     while let Some(balance) = stream.next().await {
                         yield serde_json::to_value(balance)?;
                     }
@@ -2840,6 +2945,28 @@ impl Client {
         self.primary_modules_for_unit(unit).next()
     }
 
+    /// Whether the primary module for `unit` can hold a balance for
+    /// `account`. False when there is no primary module for the unit at all.
+    ///
+    /// Enforced here rather than by each primary module: balancing a
+    /// transaction or a fee quote against an unsupported account fails, and
+    /// its balance reads as zero, so a module only ever sees accounts it
+    /// advertised.
+    pub fn supports_account(&self, unit: AmountUnit, account: Account) -> bool {
+        self.primary_module_for_unit(unit)
+            .is_some_and(|(_, module)| Self::module_supports_account(module, account))
+    }
+
+    fn module_supports_account(module: &DynClientModule, account: Account) -> bool {
+        match module.supports_being_primary() {
+            PrimaryModuleSupport::Any { accounts, .. }
+            | PrimaryModuleSupport::Selected { accounts, .. } => accounts.supports(account),
+            PrimaryModuleSupport::None => {
+                unreachable!("a module selected as primary advertises primary support")
+            }
+        }
+    }
+
     /// [`Self::primary_module_for_unit`] for Bitcoin
     pub fn primary_module_for_btc(&self) -> (ModuleInstanceId, &DynClientModule) {
         self.primary_module_for_unit(AmountUnit::BITCOIN)
@@ -2914,8 +3041,33 @@ impl ClientContextIface for Client {
         Client::fee_quote(self, operation_id, request).await
     }
 
-    async fn get_balance_for_unit(&self, unit: AmountUnit) -> anyhow::Result<Amount> {
-        Client::get_balance_for_unit(self, unit).await
+    async fn get_balance_for_unit(
+        &self,
+        unit: AmountUnit,
+        account: Account,
+    ) -> anyhow::Result<Amount> {
+        Client::get_balance_for_unit(self, unit, account).await
+    }
+
+    fn supports_account(&self, unit: AmountUnit, account: Account) -> bool {
+        Client::supports_account(self, unit, account)
+    }
+
+    async fn operation_account_dbtx(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        operation_id: OperationId,
+    ) -> Account {
+        Client::operation_account_dbtx(dbtx, operation_id).await
+    }
+
+    async fn set_operation_account_dbtx(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        operation_id: OperationId,
+        account: Account,
+    ) {
+        Client::set_operation_account_dbtx(dbtx, operation_id, account).await;
     }
 
     async fn transaction_updates(&self, operation_id: OperationId) -> TransactionUpdates {

--- a/fedimint-client/src/client/builder.rs
+++ b/fedimint-client/src/client/builder.rs
@@ -1003,14 +1003,16 @@ impl ClientBuilder {
 
         for (module_id, _kind, module) in modules.iter_modules() {
             match module.supports_being_primary() {
-                PrimaryModuleSupport::Any { priority } => {
+                PrimaryModuleSupport::Any { priority, .. } => {
                     primary_modules
                         .entry(priority)
                         .or_default()
                         .wildcard
                         .push(module_id);
                 }
-                PrimaryModuleSupport::Selected { priority, units } => {
+                PrimaryModuleSupport::Selected {
+                    priority, units, ..
+                } => {
                     for unit in units {
                         primary_modules
                             .entry(priority)

--- a/fedimint-client/src/client/global_ctx.rs
+++ b/fedimint-client/src/client/global_ctx.rs
@@ -9,7 +9,7 @@ use fedimint_client_module::{
     InstancelessDynClientOutputBundle,
 };
 use fedimint_core::config::ClientConfig;
-use fedimint_core::core::{IntoDynInstance, ModuleInstanceId, ModuleKind, OperationId};
+use fedimint_core::core::{Account, IntoDynInstance, ModuleInstanceId, ModuleKind, OperationId};
 use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_core::util::BoxStream;
 use fedimint_core::{apply, async_trait_maybe_send, maybe_add_send_sync};
@@ -45,13 +45,19 @@ impl IGlobalClientContext for ModuleGlobalClientContext {
         self.client.config().await
     }
 
+    async fn account(&self, dbtx: &mut ClientSMDatabaseTransaction<'_, '_>) -> Account {
+        Client::operation_account_dbtx(dbtx.global_tx(), self.operation).await
+    }
+
     async fn claim_inputs_dyn(
         &self,
         dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
         inputs: InstancelessDynClientInputBundle,
     ) -> anyhow::Result<OutPointRange> {
+        let account = self.account(dbtx).await;
+
         let tx_builder =
-            TransactionBuilder::new().with_inputs(inputs.into_dyn(self.module_instance_id));
+            TransactionBuilder::new(account).with_inputs(inputs.into_dyn(self.module_instance_id));
 
         self.client
             .finalize_and_submit_transaction_inner(
@@ -67,8 +73,10 @@ impl IGlobalClientContext for ModuleGlobalClientContext {
         dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
         outputs: InstancelessDynClientOutputBundle,
     ) -> anyhow::Result<OutPointRange> {
-        let tx_builder =
-            TransactionBuilder::new().with_outputs(outputs.into_dyn(self.module_instance_id));
+        let account = self.account(dbtx).await;
+
+        let tx_builder = TransactionBuilder::new(account)
+            .with_outputs(outputs.into_dyn(self.module_instance_id));
 
         self.client
             .finalize_and_submit_transaction_inner(

--- a/fedimint-client/src/db.rs
+++ b/fedimint-client/src/db.rs
@@ -9,7 +9,7 @@ use fedimint_client_module::module::recovery::RecoveryProgress;
 use fedimint_client_module::oplog::{JsonStringed, OperationLogEntry, OperationOutcome};
 use fedimint_client_module::sm::{ActiveStateMeta, InactiveStateMeta};
 use fedimint_core::config::{ClientConfig, ClientConfigV0, FederationId, GlobalClientConfig};
-use fedimint_core::core::{ModuleInstanceId, OperationId};
+use fedimint_core::core::{Account, ModuleInstanceId, OperationId};
 use fedimint_core::db::{
     Database, DatabaseTransaction, DatabaseVersion, DatabaseVersionKey, DbMigrationError,
     IDatabaseTransactionOpsCore, IDatabaseTransactionOpsCoreTyped, MODULE_GLOBAL_PREFIX,
@@ -65,6 +65,7 @@ pub enum DbKeyPrefix {
     ClientModuleRecovery = 0x40,
     GuardianMetadata = 0x42,
     TransactionFees = 0x43,
+    OperationAccount = 0x44,
 
     DatabaseVersion = fedimint_core::db::DbKeyPrefix::DatabaseVersion as u8,
     ClientBackup = fedimint_core::db::DbKeyPrefix::ClientBackup as u8,
@@ -94,6 +95,24 @@ pub enum DbKeyPrefix {
     /// Per-module instance data
     ModuleGlobalPrefix = 0xff,
 }
+
+/// The account an operation acts on: the balance the primary module funds it
+/// from and credits its change, claims and refunds to.
+///
+/// Written when the operation is created and only for non-primary accounts,
+/// so an absent row reads as [`Account::Primary`]. That is also the only
+/// account an operation recorded before accounts existed can have belonged
+/// to, which is what lets state machines stay unaware of accounts: they look
+/// up their operation's row instead of carrying the account themselves, and
+/// machines persisted before the row existed need no rewrite.
+#[derive(Debug, Clone, Encodable, Decodable)]
+pub struct OperationAccountKey(pub OperationId);
+
+impl_db_record!(
+    key = OperationAccountKey,
+    value = Account,
+    db_prefix = DbKeyPrefix::OperationAccount,
+);
 
 #[repr(u8)]
 #[derive(Clone, EnumIter, Debug)]

--- a/fedimint-client/src/ffi.rs
+++ b/fedimint-client/src/ffi.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use fedimint_client_module::OperationId;
 use fedimint_client_module::oplog::OperationLogEntry;
 use fedimint_core::config::{ClientConfig, FederationId};
+use fedimint_core::core::Account;
 use fedimint_core::invite_code::InviteCode;
 use fedimint_core::module::AmountUnit;
 use fedimint_core::util::ffi::UniffiError;
@@ -23,21 +24,22 @@ pub struct ListOperationsResponse {
 
 #[uniffi::export(async_runtime = "tokio")]
 impl ClientHandle {
-    pub async fn get_balance(&self) -> Result<Amount> {
+    pub async fn get_balance(&self, account: Account) -> Result<Amount> {
         let client = client_for_handle(self)?;
-        Ok(client.get_balance_for_btc().await?)
+        Ok(client.get_balance_for_btc(account).await?)
     }
 
     #[uniffi::method(name = "subscribe_balance_changes")]
     pub fn subscribe_balance_changes_uniffi(
         &self,
         unit: AmountUnit,
+        account: Account,
         callback: Box<dyn BalanceChangeCallback>,
     ) -> Result<()> {
         let client = client_for_handle(self)?;
         let task_client = client.clone();
         let _ = client.spawn_cancellable("uniffi-subscribe-balance-changes", async move {
-            let mut stream = task_client.subscribe_balance_changes(unit).await;
+            let mut stream = task_client.subscribe_balance_changes(unit, account).await;
             while let Some(balance) = stream.next().await {
                 callback.on_balance_change(balance);
             }

--- a/fedimint-client/src/oplog.rs
+++ b/fedimint-client/src/oplog.rs
@@ -7,7 +7,7 @@ use std::time::{Duration, SystemTime};
 use fedimint_client_module::oplog::{
     IOperationLog, JsonStringed, OperationLogEntry, OperationOutcome, UpdateStreamOrOutcome,
 };
-use fedimint_core::core::OperationId;
+use fedimint_core::core::{Account, OperationId};
 use fedimint_core::db::{Database, DatabaseTransaction, IDatabaseTransactionOpsCoreTyped as _};
 use fedimint_core::task::{MaybeSend, MaybeSync};
 use fedimint_core::time::now;
@@ -66,12 +66,14 @@ impl OperationLog {
         &self,
         dbtx: &mut DatabaseTransaction<'_>,
         operation_id: OperationId,
+        account: Account,
         operation_type: &str,
         operation_meta: impl serde::Serialize,
     ) {
         self.add_operation_log_entry_dbtx_with_creation_time(
             dbtx,
             operation_id,
+            account,
             operation_type,
             operation_meta,
             now(),
@@ -83,10 +85,13 @@ impl OperationLog {
         &self,
         dbtx: &mut DatabaseTransaction<'_>,
         operation_id: OperationId,
+        account: Account,
         operation_type: &str,
         operation_meta: impl serde::Serialize,
         creation_time: SystemTime,
     ) {
+        crate::Client::set_operation_account_dbtx(dbtx, operation_id, account).await;
+
         dbtx.insert_new_entry(
             &OperationLogKey { operation_id },
             &OperationLogEntry::new(
@@ -324,6 +329,7 @@ impl IOperationLog for OperationLog {
         &self,
         dbtx: &mut DatabaseTransaction<'_>,
         operation_id: OperationId,
+        account: Account,
         operation_type: &str,
         operation_meta: serde_json::Value,
     ) {
@@ -331,6 +337,7 @@ impl IOperationLog for OperationLog {
             self,
             dbtx,
             operation_id,
+            account,
             operation_type,
             operation_meta,
         )

--- a/fedimint-client/src/oplog/tests.rs
+++ b/fedimint-client/src/oplog/tests.rs
@@ -2,7 +2,7 @@ use std::time::{Duration, SystemTime};
 
 use assert_matches::assert_matches;
 use fedimint_client_module::oplog::{JsonStringed, OperationOutcome, UpdateStreamOrOutcome};
-use fedimint_core::core::OperationId;
+use fedimint_core::core::{Account, OperationId};
 use fedimint_core::db::mem_impl::MemDatabase;
 use fedimint_core::db::{
     Database, DatabaseTransaction, IDatabaseTransactionOpsCoreTyped, IRawDatabaseExt,
@@ -60,7 +60,7 @@ async fn test_operation_log_update() {
 
     let mut dbtx = db.begin_transaction().await;
     op_log
-        .add_operation_log_entry_dbtx(&mut dbtx.to_ref_nc(), op_id, "foo", "bar")
+        .add_operation_log_entry_dbtx(&mut dbtx.to_ref_nc(), op_id, Account::Primary, "foo", "bar")
         .await;
     dbtx.commit_tx().await;
 
@@ -104,7 +104,7 @@ async fn test_operation_log_update_from_stream() {
 
     let mut dbtx = db.begin_transaction().await;
     op_log
-        .add_operation_log_entry_dbtx(&mut dbtx.to_ref_nc(), op_id, "foo", "bar")
+        .add_operation_log_entry_dbtx(&mut dbtx.to_ref_nc(), op_id, Account::Primary, "foo", "bar")
         .await;
     dbtx.commit_tx().await;
 
@@ -145,7 +145,7 @@ async fn test_no_outcome_cached_for_non_terminal_stream_end() {
 
     let mut dbtx = db.begin_transaction().await;
     op_log
-        .add_operation_log_entry_dbtx(&mut dbtx.to_ref_nc(), op_id, "foo", "bar")
+        .add_operation_log_entry_dbtx(&mut dbtx.to_ref_nc(), op_id, Account::Primary, "foo", "bar")
         .await;
     dbtx.commit_tx().await;
 
@@ -203,7 +203,7 @@ async fn test_non_terminal_cached_outcome_falls_back_to_update_stream() {
 
     let mut dbtx = db.begin_transaction().await;
     op_log
-        .add_operation_log_entry_dbtx(&mut dbtx.to_ref_nc(), op_id, "foo", "bar")
+        .add_operation_log_entry_dbtx(&mut dbtx.to_ref_nc(), op_id, Account::Primary, "foo", "bar")
         .await;
     dbtx.commit_tx().await;
 
@@ -258,7 +258,7 @@ async fn test_undeserializable_outcome_falls_back_to_update_stream() {
 
     let mut dbtx = db.begin_transaction().await;
     op_log
-        .add_operation_log_entry_dbtx(&mut dbtx.to_ref_nc(), op_id, "foo", "bar")
+        .add_operation_log_entry_dbtx(&mut dbtx.to_ref_nc(), op_id, Account::Primary, "foo", "bar")
         .await;
     dbtx.commit_tx().await;
 
@@ -310,6 +310,7 @@ async fn test_pagination() {
             .add_operation_log_entry_dbtx(
                 &mut dbtx.to_ref_nc(),
                 OperationId([operation_idx; 32]),
+                Account::Primary,
                 "foo",
                 operation_idx,
             )
@@ -454,7 +455,13 @@ async fn test_pagination_empty_then_not() {
 
     let mut dbtx = db.begin_transaction().await;
     op_log
-        .add_operation_log_entry_dbtx(&mut dbtx.to_ref_nc(), OperationId([0; 32]), "foo", "bar")
+        .add_operation_log_entry_dbtx(
+            &mut dbtx.to_ref_nc(),
+            OperationId([0; 32]),
+            Account::Primary,
+            "foo",
+            "bar",
+        )
         .await;
     dbtx.commit_tx().await;
 
@@ -474,6 +481,7 @@ async fn test_pagination_after_historical_insert() {
         .add_operation_log_entry_dbtx_with_creation_time(
             &mut dbtx.to_ref_nc(),
             recent_operation_id,
+            Account::Primary,
             "foo",
             1u8,
             recent_creation_time,
@@ -492,6 +500,7 @@ async fn test_pagination_after_historical_insert() {
         .add_operation_log_entry_dbtx_with_creation_time(
             &mut dbtx.to_ref_nc(),
             historical_operation_id,
+            Account::Primary,
             "foo",
             0u8,
             historical_creation_time,

--- a/fedimint-core/src/core.rs
+++ b/fedimint-core/src/core.rs
@@ -144,6 +144,89 @@ impl<'de> Deserialize<'de> for OperationId {
     }
 }
 
+/// One of a client's balances within a single federation.
+///
+/// The federation cannot tell accounts apart — an account is purely a
+/// client-side split of the derivation tree and of the few client tables that
+/// hold per-account state. It lives in core rather than in the client because
+/// module event payloads are tagged with it.
+///
+/// Used as the leading component of every account-scoped table key and as a
+/// hop in the derivation tree, so the numbering is load-bearing — changing it
+/// silently re-keys every client. The discriminants are spelt out for the same
+/// reason a db prefix enum spells its own out: they are values on disk and in
+/// the derivation tree, not an implementation detail of the declaration order.
+/// A balance added later takes the next free number and leaves every existing
+/// path where it was.
+///
+/// Deliberately has no `Default` impl: every entry point that touches
+/// account-scoped state takes one of these explicitly, so an omitted argument
+/// is a compile error rather than a silent write to the wrong balance.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    PartialOrd,
+    Ord,
+    Serialize,
+    Deserialize,
+    Encodable,
+    Decodable,
+    strum_macros::Display,
+    strum_macros::EnumString,
+)]
+#[serde(rename_all = "lowercase")]
+#[strum(serialize_all = "lowercase", ascii_case_insensitive)]
+#[repr(u8)]
+pub enum Account {
+    Primary = 0,
+    Secondary = 1,
+    Tertiary = 2,
+    Quaternary = 3,
+    Quinary = 4,
+}
+
+// Crosses the FFI as its name rather than as a mirrored enum, so a consumer
+// names an account the same way the CLI does and adding a variant does not
+// reshape the generated bindings.
+#[cfg(feature = "uniffi")]
+uniffi::custom_type!(Account, String, {
+    lower: |obj| obj.to_string(),
+    try_lift: |s| Account::from_str(&s).map_err(|e| anyhow::anyhow!("Failed to parse Account: {e}")),
+    }
+);
+
+impl Account {
+    /// Every account, in key order — the set a scanner trials its keys against
+    /// and a recovery walks.
+    ///
+    /// The set is fixed on purpose: every account exists from the moment a
+    /// client is built, so no account ever joins a stream late and there is
+    /// nothing for a caller to create.
+    pub const ALL: [Self; 5] = [
+        Self::Primary,
+        Self::Secondary,
+        Self::Tertiary,
+        Self::Quaternary,
+        Self::Quinary,
+    ];
+
+    /// The account every wallet that predates accounts already is, and the one
+    /// a client falls back to when reading a record written before accounts
+    /// existed. Spelt as a function so it can be a `serde(default)`.
+    pub fn primary() -> Self {
+        Self::Primary
+    }
+
+    /// The account's discriminant: the hop it takes in the derivation tree.
+    pub fn index(self) -> u8 {
+        self as u8
+    }
+}
+
 /// Module instance ID
 ///
 /// This value uniquely identifies a single instance of a module in a

--- a/fedimint-load-test-tool/src/common.rs
+++ b/fedimint-load-test-tool/src/common.rs
@@ -11,7 +11,7 @@ use fedimint_client::secret::{PlainRootSecretStrategy, RootSecretStrategy};
 use fedimint_client::transaction::TransactionBuilder;
 use fedimint_client::{Client, ClientHandleArc, RootSecret};
 use fedimint_connectors::ConnectorRegistry;
-use fedimint_core::core::{IntoDynInstance, OperationId};
+use fedimint_core::core::{Account, IntoDynInstance, OperationId};
 use fedimint_core::db::Database;
 use fedimint_core::invite_code::InviteCode;
 use fedimint_core::module::CommonModuleInit;
@@ -394,7 +394,7 @@ pub async fn try_remint_denomination(
     let mint_client = client.get_first_module::<MintClientModule>()?;
     let mut dbtx = client.db().begin_transaction().await;
     let mut module_transaction = dbtx.to_ref_with_prefix_module_id(mint_client.id).0;
-    let mut tx = TransactionBuilder::new();
+    let mut tx = TransactionBuilder::new(Account::Primary);
     let operation_id = OperationId::new_random();
     for _ in 0..quantity {
         let outputs = mint_client

--- a/fedimint-load-test-tool/src/main.rs
+++ b/fedimint-load-test-tool/src/main.rs
@@ -25,6 +25,7 @@ use fedimint_api_client::download_from_invite_code;
 use fedimint_client::ClientHandleArc;
 use fedimint_connectors::ConnectorRegistry;
 use fedimint_core::Amount;
+use fedimint_core::core::Account;
 use fedimint_core::endpoint_constants::SESSION_COUNT_ENDPOINT;
 use fedimint_core::invite_code::InviteCode;
 use fedimint_core::module::ApiRequestErased;
@@ -568,7 +569,7 @@ async fn get_required_notes(
     minimum_amount_required: Amount,
     event_sender: &mpsc::UnboundedSender<MetricEvent>,
 ) -> anyhow::Result<()> {
-    let current_balance = coordinator.get_balance_for_btc().await?;
+    let current_balance = coordinator.get_balance_for_btc(Account::Primary).await?;
 
     if current_balance < minimum_amount_required {
         let diff = minimum_amount_required.saturating_sub(current_balance);

--- a/gateway/fedimint-gateway-server/src/federation_manager.rs
+++ b/gateway/fedimint-gateway-server/src/federation_manager.rs
@@ -6,6 +6,7 @@ use std::time::SystemTime;
 use bitcoin::secp256k1::Keypair;
 use fedimint_client::ClientHandleArc;
 use fedimint_core::config::{FederationId, FederationIdPrefix, JsonClientConfig};
+use fedimint_core::core::Account;
 use fedimint_core::db::{Committable, DatabaseTransaction, NonCommittable};
 use fedimint_core::invite_code::InviteCode;
 use fedimint_core::util::{FmtCompactAnyhow as _, Spanned};
@@ -226,7 +227,7 @@ impl FederationManager {
             .borrow()
             .with(|client| async move {
                 let balance_msat = client
-                    .get_balance_for_btc()
+                    .get_balance_for_btc(Account::Primary)
                     .await
                     // If primary module is not available, we're not really connected yet
                     .map_err(|_err| FederationNotConnected {
@@ -270,7 +271,7 @@ impl FederationManager {
         for (federation_id, client) in &self.clients {
             let balance_msat = match client
                 .borrow()
-                .with(|client| client.get_balance_for_btc())
+                .with(|client| client.get_balance_for_btc(Account::Primary))
                 .await
             {
                 Ok(balance_msat) => balance_msat,

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -56,7 +56,7 @@ use fedimint_client::secret::RootSecretStrategy;
 use fedimint_client::{Client, ClientHandleArc};
 use fedimint_core::base32::{self, FEDIMINT_PREFIX};
 use fedimint_core::config::FederationId;
-use fedimint_core::core::OperationId;
+use fedimint_core::core::{Account, OperationId};
 use fedimint_core::db::{Committable, Database, DatabaseTransaction, apply_migrations};
 use fedimint_core::envs::is_env_var_set;
 use fedimint_core::invite_code::InviteCode;
@@ -436,19 +436,22 @@ async fn withdraw_v2(
 
     let withdraw_amount = match amount {
         BitcoinAmountOrAll::All => {
-            let balance = client.get_balance_for_btc().await.map_err(|err| {
-                AdminGatewayError::Unexpected(anyhow!(
-                    "Balance not available: {}",
-                    err.fmt_compact_anyhow()
-                ))
-            })?;
+            let balance = client
+                .get_balance_for_btc(Account::Primary)
+                .await
+                .map_err(|err| {
+                    AdminGatewayError::Unexpected(anyhow!(
+                        "Balance not available: {}",
+                        err.fmt_compact_anyhow()
+                    ))
+                })?;
 
             // The on-chain fee is only part of the cost: funding the wallet
             // output also incurs the federation's per-note fees. `fee` is
             // passed on to `send` below so both are computed against the same
             // on-chain fee.
             wallet_module
-                .max_sendable_amount(balance, fee)
+                .max_sendable_amount(Account::Primary, balance, fee)
                 .await
                 .map_err(|err| AdminGatewayError::WithdrawError {
                     failure_reason: format!(
@@ -462,6 +465,7 @@ async fn withdraw_v2(
 
     let operation_id = wallet_module
         .send(
+            Account::Primary,
             address.as_unchecked().clone(),
             withdraw_amount,
             Some(fee),
@@ -504,12 +508,15 @@ async fn calculate_max_withdrawable(
     client: &ClientHandleArc,
     address: &Address,
 ) -> AdminResult<WithdrawDetails> {
-    let balance = client.get_balance_for_btc().await.map_err(|err| {
-        AdminGatewayError::Unexpected(anyhow!(
-            "Balance not available: {}",
-            err.fmt_compact_anyhow()
-        ))
-    })?;
+    let balance = client
+        .get_balance_for_btc(Account::Primary)
+        .await
+        .map_err(|err| {
+            AdminGatewayError::Unexpected(anyhow!(
+                "Balance not available: {}",
+                err.fmt_compact_anyhow()
+            ))
+        })?;
 
     if let Ok(wallet_module) =
         client.get_first_module::<fedimint_walletv2_client::WalletClientModule>()
@@ -522,7 +529,7 @@ async fn calculate_max_withdrawable(
             })?;
 
         let max_withdrawable = wallet_module
-            .max_sendable_amount(balance, fee)
+            .max_sendable_amount(Account::Primary, balance, fee)
             .await
             .map_err(|err| AdminGatewayError::WithdrawError {
                 failure_reason: err.fmt_compact_anyhow().to_string(),
@@ -1535,7 +1542,10 @@ impl Gateway {
             .value()
             .get_first_module::<fedimint_walletv2_client::WalletClientModule>()
         {
-            Ok(wallet_module.receive().await)
+            wallet_module
+                .receive(Account::Primary)
+                .await
+                .map_err(|e| AdminGatewayError::Unexpected(e.into()))
         } else {
             Err(AdminGatewayError::Unexpected(anyhow!(
                 "No wallet module found"
@@ -1750,7 +1760,7 @@ impl Gateway {
             let amount = ecash.amount();
 
             let operation_id = mint
-                .receive(ecash, serde_json::Value::Null)
+                .receive(Account::Primary, ecash, serde_json::Value::Null)
                 .await
                 .map_err(|e| PublicGatewayError::ReceiveEcashError {
                     failure_reason: e.to_string(),
@@ -2450,15 +2460,18 @@ impl IAdminGateway for Gateway {
         let federation_info = FederationInfo {
             federation_id,
             federation_name: federation_manager.federation_name(&client).await,
-            balance_msat: client.get_balance_for_btc().await.unwrap_or_else(|err| {
-                warn!(
-                    target: LOG_GATEWAY,
-                    err = %err.fmt_compact_anyhow(),
-                    %federation_id,
-                    "Balance not immediately available after joining/recovering."
-                );
-                Amount::default()
-            }),
+            balance_msat: client
+                .get_balance_for_btc(Account::Primary)
+                .await
+                .unwrap_or_else(|err| {
+                    warn!(
+                        target: LOG_GATEWAY,
+                        err = %err.fmt_compact_anyhow(),
+                        %federation_id,
+                        "Balance not immediately available after joining/recovering."
+                    );
+                    Amount::default()
+                }),
             config: federation_config.clone(),
             last_backup_time: None,
         };
@@ -2876,7 +2889,12 @@ impl IAdminGateway for Gateway {
             })
         } else if let Ok(mint_module) = client.get_first_module::<MintV2ClientModule>() {
             let (_, ecash) = mint_module
-                .send(payload.amount, serde_json::Value::Null, true)
+                .send(
+                    Account::Primary,
+                    payload.amount,
+                    serde_json::Value::Null,
+                    true,
+                )
                 .await
                 .map_err(|e| AdminGatewayError::Unexpected(e.into()))?;
 
@@ -2990,12 +3008,16 @@ impl IAdminGateway for Gateway {
                 // federation's per-note fees. The returned fees are quoted at
                 // the returned amount, so they must be used together.
                 BitcoinAmountOrAll::All => {
-                    let balance = client.value().get_balance_for_btc().await.map_err(|err| {
-                        AdminGatewayError::Unexpected(anyhow!(
-                            "Balance not available: {}",
-                            err.fmt_compact_anyhow()
-                        ))
-                    })?;
+                    let balance = client
+                        .value()
+                        .get_balance_for_btc(Account::Primary)
+                        .await
+                        .map_err(|err| {
+                            AdminGatewayError::Unexpected(anyhow!(
+                                "Balance not available: {}",
+                                err.fmt_compact_anyhow()
+                            ))
+                        })?;
 
                     wallet_module
                         .max_withdrawable_amount(&address, balance)

--- a/gateway/fedimint-gateway-server/tests/tests.rs
+++ b/gateway/fedimint-gateway-server/tests/tests.rs
@@ -15,7 +15,7 @@ use fedimint_client::transaction::{
 };
 use fedimint_client_module::module::OutPointRange;
 use fedimint_core::config::FederationId;
-use fedimint_core::core::{IntoDynInstance, OperationId};
+use fedimint_core::core::{Account, IntoDynInstance, OperationId};
 use fedimint_core::encoding::Encodable;
 use fedimint_core::module::{AmountUnit, Amounts};
 use fedimint_core::task::{TaskGroup, sleep_in_test, timeout};
@@ -243,7 +243,10 @@ async fn test_gateway_client_pay_valid_invoice() -> anyhow::Result<()> {
             dummy_module
                 .mock_receive(sats(1000), AmountUnit::BITCOIN)
                 .await?;
-            assert_eq!(user_client.get_balance_for_btc().await?, sats(1000));
+            assert_eq!(
+                user_client.get_balance_for_btc(Account::Primary).await?,
+                sats(1000)
+            );
 
             // Create test invoice
             let invoice = other_lightning_client.invoice(sats(250), None)?;
@@ -266,13 +269,13 @@ async fn test_gateway_client_pay_valid_invoice() -> anyhow::Result<()> {
             .await?;
 
             assert_eq!(
-                user_client.get_balance_for_btc().await?,
+                user_client.get_balance_for_btc(Account::Primary).await?,
                 sats(1000 - 250)
                     .checked_sub(outgoing_fee)
                     .expect("Should not be negative")
             );
             assert_eq!(
-                gateway_client.get_balance_for_btc().await?,
+                gateway_client.get_balance_for_btc(Account::Primary).await?,
                 sats(250)
                     .checked_add(outgoing_fee)
                     .expect("Should not wrap around")
@@ -293,7 +296,10 @@ async fn test_gateway_enforces_fees() -> anyhow::Result<()> {
             dummy_module
                 .mock_receive(sats(1000), AmountUnit::BITCOIN)
                 .await?;
-            assert_eq!(user_client.get_balance_for_btc().await?, sats(1000));
+            assert_eq!(
+                user_client.get_balance_for_btc(Account::Primary).await?,
+                sats(1000)
+            );
 
             let user_lightning_module = user_client.get_first_module::<LightningClientModule>()?;
             let gateway_id = gateway.http_gateway_id().await;
@@ -383,7 +389,10 @@ async fn test_gateway_cannot_claim_invalid_preimage() -> anyhow::Result<()> {
             dummy_module
                 .mock_receive(sats(1000), AmountUnit::BITCOIN)
                 .await?;
-            assert_eq!(user_client.get_balance_for_btc().await?, sats(1000));
+            assert_eq!(
+                user_client.get_balance_for_btc(Account::Primary).await?,
+                sats(1000)
+            );
 
             // Fund outgoing contract that the user client expects the gateway to pay
             let invoice = other_lightning_client.invoice(sats(250), None)?;
@@ -423,7 +432,7 @@ async fn test_gateway_cannot_claim_invalid_preimage() -> anyhow::Result<()> {
                 keys: vec![gateway_module.redeem_key],
             };
 
-            let tx = TransactionBuilder::new().with_inputs(
+            let tx = TransactionBuilder::new(Account::Primary).with_inputs(
                 ClientInputBundle::new_no_sm(vec![client_input]).into_dyn(gateway_module.id),
             );
             let operation_meta_gen = |_: OutPointRange| GatewayMeta::Pay {
@@ -449,7 +458,10 @@ async fn test_gateway_cannot_claim_invalid_preimage() -> anyhow::Result<()> {
                     .await
                     .is_err()
             );
-            assert_eq!(gateway_client.get_balance_for_btc().await?, sats(0));
+            assert_eq!(
+                gateway_client.get_balance_for_btc(Account::Primary).await?,
+                sats(0)
+            );
             Ok::<_, anyhow::Error>(())
         },
     )
@@ -468,7 +480,10 @@ async fn test_gateway_client_pay_unpayable_invoice() -> anyhow::Result<()> {
             dummy_module
                 .mock_receive(sats(1000), AmountUnit::BITCOIN)
                 .await?;
-            assert_eq!(user_client.get_balance_for_btc().await?, sats(1000));
+            assert_eq!(
+                user_client.get_balance_for_btc(Account::Primary).await?,
+                sats(1000)
+            );
 
             // Create invoice that cannot be paid
             let invoice = other_lightning_client.unpayable_invoice(sats(250), None);
@@ -530,7 +545,10 @@ async fn test_gateway_client_intercept_valid_htlc() -> anyhow::Result<()> {
         dummy_module
             .mock_receive(initial_gateway_balance, AmountUnit::BITCOIN)
             .await?;
-        assert_eq!(gateway_client.get_balance_for_btc().await?, sats(1000));
+        assert_eq!(
+            gateway_client.get_balance_for_btc(Account::Primary).await?,
+            sats(1000)
+        );
 
         // User client creates invoice in federation
         let invoice_amount = sats(100);
@@ -573,7 +591,7 @@ async fn test_gateway_client_intercept_valid_htlc() -> anyhow::Result<()> {
         );
         assert_eq!(
             initial_gateway_balance.saturating_sub(invoice_amount),
-            gateway_client.get_balance_for_btc().await?
+            gateway_client.get_balance_for_btc(Account::Primary).await?
         );
 
         Ok(())
@@ -656,7 +674,7 @@ async fn test_gateway_shutdown_completes_in_flight_payment() -> anyhow::Result<(
         );
         assert_eq!(
             initial_gateway_balance.saturating_sub(invoice_amount),
-            gateway_client.get_balance_for_btc().await?
+            gateway_client.get_balance_for_btc(Account::Primary).await?
         );
 
         Ok(())
@@ -716,7 +734,7 @@ async fn test_gateway_client_intercept_enforces_expiry_boundary() -> anyhow::Res
             .expect_err("HTLC at the expiry boundary must be rejected");
         assert!(err.to_string().contains("incoming HTLC expiry is unsafe"));
         assert_eq!(
-            gateway_client.get_balance_for_btc().await?,
+            gateway_client.get_balance_for_btc(Account::Primary).await?,
             initial_gateway_balance
         );
 
@@ -740,7 +758,7 @@ async fn test_gateway_client_intercept_enforces_expiry_boundary() -> anyhow::Res
             GatewayExtReceiveStates::Preimage { .. }
         );
         assert_eq!(
-            gateway_client.get_balance_for_btc().await?,
+            gateway_client.get_balance_for_btc(Account::Primary).await?,
             initial_gateway_balance.saturating_sub(invoice_amount)
         );
 
@@ -812,7 +830,7 @@ async fn test_gateway_client_intercept_same_circuit_replay_is_idempotent() -> an
         );
         assert_eq!(
             initial_gateway_balance.saturating_sub(invoice_amount),
-            gateway_client.get_balance_for_btc().await?
+            gateway_client.get_balance_for_btc(Account::Primary).await?
         );
         gateway_ln_module.await_completion(first_op).await;
 
@@ -824,7 +842,7 @@ async fn test_gateway_client_intercept_same_circuit_replay_is_idempotent() -> an
         assert_eq!(first_op, terminal_replay_op);
         assert_eq!(
             initial_gateway_balance.saturating_sub(invoice_amount),
-            gateway_client.get_balance_for_btc().await?
+            gateway_client.get_balance_for_btc(Account::Primary).await?
         );
 
         Ok(())
@@ -842,7 +860,10 @@ async fn test_gateway_client_intercept_offer_does_not_exist() -> anyhow::Result<
         dummy_module
             .mock_receive(initial_gateway_balance, AmountUnit::BITCOIN)
             .await?;
-        assert_eq!(gateway_client.get_balance_for_btc().await?, sats(1000));
+        assert_eq!(
+            gateway_client.get_balance_for_btc(Account::Primary).await?,
+            sats(1000)
+        );
 
         // Create HTLC that doesn't correspond to an offer in the federation
         let htlc = Htlc {
@@ -927,7 +948,10 @@ async fn test_gateway_client_intercept_htlc_invalid_offer() -> anyhow::Result<()
             gateway_dummy_module
                 .mock_receive(initial_gateway_balance, AmountUnit::BITCOIN)
                 .await?;
-            assert_eq!(gateway_client.get_balance_for_btc().await?, sats(1000));
+            assert_eq!(
+                gateway_client.get_balance_for_btc(Account::Primary).await?,
+                sats(1000)
+            );
 
             // Create test invoice
             let invoice = other_lightning_client.unpayable_invoice(sats(250), None);
@@ -953,7 +977,7 @@ async fn test_gateway_client_intercept_htlc_invalid_offer() -> anyhow::Result<()
             };
             // The client's receive state machine can be empty because the gateway should
             // not fund this contract
-            let tx = TransactionBuilder::new().with_outputs(
+            let tx = TransactionBuilder::new(Account::Primary).with_outputs(
                 ClientOutputBundle::new_no_sm(vec![client_output])
                     .into_dyn(user_lightning_module.id),
             );
@@ -1018,7 +1042,7 @@ async fn test_gateway_client_intercept_htlc_invalid_offer() -> anyhow::Result<()
                     // With simplified dummy module, balance is automatically restored
                     assert_eq!(
                         initial_gateway_balance,
-                        gateway_client.get_balance_for_btc().await?
+                        gateway_client.get_balance_for_btc(Account::Primary).await?
                     );
                 }
                 unexpected_state => panic!(
@@ -1050,7 +1074,10 @@ async fn test_gateway_cannot_pay_expired_invoice() -> anyhow::Result<()> {
             dummy_module
                 .mock_receive(sats(2000), AmountUnit::BITCOIN)
                 .await?;
-            assert_eq!(user_client.get_balance_for_btc().await?, sats(2000));
+            assert_eq!(
+                user_client.get_balance_for_btc(Account::Primary).await?,
+                sats(2000)
+            );
 
             // User client attempts to pay the expired invoice — should be
             // rejected immediately by the client-side expiry check.
@@ -1064,7 +1091,10 @@ async fn test_gateway_cannot_pay_expired_invoice() -> anyhow::Result<()> {
             );
 
             // Balance should be unchanged since no contract was created
-            assert_eq!(user_client.get_balance_for_btc().await?, sats(2000));
+            assert_eq!(
+                user_client.get_balance_for_btc(Account::Primary).await?,
+                sats(2000)
+            );
 
             Ok(())
         },
@@ -1282,7 +1312,10 @@ async fn test_gateway_executes_swaps_between_connected_federations() -> anyhow::
         client1_dummy_module
             .mock_receive(deposit_amt, AmountUnit::BITCOIN)
             .await?;
-        assert_eq!(client1.get_balance_for_btc().await?, deposit_amt);
+        assert_eq!(
+            client1.get_balance_for_btc(Account::Primary).await?,
+            deposit_amt
+        );
 
         // User creates invoice in federation 2
         let invoice_amt = msats(2_500);
@@ -1323,12 +1356,17 @@ async fn test_gateway_executes_swaps_between_connected_federations() -> anyhow::
         assert_matches!(waiting_funds, LnReceiveState::AwaitingFunds);
         let claimed = receive_sub.ok().await?;
         assert_matches!(claimed, LnReceiveState::Claimed);
-        assert_eq!(client2.get_balance_for_btc().await?, invoice_amt);
+        assert_eq!(
+            client2.get_balance_for_btc(Account::Primary).await?,
+            invoice_amt
+        );
 
         // Check gateway balances after facilitating direct swap between federations
-        let gateway_fed1_balance = gateway_client.get_balance_for_btc().await?;
+        let gateway_fed1_balance = gateway_client.get_balance_for_btc(Account::Primary).await?;
         let gateway_fed2_client = gateway.select_client(id2).await?.into_value();
-        let gateway_fed2_balance = gateway_fed2_client.get_balance_for_btc().await?;
+        let gateway_fed2_balance = gateway_fed2_client
+            .get_balance_for_btc(Account::Primary)
+            .await?;
 
         // Balance in gateway of sending federation is deducted the invoice amount
         assert_eq!(
@@ -1395,7 +1433,7 @@ async fn send_msats_to_gateway(gateway: &Gateway, federation_id: FederationId, m
 
     assert_eq!(
         client
-            .get_balance_for_btc()
+            .get_balance_for_btc(Account::Primary)
             .await
             .expect("Must have primary module"),
         Amount::from_msats(msats)
@@ -2060,6 +2098,7 @@ async fn lnv2_send_payment_join_requires_the_contract_auth() -> anyhow::Result<(
             .get_first_module::<fedimint_lnv2_client::LightningClientModule>()
             .expect("The federation has an LNv2 module")
             .send(
+                Account::Primary,
                 invoice,
                 Some(SafeUrl::parse("http://capturing-gateway.test").expect("Valid url")),
                 serde_json::Value::Null,
@@ -2294,7 +2333,7 @@ async fn test_gateway_client_pay_invoice_is_idempotent_per_contract() -> anyhow:
                 .lightning_fee
                 .fee(250_000);
             assert_eq!(
-                gateway_client.get_balance_for_btc().await?,
+                gateway_client.get_balance_for_btc(Account::Primary).await?,
                 sats(250)
                     .checked_add(outgoing_fee)
                     .expect("Should not wrap around")
@@ -2466,7 +2505,7 @@ async fn test_gateway_client_direct_swap_reentry_joins_the_funded_swap() -> anyh
             "the re-entrant swap joins the operation already holding the preimage"
         );
         assert_eq!(
-            gateway_client.get_balance_for_btc().await?,
+            gateway_client.get_balance_for_btc(Account::Primary).await?,
             initial_gateway_balance.saturating_sub(invoice_amount),
             "the incoming contract must only be funded once"
         );
@@ -2495,7 +2534,7 @@ async fn test_gateway_client_direct_swap_reentry_joins_the_funded_swap() -> anyh
             "concurrent requests for one swap must share the single funded operation"
         );
         assert_eq!(
-            gateway_client.get_balance_for_btc().await?,
+            gateway_client.get_balance_for_btc(Account::Primary).await?,
             initial_gateway_balance.saturating_sub(invoice_amount + invoice_amount),
             "the second swap's incoming contract must also only be funded once"
         );

--- a/modules/fedimint-dummy-client/src/lib.rs
+++ b/modules/fedimint-dummy-client/src/lib.rs
@@ -13,14 +13,15 @@ use fedimint_client_module::db::ClientModuleMigrationFn;
 use fedimint_client_module::module::init::{ClientModuleInit, ClientModuleInitArgs};
 use fedimint_client_module::module::recovery::NoModuleBackup;
 use fedimint_client_module::module::{
-    ClientContext, ClientModule, OutPointRange, PrimaryModulePriority, PrimaryModuleSupport,
+    AccountSupport, ClientContext, ClientModule, OutPointRange, PrimaryModulePriority,
+    PrimaryModuleSupport,
 };
 use fedimint_client_module::sm::{Context, DynState, ModuleNotifier, State, StateTransition};
 use fedimint_client_module::transaction::{
     ClientInput, ClientInputBundle, ClientInputSM, ClientOutput, ClientOutputBundle, ClientOutputSM,
 };
 use fedimint_client_module::{DynGlobalClientContext, sm_enum_variant_translation};
-use fedimint_core::core::{IntoDynInstance, ModuleInstanceId, ModuleKind, OperationId};
+use fedimint_core::core::{Account, IntoDynInstance, ModuleInstanceId, ModuleKind, OperationId};
 use fedimint_core::db::{
     Database, DatabaseTransaction, DatabaseVersion, IDatabaseTransactionOpsCoreTyped,
 };
@@ -154,6 +155,7 @@ impl ClientModule for DummyClientModule {
     fn supports_being_primary(&self) -> PrimaryModuleSupport {
         PrimaryModuleSupport::Any {
             priority: PrimaryModulePriority::LOW,
+            accounts: AccountSupport::PrimaryOnly,
         }
     }
 
@@ -164,6 +166,7 @@ impl ClientModule for DummyClientModule {
         unit: AmountUnit,
         input_amount: Amount,
         output_amount: Amount,
+        _account: Account,
     ) -> anyhow::Result<(
         ClientInputBundle<DummyInput, DummyStateMachine>,
         ClientOutputBundle<DummyOutput, DummyStateMachine>,
@@ -297,7 +300,12 @@ impl ClientModule for DummyClientModule {
         }
     }
 
-    async fn get_balance(&self, dbtc: &mut DatabaseTransaction<'_>, unit: AmountUnit) -> Amount {
+    async fn get_balance(
+        &self,
+        dbtc: &mut DatabaseTransaction<'_>,
+        unit: AmountUnit,
+        _account: Account,
+    ) -> Amount {
         get_funds(dbtc, unit).await
     }
 

--- a/modules/fedimint-empty-client/src/lib.rs
+++ b/modules/fedimint-empty-client/src/lib.rs
@@ -9,7 +9,7 @@ use fedimint_client_module::module::init::{ClientModuleInit, ClientModuleInitArg
 use fedimint_client_module::module::recovery::NoModuleBackup;
 use fedimint_client_module::module::{ClientContext, ClientModule, IClientModule};
 use fedimint_client_module::sm::Context;
-use fedimint_core::core::{Decoder, ModuleKind};
+use fedimint_core::core::{Account, Decoder, ModuleKind};
 use fedimint_core::db::{Database, DatabaseTransaction, DatabaseVersion};
 use fedimint_core::module::{
     AmountUnit, Amounts, ApiVersion, ModuleCommon, ModuleInit, MultiApiVersion,
@@ -76,7 +76,12 @@ impl ClientModule for EmptyClientModule {
         unreachable!()
     }
 
-    async fn get_balance(&self, _dbtx: &mut DatabaseTransaction<'_>, _unit: AmountUnit) -> Amount {
+    async fn get_balance(
+        &self,
+        _dbtx: &mut DatabaseTransaction<'_>,
+        _unit: AmountUnit,
+        _account: Account,
+    ) -> Amount {
         Amount::ZERO
     }
 }

--- a/modules/fedimint-gw-client/src/lib.rs
+++ b/modules/fedimint-gw-client/src/lib.rs
@@ -33,7 +33,9 @@ use fedimint_client_module::{
 };
 use fedimint_connectors::ConnectorRegistry;
 use fedimint_core::config::FederationId;
-use fedimint_core::core::{Decoder, IntoDynInstance, ModuleInstanceId, ModuleKind, OperationId};
+use fedimint_core::core::{
+    Account, Decoder, IntoDynInstance, ModuleInstanceId, ModuleKind, OperationId,
+};
 use fedimint_core::db::{AutocommitError, DatabaseTransaction};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::{Amounts, ApiVersion, ModuleInit, MultiApiVersion};
@@ -630,9 +632,12 @@ impl GatewayClientModule {
             amounts: Amounts::new_bitcoin(amount),
         };
 
-        let tx = TransactionBuilder::new().with_outputs(self.client_ctx.make_client_outputs(
-            ClientOutputBundle::new(vec![output], vec![client_output_sm]),
-        ));
+        let tx = TransactionBuilder::new(Account::Primary).with_outputs(
+            self.client_ctx.make_client_outputs(ClientOutputBundle::new(
+                vec![output],
+                vec![client_output_sm],
+            )),
+        );
         let operation_meta_gen = |_: OutPointRange| GatewayMeta::Receive;
         self.client_ctx
             .finalize_and_submit_transaction(operation_id, KIND.as_str(), operation_meta_gen, tx)
@@ -730,7 +735,7 @@ impl GatewayClientModule {
                             output: LightningOutput::V0(client_output.output),
                             amounts: client_output.amounts,
                         };
-                        let tx = TransactionBuilder::new().with_outputs(
+                        let tx = TransactionBuilder::new(Account::Primary).with_outputs(
                             self.client_ctx.make_client_outputs(ClientOutputBundle::new(
                                 vec![output],
                                 vec![client_output_sm],
@@ -943,14 +948,9 @@ impl GatewayClientModule {
                             match self.client_ctx.add_state_machines_dbtx(dbtx, dyn_states).await {
                                 Ok(()) => {
                                     self.client_ctx
-                                        .add_operation_log_entry_dbtx(
-                                            dbtx,
-                                            operation_id,
-                                            KIND.as_str(),
-                                            GatewayMeta::Pay {
+                                        .add_operation_log_entry_dbtx(dbtx, operation_id, Account::Primary, KIND.as_str(), GatewayMeta::Pay {
                                                 preimage_auth: payload.preimage_auth,
-                                            },
-                                        )
+                                            })
                                         .await;
                                 }
                                 Err(AddStateMachinesError::StateAlreadyExists) => {

--- a/modules/fedimint-gwv2-client/src/lib.rs
+++ b/modules/fedimint-gwv2-client/src/lib.rs
@@ -25,7 +25,9 @@ use fedimint_client_module::transaction::{
 };
 use fedimint_client_module::{DynGlobalClientContext, sm_enum_variant_translation};
 use fedimint_core::config::FederationId;
-use fedimint_core::core::{Decoder, IntoDynInstance, ModuleInstanceId, ModuleKind, OperationId};
+use fedimint_core::core::{
+    Account, Decoder, IntoDynInstance, ModuleInstanceId, ModuleKind, OperationId,
+};
 use fedimint_core::db::DatabaseTransaction;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::{
@@ -465,6 +467,7 @@ impl GatewayClientModuleV2 {
             .manual_operation_start_dbtx(
                 &mut dbtx.to_ref_nc(),
                 operation_id,
+                Account::Primary,
                 LightningCommonInit::KIND.as_str(),
                 GatewayOperationMetaV2::role(GatewayOperationRoleV2::Send),
                 vec![self.client_ctx.make_dyn_state(send_sm)],
@@ -598,7 +601,7 @@ impl GatewayClientModuleV2 {
                 vec![client_output],
                 vec![client_output_sm],
             ));
-            let transaction = TransactionBuilder::new().with_outputs(client_output);
+            let transaction = TransactionBuilder::new(Account::Primary).with_outputs(client_output);
 
             let creation_result = self
                 .client_ctx
@@ -644,6 +647,7 @@ impl GatewayClientModuleV2 {
             .client_ctx
             .manual_operation_start(
                 completion_operation_id,
+                Account::Primary,
                 LightningCommonInit::KIND.as_str(),
                 GatewayOperationMetaV2::role(GatewayOperationRoleV2::CircuitCompletion),
                 vec![self.client_ctx.make_dyn_state(completion)],
@@ -703,7 +707,7 @@ impl GatewayClientModuleV2 {
             vec![client_output_sm],
         ));
 
-        let transaction = TransactionBuilder::new().with_outputs(client_output);
+        let transaction = TransactionBuilder::new(Account::Primary).with_outputs(client_output);
 
         self.client_ctx
             .finalize_and_submit_transaction(

--- a/modules/fedimint-gwv2-client/src/receive_sm.rs
+++ b/modules/fedimint-gwv2-client/src/receive_sm.rs
@@ -277,8 +277,7 @@ impl ReceiveStateMachine {
 
         let outpoints = match global_context
             .claim_inputs(
-                dbtx,
-                // The input of the refund tx is managed by this state machine
+                dbtx, // The input of the refund tx is managed by this state machine
                 ClientInputBundle::new_no_sm(vec![client_input]),
             )
             .await

--- a/modules/fedimint-ln-client/src/cli.rs
+++ b/modules/fedimint-ln-client/src/cli.rs
@@ -5,7 +5,7 @@ use std::{ffi, iter};
 use anyhow::{Context as _, bail, ensure};
 use clap::{Parser, Subcommand};
 use fedimint_core::Amount;
-use fedimint_core::core::OperationId;
+use fedimint_core::core::{Account, OperationId};
 use fedimint_core::secp256k1::PublicKey;
 use fedimint_core::util::SafeUrl;
 use futures::StreamExt;
@@ -164,7 +164,10 @@ pub(crate) async fn handle_cli_command(
                 let gateway = ln_gateway.clone().context(
                     "--all requires a gateway to price the payment; internal payments are not supported",
                 )?;
-                let balance = module.client_ctx.get_balance_for_btc().await?;
+                let balance = module
+                    .client_ctx
+                    .get_balance_for_btc(Account::Primary)
+                    .await?;
                 let spendable = module.spendable_amount(balance, Some(gateway)).await?;
 
                 // The endpoint only issues invoices within

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -52,7 +52,9 @@ use fedimint_client_module::transaction::{
 };
 use fedimint_client_module::{DynGlobalClientContext, sm_enum_variant_translation};
 use fedimint_core::config::FederationId;
-use fedimint_core::core::{Decoder, IntoDynInstance, ModuleInstanceId, ModuleKind, OperationId};
+use fedimint_core::core::{
+    Account, Decoder, IntoDynInstance, ModuleInstanceId, ModuleKind, OperationId,
+};
 use fedimint_core::db::{DatabaseTransaction, DatabaseVersion, IDatabaseTransactionOpsCoreTyped};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::{
@@ -1481,7 +1483,7 @@ impl LightningClientModule {
             vec![client_output_sm],
         ));
 
-        let tx = TransactionBuilder::new().with_outputs(output);
+        let tx = TransactionBuilder::new(Account::Primary).with_outputs(output);
         let extra_meta =
             serde_json::to_value(extra_meta).context("Failed to serialize extra meta")?;
         let operation_meta_gen = move |change_range: OutPointRange| LightningOperationMeta {
@@ -1805,7 +1807,7 @@ impl LightningClientModule {
             keys: vec![key_pair],
         };
 
-        let tx = TransactionBuilder::new().with_inputs(
+        let tx = TransactionBuilder::new(Account::Primary).with_inputs(
             self.client_ctx
                 .make_client_inputs(ClientInputBundle::new_no_sm(vec![client_input])),
         );
@@ -1852,6 +1854,7 @@ impl LightningClientModule {
                     output_amount: Amounts::ZERO,
                     input_fee: Amounts::new_bitcoin(self.cfg.fee_consensus.contract_input),
                     output_fee: Amounts::ZERO,
+                    account: Account::Primary,
                 },
             )
             .await
@@ -1880,6 +1883,7 @@ impl LightningClientModule {
                     output_amount: Amounts::new_bitcoin(amount),
                     input_fee: Amounts::ZERO,
                     output_fee: Amounts::new_bitcoin(self.cfg.fee_consensus.contract_output),
+                    account: Account::Primary,
                 },
             )
             .await
@@ -2044,8 +2048,8 @@ impl LightningClientModule {
             self.cfg.network.0,
         )?;
 
-        let tx =
-            TransactionBuilder::new().with_outputs(self.client_ctx.make_client_outputs(output));
+        let tx = TransactionBuilder::new(Account::Primary)
+            .with_outputs(self.client_ctx.make_client_outputs(output));
         let extra_meta = serde_json::to_value(extra_meta).expect("extra_meta is serializable");
         let operation_meta_gen = {
             let invoice = invoice.clone();
@@ -2171,6 +2175,7 @@ impl LightningClientModule {
             .manual_operation_start_dbtx(
                 &mut dbtx.to_ref_nc(),
                 reclaim_operation_id,
+                Account::Primary,
                 LightningCommonInit::KIND.as_str(),
                 operation_meta,
                 vec![self.client_ctx.make_dyn_state(state)],

--- a/modules/fedimint-ln-client/src/pay.rs
+++ b/modules/fedimint-ln-client/src/pay.rs
@@ -591,8 +591,7 @@ async fn try_refund_outgoing_contract(
 
     let change_range = global_context
         .claim_inputs(
-            dbtx,
-            // The input of the refund tx is managed by this state machine, so no new state
+            dbtx, // The input of the refund tx is managed by this state machine, so no new state
             // machines need to be created
             ClientInputBundle::new_no_sm(vec![refund_client_input]),
         )

--- a/modules/fedimint-ln-client/src/receive.rs
+++ b/modules/fedimint-ln-client/src/receive.rs
@@ -316,8 +316,8 @@ impl LightningReceiveConfirmedInvoice {
 
         global_context
             .claim_inputs(
-                dbtx,
-                // The input of the refund tx is managed by this state machine, so no new state
+                dbtx, /* The input of the refund tx is managed by this state machine, so no new
+                       * state */
                 // machines need to be created
                 ClientInputBundle::new_no_sm(vec![client_input]),
             )

--- a/modules/fedimint-ln-client/src/recurring/mod.rs
+++ b/modules/fedimint-ln-client/src/recurring/mod.rs
@@ -17,7 +17,7 @@ use fedimint_client_module::module::ClientContext;
 use fedimint_client_module::oplog::UpdateStreamOrOutcome;
 use fedimint_core::BitcoinHash;
 use fedimint_core::config::FederationId;
-use fedimint_core::core::ModuleKind;
+use fedimint_core::core::{Account, ModuleKind};
 use fedimint_core::db::IDatabaseTransactionOpsCoreTyped;
 use fedimint_core::encoding::{
     Decodable, DecodeError, Encodable, decode_field_from_finite_reader,
@@ -326,6 +326,7 @@ impl LightningClientModule {
             .manual_operation_start_dbtx(
                 dbtx,
                 operation_id,
+                Account::Primary,
                 "ln",
                 LightningOperationMeta {
                     variant: LightningOperationMetaVariant::RecurringPaymentReceive(

--- a/modules/fedimint-ln-tests/tests/tests.rs
+++ b/modules/fedimint-ln-tests/tests/tests.rs
@@ -10,7 +10,7 @@ use fedimint_client::transaction::{
 };
 use fedimint_client::{Client, ClientHandleArc};
 use fedimint_client_module::oplog::OperationLogEntry;
-use fedimint_core::core::{IntoDynInstance, OperationId};
+use fedimint_core::core::{Account, IntoDynInstance, OperationId};
 use fedimint_core::module::{AmountUnit, Amounts, CommonModuleInit as _};
 use fedimint_core::util::backoff_util::aggressive_backoff_long;
 use fedimint_core::util::{BoxStream, NextOrPending, retry};
@@ -265,7 +265,7 @@ async fn cannot_pay_same_internal_invoice_twice() -> anyhow::Result<()> {
 
     // Pay the invoice again and verify that it does not deduct the balance, but it
     // does return the preimage
-    let prev_balance = client2.get_balance_for_btc().await?;
+    let prev_balance = client2.get_balance_for_btc(Account::Primary).await?;
     let OutgoingLightningPayment {
         payment_type,
         contract_id: _,
@@ -284,7 +284,7 @@ async fn cannot_pay_same_internal_invoice_twice() -> anyhow::Result<()> {
         _ => panic!("Expected internal payment!"),
     }
 
-    let same_balance = client2.get_balance_for_btc().await?;
+    let same_balance = client2.get_balance_for_btc(Account::Primary).await?;
     assert_eq!(prev_balance, same_balance);
 
     Ok(())
@@ -386,7 +386,7 @@ async fn cannot_pay_same_external_invoice_twice() -> anyhow::Result<()> {
         _ => panic!("Expected lightning payment!"),
     }
 
-    let prev_balance = client.get_balance_for_btc().await?;
+    let prev_balance = client.get_balance_for_btc(Account::Primary).await?;
 
     // Pay the invoice again and verify that it does not deduct the balance, but it
     // does return the preimage
@@ -410,7 +410,7 @@ async fn cannot_pay_same_external_invoice_twice() -> anyhow::Result<()> {
         _ => panic!("Expected lightning payment!"),
     }
 
-    let same_balance = client.get_balance_for_btc().await?;
+    let same_balance = client.get_balance_for_btc(Account::Primary).await?;
     assert_eq!(prev_balance, same_balance);
 
     drop(gw);
@@ -585,7 +585,10 @@ async fn can_receive_for_other_user() -> anyhow::Result<()> {
         .into_stream();
     assert_eq!(sub3.ok().await?, LnReceiveState::AwaitingFunds);
     assert_eq!(sub3.ok().await?, LnReceiveState::Claimed);
-    assert_eq!(new_client.get_balance_for_btc().await?, sats(250));
+    assert_eq!(
+        new_client.get_balance_for_btc(Account::Primary).await?,
+        sats(250)
+    );
 
     // TEST internal payment when there is a registered gateway
     let gw = gateway(&fixtures, &fed).await;
@@ -644,7 +647,10 @@ async fn can_receive_for_other_user() -> anyhow::Result<()> {
         .into_stream();
     assert_eq!(sub3.ok().await?, LnReceiveState::AwaitingFunds);
     assert_eq!(sub3.ok().await?, LnReceiveState::Claimed);
-    assert_eq!(new_client.get_balance_for_btc().await?, sats(250));
+    assert_eq!(
+        new_client.get_balance_for_btc(Account::Primary).await?,
+        sats(250)
+    );
 
     Ok(())
 }
@@ -722,7 +728,10 @@ async fn can_receive_for_other_user_tweaked() -> anyhow::Result<()> {
         assert_eq!(sub3.ok().await?, LnReceiveState::AwaitingFunds);
         assert_eq!(sub3.ok().await?, LnReceiveState::Claimed);
     }
-    assert_eq!(new_client.get_balance_for_btc().await?, sats(250));
+    assert_eq!(
+        new_client.get_balance_for_btc(Account::Primary).await?,
+        sats(250)
+    );
 
     Ok(())
 }
@@ -875,7 +884,7 @@ async fn returns_completed_payment_for_expired_invoice_already_paid() -> anyhow:
     // returned — not an "Invoice has expired" error, which would mask the
     // successful payment and push the caller toward paying again through a
     // fresh invoice.
-    let prev_balance = client2.get_balance_for_btc().await?;
+    let prev_balance = client2.get_balance_for_btc(Account::Primary).await?;
     let OutgoingLightningPayment {
         payment_type,
         contract_id: _,
@@ -886,7 +895,7 @@ async fn returns_completed_payment_for_expired_invoice_already_paid() -> anyhow:
         first_payment_type.operation_id(),
         "the completed payment is returned; no new attempt is started"
     );
-    let same_balance = client2.get_balance_for_btc().await?;
+    let same_balance = client2.get_balance_for_btc(Account::Primary).await?;
     assert_eq!(prev_balance, same_balance);
 
     Ok(())
@@ -941,7 +950,7 @@ async fn can_reclaim_receive_funded_after_invoice_expiry() -> anyhow::Result<()>
         expiry_time: Some(1),
     });
     let sm_invoice = invoice.clone();
-    let transaction_builder = TransactionBuilder::new().with_outputs(
+    let transaction_builder = TransactionBuilder::new(Account::Primary).with_outputs(
         ClientOutputBundle::new(
             vec![ClientOutput {
                 output: offer_output,
@@ -1004,7 +1013,7 @@ async fn can_reclaim_receive_funded_after_invoice_expiry() -> anyhow::Result<()>
         create_incoming_contract_output(&ln_module.api, payment_hash, amount, &gateway_redeem_key)
             .await?;
     let funding_operation_id = OperationId::new_random();
-    let funding_tx = TransactionBuilder::new().with_outputs(
+    let funding_tx = TransactionBuilder::new(Account::Primary).with_outputs(
         ClientOutputBundle::new_no_sm(vec![ClientOutput {
             output: LightningOutput::V0(incoming_output),
             amounts: Amounts::new_bitcoin(funded_amount),
@@ -1040,7 +1049,7 @@ async fn can_reclaim_receive_funded_after_invoice_expiry() -> anyhow::Result<()>
         }
     }
 
-    assert_eq!(client1.get_balance_for_btc().await?, amount);
+    assert_eq!(client1.get_balance_for_btc(Account::Primary).await?, amount);
 
     Ok(())
 }
@@ -1084,7 +1093,7 @@ async fn funder_refuses_to_fund_an_already_funded_payment_hash() -> anyhow::Resu
                 operation_id,
                 "",
                 |_| (),
-                TransactionBuilder::new().with_outputs(
+                TransactionBuilder::new(Account::Primary).with_outputs(
                     ClientOutputBundle::new_no_sm(vec![ClientOutput {
                         output: offer_output,
                         amounts: Amounts::ZERO,
@@ -1115,7 +1124,7 @@ async fn funder_refuses_to_fund_an_already_funded_payment_hash() -> anyhow::Resu
             operation_id,
             LightningCommonInit::KIND.as_str(),
             |_| (),
-            TransactionBuilder::new().with_outputs(
+            TransactionBuilder::new(Account::Primary).with_outputs(
                 ClientOutputBundle::new_no_sm(vec![ClientOutput {
                     output: LightningOutput::V0(incoming_output),
                     amounts: Amounts::new_bitcoin(funded_amount),
@@ -1173,7 +1182,7 @@ async fn server_rejects_duplicate_offer() -> anyhow::Result<()> {
         encrypted_preimage: encrypted_preimage_1.clone(),
         expiry_time: None,
     });
-    let transaction_builder_1 = TransactionBuilder::new().with_outputs(
+    let transaction_builder_1 = TransactionBuilder::new(Account::Primary).with_outputs(
         ClientOutputBundle::new_no_sm(vec![ClientOutput {
             output: offer_output_1,
             amounts: Amounts::ZERO,
@@ -1189,7 +1198,7 @@ async fn server_rejects_duplicate_offer() -> anyhow::Result<()> {
         encrypted_preimage: encrypted_preimage_2.clone(),
         expiry_time: None,
     });
-    let transaction_builder_2 = TransactionBuilder::new().with_outputs(
+    let transaction_builder_2 = TransactionBuilder::new(Account::Primary).with_outputs(
         ClientOutputBundle::new_no_sm(vec![ClientOutput {
             output: offer_output_2,
             amounts: Amounts::ZERO,

--- a/modules/fedimint-lnv2-client/src/cli.rs
+++ b/modules/fedimint-lnv2-client/src/cli.rs
@@ -1,7 +1,7 @@
 use std::{ffi, iter};
 
 use clap::{Parser, Subcommand};
-use fedimint_core::core::OperationId;
+use fedimint_core::core::{Account, OperationId};
 use fedimint_core::util::SafeUrl;
 use fedimint_core::{Amount, PeerId};
 use lightning_invoice::Bolt11Invoice;
@@ -19,6 +19,8 @@ enum Opts {
         invoice: Bolt11Invoice,
         #[arg(long)]
         gateway: Option<SafeUrl>,
+        #[arg(long, default_value_t = Account::Primary)]
+        account: Account,
     },
     /// Await the final state of the send operation.
     AwaitSend { operation_id: OperationId },
@@ -29,6 +31,8 @@ enum Opts {
         amount: Amount,
         #[arg(long)]
         gateway: Option<SafeUrl>,
+        #[arg(long, default_value_t = Account::Primary)]
+        account: Account,
     },
     /// Await the final state of the receive operation.
     AwaitReceive { operation_id: OperationId },
@@ -47,6 +51,8 @@ enum LnurlOpts {
         recurringd: SafeUrl,
         #[arg(long)]
         gateway: Option<SafeUrl>,
+        #[arg(long, default_value_t = Account::Primary)]
+        account: Account,
     },
 }
 
@@ -79,17 +85,28 @@ pub(crate) async fn handle_cli_command(
     let opts = Opts::parse_from(iter::once(&ffi::OsString::from("lnv2")).chain(args.iter()));
 
     let value = match opts {
-        Opts::Send { gateway, invoice } => {
-            json(lightning.send(invoice, gateway, Value::Null).await?)
-        }
+        Opts::Send {
+            gateway,
+            invoice,
+            account,
+        } => json(
+            lightning
+                .send(account, invoice, gateway, Value::Null)
+                .await?,
+        ),
         Opts::AwaitSend { operation_id } => json(
             lightning
                 .await_final_send_operation_state(operation_id)
                 .await?,
         ),
-        Opts::Receive { amount, gateway } => json(
+        Opts::Receive {
+            amount,
+            gateway,
+            account,
+        } => json(
             lightning
                 .receive(
+                    account,
                     amount,
                     3600,
                     Bolt11InvoiceDescription::Direct(String::new()),
@@ -107,7 +124,12 @@ pub(crate) async fn handle_cli_command(
             LnurlOpts::Generate {
                 recurringd,
                 gateway,
-            } => json(lightning.generate_lnurl(recurringd, gateway).await?),
+                account,
+            } => json(
+                lightning
+                    .generate_lnurl(account, recurringd, gateway)
+                    .await?,
+            ),
         },
         Opts::Gateways(gateway_opts) => match gateway_opts {
             #[allow(clippy::unit_arg)]

--- a/modules/fedimint-lnv2-client/src/events.rs
+++ b/modules/fedimint-lnv2-client/src/events.rs
@@ -1,5 +1,5 @@
 use fedimint_core::Amount;
-use fedimint_core::core::{ModuleKind, OperationId};
+use fedimint_core::core::{Account, ModuleKind, OperationId};
 use fedimint_eventlog::{Event, EventKind, EventPersistence};
 use serde::{Deserialize, Serialize};
 
@@ -9,6 +9,11 @@ pub struct SendPaymentEvent {
     pub operation_id: OperationId,
     pub amount: Amount,
     pub fee: Amount,
+    /// Balance the contract was funded from. Defaulted rather than required,
+    /// so entries written before accounts existed still decode — they can only
+    /// have been the one account there was.
+    #[serde(default = "Account::primary")]
+    pub account: Account,
 }
 
 impl Event for SendPaymentEvent {
@@ -31,6 +36,12 @@ pub enum SendPaymentStatus {
 pub struct SendPaymentUpdateEvent {
     pub operation_id: OperationId,
     pub status: SendPaymentStatus,
+    /// Balance the operation acts on, repeated from the initiating event so a
+    /// consumer can filter the final state by account without joining on the
+    /// operation id. Defaulted so entries written before accounts existed
+    /// still decode.
+    #[serde(default = "Account::primary")]
+    pub account: Account,
 }
 
 impl Event for SendPaymentUpdateEvent {
@@ -49,6 +60,10 @@ pub struct ReceivePaymentEvent {
     /// before this field was added.
     #[serde(default)]
     pub fee: Amount,
+    /// Balance the claimed contract is credited to. See
+    /// [`SendPaymentEvent::account`] for why it is defaulted.
+    #[serde(default = "Account::primary")]
+    pub account: Account,
 }
 
 impl Event for ReceivePaymentEvent {

--- a/modules/fedimint-lnv2-client/src/lib.rs
+++ b/modules/fedimint-lnv2-client/src/lib.rs
@@ -26,6 +26,7 @@ use fedimint_client_module::module::init::{ClientModuleInit, ClientModuleInitArg
 use fedimint_client_module::module::recovery::NoModuleBackup;
 use fedimint_client_module::module::{ClientContext, ClientModule, OutPointRange};
 use fedimint_client_module::oplog::UpdateStreamOrOutcome;
+use fedimint_client_module::secret::DeriveableSecretClientExt;
 use fedimint_client_module::sm::{Context, DynState, ModuleNotifier, State, StateTransition};
 use fedimint_client_module::transaction::{
     ClientOutput, ClientOutputBundle, ClientOutputSM, FeeQuote, FeeQuoteRequest,
@@ -33,11 +34,12 @@ use fedimint_client_module::transaction::{
 };
 use fedimint_client_module::{DynGlobalClientContext, sm_enum_variant_translation};
 use fedimint_core::config::FederationId;
-use fedimint_core::core::{IntoDynInstance, ModuleInstanceId, ModuleKind, OperationId};
+use fedimint_core::core::{Account, IntoDynInstance, ModuleInstanceId, ModuleKind, OperationId};
 use fedimint_core::db::{DatabaseTransaction, IDatabaseTransactionOpsCoreTyped};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::{
-    Amounts, ApiAuth, ApiVersion, CommonModuleInit, ModuleCommon, ModuleInit, MultiApiVersion,
+    AmountUnit, Amounts, ApiAuth, ApiVersion, CommonModuleInit, ModuleCommon, ModuleInit,
+    MultiApiVersion,
 };
 use fedimint_core::secp256k1::SECP256K1;
 use fedimint_core::task::TaskGroup;
@@ -323,8 +325,11 @@ pub struct LightningClientModule {
     notifier: ModuleNotifier<LightningClientStateMachines>,
     client_ctx: ClientContext<Self>,
     module_api: DynModuleApi,
-    keypair: Keypair,
-    lnurl_keypair: Keypair,
+    /// Every account's static receive key and lnurl key, derived once at
+    /// startup and indexed by [`Account::index`]. Both are static per account,
+    /// so an extra account costs one more trial decryption per streamed
+    /// contract rather than another pass over the stream.
+    keys: [AccountKeys; Account::ALL.len()],
     gateway_conn: Arc<dyn GatewayConnection + Send + Sync>,
     #[allow(unused)] // The field is only used by the cli feature
     admin_auth: Option<ApiAuth>,
@@ -375,7 +380,22 @@ impl ClientModule for LightningClientModule {
     }
 }
 
+/// The two static keys an account receives on.
+#[derive(Debug, Clone, Copy)]
+struct AccountKeys {
+    /// Contracts are locked to a tweak of this, so it is what a gateway
+    /// invoice names and what the stream scanner trials each contract against.
+    keypair: Keypair,
+    /// The key an lnurl advertises, kept distinct from `keypair` so a
+    /// shareable address cannot be correlated with a one-shot invoice.
+    lnurl_keypair: Keypair,
+}
+
 impl LightningClientModule {
+    fn keys(&self, account: Account) -> AccountKeys {
+        self.keys[usize::from(account.index())]
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn new(
         federation_id: FederationId,
@@ -396,12 +416,14 @@ impl LightningClientModule {
             notifier,
             client_ctx,
             module_api,
-            keypair: module_root_secret
-                .child_key(ChildId(0))
-                .to_secp_key(SECP256K1),
-            lnurl_keypair: module_root_secret
-                .child_key(ChildId(1))
-                .to_secp_key(SECP256K1),
+            keys: Account::ALL.map(|account| {
+                let account_secret = module_root_secret.derive_account_secret(account);
+
+                AccountKeys {
+                    keypair: account_secret.child_key(ChildId(0)).to_secp_key(SECP256K1),
+                    lnurl_keypair: account_secret.child_key(ChildId(1)).to_secp_key(SECP256K1),
+                }
+            }),
             gateway_conn,
             admin_auth,
         };
@@ -545,6 +567,7 @@ impl LightningClientModule {
     #[allow(clippy::too_many_lines)]
     pub async fn send(
         &self,
+        account: Account,
         invoice: Bolt11Invoice,
         gateway: Option<SafeUrl>,
         custom_meta: Value,
@@ -564,6 +587,13 @@ impl LightningClientModule {
             });
         }
 
+        if !self
+            .client_ctx
+            .supports_account(AmountUnit::BITCOIN, account)
+        {
+            return Err(SendPaymentError::AccountNotSupported);
+        }
+
         // The attempt index is fixed at `0` so the operation id matches the one
         // older clients derived for the first payment attempt, ensuring an
         // already-paid or in-flight invoice is still detected after an upgrade.
@@ -573,7 +603,8 @@ impl LightningClientModule {
             return Err(SendPaymentError::DuplicatePaymentAttempt(operation_id));
         }
 
-        let (ephemeral_tweak, ephemeral_pk) = tweak::generate(self.keypair.public_key());
+        let (ephemeral_tweak, ephemeral_pk) =
+            tweak::generate(self.keys(account).keypair.public_key());
 
         let refund_keypair = SecretKey::from_slice(&ephemeral_tweak)
             .expect("32 bytes, within curve order")
@@ -648,7 +679,7 @@ impl LightningClientModule {
             vec![client_output_sm],
         ));
 
-        let transaction = TransactionBuilder::new().with_outputs(client_output);
+        let transaction = TransactionBuilder::new(account).with_outputs(client_output);
 
         self.client_ctx
             .finalize_and_submit_transaction(
@@ -677,6 +708,7 @@ impl LightningClientModule {
                     operation_id,
                     amount: Amount::from_msats(amount),
                     fee: send_fee.fee(amount),
+                    account,
                 },
             )
             .await;
@@ -841,15 +873,24 @@ impl LightningClientModule {
     /// to be shown to the user in the transaction history.
     pub async fn receive(
         &self,
+        account: Account,
         amount: Amount,
         expiry_secs: u32,
         description: Bolt11InvoiceDescription,
         gateway: Option<SafeUrl>,
         custom_meta: Value,
     ) -> Result<(Bolt11Invoice, OperationId), ReceiveError> {
+        if !self
+            .client_ctx
+            .supports_account(AmountUnit::BITCOIN, account)
+        {
+            return Err(ReceiveError::AccountNotSupported);
+        }
+
         let (gateway, contract, invoice) = self
             .create_contract_and_fetch_invoice(
-                self.keypair.public_key(),
+                account,
+                self.keys(account).keypair.public_key(),
                 amount,
                 expiry_secs,
                 description,
@@ -859,7 +900,8 @@ impl LightningClientModule {
 
         let operation_id = self
             .receive_incoming_contract(
-                self.keypair.secret_key(),
+                account,
+                self.keys(account).keypair.secret_key(),
                 contract.clone(),
                 LightningOperationMeta::Receive(ReceiveOperationMeta {
                     gateway,
@@ -888,7 +930,11 @@ impl LightningClientModule {
     /// only the fee of the on-federation transaction. For that reason the quote
     /// is taken on `amount` directly (rather than the gateway-reduced contract
     /// amount), and no gateway round-trip is needed.
-    pub async fn receive_fee_quote(&self, amount: Amount) -> anyhow::Result<FeeQuote> {
+    pub async fn receive_fee_quote(
+        &self,
+        account: Account,
+        amount: Amount,
+    ) -> anyhow::Result<FeeQuote> {
         self.client_ctx
             .fee_quote(
                 OperationId::new_random(),
@@ -897,6 +943,7 @@ impl LightningClientModule {
                     output_amount: Amounts::ZERO,
                     input_fee: Amounts::new_bitcoin(self.cfg.fee_consensus.fee(amount)),
                     output_fee: Amounts::ZERO,
+                    account,
                 },
             )
             .await
@@ -912,8 +959,8 @@ impl LightningClientModule {
     /// assuming a floor. A quote that fails outright is the same verdict: the
     /// claim spends the contract as the transaction's only input, so a fee
     /// larger than the contract leaves a transaction that cannot be balanced.
-    async fn is_worth_claiming(&self, amount: Amount) -> bool {
-        match self.receive_fee_quote(amount).await {
+    async fn is_worth_claiming(&self, account: Account, amount: Amount) -> bool {
+        match self.receive_fee_quote(account, amount).await {
             Ok(quote) => quote.total().get_bitcoin() < amount,
             Err(_) => false,
         }
@@ -934,7 +981,11 @@ impl LightningClientModule {
     /// part of the contract `amount` the gateway claims, not the on-federation
     /// transaction fee. So `amount` is the full outgoing contract value
     /// (`send_fee.add_to(invoice_amount)`).
-    pub async fn send_fee_quote(&self, amount: Amount) -> anyhow::Result<FeeQuote> {
+    pub async fn send_fee_quote(
+        &self,
+        account: Account,
+        amount: Amount,
+    ) -> anyhow::Result<FeeQuote> {
         self.client_ctx
             .fee_quote(
                 OperationId::new_random(),
@@ -943,6 +994,7 @@ impl LightningClientModule {
                     output_amount: Amounts::new_bitcoin(amount),
                     input_fee: Amounts::ZERO,
                     output_fee: Amounts::new_bitcoin(self.cfg.fee_consensus.fee(amount)),
+                    account,
                 },
             )
             .await
@@ -982,6 +1034,7 @@ impl LightningClientModule {
     /// caller's responsibility to apply.
     pub async fn spendable_amount(
         &self,
+        account: Account,
         balance: Amount,
         gateway: Option<SafeUrl>,
     ) -> anyhow::Result<Amount> {
@@ -1009,7 +1062,7 @@ impl LightningClientModule {
             Amount::from_msats(1),
             balance,
             |invoice_amount: Amount| send_fee.add_to(invoice_amount.msats),
-            |contract_amount: Amount| self.send_fee_quote(contract_amount),
+            |contract_amount: Amount| self.send_fee_quote(account, contract_amount),
         )
         .await
         .ok_or_else(|| anyhow::anyhow!("Balance is too low to send any amount after fees"))
@@ -1020,6 +1073,7 @@ impl LightningClientModule {
     /// invoice.
     async fn create_contract_and_fetch_invoice(
         &self,
+        account: Account,
         recipient_static_pk: PublicKey,
         amount: Amount,
         expiry_secs: u32,
@@ -1066,7 +1120,7 @@ impl LightningClientModule {
         // Quoting the claim against this federation's fee consensus is exact, where a
         // fixed floor is either too permissive or too strict depending on how the
         // federation is configured.
-        if !self.is_worth_claiming(contract_amount).await {
+        if !self.is_worth_claiming(account, contract_amount).await {
             return Err(ReceiveError::AmountTooSmall);
         }
 
@@ -1121,6 +1175,7 @@ impl LightningClientModule {
     // static module public key.
     async fn receive_incoming_contract(
         &self,
+        account: Account,
         sk: SecretKey,
         contract: IncomingContract,
         operation_meta: LightningOperationMeta,
@@ -1144,6 +1199,7 @@ impl LightningClientModule {
         self.client_ctx
             .manual_operation_start(
                 operation_id,
+                account,
                 LightningCommonInit::KIND.as_str(),
                 operation_meta,
                 vec![self.client_ctx.make_dyn_state(receive_sm)],
@@ -1269,9 +1325,20 @@ impl LightningClientModule {
     /// to use for testing purposes.
     pub async fn generate_lnurl(
         &self,
+        account: Account,
         recurringd: SafeUrl,
         gateway: Option<SafeUrl>,
     ) -> Result<String, GenerateLnurlError> {
+        // Checked before the lnurl exists: anyone can pay into a published
+        // key, and a contract locked to an account the primary module cannot
+        // fund a claim for would strand the payer's money.
+        if !self
+            .client_ctx
+            .supports_account(AmountUnit::BITCOIN, account)
+        {
+            return Err(GenerateLnurlError::AccountNotSupported);
+        }
+
         let gateways = if let Some(gateway) = gateway {
             vec![gateway]
         } else {
@@ -1292,7 +1359,7 @@ impl LightningClientModule {
             fedimint_core::base32::FEDIMINT_PREFIX,
             &lnurl::LnurlRequest {
                 federation_id: self.federation_id,
-                recipient_pk: self.lnurl_keypair.public_key(),
+                recipient_pk: self.keys(account).lnurl_keypair.public_key(),
                 aggregate_pk: self.cfg.tpe_agg_pk,
                 gateways,
             },
@@ -1351,18 +1418,25 @@ impl LightningClientModule {
 
         for contract in &contracts {
             // The stream carries every incoming contract the federation funded, and
-            // anyone can address one to a published lnurl key. Check that it is ours
-            // before quoting - recovering the keys is local arithmetic, the quote
-            // reads the wallet - and skip the contracts the claim fee would swallow,
-            // so that unsolicited dust never becomes an operation in the first place.
-            if self
-                .recover_contract_keys(self.lnurl_keypair.secret_key(), contract)
-                .is_none()
-            {
+            // anyone can address one to a published lnurl key. Trialling each account's
+            // key both finds the one the contract is locked to and establishes that it
+            // is ours at all, before quoting - recovering the keys is local arithmetic,
+            // the quote reads the wallet. The stream and its cursor are shared, so an
+            // extra account costs one more trial decryption per contract rather than
+            // another sweep.
+            let Some(account) = Account::ALL.into_iter().find(|account| {
+                self.recover_contract_keys(self.keys(*account).lnurl_keypair.secret_key(), contract)
+                    .is_some()
+            }) else {
                 continue;
-            }
+            };
 
-            if !self.is_worth_claiming(contract.commitment.amount).await {
+            // Skip the contracts the claim fee would swallow, so that unsolicited dust
+            // never becomes an operation in the first place.
+            if !self
+                .is_worth_claiming(account, contract.commitment.amount)
+                .await
+            {
                 warn!(
                     target: LOG_CLIENT_MODULE_LNV2,
                     amount = %contract.commitment.amount,
@@ -1374,7 +1448,8 @@ impl LightningClientModule {
 
             if let Some(operation_id) = self
                 .receive_incoming_contract(
-                    self.lnurl_keypair.secret_key(),
+                    account,
+                    self.keys(account).lnurl_keypair.secret_key(),
                     contract.clone(),
                     LightningOperationMeta::LnurlReceive(LnurlReceiveOperationMeta {
                         contract: contract.clone(),
@@ -1433,6 +1508,8 @@ pub enum InvoiceSendStatus {
 
 #[derive(Error, Debug, Clone, Eq, PartialEq)]
 pub enum SendPaymentError {
+    #[error("The primary module only holds a balance for the primary account")]
+    AccountNotSupported,
     #[error("Invoice is missing an amount")]
     InvoiceMissingAmount,
     #[error("Invoice has expired")]
@@ -1462,6 +1539,8 @@ pub enum SendPaymentError {
 
 #[derive(Error, Debug, Clone, Eq, PartialEq)]
 pub enum ReceiveError {
+    #[error("The primary module only holds a balance for the primary account")]
+    AccountNotSupported,
     #[error(transparent)]
     SelectGateway(SelectGatewayError),
     #[error("Failed to connect to gateway")]
@@ -1482,6 +1561,8 @@ pub enum ReceiveError {
 
 #[derive(Error, Debug, Clone, Eq, PartialEq)]
 pub enum GenerateLnurlError {
+    #[error("The primary module only holds a balance for the primary account")]
+    AccountNotSupported,
     #[error("No gateways are available")]
     NoGatewaysAvailable,
     #[error("Failed to request gateways")]

--- a/modules/fedimint-lnv2-client/src/receive_sm.rs
+++ b/modules/fedimint-lnv2-client/src/receive_sm.rs
@@ -182,6 +182,8 @@ impl ReceiveStateMachine {
         };
 
         // Log event when receive completes successfully
+        let account = global_context.account(dbtx).await;
+
         context
             .client_ctx
             .log_event(
@@ -190,6 +192,7 @@ impl ReceiveStateMachine {
                     operation_id: old_state.common.operation_id,
                     amount: old_state.common.contract.commitment.amount + fee,
                     fee,
+                    account,
                 },
             )
             .await;

--- a/modules/fedimint-lnv2-client/src/send_sm.rs
+++ b/modules/fedimint-lnv2-client/src/send_sm.rs
@@ -58,10 +58,13 @@ pub enum SendSMState {
 
 async fn send_update_event(
     context: LightningClientContext,
+    global_context: &DynGlobalClientContext,
     dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
     operation_id: OperationId,
     status: SendPaymentStatus,
 ) {
+    let account = global_context.account(dbtx).await;
+
     context
         .client_ctx
         .log_event(
@@ -69,6 +72,7 @@ async fn send_update_event(
             SendPaymentUpdateEvent {
                 operation_id,
                 status,
+                account,
             },
         )
         .await;
@@ -227,6 +231,7 @@ impl SendStateMachine {
             Ok(preimage) => {
                 send_update_event(
                     context,
+                    &global_context,
                     dbtx,
                     old_state.common.operation_id,
                     SendPaymentStatus::Success(preimage),
@@ -256,6 +261,7 @@ impl SendStateMachine {
 
                 send_update_event(
                     context,
+                    &global_context,
                     dbtx,
                     old_state.common.operation_id,
                     SendPaymentStatus::Refunded,
@@ -297,6 +303,7 @@ impl SendStateMachine {
         if let Some(preimage) = preimage {
             send_update_event(
                 context,
+                &global_context,
                 dbtx,
                 old_state.common.operation_id,
                 SendPaymentStatus::Success(preimage),
@@ -322,6 +329,7 @@ impl SendStateMachine {
 
         send_update_event(
             context,
+            &global_context,
             dbtx,
             old_state.common.operation_id,
             SendPaymentStatus::Refunded,

--- a/modules/fedimint-lnv2-tests/tests/tests.rs
+++ b/modules/fedimint-lnv2-tests/tests/tests.rs
@@ -12,7 +12,7 @@ use fedimint_client::transaction::{
 };
 use fedimint_client_module::module::ClientModule;
 use fedimint_core::base32::{FEDIMINT_PREFIX, decode_prefixed};
-use fedimint_core::core::{IntoDynInstance, OperationId};
+use fedimint_core::core::{Account, IntoDynInstance, OperationId};
 use fedimint_core::encoding::Encodable as _;
 use fedimint_core::module::{AmountUnit, Amounts};
 use fedimint_core::secp256k1::{PublicKey, Scalar};
@@ -27,8 +27,9 @@ use fedimint_lnv2_client::events::{
     ReceivePaymentEvent, SendPaymentEvent, SendPaymentStatus, SendPaymentUpdateEvent,
 };
 use fedimint_lnv2_client::{
-    FinalReceiveOperationState, InvoiceSendStatus, LightningClientInit, LightningClientModule,
-    LightningOperationMeta, ReceiveOperationState, SendOperationState, SendPaymentError,
+    FinalReceiveOperationState, GenerateLnurlError, InvoiceSendStatus, LightningClientInit,
+    LightningClientModule, LightningOperationMeta, ReceiveError, ReceiveOperationState,
+    SendOperationState, SendPaymentError,
 };
 use fedimint_lnv2_common::contracts::{IncomingContract, PaymentImage};
 use fedimint_lnv2_common::lnurl::LnurlRequest;
@@ -138,7 +139,12 @@ async fn can_pay_external_invoice_exactly_once() -> anyhow::Result<()> {
 
     let operation_id = client
         .get_first_module::<LightningClientModule>()?
-        .send(invoice.clone(), Some(gateway_api.clone()), Value::Null)
+        .send(
+            Account::Primary,
+            invoice.clone(),
+            Some(gateway_api.clone()),
+            Value::Null,
+        )
         .await?;
 
     let Some(LnEvent::Send(send)) = events.next().await else {
@@ -149,7 +155,12 @@ async fn can_pay_external_invoice_exactly_once() -> anyhow::Result<()> {
     assert_eq!(
         client
             .get_first_module::<LightningClientModule>()?
-            .send(invoice.clone(), Some(gateway_api.clone()), Value::Null)
+            .send(
+                Account::Primary,
+                invoice.clone(),
+                Some(gateway_api.clone()),
+                Value::Null
+            )
             .await,
         Err(SendPaymentError::DuplicatePaymentAttempt(operation_id)),
     );
@@ -179,7 +190,12 @@ async fn can_pay_external_invoice_exactly_once() -> anyhow::Result<()> {
     assert_eq!(
         client
             .get_first_module::<LightningClientModule>()?
-            .send(invoice.clone(), Some(gateway_api), Value::Null)
+            .send(
+                Account::Primary,
+                invoice.clone(),
+                Some(gateway_api),
+                Value::Null
+            )
             .await,
         Err(SendPaymentError::DuplicatePaymentAttempt(operation_id)),
     );
@@ -213,7 +229,12 @@ async fn refund_failed_payment() -> anyhow::Result<()> {
 
     let operation_id = client
         .get_first_module::<LightningClientModule>()?
-        .send(invoice.clone(), Some(mock::gateway()), Value::Null)
+        .send(
+            Account::Primary,
+            invoice.clone(),
+            Some(mock::gateway()),
+            Value::Null,
+        )
         .await?;
 
     let Some(LnEvent::Send(send)) = events.next().await else {
@@ -275,7 +296,12 @@ async fn unilateral_refund_of_outgoing_contracts() -> anyhow::Result<()> {
 
     let operation_id = client
         .get_first_module::<LightningClientModule>()?
-        .send(invoice.clone(), Some(mock::gateway()), Value::Null)
+        .send(
+            Account::Primary,
+            invoice.clone(),
+            Some(mock::gateway()),
+            Value::Null,
+        )
         .await?;
 
     let Some(LnEvent::Send(send)) = events.next().await else {
@@ -337,7 +363,12 @@ async fn claiming_outgoing_contract_triggers_success() -> anyhow::Result<()> {
 
     let operation_id = client
         .get_first_module::<LightningClientModule>()?
-        .send(mock::crash_invoice(), Some(mock::gateway()), Value::Null)
+        .send(
+            Account::Primary,
+            mock::crash_invoice(),
+            Some(mock::gateway()),
+            Value::Null,
+        )
         .await?;
 
     let Some(LnEvent::Send(send)) = events.next().await else {
@@ -386,7 +417,7 @@ async fn claiming_outgoing_contract_triggers_success() -> anyhow::Result<()> {
             OperationId::new_random(),
             "Claiming Outgoing Contract",
             |_| (),
-            TransactionBuilder::new().with_inputs(
+            TransactionBuilder::new(Account::Primary).with_inputs(
                 ClientInputBundle::new_no_sm(vec![client_input]).into_dyn(lnv2_module_id),
             ),
         )
@@ -419,6 +450,7 @@ async fn receive_operation_expires() -> anyhow::Result<()> {
     let op = client
         .get_first_module::<LightningClientModule>()?
         .receive(
+            Account::Primary,
             Amount::from_sats(1000),
             5, // receive operation expires in 5 seconds
             Bolt11InvoiceDescription::Direct(String::new()),
@@ -494,7 +526,7 @@ async fn fund_incoming_contract(
             OperationId::new_random(),
             "Funding an incoming contract",
             |_| (),
-            TransactionBuilder::new().with_outputs(
+            TransactionBuilder::new(Account::Primary).with_outputs(
                 ClientOutputBundle::new_no_sm(vec![ClientOutput {
                     output: LightningOutput::V0(LightningOutputV0::Incoming(contract.clone())),
                     amounts: Amounts::new_bitcoin(contract.commitment.amount),
@@ -535,6 +567,7 @@ async fn unsolicited_dust_contract_does_not_wedge_the_client() -> anyhow::Result
     let lnurl = victim
         .get_first_module::<LightningClientModule>()?
         .generate_lnurl(
+            Account::Primary,
             SafeUrl::parse("https://recurring.xyz/").expect("Valid Url"),
             Some(mock::gateway()),
         )
@@ -593,6 +626,57 @@ async fn unsolicited_dust_contract_does_not_wedge_the_client() -> anyhow::Result
 }
 
 #[tokio::test(flavor = "multi_thread")]
+/// The test fixture's primary module is the dummy module, which holds a single
+/// balance. Every entry point that binds money to an account has to refuse
+/// the others up front, before a gateway or a payer is involved.
+async fn primary_only_mint_rejects_other_accounts() -> anyhow::Result<()> {
+    let fixtures = fixtures();
+    let fed = fixtures.new_fed_degraded().await;
+    let client = fed.new_client().await;
+    let lightning = client.get_first_module::<LightningClientModule>()?;
+
+    assert_eq!(
+        lightning
+            .send(
+                Account::Secondary,
+                mock::payable_invoice(),
+                Some(mock::gateway()),
+                Value::Null,
+            )
+            .await,
+        Err(SendPaymentError::AccountNotSupported),
+    );
+
+    assert_eq!(
+        lightning
+            .receive(
+                Account::Secondary,
+                Amount::from_sats(1_000),
+                3600,
+                Bolt11InvoiceDescription::Direct(String::new()),
+                Some(mock::gateway()),
+                Value::Null,
+            )
+            .await
+            .map(|(invoice, _)| invoice),
+        Err(ReceiveError::AccountNotSupported),
+    );
+
+    assert_eq!(
+        lightning
+            .generate_lnurl(
+                Account::Secondary,
+                SafeUrl::parse("https://recurring.xyz/").expect("Valid Url"),
+                Some(mock::gateway()),
+            )
+            .await,
+        Err(GenerateLnurlError::AccountNotSupported),
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn rejects_wrong_network_invoice() -> anyhow::Result<()> {
     let fixtures = fixtures();
     let fed = fixtures.new_fed_degraded().await;
@@ -602,6 +686,7 @@ async fn rejects_wrong_network_invoice() -> anyhow::Result<()> {
         client
             .get_first_module::<LightningClientModule>()?
             .send(
+                Account::Primary,
                 mock::signet_bolt_11_invoice(),
                 Some(mock::gateway()),
                 Value::Null

--- a/modules/fedimint-mint-client/src/input.rs
+++ b/modules/fedimint-mint-client/src/input.rs
@@ -255,8 +255,8 @@ impl MintInputStateCreated {
 
         let change_range = global_context
             .claim_inputs(
-                dbtx,
-                // The input of the refund tx is managed by this state machine, so no new state
+                dbtx, /* The input of the refund tx is managed by this state machine, so no new
+                       * state */
                 // machines need to be created
                 ClientInputBundle::new_no_sm(vec![refund_input]),
             )
@@ -351,8 +351,7 @@ impl MintInputStateCreatedBundle {
 
         let change_range = global_context
             .claim_inputs(
-                dbtx,
-                // We are inside an input state machine, so no need to spawn new ones
+                dbtx, // We are inside an input state machine, so no need to spawn new ones
                 ClientInputBundle::new_no_sm(inputs),
             )
             .await
@@ -451,8 +450,8 @@ impl MintInputStateRefundedBundle {
             };
             match global_context
                 .claim_inputs(
-                    dbtx,
-                    // The input of the refund tx is managed by this state machine, so no new state
+                    dbtx, /* The input of the refund tx is managed by this state machine, so no
+                           * new state */
                     // machines need to be created
                     ClientInputBundle::new_no_sm(vec![refund_input.clone()]),
                 )

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -62,8 +62,8 @@ use fedimint_client_module::module::init::{
 };
 use fedimint_client_module::module::recovery::RecoveryProgress;
 use fedimint_client_module::module::{
-    ClientContext, ClientModule, IClientModule, OutPointRange, PrimaryModulePriority,
-    PrimaryModuleSupport,
+    AccountSupport, ClientContext, ClientModule, IClientModule, OutPointRange,
+    PrimaryModulePriority, PrimaryModuleSupport,
 };
 use fedimint_client_module::oplog::{OperationLogEntry, UpdateStreamOrOutcome};
 use fedimint_client_module::sm::{Context, DynState, ModuleNotifier, State, StateTransition};
@@ -74,7 +74,9 @@ use fedimint_client_module::transaction::{
 use fedimint_client_module::{DynGlobalClientContext, sm_enum_variant_translation};
 use fedimint_core::base32::{FEDIMINT_PREFIX, encode_prefixed};
 use fedimint_core::config::{FederationId, FederationIdPrefix};
-use fedimint_core::core::{Decoder, IntoDynInstance, ModuleInstanceId, ModuleKind, OperationId};
+use fedimint_core::core::{
+    Account, Decoder, IntoDynInstance, ModuleInstanceId, ModuleKind, OperationId,
+};
 use fedimint_core::db::{
     AutocommitError, Database, DatabaseTransaction, DatabaseVersion,
     IDatabaseTransactionOpsCoreTyped,
@@ -1053,7 +1055,11 @@ impl ClientModule for MintClientModule {
     }
 
     fn supports_being_primary(&self) -> PrimaryModuleSupport {
-        PrimaryModuleSupport::selected(PrimaryModulePriority::HIGH, [AmountUnit::BITCOIN])
+        PrimaryModuleSupport::selected(
+            PrimaryModulePriority::HIGH,
+            [AmountUnit::BITCOIN],
+            AccountSupport::PrimaryOnly,
+        )
     }
 
     async fn create_final_inputs_and_outputs(
@@ -1063,15 +1069,16 @@ impl ClientModule for MintClientModule {
         unit: AmountUnit,
         mut input_amount: Amount,
         mut output_amount: Amount,
+        _account: Account,
     ) -> anyhow::Result<(
         ClientInputBundle<MintInput, MintClientStateMachines>,
         ClientOutputBundle<MintOutput, MintClientStateMachines>,
     )> {
-        let consolidation_inputs = self.consolidate_notes(dbtx).await?;
-
         if unit != AmountUnit::BITCOIN {
             bail!("Module can only handle Bitcoin");
         }
+
+        let consolidation_inputs = self.consolidate_notes(dbtx).await?;
 
         input_amount += consolidation_inputs
             .iter()
@@ -1123,10 +1130,16 @@ impl ClientModule for MintClientModule {
         self.await_output_finalized(operation_id, out_point).await
     }
 
-    async fn get_balance(&self, dbtx: &mut DatabaseTransaction<'_>, unit: AmountUnit) -> Amount {
+    async fn get_balance(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        unit: AmountUnit,
+        _account: Account,
+    ) -> Amount {
         if unit != AmountUnit::BITCOIN {
             return Amount::ZERO;
         }
+
         self.get_note_counts_by_denomination(dbtx)
             .await
             .total_amount()
@@ -1134,7 +1147,8 @@ impl ClientModule for MintClientModule {
 
     async fn get_balances(&self, dbtx: &mut DatabaseTransaction<'_>) -> Amounts {
         Amounts::new_bitcoin(
-            <Self as ClientModule>::get_balance(self, dbtx, AmountUnit::BITCOIN).await,
+            <Self as ClientModule>::get_balance(self, dbtx, AmountUnit::BITCOIN, Account::Primary)
+                .await,
         )
     }
 
@@ -1908,6 +1922,7 @@ impl MintClientModule {
                     output_amount: Amounts::ZERO,
                     input_fee: Amounts::new_bitcoin(input_fee),
                     output_fee: Amounts::ZERO,
+                    account: Account::Primary,
                 },
             )
             .await
@@ -1969,6 +1984,7 @@ impl MintClientModule {
                     output_amount: Amounts::new_bitcoin(output_amount),
                     input_fee: Amounts::ZERO,
                     output_fee: Amounts::new_bitcoin(output_fee),
+                    account: Account::Primary,
                 },
             )
             .await
@@ -2013,7 +2029,7 @@ impl MintClientModule {
         let amount = notes.total_amount();
         let mint_inputs = self.create_input_from_notes(notes)?;
 
-        let tx = TransactionBuilder::new().with_inputs(
+        let tx = TransactionBuilder::new(Account::Primary).with_inputs(
             self.client_ctx
                 .make_dyn(create_bundle_for_inputs(mint_inputs, operation_id)),
         );
@@ -2229,6 +2245,7 @@ impl MintClientModule {
                             .add_operation_log_entry_dbtx(
                                 dbtx,
                                 operation_id,
+                                Account::Primary,
                                 MintCommonInit::KIND.as_str(),
                                 MintOperationMeta {
                                     variant: MintOperationMetaVariant::SpendOOB {
@@ -2408,7 +2425,7 @@ impl MintClientModule {
                     amount,
                     extra_meta: em_clone.clone(),
                 },
-                TransactionBuilder::new().with_outputs(outputs),
+                TransactionBuilder::new(Account::Primary).with_outputs(outputs),
             )
             .await
             .context("Failed to submit reissuance transaction")?;
@@ -2467,6 +2484,7 @@ impl MintClientModule {
             .add_operation_log_entry_dbtx(
                 dbtx,
                 operation_id,
+                Account::Primary,
                 MintCommonInit::KIND.as_str(),
                 MintOperationMeta {
                     variant: MintOperationMetaVariant::SpendOOB {

--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -7,7 +7,7 @@ use fedimint_client::ClientHandleArc;
 use fedimint_client::backup::{ClientBackup, Metadata};
 use fedimint_client::transaction::{ClientInput, ClientInputBundle, TransactionBuilder};
 use fedimint_client_module::ClientModule;
-use fedimint_core::core::OperationId;
+use fedimint_core::core::{Account, OperationId};
 use fedimint_core::db::IDatabaseTransactionOpsCoreTyped;
 use fedimint_core::module::{AmountUnit, Amounts};
 use fedimint_core::task::sleep_in_test;
@@ -55,7 +55,7 @@ async fn issue_ecash(client: &ClientHandleArc, amount: Amount) -> anyhow::Result
             operation_id,
             "Issue e-cash via dummy module",
             |_| (),
-            TransactionBuilder::new().with_inputs(dummy_input),
+            TransactionBuilder::new(Account::Primary).with_inputs(dummy_input),
         )
         .await?;
 
@@ -98,7 +98,7 @@ async fn transaction_with_invalid_signature_is_rejected() -> anyhow::Result<()> 
             operation_id,
             "Claiming Invalid Ecash Note",
             |_| (),
-            TransactionBuilder::new().with_inputs(
+            TransactionBuilder::new(Account::Primary).with_inputs(
                 client
                     .get_first_module::<MintClientModule>()?
                     .client_ctx
@@ -161,7 +161,7 @@ async fn sends_ecash_out_of_band() -> anyhow::Result<()> {
     let fees_from_balance = sats(750)
         .checked_sub(
             client2
-                .get_balance_for_btc()
+                .get_balance_for_btc(Account::Primary)
                 .await
                 .expect("Can fetch balance"),
         )
@@ -182,8 +182,14 @@ async fn sends_ecash_out_of_band() -> anyhow::Result<()> {
         "Operation fees differ from actual fees"
     );
 
-    assert!(client1.get_balance_for_btc().await? >= sats(250).saturating_sub(EXPECTED_MAXIMUM_FEE));
-    assert!(client2.get_balance_for_btc().await? >= sats(750).saturating_sub(EXPECTED_MAXIMUM_FEE));
+    assert!(
+        client1.get_balance_for_btc(Account::Primary).await?
+            >= sats(250).saturating_sub(EXPECTED_MAXIMUM_FEE)
+    );
+    assert!(
+        client2.get_balance_for_btc(Account::Primary).await?
+            >= sats(750).saturating_sub(EXPECTED_MAXIMUM_FEE)
+    );
     Ok(())
 }
 
@@ -217,7 +223,7 @@ async fn reissue_fee_quote_matches_actual_fee() -> anyhow::Result<()> {
         let reissued_value = notes.total_amount();
 
         let quote = receive_mint.reissue_fee_quote(&notes).await?;
-        let before = client_receive.get_balance_for_btc().await?;
+        let before = client_receive.get_balance_for_btc(Account::Primary).await?;
 
         let op = receive_mint.reissue_external_notes(notes, ()).await?;
         let mut sub = receive_mint
@@ -231,7 +237,7 @@ async fn reissue_fee_quote_matches_actual_fee() -> anyhow::Result<()> {
         assert_eq!(sub.ok().await?, ReissueExternalNotesState::Done);
         assert_eq!(send_sub.ok().await?, SpendOOBState::Success);
 
-        let after = client_receive.get_balance_for_btc().await?;
+        let after = client_receive.get_balance_for_btc(Account::Primary).await?;
         let actual_fee = reissued_value - (after - before);
 
         assert_eq!(
@@ -261,7 +267,7 @@ async fn send_fee_quote_matches_actual_fee() -> anyhow::Result<()> {
         client.wait_for_all_active_state_machines().await?;
 
         let quote = mint.send_fee_quote(sats(1_000)).await?;
-        let before = client.get_balance_for_btc().await?;
+        let before = client.get_balance_for_btc(Account::Primary).await?;
 
         let notes = mint.send_oob_notes(sats(1_000), ()).await?;
         let sent_value = notes.total_amount();
@@ -269,7 +275,7 @@ async fn send_fee_quote_matches_actual_fee() -> anyhow::Result<()> {
         // A send may trigger an internal reissue whose change notes are credited
         // by output state machines; wait for them before reading the balance.
         client.wait_for_all_active_state_machines().await?;
-        let after = client.get_balance_for_btc().await?;
+        let after = client.get_balance_for_btc(Account::Primary).await?;
 
         // Value conservation: the wallet loses exactly the sent value plus the fee.
         let actual_fee = before - after - sent_value;
@@ -342,7 +348,8 @@ async fn blind_nonce_index() -> anyhow::Result<()> {
         "Blind nonce should not be used yet"
     );
 
-    let tx = TransactionBuilder::new().with_outputs(client_mint.client_ctx.make_dyn(issuance_req));
+    let tx = TransactionBuilder::new(Account::Primary)
+        .with_outputs(client_mint.client_ctx.make_dyn(issuance_req));
 
     let change_range = client_mint
         .client_ctx
@@ -459,7 +466,8 @@ async fn single_peer_nonce_checks() -> anyhow::Result<()> {
         );
     }
 
-    let tx = TransactionBuilder::new().with_outputs(client1_mint.client_ctx.make_dyn(issuance_req));
+    let tx = TransactionBuilder::new(Account::Primary)
+        .with_outputs(client1_mint.client_ctx.make_dyn(issuance_req));
     let change_range = client1_mint
         .client_ctx
         .finalize_and_submit_transaction(operation_id, "mint", |_| (), tx)
@@ -517,7 +525,7 @@ async fn duplicate_blind_nonce_index_rejected() -> anyhow::Result<()> {
     let duplicate_bundle = fedimint_client_module::transaction::ClientOutputBundle::new_no_sm(
         issuance_req.outputs().to_vec(),
     );
-    let tx = TransactionBuilder::new()
+    let tx = TransactionBuilder::new(Account::Primary)
         .with_outputs(client_mint.client_ctx.make_dyn(issuance_req))
         .with_outputs(client_mint.client_ctx.make_dyn(duplicate_bundle));
 
@@ -598,7 +606,7 @@ async fn sends_ecash_oob_highly_parallel() -> anyhow::Result<()> {
     let total_amount_spent: Amount = note_bags.iter().map(|bag| bag.total_amount()).sum();
 
     assert_eq!(
-        client1.get_balance_for_btc().await?,
+        client1.get_balance_for_btc(Account::Primary).await?,
         sats(1000).saturating_sub(total_amount_spent)
     );
 
@@ -636,7 +644,7 @@ async fn sends_ecash_oob_highly_parallel() -> anyhow::Result<()> {
     }
 
     assert!(
-        client2.get_balance_for_btc().await?
+        client2.get_balance_for_btc(Account::Primary).await?
             >= total_amount_spent.saturating_sub(EXPECTED_MAXIMUM_FEE)
     );
 
@@ -725,7 +733,7 @@ async fn sends_ecash_out_of_band_cancel() -> anyhow::Result<()> {
 
     // FIXME: UserCanceledSuccess should mean the money is in our wallet
     for _ in 0..120 {
-        let balance = client.get_balance_for_btc().await?;
+        let balance = client.get_balance_for_btc(Account::Primary).await?;
         let expected_min_balance = sats(1000).saturating_sub(EXPECTED_MAXIMUM_FEE);
         if expected_min_balance <= balance {
             return Ok(());
@@ -816,7 +824,7 @@ async fn sends_ecash_out_of_band_cancel_partial() -> anyhow::Result<()> {
 
     // FIXME: UserCanceledSuccess should mean the money is in our wallet
     for _ in 0..120 {
-        let balance = client.get_balance_for_btc().await?;
+        let balance = client.get_balance_for_btc(Account::Primary).await?;
         let expected_min_balance = sats(1000)
             .saturating_sub(EXPECTED_MAXIMUM_FEE)
             .saturating_sub(single_note.0);
@@ -902,6 +910,7 @@ async fn repair_wallet() -> anyhow::Result<()> {
             .get_balance(
                 &mut client_mint.db.begin_transaction_nc().await,
                 AmountUnit::BITCOIN,
+                Account::Primary,
             )
             .await;
         let repair_summary = client_mint
@@ -922,6 +931,7 @@ async fn repair_wallet() -> anyhow::Result<()> {
             .get_balance(
                 &mut client_mint.db.begin_transaction_nc().await,
                 AmountUnit::BITCOIN,
+                Account::Primary,
             )
             .await;
         assert_eq!(
@@ -974,6 +984,7 @@ async fn repair_wallet() -> anyhow::Result<()> {
             .get_balance(
                 &mut client_mint.db.begin_transaction_nc().await,
                 AmountUnit::BITCOIN,
+                Account::Primary,
             )
             .await;
 
@@ -996,6 +1007,7 @@ async fn repair_wallet() -> anyhow::Result<()> {
             .get_balance(
                 &mut client_mint.db.begin_transaction_nc().await,
                 AmountUnit::BITCOIN,
+                Account::Primary,
             )
             .await;
         assert_eq!(
@@ -1025,6 +1037,7 @@ async fn repair_wallet() -> anyhow::Result<()> {
             .get_balance(
                 &mut client_mint.db.begin_transaction_nc().await,
                 AmountUnit::BITCOIN,
+                Account::Primary,
             )
             .await;
 
@@ -1047,6 +1060,7 @@ async fn repair_wallet() -> anyhow::Result<()> {
             .get_balance(
                 &mut client_mint.db.begin_transaction_nc().await,
                 AmountUnit::BITCOIN,
+                Account::Primary,
             )
             .await;
         assert_eq!(
@@ -1099,6 +1113,7 @@ async fn repair_wallet() -> anyhow::Result<()> {
             .get_balance(
                 &mut client_mint.db.begin_transaction_nc().await,
                 AmountUnit::BITCOIN,
+                Account::Primary,
             )
             .await;
 
@@ -1121,6 +1136,7 @@ async fn repair_wallet() -> anyhow::Result<()> {
             .get_balance(
                 &mut client_mint.db.begin_transaction_nc().await,
                 AmountUnit::BITCOIN,
+                Account::Primary,
             )
             .await;
         assert_eq!(

--- a/modules/fedimint-mintv2-client/benches/recovery.rs
+++ b/modules/fedimint-mintv2-client/benches/recovery.rs
@@ -1,3 +1,4 @@
+use fedimint_core::core::Account;
 use fedimint_core::encoding::Encodable;
 use fedimint_derive_secret::DerivableSecret;
 use fedimint_mintv2_client::issuance;
@@ -28,7 +29,8 @@ fn check_nonce(bencher: divan::Bencher) {
     let root_secret = DerivableSecret::new_root(&[0u8; 32], &[0u8; 8]);
     let denomination = Denomination(0);
     let tweak = issuance::grind_tweak(&root_secret);
-    let output_secret = issuance::output_secret(denomination, tweak, &root_secret);
+    let output_secret =
+        issuance::output_secret(Account::Primary, denomination, tweak, &root_secret);
     let nonce_hash = issuance::nonce(&output_secret).consensus_hash();
 
     bencher.bench(|| issuance::check_nonce(&output_secret, nonce_hash));

--- a/modules/fedimint-mintv2-client/src/cli.rs
+++ b/modules/fedimint-mintv2-client/src/cli.rs
@@ -3,6 +3,7 @@ use std::{ffi, iter};
 use clap::Parser;
 use fedimint_core::Amount;
 use fedimint_core::base32::{self, FEDIMINT_PREFIX};
+use fedimint_core::core::Account;
 use serde::Serialize;
 use serde_json::Value;
 
@@ -10,18 +11,35 @@ use crate::MintClientModule;
 
 #[derive(Parser, Serialize)]
 enum Opts {
-    /// Count the `ECash` notes in the client's database by denomination.
-    Count,
+    /// Count the `ECash` notes an account holds by denomination.
+    Count {
+        #[clap(long, default_value_t = Account::Primary)]
+        account: Account,
+    },
     /// Send `ECash` for the given amount.
     Send {
         amount: Amount,
+        #[clap(long, default_value_t = Account::Primary)]
+        account: Account,
         /// Embed the federation's invite code in the serialized ecash so a
         /// recipient that hasn't joined the federation can do so from it.
         #[clap(long)]
         include_invite: bool,
     },
+    /// Hand out everything an account holds as one bundle. Receive it into
+    /// another account to move a balance across.
+    SendMax {
+        #[clap(long, default_value_t = Account::Primary)]
+        account: Account,
+        #[clap(long)]
+        include_invite: bool,
+    },
     /// Receive the `ECash` by reissuing the notes and return the amount.
-    Receive { ecash: String },
+    Receive {
+        ecash: String,
+        #[clap(long, default_value_t = Account::Primary)]
+        account: Account,
+    },
 }
 
 pub(crate) async fn handle_cli_command(
@@ -31,20 +49,34 @@ pub(crate) async fn handle_cli_command(
     let opts = Opts::parse_from(iter::once(&ffi::OsString::from("mintv2")).chain(args.iter()));
 
     match opts {
-        Opts::Count => Ok(json(mint.get_count_by_denomination().await)),
+        Opts::Count { account } => Ok(json(mint.get_count_by_denomination(account).await)),
         Opts::Send {
             amount,
+            account,
             include_invite,
         } => {
-            let (_, ecash) = mint.send(amount, Value::Null, include_invite).await?;
+            let (_, ecash) = mint
+                .send(account, amount, Value::Null, include_invite)
+                .await?;
             let ecash = base32::encode_prefixed(FEDIMINT_PREFIX, &ecash);
 
             Ok(json(ecash))
         }
-        Opts::Receive { ecash } => {
+        Opts::SendMax {
+            account,
+            include_invite,
+        } => {
+            let ecash = mint
+                .send_max(account, Value::Null, include_invite)
+                .await
+                .map(|(_, ecash)| base32::encode_prefixed(FEDIMINT_PREFIX, &ecash));
+
+            Ok(json(ecash))
+        }
+        Opts::Receive { ecash, account } => {
             let ecash = base32::decode_prefixed(FEDIMINT_PREFIX, &ecash)?;
 
-            let operation_id = mint.receive(ecash, Value::Null).await?;
+            let operation_id = mint.receive(account, ecash, Value::Null).await?;
 
             let state = mint
                 .await_final_receive_operation_state(operation_id)

--- a/modules/fedimint-mintv2-client/src/client_db.rs
+++ b/modules/fedimint-mintv2-client/src/client_db.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use bitcoin_hashes::hash160;
+use fedimint_core::core::Account;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::{impl_db_lookup, impl_db_record};
 use fedimint_mintv2_common::Denomination;
@@ -17,14 +18,19 @@ pub enum DbKeyPrefix {
     RecoveryState = 0x21,
 }
 
+/// Every account's notes share one table, split by the key's leading
+/// [`Account`]. Nonces derive from per-account secrets, so two accounts can
+/// never produce the same note.
 #[derive(Debug, Clone, Encodable, Decodable)]
-pub struct SpendableNoteKey(pub SpendableNote);
+pub struct SpendableNoteKey(pub Account, pub SpendableNote);
 
 #[derive(Debug, Clone, Encodable, Decodable)]
-pub struct SpendableNotePrefix;
+pub struct SpendableNotePrefix(pub Account);
 
+/// Relies on [`SpendableNote`] encoding its denomination first, so an account
+/// and a denomination are a prefix of the whole key.
 #[derive(Debug, Clone, Encodable, Decodable)]
-pub struct SpendableNoteAmountPrefix(pub Denomination);
+pub struct SpendableNoteAmountPrefix(pub Account, pub Denomination);
 
 impl_db_record!(
     key = SpendableNoteKey,
@@ -51,8 +57,9 @@ pub struct RecoveryState {
     /// Total items (for progress calculation)
     pub total_items: u64,
     /// Already recovered note requests, keyed by `nonce_hash` (for efficient
-    /// removal when inputs are seen)
-    pub requests: BTreeMap<hash160::Hash, NoteIssuanceRequest>,
+    /// removal when inputs are seen), each with the account whose subtree
+    /// re-derived it.
+    pub requests: BTreeMap<hash160::Hash, (Account, NoteIssuanceRequest)>,
     /// Nonces seen (to detect duplicates)
     pub nonces: BTreeSet<hash160::Hash>,
 }

--- a/modules/fedimint-mintv2-client/src/events.rs
+++ b/modules/fedimint-mintv2-client/src/events.rs
@@ -1,5 +1,5 @@
 use fedimint_core::Amount;
-use fedimint_core::core::{ModuleKind, OperationId};
+use fedimint_core::core::{Account, ModuleKind, OperationId};
 use fedimint_eventlog::{Event, EventKind, EventPersistence};
 use fedimint_mintv2_common::KIND;
 use serde::{Deserialize, Serialize};
@@ -10,6 +10,11 @@ use serde::{Deserialize, Serialize};
 pub struct SendPaymentEvent {
     pub operation_id: OperationId,
     pub amount: Amount,
+    /// Balance the notes left. Defaulted rather than required, so entries
+    /// written before accounts existed still decode — they can only have been
+    /// the one account there was.
+    #[serde(default = "Account::primary")]
+    pub account: Account,
     pub ecash: String,
 }
 
@@ -24,6 +29,10 @@ impl Event for SendPaymentEvent {
 pub struct ReceivePaymentEvent {
     pub operation_id: OperationId,
     pub amount: Amount,
+    /// Balance the notes are reissued into. See [`SendPaymentEvent::account`]
+    /// for why it is defaulted.
+    #[serde(default = "Account::primary")]
+    pub account: Account,
 }
 
 impl Event for ReceivePaymentEvent {
@@ -46,6 +55,12 @@ pub enum ReceivePaymentStatus {
 pub struct ReceivePaymentUpdateEvent {
     pub operation_id: OperationId,
     pub status: ReceivePaymentStatus,
+    /// Balance the operation acts on, repeated from the initiating event so a
+    /// consumer can filter the final state by account without joining on the
+    /// operation id. Defaulted so entries written before accounts existed
+    /// still decode.
+    #[serde(default = "Account::primary")]
+    pub account: Account,
 }
 
 impl Event for ReceivePaymentUpdateEvent {

--- a/modules/fedimint-mintv2-client/src/issuance.rs
+++ b/modules/fedimint-mintv2-client/src/issuance.rs
@@ -1,4 +1,6 @@
 use bitcoin_hashes::{Hash, hash160, sha256};
+use fedimint_client_module::secret::DeriveableSecretClientExt;
+use fedimint_core::core::Account;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::secp256k1::rand::Rng;
 use fedimint_core::secp256k1::{Keypair, PublicKey, SECP256K1};
@@ -17,8 +19,13 @@ pub struct NoteIssuanceRequest {
 }
 
 impl NoteIssuanceRequest {
-    pub fn new(denomination: Denomination, tweak: [u8; 16], root_secret: &DerivableSecret) -> Self {
-        let secret = output_secret(denomination, tweak, root_secret);
+    pub fn new(
+        account: Account,
+        denomination: Denomination,
+        tweak: [u8; 16],
+        root_secret: &DerivableSecret,
+    ) -> Self {
+        let secret = output_secret(account, denomination, tweak, root_secret);
 
         Self {
             denomination,
@@ -47,6 +54,14 @@ impl NoteIssuanceRequest {
 
 // ============ Grinding Functions ============
 
+/// Deliberately derived from the module root rather than from an account's
+/// subtree, so every account grinds against the same filter.
+///
+/// One pre-grinder therefore serves the whole wallet instead of one per
+/// account, and a recovery still runs a single [`check_tweak`] per output —
+/// only the ~1/65536 that pass it are then tried against each account's
+/// nonces. It also leaves the filter of a wallet that predates accounts
+/// byte-for-byte what it was.
 pub fn tweak_filter(root_secret: &DerivableSecret) -> [u8; 32] {
     root_secret.to_random_bytes()
 }
@@ -83,12 +98,14 @@ pub fn check_nonce(secret: &OutputSecret, nonce_hash: hash160::Hash) -> bool {
 pub struct OutputSecret(DerivableSecret);
 
 pub fn output_secret(
+    account: Account,
     denomination: Denomination,
     tweak: [u8; 16],
     root: &DerivableSecret,
 ) -> OutputSecret {
     OutputSecret(
-        root.child_key(ChildId(u64::from(denomination.0)))
+        root.derive_account_secret(account)
+            .child_key(ChildId(u64::from(denomination.0)))
             .tweak(&tweak),
     )
 }

--- a/modules/fedimint-mintv2-client/src/lib.rs
+++ b/modules/fedimint-mintv2-client/src/lib.rs
@@ -17,6 +17,7 @@ mod ecash;
 mod events;
 mod input;
 pub mod issuance;
+mod migrations;
 mod output;
 mod receive;
 
@@ -42,13 +43,13 @@ use fedimint_client_module::module::init::{
 };
 use fedimint_client_module::module::recovery::{NoModuleBackup, RecoveryProgress};
 use fedimint_client_module::module::{
-    ClientContext, OutPointRange, PrimaryModulePriority, PrimaryModuleSupport,
+    AccountSupport, ClientContext, OutPointRange, PrimaryModulePriority, PrimaryModuleSupport,
 };
 use fedimint_client_module::sm::{Context, DynState, ModuleNotifier, State, StateTransition};
 use fedimint_client_module::{DynGlobalClientContext, sm_enum_variant_translation};
 use fedimint_core::base32::{self, FEDIMINT_PREFIX};
 use fedimint_core::config::FederationId;
-use fedimint_core::core::{IntoDynInstance, ModuleInstanceId, ModuleKind, OperationId};
+use fedimint_core::core::{Account, IntoDynInstance, ModuleInstanceId, ModuleKind, OperationId};
 use fedimint_core::db::{DatabaseTransaction, DatabaseVersion, IDatabaseTransactionOpsCoreTyped};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::{
@@ -251,6 +252,8 @@ impl ClientModuleInit for MintClientInit {
         // runs ahead of it instead, and the items are put back in order below.
         .buffer_unordered(PARALLEL_SLICE_REQUESTS);
 
+        // One filter for the whole wallet, so a candidate is found in a single
+        // pass and only then tried against each account's nonces.
         let tweak_filter = issuance::tweak_filter(args.module_root_secret());
 
         // Slices that arrived before the ones in front of them. An input
@@ -283,31 +286,46 @@ impl ClientModuleInit for MintClientInit {
                         if !issuance::check_tweak(*tweak, tweak_filter) {
                             continue;
                         }
-                        let output_secret = issuance::output_secret(
-                            *denomination,
-                            *tweak,
-                            args.module_root_secret(),
-                        );
 
-                        if !issuance::check_nonce(&output_secret, *nonce_hash) {
-                            continue;
-                        }
-
-                        let computed_nonce_hash = issuance::nonce(&output_secret).consensus_hash();
-
-                        // Ignore possible duplicate nonces
-                        if !state.nonces.insert(computed_nonce_hash) {
-                            continue;
-                        }
-
-                        state.requests.insert(
-                            computed_nonce_hash,
-                            NoteIssuanceRequest::new(
+                        // Only the ~1/65536 of outputs that pass the filter get
+                        // here, so trying every account costs a handful of
+                        // derivations per candidate rather than per output.
+                        for account in Account::ALL {
+                            let output_secret = issuance::output_secret(
+                                account,
                                 *denomination,
                                 *tweak,
                                 args.module_root_secret(),
-                            ),
-                        );
+                            );
+
+                            if !issuance::check_nonce(&output_secret, *nonce_hash) {
+                                continue;
+                            }
+
+                            let computed_nonce_hash =
+                                issuance::nonce(&output_secret).consensus_hash();
+
+                            // Ignore possible duplicate nonces
+                            if !state.nonces.insert(computed_nonce_hash) {
+                                continue;
+                            }
+
+                            state.requests.insert(
+                                computed_nonce_hash,
+                                (
+                                    account,
+                                    NoteIssuanceRequest::new(
+                                        account,
+                                        *denomination,
+                                        *tweak,
+                                        args.module_root_secret(),
+                                    ),
+                                ),
+                            );
+
+                            // A nonce belongs to exactly one account.
+                            break;
+                        }
                     }
                     RecoveryItem::Input { nonce_hash } => {
                         state.requests.remove(nonce_hash);
@@ -327,22 +345,42 @@ impl ClientModuleInit for MintClientInit {
                 let recovered_amount = state
                     .requests
                     .values()
-                    .map(|request| request.denomination.amount())
+                    .map(|(_, request)| request.denomination.amount())
                     .sum::<Amount>();
 
-                let state_machines = args
-                    .context()
-                    .map_dyn(vec![MintClientStateMachines::Output(
-                        MintOutputStateMachine {
-                            common: OutputSMCommon {
-                                operation_id: OperationId::new_random(),
-                                range: None,
-                                issuance_requests: state.requests.into_values().collect(),
-                            },
-                            state: OutputSMState::Pending,
+                // A state machine credits its notes to its operation's
+                // account, so the scan's requests are split by account into
+                // one operation each, with the account recorded up front.
+                let mut requests_by_account: BTreeMap<Account, Vec<NoteIssuanceRequest>> =
+                    BTreeMap::new();
+
+                for (account, request) in state.requests.into_values() {
+                    requests_by_account
+                        .entry(account)
+                        .or_default()
+                        .push(request);
+                }
+
+                let mut state_machines = Vec::new();
+
+                for (account, issuance_requests) in requests_by_account {
+                    let operation_id = OperationId::new_random();
+
+                    args.context()
+                        .set_operation_account_dbtx(&mut dbtx.to_ref_nc(), operation_id, account)
+                        .await;
+
+                    state_machines.push(MintClientStateMachines::Output(MintOutputStateMachine {
+                        common: OutputSMCommon {
+                            operation_id,
+                            range: None,
+                            issuance_requests,
                         },
-                    )])
-                    .collect();
+                        state: OutputSMState::Pending,
+                    }));
+                }
+
+                let state_machines = args.context().map_dyn(state_machines).collect();
 
                 args.context()
                     .add_state_machines_dbtx(&mut dbtx.to_ref_nc(), state_machines)
@@ -402,7 +440,13 @@ impl ClientModuleInit for MintClientInit {
     }
 
     fn get_database_migrations(&self) -> BTreeMap<DatabaseVersion, ClientModuleMigrationFn> {
-        BTreeMap::new()
+        let mut migrations: BTreeMap<DatabaseVersion, ClientModuleMigrationFn> = BTreeMap::new();
+
+        migrations.insert(DatabaseVersion(0), |dbtx, active, inactive| {
+            Box::pin(migrations::migrate_to_accounts_v1(dbtx, active, inactive))
+        });
+
+        migrations
     }
 }
 
@@ -479,7 +523,11 @@ impl ClientModule for MintClientModule {
     }
 
     fn supports_being_primary(&self) -> PrimaryModuleSupport {
-        PrimaryModuleSupport::selected(PrimaryModulePriority::HIGH, [self.cfg.amount_unit])
+        PrimaryModuleSupport::selected(
+            PrimaryModulePriority::HIGH,
+            [self.cfg.amount_unit],
+            AccountSupport::All,
+        )
     }
 
     async fn create_final_inputs_and_outputs(
@@ -489,6 +537,7 @@ impl ClientModule for MintClientModule {
         unit: AmountUnit,
         mut input_amount: Amount,
         mut output_amount: Amount,
+        account: Account,
     ) -> anyhow::Result<(
         ClientInputBundle<MintInput, MintClientStateMachines>,
         ClientOutputBundle<MintOutput, MintClientStateMachines>,
@@ -498,12 +547,12 @@ impl ClientModule for MintClientModule {
         }
 
         let funding_notes = self
-            .select_funding_input(dbtx, output_amount.saturating_sub(input_amount))
+            .select_funding_input(dbtx, account, output_amount.saturating_sub(input_amount))
             .await
             .context("Insufficient funds")?;
 
         for note in &funding_notes {
-            self.remove_spendable_note(dbtx, note).await;
+            self.remove_spendable_note(dbtx, account, note).await;
         }
 
         input_amount += funding_notes.iter().map(SpendableNote::amount).sum();
@@ -516,11 +565,16 @@ impl ClientModule for MintClientModule {
         assert!(output_amount <= input_amount);
 
         let (input_notes, output_amounts) = self
-            .rebalance(dbtx, &self.cfg.fee_consensus, input_amount - output_amount)
+            .rebalance(
+                dbtx,
+                account,
+                &self.cfg.fee_consensus,
+                input_amount - output_amount,
+            )
             .await;
 
         for note in &input_notes {
-            self.remove_spendable_note(dbtx, note).await;
+            self.remove_spendable_note(dbtx, account, note).await;
         }
 
         input_amount += input_notes.iter().map(SpendableNote::amount).sum();
@@ -561,7 +615,9 @@ impl ClientModule for MintClientModule {
         // We sort the amounts to minimize the leaked information.
         denominations.sort();
 
-        let output_bundle = self.create_output_bundle(operation_id, denominations).await;
+        let output_bundle = self
+            .create_output_bundle(account, operation_id, denominations)
+            .await;
 
         let sender = self.balance_update_sender.clone();
         dbtx.on_commit(move || sender.send_replace(()));
@@ -577,12 +633,17 @@ impl ClientModule for MintClientModule {
         self.await_output_sm_success(operation_id, outpoint).await
     }
 
-    async fn get_balance(&self, dbtx: &mut DatabaseTransaction<'_>, unit: AmountUnit) -> Amount {
+    async fn get_balance(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        unit: AmountUnit,
+        account: Account,
+    ) -> Amount {
         if unit != self.cfg.amount_unit {
             return Amount::ZERO;
         }
 
-        self.get_count_by_denomination_dbtx(dbtx)
+        self.get_count_by_denomination_dbtx(dbtx, account)
             .await
             .into_iter()
             .map(|(denomination, count)| denomination.amount().mul_u64(count))
@@ -600,6 +661,7 @@ impl MintClientModule {
     async fn select_funding_input(
         &self,
         dbtx: &mut DatabaseTransaction<'_>,
+        account: Account,
         mut excess_output: Amount,
     ) -> Option<Vec<SpendableNote>> {
         let mut selected_notes = Vec::new();
@@ -608,9 +670,9 @@ impl MintClientModule {
 
         for amount in client_denominations().rev() {
             let notes_amount = dbtx
-                .find_by_prefix(&SpendableNoteAmountPrefix(amount))
+                .find_by_prefix(&SpendableNoteAmountPrefix(account, amount))
                 .await
-                .map(|entry| entry.0.0)
+                .map(|entry| entry.0.1)
                 .collect::<Vec<SpendableNote>>()
                 .await;
 
@@ -659,15 +721,16 @@ impl MintClientModule {
     async fn rebalance(
         &self,
         dbtx: &mut DatabaseTransaction<'_>,
+        account: Account,
         fee: &FeeConsensus,
         mut excess_input: Amount,
     ) -> (Vec<SpendableNote>, Vec<Denomination>) {
-        let n_denominations = self.get_count_by_denomination_dbtx(dbtx).await;
+        let n_denominations = self.get_count_by_denomination_dbtx(dbtx, account).await;
 
         let mut notes = dbtx
-            .find_by_prefix_sorted_descending(&SpendableNotePrefix)
+            .find_by_prefix_sorted_descending(&SpendableNotePrefix(account))
             .await
-            .map(|entry| entry.0.0)
+            .map(|entry| entry.0.1)
             .fuse();
 
         let mut input_notes = Vec::new();
@@ -757,12 +820,13 @@ impl MintClientModule {
     /// background grinder task.
     async fn create_output_bundle(
         &self,
+        account: Account,
         operation_id: OperationId,
         requested_denominations: Vec<Denomination>,
     ) -> ClientOutputBundle<MintOutput, MintClientStateMachines> {
         let issuance_requests = futures::stream::iter(requested_denominations)
             .zip(self.tweak_receiver.clone())
-            .map(|(d, tweak)| NoteIssuanceRequest::new(d, tweak, &self.root_secret))
+            .map(|(d, tweak)| NoteIssuanceRequest::new(account, d, tweak, &self.root_secret))
             .collect::<Vec<NoteIssuanceRequest>>()
             .await;
 
@@ -831,10 +895,11 @@ impl MintClientModule {
         stream.next_or_pending().await
     }
 
-    /// Count the `ECash` notes in the client's database by denomination.
-    pub async fn get_count_by_denomination(&self) -> BTreeMap<Denomination, u64> {
+    /// Count the `ECash` notes an account holds by denomination.
+    pub async fn get_count_by_denomination(&self, account: Account) -> BTreeMap<Denomination, u64> {
         self.get_count_by_denomination_dbtx(
             &mut self.client_ctx.module_db().begin_transaction_nc().await,
+            account,
         )
         .await
     }
@@ -842,11 +907,12 @@ impl MintClientModule {
     async fn get_count_by_denomination_dbtx(
         &self,
         dbtx: &mut DatabaseTransaction<'_>,
+        account: Account,
     ) -> BTreeMap<Denomination, u64> {
-        dbtx.find_by_prefix(&SpendableNotePrefix)
+        dbtx.find_by_prefix(&SpendableNotePrefix(account))
             .await
             .fold(BTreeMap::new(), |mut acc, entry| async move {
-                acc.entry(entry.0.0.denomination)
+                acc.entry(entry.0.1.denomination)
                     .and_modify(|count| *count += 1)
                     .or_insert(1);
 
@@ -882,6 +948,7 @@ impl MintClientModule {
     /// submitted it completes on its own and the notes return to the balance.
     pub async fn send(
         &self,
+        account: Account,
         amount: Amount,
         custom_meta: Value,
         include_invite: bool,
@@ -895,6 +962,7 @@ impl MintClientModule {
                 |dbtx, _| {
                     Box::pin(self.send_ecash_dbtx(
                         dbtx,
+                        account,
                         amount,
                         custom_meta.clone(),
                         include_invite,
@@ -917,7 +985,7 @@ impl MintClientModule {
         let operation_id = OperationId::new_random();
 
         let output = self
-            .create_output_bundle(operation_id, represent_amount(amount))
+            .create_output_bundle(account, operation_id, represent_amount(amount))
             .await;
         let output = self.client_ctx.make_client_outputs(output);
         let cm = custom_meta.clone();
@@ -932,7 +1000,7 @@ impl MintClientModule {
                     amount,
                     custom_meta: cm.clone(),
                 },
-                TransactionBuilder::new().with_outputs(output),
+                TransactionBuilder::new(account).with_outputs(output),
             )
             .await
             .map_err(|_| SendECashError::InsufficientBalance)?;
@@ -943,7 +1011,7 @@ impl MintClientModule {
                 .map_err(|_| SendECashError::Failure)?;
         }
 
-        Box::pin(self.send(amount, custom_meta, include_invite)).await
+        Box::pin(self.send(account, amount, custom_meta, include_invite)).await
     }
 
     /// Fast path for [`Self::send`]: if exact change is already held, spend
@@ -959,19 +1027,40 @@ impl MintClientModule {
     async fn send_ecash_dbtx(
         &self,
         dbtx: &mut DatabaseTransaction<'_>,
+        account: Account,
         remaining_amount: Amount,
         custom_meta: Value,
         include_invite: bool,
     ) -> Result<Option<(OperationId, ECash)>, Infallible> {
-        let Some(notes) = Self::select_exact_change(&mut dbtx.to_ref_nc(), remaining_amount).await
+        let Some(notes) =
+            Self::select_exact_change(&mut dbtx.to_ref_nc(), account, remaining_amount).await
         else {
             return Ok(None);
         };
 
         for spendable_note in &notes {
-            self.remove_spendable_note(dbtx, spendable_note).await;
+            self.remove_spendable_note(dbtx, account, spendable_note)
+                .await;
         }
 
+        Ok(Some(
+            self.record_send(dbtx, account, notes, custom_meta, include_invite)
+                .await,
+        ))
+    }
+
+    /// Bundle notes already removed from `account` and record the send: the
+    /// operation log entry, the event and the balance ping. Shared by the
+    /// exact-change [`Self::send`] and by [`Self::send_max`], which differ only
+    /// in how they pick the notes.
+    async fn record_send(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        account: Account,
+        notes: Vec<SpendableNote>,
+        custom_meta: Value,
+        include_invite: bool,
+    ) -> (OperationId, ECash) {
         let ecash = if include_invite {
             let invite = self.client_ctx.get_invite_code().await;
             ECash::new_with_invite(notes, &invite)
@@ -985,6 +1074,7 @@ impl MintClientModule {
             .add_operation_log_entry_dbtx(
                 dbtx,
                 operation_id,
+                account,
                 MintCommonInit::KIND.as_str(),
                 MintOperationMeta::Send {
                     ecash: base32::encode_prefixed(FEDIMINT_PREFIX, &ecash),
@@ -999,6 +1089,7 @@ impl MintClientModule {
                 SendPaymentEvent {
                     operation_id,
                     amount,
+                    account,
                     ecash: base32::encode_prefixed(FEDIMINT_PREFIX, &ecash),
                 },
             )
@@ -1007,12 +1098,75 @@ impl MintClientModule {
         let sender = self.balance_update_sender.clone();
         dbtx.on_commit(move || sender.send_replace(()));
 
-        Ok(Some((operation_id, ecash)))
+        (operation_id, ecash)
+    }
+
+    /// Hand out everything `account` holds as one note bundle, or `None` if it
+    /// holds nothing.
+    ///
+    /// Not [`Self::send`] with the account's balance as its amount: a send
+    /// rounds up to a whole denomination and takes its free path only when the
+    /// notes sum to that amount exactly, which a figure in whole sats
+    /// generally is not. Missing the free path drops the send onto the path
+    /// that builds a real transaction, which covers its fee out of the same
+    /// account, so asking for everything fails on the balance the user is
+    /// looking at.
+    ///
+    /// This is how funds move between accounts: `send_max` one, then
+    /// [`Self::receive`] the bundle into another, which reissues the notes to
+    /// the destination's own nonces so a later recovery finds them where they
+    /// now are.
+    pub async fn send_max(
+        &self,
+        account: Account,
+        custom_meta: Value,
+        include_invite: bool,
+    ) -> Option<(OperationId, ECash)> {
+        self.client_ctx
+            .module_db()
+            .autocommit(
+                |dbtx, _| {
+                    Box::pin(self.send_max_dbtx(dbtx, account, custom_meta.clone(), include_invite))
+                },
+                Some(100),
+            )
+            .await
+            .expect("Failed to commit dbtx after 100 retries")
+    }
+
+    async fn send_max_dbtx(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        account: Account,
+        custom_meta: Value,
+        include_invite: bool,
+    ) -> Result<Option<(OperationId, ECash)>, Infallible> {
+        let notes = dbtx
+            .find_by_prefix(&SpendableNotePrefix(account))
+            .await
+            .map(|entry| entry.0.1)
+            .collect::<Vec<SpendableNote>>()
+            .await;
+
+        if notes.is_empty() {
+            return Ok(None);
+        }
+
+        for spendable_note in &notes {
+            self.remove_spendable_note(dbtx, account, spendable_note)
+                .await;
+        }
+
+        Ok(Some(
+            self.record_send(dbtx, account, notes, custom_meta, include_invite)
+                .await,
+        ))
     }
 
     /// Receive the `ECash` by reissuing the notes and return the operation ID.
     pub async fn receive(
         &self,
+        account: Account,
         ecash: ECash,
         custom_meta: Value,
     ) -> Result<OperationId, ReceiveECashError> {
@@ -1048,7 +1202,7 @@ impl MintClientModule {
                     ecash: ec.clone(),
                     custom_meta: custom_meta.clone(),
                 },
-                TransactionBuilder::new().with_inputs(input),
+                TransactionBuilder::new(account).with_inputs(input),
             )
             .or_else(|_| async {
                 if self.client_ctx.operation_exists(operation_id).await {
@@ -1067,6 +1221,7 @@ impl MintClientModule {
                 ReceivePaymentEvent {
                     operation_id,
                     amount: ecash.amount(),
+                    account,
                 },
             )
             .await;
@@ -1085,7 +1240,11 @@ impl MintClientModule {
     /// rather than committed, so the client's notes are read but left
     /// untouched. The quote is point-in-time: it depends on the current
     /// inventory and can move as notes change.
-    pub async fn receive_fee_quote(&self, ecash: &ECash) -> anyhow::Result<FeeQuote> {
+    pub async fn receive_fee_quote(
+        &self,
+        account: Account,
+        ecash: &ECash,
+    ) -> anyhow::Result<FeeQuote> {
         // A receive submits the ecash notes as explicit inputs and no explicit
         // outputs; the shared, module-agnostic fee quote runs the primary-module
         // balancing (rebalancing + minting change) over the real inventory.
@@ -1104,6 +1263,7 @@ impl MintClientModule {
                     output_amount: Amounts::ZERO,
                     input_fee: Amounts::new_custom(self.cfg.amount_unit, input_fee),
                     output_fee: Amounts::ZERO,
+                    account,
                 },
             )
             .await
@@ -1122,11 +1282,15 @@ impl MintClientModule {
     /// inputs) via the shared, module-agnostic fee quote over the real
     /// inventory. The quote is point-in-time: it depends on the current
     /// inventory and can move as notes change.
-    pub async fn send_fee_quote(&self, amount: Amount) -> anyhow::Result<FeeQuote> {
+    pub async fn send_fee_quote(
+        &self,
+        account: Account,
+        amount: Amount,
+    ) -> anyhow::Result<FeeQuote> {
         let amount = round_to_multiple(amount, client_denominations().next().unwrap().amount());
 
         // Exact-change path: handing out existing notes never costs a fee.
-        if self.can_make_exact_change(amount).await {
+        if self.can_make_exact_change(account, amount).await {
             return Ok(FeeQuote::ZERO);
         }
 
@@ -1148,6 +1312,7 @@ impl MintClientModule {
                     output_amount: Amounts::new_custom(self.cfg.amount_unit, output_amount),
                     input_fee: Amounts::ZERO,
                     output_fee: Amounts::new_custom(self.cfg.amount_unit, output_fee),
+                    account,
                 },
             )
             .await
@@ -1157,10 +1322,10 @@ impl MintClientModule {
     /// `amount` exactly — the free path in [`Self::send`] — without modifying
     /// the inventory. Shares its greedy selection with
     /// [`Self::send_ecash_dbtx`] via [`Self::select_exact_change`].
-    async fn can_make_exact_change(&self, remaining_amount: Amount) -> bool {
+    async fn can_make_exact_change(&self, account: Account, remaining_amount: Amount) -> bool {
         let mut dbtx = self.client_ctx.module_db().begin_transaction_nc().await;
 
-        Self::select_exact_change(&mut dbtx, remaining_amount)
+        Self::select_exact_change(&mut dbtx, account, remaining_amount)
             .await
             .is_some()
     }
@@ -1172,12 +1337,13 @@ impl MintClientModule {
     /// and [`Self::can_make_exact_change`].
     async fn select_exact_change(
         dbtx: &mut DatabaseTransaction<'_>,
+        account: Account,
         mut remaining_amount: Amount,
     ) -> Option<Vec<SpendableNote>> {
         let mut stream = dbtx
-            .find_by_prefix_sorted_descending(&SpendableNotePrefix)
+            .find_by_prefix_sorted_descending(&SpendableNotePrefix(account))
             .await
-            .map(|entry| entry.0.0);
+            .map(|entry| entry.0.1);
 
         let mut notes = vec![];
 
@@ -1240,9 +1406,10 @@ impl MintClientModule {
     async fn remove_spendable_note(
         &self,
         dbtx: &mut DatabaseTransaction<'_>,
+        account: Account,
         spendable_note: &SpendableNote,
     ) {
-        dbtx.remove_entry(&SpendableNoteKey(spendable_note.clone()))
+        dbtx.remove_entry(&SpendableNoteKey(account, spendable_note.clone()))
             .await
             .expect("Must delete existing spendable note");
     }

--- a/modules/fedimint-mintv2-client/src/migrations.rs
+++ b/modules/fedimint-mintv2-client/src/migrations.rs
@@ -1,0 +1,104 @@
+//! Client database migrations.
+
+use fedimint_core::core::{Account, OperationId};
+use fedimint_core::db::{
+    DatabaseTransaction, DbMigrationError, IDatabaseTransactionOpsCore,
+    IDatabaseTransactionOpsCoreTyped,
+};
+use fedimint_core::encoding::Decodable;
+use fedimint_core::module::registry::ModuleDecoderRegistry;
+use futures::StreamExt;
+
+use crate::SpendableNote;
+use crate::client_db::{DbKeyPrefix, RecoveryState, RecoveryStateKey, SpendableNoteKey};
+
+/// Accounts split the note table, so every note a pre-accounts client wrote is
+/// re-keyed as belonging to [`Account::Primary`] — the only account it could
+/// have meant.
+///
+/// Neither the derivation tree nor the state machines need an equivalent:
+/// primary derives exactly where it always did, so no note has to be
+/// re-issued, and a state machine reads its account off its operation rather
+/// than carrying it, so the ones in flight keep their shape.
+pub(crate) async fn migrate_to_accounts_v1(
+    dbtx: &mut DatabaseTransaction<'_>,
+    _active_states: Vec<(Vec<u8>, OperationId)>,
+    _inactive_states: Vec<(Vec<u8>, OperationId)>,
+) -> Result<Option<(Vec<(Vec<u8>, OperationId)>, Vec<(Vec<u8>, OperationId)>)>, DbMigrationError> {
+    // Read raw: the old key is the note alone, so decoding one through the
+    // current two-field key would read the note's leading denomination byte as
+    // an account and fail. The rows are rewritten rather than edited in place.
+    let prefix = vec![DbKeyPrefix::Note as u8];
+
+    let notes = dbtx
+        .raw_find_by_prefix(&prefix)
+        .await?
+        .map(|(key, _)| key)
+        .collect::<Vec<Vec<u8>>>()
+        .await;
+
+    for key in notes {
+        let note = SpendableNote::consensus_decode_whole(
+            &key[prefix.len()..],
+            &ModuleDecoderRegistry::default(),
+        )?;
+
+        dbtx.raw_remove_entry(&key).await?;
+
+        dbtx.insert_new_entry(&SpendableNoteKey(Account::Primary, note), &())
+            .await;
+    }
+
+    // Recovery keeps its scanned requests tagged with an account now. A
+    // pre-accounts checkpoint can only have scanned primary's subtree, so it
+    // is carried over with every request tagged primary and its progress
+    // intact. Restarting the scan from zero instead would re-derive the notes
+    // a client in usable recovery has minted since the scan's bound and try
+    // to insert them a second time.
+    if let Some(state) = dbtx.remove_entry(&legacy::RecoveryStateKey).await {
+        let state = RecoveryState {
+            next_index: state.next_index,
+            total_items: state.total_items,
+            requests: state
+                .requests
+                .into_iter()
+                .map(|(nonce_hash, request)| (nonce_hash, (Account::Primary, request)))
+                .collect(),
+            nonces: state.nonces,
+        };
+
+        dbtx.insert_new_entry(&RecoveryStateKey, &state).await;
+    }
+
+    Ok(None)
+}
+
+/// The shape the recovery checkpoint had before its requests carried an
+/// account.
+mod legacy {
+    use std::collections::{BTreeMap, BTreeSet};
+
+    use bitcoin_hashes::hash160;
+    use fedimint_core::encoding::{Decodable, Encodable};
+    use fedimint_core::impl_db_record;
+
+    use crate::client_db::DbKeyPrefix;
+    use crate::issuance::NoteIssuanceRequest;
+
+    #[derive(Debug, Clone, Encodable, Decodable)]
+    pub struct RecoveryStateKey;
+
+    #[derive(Debug, Clone, Encodable, Decodable)]
+    pub struct RecoveryState {
+        pub next_index: u64,
+        pub total_items: u64,
+        pub requests: BTreeMap<hash160::Hash, NoteIssuanceRequest>,
+        pub nonces: BTreeSet<hash160::Hash>,
+    }
+
+    impl_db_record!(
+        key = RecoveryStateKey,
+        value = RecoveryState,
+        db_prefix = DbKeyPrefix::RecoveryState,
+    );
+}

--- a/modules/fedimint-mintv2-client/src/output.rs
+++ b/modules/fedimint-mintv2-client/src/output.rs
@@ -53,6 +53,7 @@ impl State for MintOutputStateMachine {
         global_context: &DynGlobalClientContext,
     ) -> Vec<StateTransition<Self>> {
         let context = context.clone();
+        let global_context = global_context.clone();
 
         match &self.state {
             OutputSMState::Pending => {
@@ -70,6 +71,7 @@ impl State for MintOutputStateMachine {
                             .on_commit(move || balance_update_sender.send_replace(()));
 
                         Box::pin(Self::transition_outcome_ready(
+                            global_context.clone(),
                             dbtx,
                             signature_shares,
                             old_state,
@@ -116,6 +118,7 @@ impl MintOutputStateMachine {
     }
 
     async fn transition_outcome_ready(
+        global_context: DynGlobalClientContext,
         dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
         signature_shares: Result<BTreeMap<PeerId, Vec<BlindedSignatureShare>>, String>,
         old_state: MintOutputStateMachine,
@@ -127,6 +130,9 @@ impl MintOutputStateMachine {
                 state: OutputSMState::Aborted,
             };
         };
+
+        // The notes land in the operation's account, whichever that is.
+        let account = global_context.account(dbtx).await;
 
         for (i, request) in old_state.common.issuance_requests.iter().enumerate() {
             let agg_blind_signature = aggregate_signature_shares(
@@ -150,7 +156,7 @@ impl MintOutputStateMachine {
             }
 
             dbtx.module_tx()
-                .insert_new_entry(&SpendableNoteKey(spendable_note), &())
+                .insert_new_entry(&SpendableNoteKey(account, spendable_note), &())
                 .await;
         }
 

--- a/modules/fedimint-mintv2-client/src/receive.rs
+++ b/modules/fedimint-mintv2-client/src/receive.rs
@@ -45,6 +45,7 @@ impl State for ReceiveStateMachine {
         global_context: &DynGlobalClientContext,
     ) -> Vec<StateTransition<Self>> {
         let client_ctx = context.client_ctx.clone();
+        let global_context = global_context.clone();
 
         match &self.state {
             ReceiveSMState::Pending => vec![StateTransition::new(
@@ -52,6 +53,7 @@ impl State for ReceiveStateMachine {
                 move |dbtx, result, old_state| {
                     Box::pin(Self::transition_tx_outcome(
                         client_ctx.clone(),
+                        global_context.clone(),
                         dbtx,
                         result,
                         old_state,
@@ -77,10 +79,13 @@ impl ReceiveStateMachine {
 
     async fn transition_tx_outcome(
         client_ctx: ClientContext<MintClientModule>,
+        global_context: DynGlobalClientContext,
         dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
         result: Result<(), String>,
         old_state: ReceiveStateMachine,
     ) -> ReceiveStateMachine {
+        let account = global_context.account(dbtx).await;
+
         let (status, new_state) = match result {
             Ok(()) => (ReceivePaymentStatus::Success, ReceiveSMState::Success),
             Err(e) => (ReceivePaymentStatus::Rejected, ReceiveSMState::Rejected(e)),
@@ -92,6 +97,7 @@ impl ReceiveStateMachine {
                 ReceivePaymentUpdateEvent {
                     operation_id: old_state.common.operation_id,
                     status,
+                    account,
                 },
             )
             .await;

--- a/modules/fedimint-mintv2-tests/tests/tests.rs
+++ b/modules/fedimint-mintv2-tests/tests/tests.rs
@@ -8,7 +8,7 @@ use fedimint_client::{ClientHandleArc, ModuleRecoveryCompleted, RootSecret};
 use fedimint_core::Amount;
 use fedimint_core::base32::{self, FEDIMINT_PREFIX};
 use fedimint_core::config::FederationId;
-use fedimint_core::core::OperationId;
+use fedimint_core::core::{Account, OperationId};
 use fedimint_core::db::mem_impl::MemDatabase;
 use fedimint_core::module::Amounts;
 use fedimint_core::secp256k1::{Keypair, SECP256K1};
@@ -93,7 +93,7 @@ async fn issue_ecash(client: &ClientHandleArc, amount: Amount) -> anyhow::Result
             operation_id,
             "Issue e-cash via dummy module",
             |_| (),
-            TransactionBuilder::new().with_inputs(dummy_input),
+            TransactionBuilder::new(Account::Primary).with_inputs(dummy_input),
         )
         .await?;
 
@@ -136,7 +136,12 @@ async fn send_and_receive() -> anyhow::Result<()> {
 
         let (operation_id, ecash) = client_send
             .get_first_module::<MintClientModule>()?
-            .send(Amount::from_sats(1_000), Value::Null, include_invite)
+            .send(
+                Account::Primary,
+                Amount::from_sats(1_000),
+                Value::Null,
+                include_invite,
+            )
             .await?;
 
         let Some(MintEvent::Send(send)) = send_events.next().await else {
@@ -160,7 +165,7 @@ async fn send_and_receive() -> anyhow::Result<()> {
 
         let operation_id = client_receive
             .get_first_module::<MintClientModule>()?
-            .receive(ecash, Value::Null)
+            .receive(Account::Primary, ecash, Value::Null)
             .await?;
 
         let state = client_receive
@@ -185,7 +190,7 @@ async fn send_and_receive() -> anyhow::Result<()> {
         test_client_recovery(&fed, &client_receive, root_secret(&RECEIVE_SK)).await?;
     }
 
-    ensure!(client_receive.get_balance_for_btc().await? >= Amount::from_sats(9900));
+    ensure!(client_receive.get_balance_for_btc(Account::Primary).await? >= Amount::from_sats(9900));
 
     Ok(())
 }
@@ -210,7 +215,12 @@ async fn receive_fee_quote_matches_actual_fee() -> anyhow::Result<()> {
     for i in 0..5 {
         let (_operation_id, ecash) = client_send
             .get_first_module::<MintClientModule>()?
-            .send(Amount::from_sats(1_000), Value::Null, false)
+            .send(
+                Account::Primary,
+                Amount::from_sats(1_000),
+                Value::Null,
+                false,
+            )
             .await?;
         let ecash: ECash = base32::decode_prefixed(
             FEDIMINT_PREFIX,
@@ -221,10 +231,10 @@ async fn receive_fee_quote_matches_actual_fee() -> anyhow::Result<()> {
         let mint = client_receive.get_first_module::<MintClientModule>()?;
         let ecash_value = ecash.amount();
 
-        let quote = mint.receive_fee_quote(&ecash).await?;
-        let before = client_receive.get_balance_for_btc().await?;
+        let quote = mint.receive_fee_quote(Account::Primary, &ecash).await?;
+        let before = client_receive.get_balance_for_btc(Account::Primary).await?;
 
-        let operation_id = mint.receive(ecash, Value::Null).await?;
+        let operation_id = mint.receive(Account::Primary, ecash, Value::Null).await?;
         let state = mint
             .await_final_receive_operation_state(operation_id)
             .await?;
@@ -252,7 +262,7 @@ async fn receive_fee_quote_matches_actual_fee() -> anyhow::Result<()> {
             )
             .await?;
 
-        let after = client_receive.get_balance_for_btc().await?;
+        let after = client_receive.get_balance_for_btc(Account::Primary).await?;
         let actual_fee = ecash_value - (after - before);
 
         ensure!(
@@ -285,18 +295,25 @@ async fn send_fee_quote_matches_actual_fee() -> anyhow::Result<()> {
         // the send observe the same inventory.
         client.wait_for_all_active_state_machines().await?;
 
-        let quote = mint.send_fee_quote(Amount::from_sats(1_000)).await?;
-        let before = client.get_balance_for_btc().await?;
+        let quote = mint
+            .send_fee_quote(Account::Primary, Amount::from_sats(1_000))
+            .await?;
+        let before = client.get_balance_for_btc(Account::Primary).await?;
 
         let (_operation_id, ecash) = mint
-            .send(Amount::from_sats(1_000), Value::Null, false)
+            .send(
+                Account::Primary,
+                Amount::from_sats(1_000),
+                Value::Null,
+                false,
+            )
             .await?;
         let sent_value = ecash.amount();
 
         // A send may trigger an internal reissue whose change notes are credited
         // by output state machines; wait for them before reading the balance.
         client.wait_for_all_active_state_machines().await?;
-        let after = client.get_balance_for_btc().await?;
+        let after = client.get_balance_for_btc(Account::Primary).await?;
 
         // Value conservation: the wallet loses exactly the sent value plus the fee.
         let actual_fee = before - after - sent_value;
@@ -356,7 +373,7 @@ async fn test_client_recovery(
     // Wait for state machines to complete
     client.wait_for_all_active_state_machines().await?;
 
-    let expected_balance = client.get_balance_for_btc().await?;
+    let expected_balance = client.get_balance_for_btc(Account::Primary).await?;
 
     assert_ne!(expected_balance, Amount::ZERO);
 
@@ -391,7 +408,9 @@ async fn test_client_recovery(
         .wait_for_all_active_state_machines()
         .await?;
 
-    let recovered_balance = recovering_client.get_balance_for_btc().await?;
+    let recovered_balance = recovering_client
+        .get_balance_for_btc(Account::Primary)
+        .await?;
 
     ensure!(
         recovered_balance == expected_balance,
@@ -406,7 +425,9 @@ async fn test_client_recovery(
 
     reopened_client.wait_for_all_active_state_machines().await?;
 
-    let reopened_balance = reopened_client.get_balance_for_btc().await?;
+    let reopened_balance = reopened_client
+        .get_balance_for_btc(Account::Primary)
+        .await?;
 
     ensure!(
         reopened_balance == expected_balance,
@@ -430,7 +451,12 @@ async fn double_spend_is_rejected() -> anyhow::Result<()> {
 
     let (send_operation_id, ecash) = client_send
         .get_first_module::<MintClientModule>()?
-        .send(Amount::from_sats(1_000), Value::Null, false)
+        .send(
+            Account::Primary,
+            Amount::from_sats(1_000),
+            Value::Null,
+            false,
+        )
         .await?;
 
     let Some(MintEvent::Send(send)) = send_events.next().await else {
@@ -440,7 +466,7 @@ async fn double_spend_is_rejected() -> anyhow::Result<()> {
 
     let operation_id = client_send
         .get_first_module::<MintClientModule>()?
-        .receive(ecash.clone(), Value::Null)
+        .receive(Account::Primary, ecash.clone(), Value::Null)
         .await?;
 
     let state = client_send
@@ -463,7 +489,7 @@ async fn double_spend_is_rejected() -> anyhow::Result<()> {
 
     let operation_id = client_receive
         .get_first_module::<MintClientModule>()?
-        .receive(ecash, Value::Null)
+        .receive(Account::Primary, ecash, Value::Null)
         .await?;
 
     let state = client_receive
@@ -500,7 +526,12 @@ async fn transaction_with_invalid_signature_is_rejected() -> anyhow::Result<()> 
 
     let (operation_id, ecash) = client
         .get_first_module::<MintClientModule>()?
-        .send(Amount::from_sats(1_000), Value::Null, false)
+        .send(
+            Account::Primary,
+            Amount::from_sats(1_000),
+            Value::Null,
+            false,
+        )
         .await?;
 
     let Some(MintEvent::Send(send)) = events.next().await else {
@@ -518,7 +549,7 @@ async fn transaction_with_invalid_signature_is_rejected() -> anyhow::Result<()> 
 
     let operation_id = client
         .get_first_module::<MintClientModule>()?
-        .receive(invalid_ecash, Value::Null)
+        .receive(Account::Primary, invalid_ecash, Value::Null)
         .await?;
 
     let state = client
@@ -543,7 +574,7 @@ async fn transaction_with_invalid_signature_is_rejected() -> anyhow::Result<()> 
 
     let operation_id = client
         .get_first_module::<MintClientModule>()?
-        .receive(valid_ecash, Value::Null)
+        .receive(Account::Primary, valid_ecash, Value::Null)
         .await?;
 
     let state = client
@@ -577,7 +608,12 @@ async fn receive_rejects_ecash_from_another_federation() -> anyhow::Result<()> {
 
     let (_operation_id, ecash) = client
         .get_first_module::<MintClientModule>()?
-        .send(Amount::from_sats(1_000), Value::Null, false)
+        .send(
+            Account::Primary,
+            Amount::from_sats(1_000),
+            Value::Null,
+            false,
+        )
         .await?;
 
     // Re-wrap the same notes under a federation id that is not ours. `receive`
@@ -587,7 +623,7 @@ async fn receive_rejects_ecash_from_another_federation() -> anyhow::Result<()> {
     assert_eq!(
         client
             .get_first_module::<MintClientModule>()?
-            .receive(foreign_ecash, Value::Null)
+            .receive(Account::Primary, foreign_ecash, Value::Null)
             .await,
         Err(ReceiveECashError::WrongFederation),
     );
@@ -605,12 +641,17 @@ async fn receiving_the_same_ecash_twice_is_rejected() -> anyhow::Result<()> {
 
     let (_operation_id, ecash) = client
         .get_first_module::<MintClientModule>()?
-        .send(Amount::from_sats(1_000), Value::Null, false)
+        .send(
+            Account::Primary,
+            Amount::from_sats(1_000),
+            Value::Null,
+            false,
+        )
         .await?;
 
     let operation_id = client
         .get_first_module::<MintClientModule>()?
-        .receive(ecash.clone(), Value::Null)
+        .receive(Account::Primary, ecash.clone(), Value::Null)
         .await?;
 
     assert_eq!(
@@ -627,7 +668,7 @@ async fn receiving_the_same_ecash_twice_is_rejected() -> anyhow::Result<()> {
     assert_eq!(
         client
             .get_first_module::<MintClientModule>()?
-            .receive(ecash, Value::Null)
+            .receive(Account::Primary, ecash, Value::Null)
             .await,
         Err(ReceiveECashError::AlreadyReceived),
     );
@@ -655,7 +696,7 @@ async fn receive_rejects_notes_below_the_base_fee() -> anyhow::Result<()> {
     assert_eq!(
         client
             .get_first_module::<MintClientModule>()?
-            .receive(dust_ecash, Value::Null)
+            .receive(Account::Primary, dust_ecash, Value::Null)
             .await,
         Err(ReceiveECashError::UneconomicalDenomination),
     );
@@ -674,7 +715,12 @@ async fn send_without_funds_reports_insufficient_balance() -> anyhow::Result<()>
     assert_eq!(
         client
             .get_first_module::<MintClientModule>()?
-            .send(Amount::from_sats(1_000), Value::Null, false)
+            .send(
+                Account::Primary,
+                Amount::from_sats(1_000),
+                Value::Null,
+                false
+            )
             .await
             .map(|(_operation_id, ecash)| ecash.amount()),
         Err(SendECashError::InsufficientBalance),
@@ -690,15 +736,15 @@ mod db {
     use bitcoin_hashes::{Hash as _, hash160};
     use bls12_381::G1Affine;
     use fedimint_client::module_init::DynClientModuleInit;
+    use fedimint_core::core::Account;
     use fedimint_core::db::{
         Database, DatabaseVersion, DatabaseVersionKeyV0, IDatabaseTransactionOpsCoreTyped,
     };
+    use fedimint_core::encoding::{Decodable, Encodable};
     use fedimint_core::secp256k1::{Keypair, SECP256K1};
-    use fedimint_core::{OutPoint, TransactionId};
+    use fedimint_core::{OutPoint, TransactionId, impl_db_record};
     use fedimint_logging::TracingSetup;
-    use fedimint_mintv2_client::client_db::{
-        self, RecoveryState, RecoveryStateKey, SpendableNoteKey, SpendableNotePrefix,
-    };
+    use fedimint_mintv2_client::client_db::{self, RecoveryStateKey, SpendableNotePrefix};
     use fedimint_mintv2_client::issuance::NoteIssuanceRequest;
     use fedimint_mintv2_common::{MintCommonInit, RecoveryItem};
     use fedimint_mintv2_server::db::{
@@ -960,12 +1006,12 @@ mod db {
         dbtx.insert_new_entry(&DatabaseVersionKeyV0, &DatabaseVersion(0))
             .await;
 
-        dbtx.insert_new_entry(&SpendableNoteKey(spendable_note(1)), &())
+        dbtx.insert_new_entry(&SpendableNoteKeyV0(spendable_note(1)), &())
             .await;
 
         dbtx.insert_new_entry(
-            &RecoveryStateKey,
-            &RecoveryState {
+            &RecoveryStateKeyV0,
+            &RecoveryStateV0 {
                 next_index: 3,
                 total_items: 10,
                 requests: BTreeMap::from([(nonce_hash(1), issuance_request(1))]),
@@ -976,6 +1022,35 @@ mod db {
 
         dbtx.commit_tx().await;
     }
+
+    /// The v0 shapes of the two client records, before accounts split the note
+    /// table and tagged each recovered request. Spelt out here so the snapshot
+    /// keeps producing v0 bytes now that the live types carry an account.
+    #[derive(Debug, Clone, Encodable, Decodable)]
+    struct SpendableNoteKeyV0(SpendableNote);
+
+    impl_db_record!(
+        key = SpendableNoteKeyV0,
+        value = (),
+        db_prefix = client_db::DbKeyPrefix::Note,
+    );
+
+    #[derive(Debug, Clone, Encodable, Decodable)]
+    struct RecoveryStateV0 {
+        next_index: u64,
+        total_items: u64,
+        requests: BTreeMap<hash160::Hash, NoteIssuanceRequest>,
+        nonces: BTreeSet<hash160::Hash>,
+    }
+
+    #[derive(Debug, Clone, Encodable, Decodable)]
+    struct RecoveryStateKeyV0;
+
+    impl_db_record!(
+        key = RecoveryStateKeyV0,
+        value = RecoveryStateV0,
+        db_prefix = client_db::DbKeyPrefix::RecoveryState,
+    );
 
     #[tokio::test(flavor = "multi_thread")]
     async fn snapshot_client_db_migrations() -> anyhow::Result<()> {
@@ -1000,9 +1075,12 @@ mod db {
 
                 for prefix in client_db::DbKeyPrefix::iter() {
                     match prefix {
+                        // The accounts migration re-keys every pre-accounts
+                        // note as primary's — the only account it could have
+                        // meant — and the note itself is untouched.
                         client_db::DbKeyPrefix::Note => {
                             let notes = dbtx
-                                .find_by_prefix(&SpendableNotePrefix)
+                                .find_by_prefix(&SpendableNotePrefix(Account::Primary))
                                 .await
                                 .collect::<Vec<_>>()
                                 .await;
@@ -1013,10 +1091,31 @@ mod db {
                                 notes.len()
                             );
                             ensure!(
-                                notes[0].0.0 == spendable_note(1),
+                                notes[0].0.1 == spendable_note(1),
                                 "the spendable note must round-trip unchanged"
                             );
+
+                            for account in Account::ALL.into_iter().skip(1) {
+                                let notes = dbtx
+                                    .find_by_prefix(&SpendableNotePrefix(account))
+                                    .await
+                                    .collect::<Vec<_>>()
+                                    .await;
+
+                                ensure!(
+                                    notes.is_empty(),
+                                    "{account} must hold nothing after the migration, got {} \
+                                     entries",
+                                    notes.len()
+                                );
+                            }
                         }
+                        // A recovery checkpoint restarts from index zero and
+                        // rebuilds everything it held, so the migration drops
+                        // it rather than translating it.
+                        // The accounts migration carries an in-progress
+                        // checkpoint over with its progress intact, tagging
+                        // every request as primary's.
                         client_db::DbKeyPrefix::RecoveryState => {
                             let state = dbtx
                                 .get_value(&RecoveryStateKey)
@@ -1031,8 +1130,11 @@ mod db {
                             );
                             ensure!(
                                 state.requests
-                                    == BTreeMap::from([(nonce_hash(1), issuance_request(1))]),
-                                "the pending issuance requests must round-trip unchanged"
+                                    == BTreeMap::from([(
+                                        nonce_hash(1),
+                                        (Account::Primary, issuance_request(1))
+                                    )]),
+                                "the pending issuance requests must be re-tagged as primary's"
                             );
                             ensure!(
                                 state.nonces == BTreeSet::from([nonce_hash(2)]),

--- a/modules/fedimint-wallet-client/src/cli.rs
+++ b/modules/fedimint-wallet-client/src/cli.rs
@@ -5,7 +5,7 @@ use anyhow::bail;
 use bitcoin::address::NetworkUnchecked;
 use clap::Parser;
 use fedimint_core::BitcoinAmountOrAll;
-use fedimint_core::core::OperationId;
+use fedimint_core::core::{Account, OperationId};
 use fedimint_core::encoding::Encodable;
 use futures::StreamExt;
 use serde::Serialize;
@@ -107,7 +107,10 @@ async fn withdraw(
         // fees. The returned fees are quoted at the returned amount, so they
         // must be used together.
         BitcoinAmountOrAll::All => {
-            let balance = module.client_ctx.get_balance_for_btc().await?;
+            let balance = module
+                .client_ctx
+                .get_balance_for_btc(Account::Primary)
+                .await?;
             module.max_withdrawable_amount(&address, balance).await?
         }
         BitcoinAmountOrAll::Amount(amount) => {

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -52,7 +52,9 @@ use fedimint_client_module::transaction::{
     TransactionBuilder, max_affordable_send_amount,
 };
 use fedimint_client_module::{DynGlobalClientContext, sm_enum_variant_translation};
-use fedimint_core::core::{Decoder, IntoDynInstance, ModuleInstanceId, ModuleKind, OperationId};
+use fedimint_core::core::{
+    Account, Decoder, IntoDynInstance, ModuleInstanceId, ModuleKind, OperationId,
+};
 use fedimint_core::db::{
     AutocommitError, Committable, Database, DatabaseError, DatabaseTransaction,
     IDatabaseTransactionOpsCoreTyped,
@@ -899,6 +901,7 @@ impl WalletClientModule {
                     output_amount: Amounts::new_bitcoin(amount),
                     input_fee: Amounts::ZERO,
                     output_fee: Amounts::new_bitcoin(self.cfg().fee_consensus.peg_out_abs),
+                    account: Account::Primary,
                 },
             )
             .await
@@ -1172,6 +1175,7 @@ impl WalletClientModule {
                             .manual_operation_start_dbtx(
                                 dbtx,
                                 deposit_address.operation_id,
+                                Account::Primary,
                                 WalletCommonInit::KIND.as_str(),
                                 WalletOperationMeta {
                                     variant: WalletOperationMetaVariant::Deposit {
@@ -1298,6 +1302,7 @@ impl WalletClientModule {
                             .manual_operation_start_dbtx(
                                 dbtx,
                                 deposit_address.operation_id,
+                                Account::Primary,
                                 WalletCommonInit::KIND.as_str(),
                                 WalletOperationMeta {
                                     variant: WalletOperationMetaVariant::Deposit {
@@ -1862,7 +1867,7 @@ impl WalletClientModule {
 
             let withdraw_output =
                 self.create_withdraw_output(operation_id, address.clone(), amount, fee)?;
-            let tx_builder = TransactionBuilder::new()
+            let tx_builder = TransactionBuilder::new(Account::Primary)
                 .with_outputs(self.client_ctx.make_client_outputs(withdraw_output));
 
             let extra_meta =
@@ -1922,7 +1927,7 @@ impl WalletClientModule {
         let operation_id = OperationId(thread_rng().r#gen());
 
         let withdraw_output = self.create_rbf_withdraw_output(operation_id, &rbf)?;
-        let tx_builder = TransactionBuilder::new()
+        let tx_builder = TransactionBuilder::new(Account::Primary)
             .with_outputs(self.client_ctx.make_client_outputs(withdraw_output));
 
         let extra_meta = serde_json::to_value(extra_meta).expect("Failed to serialize extra meta");

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -10,6 +10,7 @@ use fedimint_api_client::api::DynGlobalApi;
 use fedimint_client::ClientHandleArc;
 use fedimint_client::secret::{PlainRootSecretStrategy, RootSecretStrategy};
 use fedimint_connectors::ConnectorRegistry;
+use fedimint_core::core::Account;
 use fedimint_core::db::mem_impl::MemDatabase;
 use fedimint_core::db::{
     DatabaseError, DatabaseTransaction, IDatabaseTransactionOpsCoreTyped, IRawDatabaseExt,
@@ -89,7 +90,9 @@ async fn peg_in<'a>(
     finality_delay: u64,
     fed: &FederationTest,
 ) -> anyhow::Result<(BoxStream<'a, Amount>, bitcoin::Transaction)> {
-    let mut balance_sub = client.subscribe_balance_changes(AmountUnit::BITCOIN).await;
+    let mut balance_sub = client
+        .subscribe_balance_changes(AmountUnit::BITCOIN, Account::Primary)
+        .await;
     let initial_balance = balance_sub.ok().await?;
 
     await_consensus_upgrade(client, fed).await?;
@@ -120,7 +123,7 @@ async fn peg_in<'a>(
         .await_num_deposits_by_operation_id(op, 1)
         .await?;
     assert_eq!(
-        client.get_balance_for_btc().await?,
+        client.get_balance_for_btc(Account::Primary).await?,
         initial_balance + sats(PEG_IN_AMOUNT_SATS)
     );
     assert_eq!(
@@ -264,7 +267,7 @@ async fn on_chain_peg_in_and_peg_out_happy_case() -> anyhow::Result<()> {
     await_consensus_to_catch_up(&client, 1).await?;
     await_consensus_upgrade(&client, &fed).await?;
 
-    assert_eq!(client.get_balance_for_btc().await?, sats(0));
+    assert_eq!(client.get_balance_for_btc(Account::Primary).await?, sats(0));
     let deposit_address = wallet_module
         .allocate_deposit_address_expert_only(())
         .await?;
@@ -357,9 +360,11 @@ async fn on_chain_peg_in_and_peg_out_happy_case() -> anyhow::Result<()> {
     );
 
     info!("Checking balance after deposit");
-    let mut balance_sub = client.subscribe_balance_changes(AmountUnit::BITCOIN).await;
+    let mut balance_sub = client
+        .subscribe_balance_changes(AmountUnit::BITCOIN, Account::Primary)
+        .await;
     assert_eq!(
-        client.get_balance_for_btc().await?,
+        client.get_balance_for_btc(Account::Primary).await?,
         sats(PEG_IN_AMOUNT_SATS)
     );
     assert_eq!(balance_sub.ok().await?, sats(PEG_IN_AMOUNT_SATS));
@@ -379,7 +384,10 @@ async fn on_chain_peg_in_and_peg_out_happy_case() -> anyhow::Result<()> {
 
     let balance_after_peg_out =
         sats(PEG_IN_AMOUNT_SATS - PEG_OUT_AMOUNT_SATS - fees.amount().to_sat());
-    assert_eq!(client.get_balance_for_btc().await?, balance_after_peg_out);
+    assert_eq!(
+        client.get_balance_for_btc(Account::Primary).await?,
+        balance_after_peg_out
+    );
     assert_eq!(balance_sub.ok().await?, balance_after_peg_out);
 
     let sub = wallet_module.subscribe_withdraw_updates(op).await?;
@@ -418,7 +426,7 @@ async fn on_chain_peg_in_detects_multiple() -> anyhow::Result<()> {
     bitcoin.mine_blocks(finality_delay).await;
     await_consensus_to_catch_up(&client, 1).await?;
 
-    let starting_balance = client.get_balance_for_btc().await?;
+    let starting_balance = client.get_balance_for_btc(Account::Primary).await?;
     info!(?starting_balance, "Starting balance");
 
     await_consensus_upgrade(&client, &fed).await?;
@@ -451,7 +459,7 @@ async fn on_chain_peg_in_detects_multiple() -> anyhow::Result<()> {
             .await_num_deposits_by_operation_id(op, 1)
             .await?;
         assert_eq!(
-            client.get_balance_for_btc().await?,
+            client.get_balance_for_btc(Account::Primary).await?,
             sats(PEG_IN_AMOUNT_SATS) + starting_balance
         );
         info!(?height, ?tx, "First peg-in transaction claimed");
@@ -476,7 +484,7 @@ async fn on_chain_peg_in_detects_multiple() -> anyhow::Result<()> {
         bitcoin.mine_blocks(finality_delay).await;
         wallet_module.await_num_deposits(tweak_idx, 2).await?;
         assert_eq!(
-            client.get_balance_for_btc().await?,
+            client.get_balance_for_btc(Account::Primary).await?,
             sats(PEG_IN_AMOUNT_SATS * 2) + starting_balance
         );
         info!(?height, ?tx, "Second peg-in transaction claimed");
@@ -527,7 +535,7 @@ async fn peg_out_fail_refund() -> anyhow::Result<()> {
     // Check that we get our money back if the peg-out fails
     assert_eq!(balance_sub.next().await.unwrap(), sats(PEG_IN_AMOUNT_SATS));
     assert_eq!(
-        client.get_balance_for_btc().await?,
+        client.get_balance_for_btc(Account::Primary).await?,
         sats(PEG_IN_AMOUNT_SATS)
     );
 
@@ -572,7 +580,7 @@ async fn rbf_withdrawals_are_rejected() -> anyhow::Result<()> {
     let balance_after_normal_peg_out =
         sats(PEG_IN_AMOUNT_SATS - PEG_OUT_AMOUNT_SATS - fees.amount().to_sat());
     assert_eq!(
-        client.get_balance_for_btc().await?,
+        client.get_balance_for_btc(Account::Primary).await?,
         balance_after_normal_peg_out
     );
     assert_eq!(balance_sub.ok().await?, balance_after_normal_peg_out);
@@ -612,7 +620,7 @@ async fn rbf_withdrawals_are_rejected() -> anyhow::Result<()> {
             Some(100),
         ),
         || async {
-            let current_balance = client.get_balance_for_btc().await?;
+            let current_balance = client.get_balance_for_btc(Account::Primary).await?;
             if current_balance == balance_after_normal_peg_out {
                 Ok(())
             } else {
@@ -661,7 +669,10 @@ async fn peg_outs_must_wait_for_available_utxos() -> anyhow::Result<()> {
         .await?;
     let balance_after_peg_out =
         sats(PEG_IN_AMOUNT_SATS - PEG_OUT_AMOUNT_SATS - fees1.amount().to_sat());
-    assert_eq!(client.get_balance_for_btc().await?, balance_after_peg_out);
+    assert_eq!(
+        client.get_balance_for_btc(Account::Primary).await?,
+        balance_after_peg_out
+    );
     assert_eq!(balance_sub.ok().await?, balance_after_peg_out);
 
     let sub = wallet_module.subscribe_withdraw_updates(op).await?;
@@ -712,7 +723,7 @@ async fn peg_outs_must_wait_for_available_utxos() -> anyhow::Result<()> {
             - fees2.amount().to_sat(),
     );
     assert_eq!(
-        client.get_balance_for_btc().await?,
+        client.get_balance_for_btc(Account::Primary).await?,
         balance_after_second_peg_out
     );
     assert_eq!(balance_sub.ok().await?, balance_after_second_peg_out);
@@ -1236,7 +1247,7 @@ async fn dust_deposits_are_ignored() -> anyhow::Result<()> {
     await_consensus_to_catch_up(&client, 1).await?;
     await_consensus_upgrade(&client, &fed).await?;
 
-    assert_eq!(client.get_balance_for_btc().await?, sats(0));
+    assert_eq!(client.get_balance_for_btc(Account::Primary).await?, sats(0));
     let deposit_address = wallet_module
         .allocate_deposit_address_expert_only(())
         .await?;
@@ -1295,7 +1306,10 @@ async fn dust_deposits_are_ignored() -> anyhow::Result<()> {
     );
 
     info!("Checking balance after deposit");
-    assert_eq!(client.get_balance_for_btc().await?, Amount::ZERO);
+    assert_eq!(
+        client.get_balance_for_btc(Account::Primary).await?,
+        Amount::ZERO
+    );
     Ok(())
 }
 

--- a/modules/fedimint-walletv2-client/src/cli.rs
+++ b/modules/fedimint-walletv2-client/src/cli.rs
@@ -4,6 +4,7 @@ use bitcoin::Address;
 use bitcoin::address::NetworkUnchecked;
 use clap::{Parser, Subcommand};
 use fedimint_core::BitcoinAmountOrAll;
+use fedimint_core::core::Account;
 use fedimint_eventlog::EventLogId;
 use serde::Serialize;
 use serde_json::Value;
@@ -26,13 +27,18 @@ enum Opts {
         value: BitcoinAmountOrAll,
         #[arg(long)]
         fee: Option<bitcoin::Amount>,
+        #[arg(long, default_value_t = Account::Primary)]
+        account: Account,
     },
     /// Return the next unused receive address.
     ///
     /// To wait for a payment to this address, read the current event log
     /// position with `dev next-event-log-id` *before* running this, then pass
     /// that position to `await-receive`.
-    Receive,
+    Receive {
+        #[arg(long, default_value_t = Account::Primary)]
+        account: Account,
+    },
     /// Block until the next payment is received, starting from the given event
     /// log position. Returns the receive's final state and the event log
     /// position to pass to the following `await-receive`.
@@ -77,6 +83,7 @@ pub(crate) async fn handle_cli_command(
             address,
             value,
             fee,
+            account,
         } => {
             // Resolve the on-chain fee up front so the same value sizes the
             // sweep and funds the send: the required feerate rises with each
@@ -92,8 +99,8 @@ pub(crate) async fn handle_cli_command(
                 // everything: funding the wallet output also incurs the
                 // federation's per-note fees.
                 BitcoinAmountOrAll::All => {
-                    let balance = wallet.client_ctx.get_balance_for_btc().await?;
-                    wallet.max_sendable_amount(balance, fee).await?
+                    let balance = wallet.client_ctx.get_balance_for_btc(account).await?;
+                    wallet.max_sendable_amount(account, balance, fee).await?
                 }
                 BitcoinAmountOrAll::Amount(value) => value,
             };
@@ -102,13 +109,13 @@ pub(crate) async fn handle_cli_command(
                 wallet
                     .await_final_send_operation_state(
                         wallet
-                            .send(address, value, Some(fee), serde_json::Value::Null)
+                            .send(account, address, value, Some(fee), serde_json::Value::Null)
                             .await?,
                     )
                     .await?,
             )
         }
-        Opts::Receive => json(wallet.receive().await),
+        Opts::Receive { account } => json(wallet.receive(account).await?),
         Opts::AwaitReceive { position } => json(wallet.await_receive(position).await?),
     };
 

--- a/modules/fedimint-walletv2-client/src/db.rs
+++ b/modules/fedimint-walletv2-client/src/db.rs
@@ -1,3 +1,4 @@
+use fedimint_core::core::Account;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::{impl_db_lookup, impl_db_record};
 use serde::Serialize;
@@ -16,6 +17,9 @@ impl std::fmt::Display for DbKeyPrefix {
     }
 }
 
+/// How far the scanner has walked the federation's output stream. The stream is
+/// federation-wide and one sweep serves every account, so this is a single
+/// cursor rather than one per account.
 #[derive(Clone, Debug, Encodable, Decodable, Serialize)]
 pub struct NextOutputIndexKey;
 
@@ -25,8 +29,11 @@ impl_db_record!(
     db_prefix = DbKeyPrefix::NextOutputIndex
 );
 
+/// Address indices whose derived script the federation can pay, split by the
+/// key's leading [`Account`]. Iterating a federation's whole prefix yields
+/// `(account, index)` pairs — exactly what the scanner's address map wants.
 #[derive(Clone, Debug, Encodable, Decodable, Serialize)]
-pub struct ValidAddressIndexKey(pub u64);
+pub struct ValidAddressIndexKey(pub Account, pub u64);
 
 impl_db_record!(
     key = ValidAddressIndexKey,
@@ -34,10 +41,19 @@ impl_db_record!(
     db_prefix = DbKeyPrefix::ValidAddressIndex
 );
 
+/// Every account's indices, in account order.
 #[derive(Clone, Debug, Encodable, Decodable, Serialize)]
 pub struct ValidAddressIndexPrefix;
 
 impl_db_lookup!(
     key = ValidAddressIndexKey,
     query_prefix = ValidAddressIndexPrefix
+);
+
+#[derive(Clone, Debug, Encodable, Decodable, Serialize)]
+pub struct ValidAddressIndexAccountPrefix(pub Account);
+
+impl_db_lookup!(
+    key = ValidAddressIndexKey,
+    query_prefix = ValidAddressIndexAccountPrefix
 );

--- a/modules/fedimint-walletv2-client/src/events.rs
+++ b/modules/fedimint-walletv2-client/src/events.rs
@@ -1,6 +1,6 @@
 use bitcoin::address::NetworkUnchecked;
 use bitcoin::{Address, Txid};
-use fedimint_core::core::{ModuleKind, OperationId};
+use fedimint_core::core::{Account, ModuleKind, OperationId};
 use fedimint_eventlog::{Event, EventKind, EventPersistence};
 use serde::{Deserialize, Serialize};
 
@@ -11,6 +11,11 @@ pub struct SendPaymentEvent {
     pub address: Address<NetworkUnchecked>,
     pub value: bitcoin::Amount,
     pub fee: bitcoin::Amount,
+    /// Balance the payment was funded from. Defaulted rather than required, so
+    /// entries written before accounts existed still decode — they can only
+    /// have been the one account there was.
+    #[serde(default = "Account::primary")]
+    pub account: Account,
 }
 
 impl Event for SendPaymentEvent {
@@ -33,6 +38,12 @@ pub enum SendPaymentStatus {
 pub struct SendPaymentUpdateEvent {
     pub operation_id: OperationId,
     pub status: SendPaymentStatus,
+    /// Balance the operation acts on, repeated from the initiating event so a
+    /// consumer can filter the final state by account without joining on the
+    /// operation id. Defaulted so entries written before accounts existed
+    /// still decode.
+    #[serde(default = "Account::primary")]
+    pub account: Account,
 }
 
 impl Event for SendPaymentUpdateEvent {
@@ -49,6 +60,10 @@ pub struct ReceivePaymentEvent {
     pub fee: bitcoin::Amount,
     pub address: Address<NetworkUnchecked>,
     pub outpoint: Option<bitcoin::OutPoint>,
+    /// Balance the deposit is credited to. See [`SendPaymentEvent::account`]
+    /// for why it is defaulted.
+    #[serde(default = "Account::primary")]
+    pub account: Account,
 }
 
 impl Event for ReceivePaymentEvent {
@@ -71,6 +86,12 @@ pub enum ReceivePaymentStatus {
 pub struct ReceivePaymentUpdateEvent {
     pub operation_id: OperationId,
     pub status: ReceivePaymentStatus,
+    /// Balance the operation acts on, repeated from the initiating event so a
+    /// consumer can filter the final state by account without joining on the
+    /// operation id. Defaulted so entries written before accounts existed
+    /// still decode.
+    #[serde(default = "Account::primary")]
+    pub account: Account,
 }
 
 impl Event for ReceivePaymentUpdateEvent {

--- a/modules/fedimint-walletv2-client/src/lib.rs
+++ b/modules/fedimint-walletv2-client/src/lib.rs
@@ -11,6 +11,7 @@ mod api;
 mod cli;
 pub mod db;
 pub mod events;
+mod migrations;
 mod receive_sm;
 mod send_sm;
 
@@ -22,7 +23,10 @@ use anyhow::anyhow;
 use api::WalletFederationApi;
 use bitcoin::address::NetworkUnchecked;
 use bitcoin::{Address, ScriptBuf};
-use db::{NextOutputIndexKey, ValidAddressIndexKey, ValidAddressIndexPrefix};
+use db::{
+    NextOutputIndexKey, ValidAddressIndexAccountPrefix, ValidAddressIndexKey,
+    ValidAddressIndexPrefix,
+};
 use events::{ReceivePaymentEvent, SendPaymentEvent};
 use fedimint_api_client::api::{DynModuleApi, FederationResult};
 use fedimint_client::DynGlobalClientContext;
@@ -34,9 +38,10 @@ use fedimint_client_module::db::ClientModuleMigrationFn;
 use fedimint_client_module::module::init::{ClientModuleInit, ClientModuleInitArgs};
 use fedimint_client_module::module::recovery::NoModuleBackup;
 use fedimint_client_module::module::{ClientContext, ClientModule, OutPointRange};
+use fedimint_client_module::secret::DeriveableSecretClientExt;
 use fedimint_client_module::sm::{Context, DynState, ModuleNotifier, State, StateTransition};
 use fedimint_client_module::sm_enum_variant_translation;
-use fedimint_core::core::{IntoDynInstance, ModuleInstanceId, ModuleKind, OperationId};
+use fedimint_core::core::{Account, IntoDynInstance, ModuleInstanceId, ModuleKind, OperationId};
 use fedimint_core::db::{
     Database, DatabaseTransaction, DatabaseVersion, IDatabaseTransactionOpsCoreTyped,
 };
@@ -116,7 +121,9 @@ pub enum FinalReceiveOperationState {
 
 #[derive(Debug, Clone)]
 pub struct WalletClientModule {
-    root_secret: DerivableSecret,
+    /// Every account's derivation root, derived once so the address grind
+    /// pays a single child derivation per index.
+    account_secrets: [DerivableSecret; Account::ALL.len()],
     cfg: WalletClientConfig,
     notifier: ModuleNotifier<WalletClientStateMachines>,
     client_ctx: ClientContext<Self>,
@@ -200,9 +207,20 @@ impl ClientModuleInit for WalletClientInit {
             .expect("no version conflicts")
     }
 
+    fn get_database_migrations(&self) -> BTreeMap<DatabaseVersion, ClientModuleMigrationFn> {
+        let mut migrations: BTreeMap<DatabaseVersion, ClientModuleMigrationFn> = BTreeMap::new();
+
+        migrations.insert(DatabaseVersion(0), |dbtx, active, inactive| {
+            Box::pin(migrations::migrate_to_accounts_v1(dbtx, active, inactive))
+        });
+
+        migrations
+    }
+
     async fn init(&self, args: &ClientModuleInitArgs<Self>) -> anyhow::Result<Self::Module> {
         let module = WalletClientModule {
-            root_secret: args.module_root_secret().clone(),
+            account_secrets: Account::ALL
+                .map(|account| args.module_root_secret().derive_account_secret(account)),
             cfg: args.cfg().clone(),
             notifier: args.notifier().clone(),
             client_ctx: args.context(),
@@ -213,10 +231,6 @@ impl ClientModuleInit for WalletClientInit {
         module.spawn_output_scanner(args.task_group(), args.client_span());
 
         Ok(module)
-    }
-
-    fn get_database_migrations(&self) -> BTreeMap<DatabaseVersion, ClientModuleMigrationFn> {
-        BTreeMap::new()
     }
 
     fn used_db_prefixes(&self) -> Option<BTreeSet<u8>> {
@@ -281,7 +295,11 @@ impl WalletClientModule {
     /// The on-chain Bitcoin miner fee is deliberately excluded: it is part of
     /// the output `amount` (see [`Self::send_fee`]), not the on-federation
     /// transaction fee.
-    pub async fn send_fee_quote(&self, amount: bitcoin::Amount) -> anyhow::Result<FeeQuote> {
+    pub async fn send_fee_quote(
+        &self,
+        account: Account,
+        amount: bitcoin::Amount,
+    ) -> anyhow::Result<FeeQuote> {
         let amount = Amount::from_sats(amount.to_sat());
         self.client_ctx
             .fee_quote(
@@ -291,6 +309,7 @@ impl WalletClientModule {
                     output_amount: Amounts::new_bitcoin(amount),
                     input_fee: Amounts::ZERO,
                     output_fee: Amounts::new_bitcoin(self.cfg.fee_consensus.fee(amount)),
+                    account,
                 },
             )
             .await
@@ -332,6 +351,7 @@ impl WalletClientModule {
     /// fees.
     pub async fn max_sendable_amount(
         &self,
+        account: Account,
         balance: Amount,
         fee: bitcoin::Amount,
     ) -> anyhow::Result<bitcoin::Amount> {
@@ -346,7 +366,9 @@ impl WalletClientModule {
             // keeps the predicate conservative and makes the value handed to
             // the quote below an exact satoshi multiple.
             |value: Amount| Amount::from_sats(value.msats.div_ceil(1000)) + fee_msats,
-            |funded: Amount| self.send_fee_quote(bitcoin::Amount::from_sat(funded.msats / 1000)),
+            |funded: Amount| {
+                self.send_fee_quote(account, bitcoin::Amount::from_sat(funded.msats / 1000))
+            },
         )
         .await
         .ok_or_else(|| anyhow!("Balance is too low to send any amount on chain after fees"))?;
@@ -368,11 +390,19 @@ impl WalletClientModule {
     /// Send an onchain payment with the given fee.
     pub async fn send(
         &self,
+        account: Account,
         address: Address<NetworkUnchecked>,
         value: bitcoin::Amount,
         fee: Option<bitcoin::Amount>,
         custom_meta: serde_json::Value,
     ) -> Result<OperationId, SendError> {
+        if !self
+            .client_ctx
+            .supports_account(AmountUnit::BITCOIN, account)
+        {
+            return Err(SendError::AccountNotSupported);
+        }
+
         if !address.is_valid_for_network(self.cfg.network) {
             return Err(SendError::WrongNetwork);
         }
@@ -442,7 +472,7 @@ impl WalletClientModule {
                         custom_meta: custom_meta.clone(),
                     })
                 },
-                TransactionBuilder::new().with_outputs(client_output_bundle),
+                TransactionBuilder::new(account).with_outputs(client_output_bundle),
             )
             .await
             .map_err(|_| SendError::InsufficientFunds)?;
@@ -457,6 +487,7 @@ impl WalletClientModule {
                     address,
                     value,
                     fee,
+                    account,
                 },
             )
             .await;
@@ -552,15 +583,17 @@ impl WalletClientModule {
 
     /// Returns the highest valid receive address index that the background
     /// scanner has derived so far, or `None` if it has not derived one yet.
-    async fn valid_index(&self) -> Option<u64> {
+    /// All accounts share one table, so this reads the tail of the account's
+    /// own key prefix rather than the table's.
+    async fn valid_index(&self, account: Account) -> Option<u64> {
         self.db
             .begin_transaction_nc()
             .await
-            .find_by_prefix_sorted_descending(&ValidAddressIndexPrefix)
+            .find_by_prefix_sorted_descending(&ValidAddressIndexAccountPrefix(account))
             .await
             .next()
             .await
-            .map(|entry| entry.0.0)
+            .map(|entry| entry.0.1)
     }
 
     /// Returns the next unused receive address.
@@ -575,10 +608,20 @@ impl WalletClientModule {
     /// returns immediately. Otherwise it blocks, letting the scanner grind
     /// until it finds the next valid index, and returns once one is
     /// available.
-    pub async fn receive(&self) -> Address {
+    ///
+    /// Refuses an account the primary module cannot hold a balance for before
+    /// handing out an address, since a deposit to it could never be claimed.
+    pub async fn receive(&self, account: Account) -> Result<Address, ReceiveError> {
+        if !self
+            .client_ctx
+            .supports_account(AmountUnit::BITCOIN, account)
+        {
+            return Err(ReceiveError::AccountNotSupported);
+        }
+
         loop {
-            if let Some(index) = self.valid_index().await {
-                return self.derive_address(index);
+            if let Some(index) = self.valid_index(account).await {
+                return Ok(self.derive_address(account, index));
             }
 
             sleep(Duration::from_secs(1)).await;
@@ -668,16 +711,19 @@ impl WalletClientModule {
         }
     }
 
-    fn derive_address(&self, index: u64) -> Address {
+    fn derive_address(&self, account: Account, index: u64) -> Address {
         descriptor(
             &self.cfg.bitcoin_pks,
-            &self.derive_tweak(index).public_key().consensus_hash(),
+            &self
+                .derive_tweak(account, index)
+                .public_key()
+                .consensus_hash(),
         )
         .address(self.cfg.network)
     }
 
-    fn derive_tweak(&self, index: u64) -> Keypair {
-        self.root_secret
+    fn derive_tweak(&self, account: Account, index: u64) -> Keypair {
+        self.account_secrets[usize::from(account.index())]
             .child_key(ChildId(index))
             .to_secp_key(secp256k1::SECP256K1)
     }
@@ -689,7 +735,12 @@ impl WalletClientModule {
     /// yields to the executor between them, so it does not stall the runtime —
     /// important on wasm, which is single-threaded. It stops and returns `None`
     /// once the task group begins shutting down.
-    async fn next_valid_index(&self, start_index: u64, handle: &TaskHandle) -> Option<u64> {
+    async fn next_valid_index(
+        &self,
+        account: Account,
+        start_index: u64,
+        handle: &TaskHandle,
+    ) -> Option<u64> {
         /// Indices to scan per batch before yielding to the executor.
         const SCAN_BATCH: u64 = 256;
 
@@ -699,7 +750,10 @@ impl WalletClientModule {
 
         while !handle.is_shutting_down() {
             for _ in 0..SCAN_BATCH {
-                if is_potential_receive(&self.derive_address(index).script_pubkey(), &pks_hash) {
+                if is_potential_receive(
+                    &self.derive_address(account, index).script_pubkey(),
+                    &pks_hash,
+                ) {
                     return Some(index);
                 }
 
@@ -719,6 +773,7 @@ impl WalletClientModule {
     /// remainder is too small to fund the claim transaction's fees.
     async fn receive_output(
         &self,
+        account: Account,
         output_index: u64,
         value: bitcoin::Amount,
         address_index: u64,
@@ -731,9 +786,9 @@ impl WalletClientModule {
             input: WalletInput::V0(WalletInputV0 {
                 output_index,
                 fee,
-                tweak: self.derive_tweak(address_index).public_key(),
+                tweak: self.derive_tweak(account, address_index).public_key(),
             }),
-            keys: vec![self.derive_tweak(address_index)],
+            keys: vec![self.derive_tweak(account, address_index)],
             amounts: Amounts::new_bitcoin(Amount::from_sats(value.checked_sub(fee)?.to_sat())),
         };
 
@@ -756,7 +811,10 @@ impl WalletClientModule {
             vec![client_input_sm],
         ));
 
-        let address = self.derive_address(address_index).as_unchecked().clone();
+        let address = self
+            .derive_address(account, address_index)
+            .as_unchecked()
+            .clone();
 
         let meta_address = address.clone();
         let range = self
@@ -773,7 +831,7 @@ impl WalletClientModule {
                         outpoint,
                     })
                 },
-                TransactionBuilder::new().with_inputs(client_input_bundle),
+                TransactionBuilder::new(account).with_inputs(client_input_bundle),
             )
             .await
             .ok()?;
@@ -789,6 +847,7 @@ impl WalletClientModule {
                     fee,
                     address,
                     outpoint,
+                    account,
                 },
             )
             .await;
@@ -805,18 +864,27 @@ impl WalletClientModule {
         task_group.spawn_cancellable_with_span(client_span.clone(), "output-scanner", async move {
             let mut dbtx = module.db.begin_transaction().await;
 
-            if dbtx
-                .find_by_prefix(&ValidAddressIndexPrefix)
-                .await
-                .next()
-                .await
-                .is_none()
-            {
-                let Some(index) = module.next_valid_index(0, &handle).await else {
+            // Every account is seeded, not just the ones the user has opened:
+            // a restored seed may have been paid into any of them, and an
+            // account whose frontier was never derived would never be scanned
+            // for. Not filtered by what the primary module supports: this runs
+            // from `init`, before the client handle the query needs is set.
+            for account in Account::ALL {
+                if dbtx
+                    .find_by_prefix(&ValidAddressIndexAccountPrefix(account))
+                    .await
+                    .next()
+                    .await
+                    .is_some()
+                {
+                    continue;
+                }
+
+                let Some(index) = module.next_valid_index(account, 0, &handle).await else {
                     return;
                 };
 
-                dbtx.insert_new_entry(&ValidAddressIndexKey(index), &())
+                dbtx.insert_new_entry(&ValidAddressIndexKey(account, index), &())
                     .await;
             }
 
@@ -844,17 +912,35 @@ impl WalletClientModule {
 
         let next_output_index = dbtx.get_value(&NextOutputIndexKey).await.unwrap_or(0);
 
-        let mut valid_indices: Vec<u64> = dbtx
+        // Every account's indices come out of one prefix scan, already tagged
+        // with the account they belong to.
+        let valid_indices: Vec<(Account, u64)> = dbtx
             .find_by_prefix(&ValidAddressIndexPrefix)
             .await
-            .map(|entry| entry.0.0)
+            .map(|entry| (entry.0.0, entry.0.1))
             .collect()
             .await;
 
-        let mut address_map: BTreeMap<ScriptBuf, u64> = valid_indices
+        let mut address_map: BTreeMap<ScriptBuf, (Account, u64)> = valid_indices
             .iter()
-            .map(|&i| (self.derive_address(i).script_pubkey(), i))
+            .map(|&(account, i)| {
+                (
+                    self.derive_address(account, i).script_pubkey(),
+                    (account, i),
+                )
+            })
             .collect();
+
+        // Highest index reached per account, so a match on one account's
+        // frontier extends that account rather than the whole table's.
+        let mut frontier: BTreeMap<Account, u64> = BTreeMap::new();
+
+        for &(account, i) in &valid_indices {
+            frontier
+                .entry(account)
+                .and_modify(|highest| *highest = (*highest).max(i))
+                .or_insert(i);
+        }
 
         let outputs = self
             .module_api
@@ -865,38 +951,47 @@ impl WalletClientModule {
         let mut matched_num: usize = 0;
 
         for output in &outputs {
-            if let Some(&address_index) = address_map.get(&output.script) {
+            if let Some(&(account, address_index)) = address_map.get(&output.script) {
                 matched_num += 1;
 
                 // Claim before extending the valid index list: the index search
                 // below is CPU-bound and can take longer than a short-lived
                 // client process (e.g. a cli invocation) lives. The claim is
                 // quick and the extension can be retried on the next scan.
-                if !output.spent && !self.process_unspent_output(output, address_index).await? {
+                if !output.spent
+                    && !self
+                        .process_unspent_output(account, output, address_index)
+                        .await?
+                {
                     return Ok(false);
                 }
 
-                let next_address_index = valid_indices
-                    .last()
-                    .copied()
-                    .expect("we have at least one address index");
+                let next_address_index = *frontier
+                    .get(&account)
+                    .expect("every account in the map has a frontier");
 
-                // If we used the highest valid index, add the next valid one
+                // If we used this account's highest valid index, add its next
                 if address_index == next_address_index {
-                    let Some(index) = self.next_valid_index(next_address_index + 1, handle).await
+                    let Some(index) = self
+                        .next_valid_index(account, next_address_index + 1, handle)
+                        .await
                     else {
                         return Ok(false);
                     };
 
                     let mut dbtx = self.db.begin_transaction().await;
 
-                    dbtx.insert_entry(&ValidAddressIndexKey(index), &()).await;
+                    dbtx.insert_entry(&ValidAddressIndexKey(account, index), &())
+                        .await;
 
                     dbtx.commit_tx_result().await?;
 
-                    valid_indices.push(index);
+                    frontier.insert(account, index);
 
-                    address_map.insert(self.derive_address(index).script_pubkey(), index);
+                    address_map.insert(
+                        self.derive_address(account, index).script_pubkey(),
+                        (account, index),
+                    );
                 }
             }
 
@@ -922,6 +1017,7 @@ impl WalletClientModule {
 
     async fn process_unspent_output(
         &self,
+        account: Account,
         output: &OutputInfo,
         address_index: u64,
     ) -> anyhow::Result<bool> {
@@ -955,6 +1051,7 @@ impl WalletClientModule {
 
         if let Some((operation_id, txid)) = self
             .receive_output(
+                account,
                 output.index,
                 output.value,
                 address_index,
@@ -999,6 +1096,8 @@ impl WalletClientModule {
 
 #[derive(Error, Debug, Clone, Eq, PartialEq)]
 pub enum SendError {
+    #[error("The primary module only holds a balance for the primary account")]
+    AccountNotSupported,
     #[error("Address is from a different network than the federation.")]
     WrongNetwork,
     #[error("The value is too small")]
@@ -1015,6 +1114,8 @@ pub enum SendError {
 
 #[derive(Error, Debug, Clone, Eq, PartialEq)]
 pub enum ReceiveError {
+    #[error("The primary module only holds a balance for the primary account")]
+    AccountNotSupported,
     #[error("Federation returned an error: {0}")]
     FederationError(String),
     #[error("No consensus feerate is available at this time")]

--- a/modules/fedimint-walletv2-client/src/migrations.rs
+++ b/modules/fedimint-walletv2-client/src/migrations.rs
@@ -1,0 +1,33 @@
+//! Client database migrations.
+
+use fedimint_core::core::OperationId;
+use fedimint_core::db::{DatabaseTransaction, DbMigrationError, IDatabaseTransactionOpsCoreTyped};
+
+use crate::db::{NextOutputIndexKey, ValidAddressIndexPrefix};
+
+/// Address indices are per-account now, and the scanner has to know which
+/// account each one belongs to.
+///
+/// Rather than re-key what is there, this drops the scan cursor and every
+/// derived index and lets the scanner rebuild both from zero. That is cheaper
+/// to get right than a rewrite and it is safe: the federation reports whether
+/// an output is already spent, so a replay from index zero re-derives the same
+/// addresses and claims nothing twice.
+///
+/// The cost is one full re-walk of the federation's output stream and one
+/// address-frontier search per account, both of which the scanner already does
+/// on a fresh join.
+///
+/// The state machines need nothing: they read their account off their
+/// operation rather than carrying it, so the ones in flight keep their shape.
+pub(crate) async fn migrate_to_accounts_v1(
+    dbtx: &mut DatabaseTransaction<'_>,
+    _active_states: Vec<(Vec<u8>, OperationId)>,
+    _inactive_states: Vec<(Vec<u8>, OperationId)>,
+) -> Result<Option<(Vec<(Vec<u8>, OperationId)>, Vec<(Vec<u8>, OperationId)>)>, DbMigrationError> {
+    dbtx.remove_by_prefix(&ValidAddressIndexPrefix).await;
+
+    dbtx.remove_entry(&NextOutputIndexKey).await;
+
+    Ok(None)
+}

--- a/modules/fedimint-walletv2-client/src/receive_sm.rs
+++ b/modules/fedimint-walletv2-client/src/receive_sm.rs
@@ -46,6 +46,7 @@ impl State for ReceiveStateMachine {
         global_context: &DynGlobalClientContext,
     ) -> Vec<StateTransition<Self>> {
         let ctx = context.clone();
+        let global_context = global_context.clone();
 
         match &self.state {
             ReceiveSMState::Funding => {
@@ -54,6 +55,7 @@ impl State for ReceiveStateMachine {
                     move |dbtx, result, old_state| {
                         Box::pin(Self::transition_funding(
                             ctx.clone(),
+                            global_context.clone(),
                             dbtx,
                             result,
                             old_state,
@@ -82,10 +84,13 @@ impl ReceiveStateMachine {
 
     async fn transition_funding(
         context: WalletClientContext,
+        global_context: DynGlobalClientContext,
         dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
         result: Result<(), String>,
         old_state: ReceiveStateMachine,
     ) -> ReceiveStateMachine {
+        let account = global_context.account(dbtx).await;
+
         match result {
             Ok(()) => {
                 context
@@ -95,6 +100,7 @@ impl ReceiveStateMachine {
                         ReceivePaymentUpdateEvent {
                             operation_id: old_state.common.operation_id,
                             status: ReceivePaymentStatus::Success,
+                            account,
                         },
                     )
                     .await;
@@ -109,6 +115,7 @@ impl ReceiveStateMachine {
                         ReceivePaymentUpdateEvent {
                             operation_id: old_state.common.operation_id,
                             status: ReceivePaymentStatus::Aborted,
+                            account,
                         },
                     )
                     .await;

--- a/modules/fedimint-walletv2-client/src/send_sm.rs
+++ b/modules/fedimint-walletv2-client/src/send_sm.rs
@@ -48,6 +48,7 @@ impl State for SendStateMachine {
         global_context: &DynGlobalClientContext,
     ) -> Vec<StateTransition<Self>> {
         let ctx = context.clone();
+        let global_context = global_context.clone();
 
         match &self.state {
             SendSMState::Funding => {
@@ -56,6 +57,7 @@ impl State for SendStateMachine {
                     move |dbtx, result, old_state| {
                         Box::pin(Self::transition_funding(
                             ctx.clone(),
+                            global_context.clone(),
                             dbtx,
                             result,
                             old_state,
@@ -96,10 +98,13 @@ impl SendStateMachine {
 
     async fn transition_funding(
         context: WalletClientContext,
+        global_context: DynGlobalClientContext,
         dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
         result: AwaitFundingResult,
         old_state: SendStateMachine,
     ) -> SendStateMachine {
+        let account = global_context.account(dbtx).await;
+
         match result {
             AwaitFundingResult::Success(txid) => {
                 context
@@ -109,6 +114,7 @@ impl SendStateMachine {
                         SendPaymentUpdateEvent {
                             operation_id: old_state.common.operation_id,
                             status: SendPaymentStatus::Success(txid),
+                            account,
                         },
                     )
                     .await;
@@ -123,6 +129,7 @@ impl SendStateMachine {
                         SendPaymentUpdateEvent {
                             operation_id: old_state.common.operation_id,
                             status: SendPaymentStatus::Aborted,
+                            account,
                         },
                     )
                     .await;

--- a/modules/fedimint-walletv2-tests/tests/tests.rs
+++ b/modules/fedimint-walletv2-tests/tests/tests.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 use async_stream::stream;
 use bitcoin::Amount;
 use fedimint_client::ClientHandleArc;
+use fedimint_core::core::Account;
 use fedimint_core::task::sleep_in_test;
 use fedimint_dummy_client::DummyClientInit;
 use fedimint_dummy_server::DummyInit;
@@ -16,7 +17,7 @@ use fedimint_walletv2_client::events::{
     SendPaymentUpdateEvent,
 };
 use fedimint_walletv2_client::{
-    FinalSendOperationState, SendError, WalletClientInit, WalletClientModule,
+    FinalSendOperationState, ReceiveError, SendError, WalletClientInit, WalletClientModule,
 };
 use fedimint_walletv2_common::KIND;
 use fedimint_walletv2_server::{CONFIRMATION_FINALITY_DELAY, WalletInit};
@@ -170,8 +171,8 @@ async fn fee_exceeds_one_bitcoin_with_many_pending_txs() -> anyhow::Result<()> {
 
     let federation_address = client
         .get_first_module::<WalletClientModule>()?
-        .receive()
-        .await;
+        .receive(Account::Primary)
+        .await?;
 
     bitcoin
         .send_and_mine_block(&federation_address, Amount::from_int_btc(100))
@@ -209,6 +210,7 @@ async fn fee_exceeds_one_bitcoin_with_many_pending_txs() -> anyhow::Result<()> {
         let send_op = client
             .get_first_module::<WalletClientModule>()?
             .send(
+                Account::Primary,
                 address.clone(),
                 Amount::from_sat(10_000),
                 None,
@@ -252,14 +254,50 @@ async fn send_to_a_mainnet_address_is_rejected() -> anyhow::Result<()> {
         client
             .get_first_module::<WalletClientModule>()?
             .send(
+                Account::Primary,
                 mainnet_address,
                 Amount::from_sat(100_000),
+                None,
+                serde_json::Value::Null
+            )
+            .await
+            .err(),
+        Some(SendError::WrongNetwork),
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+/// The test fixture's primary module is the dummy module, which holds a single
+/// balance, so neither a send from nor an address for another account may be
+/// handed out.
+async fn primary_only_mint_rejects_other_accounts() -> anyhow::Result<()> {
+    let fixtures = fixtures();
+    let fed = fixtures.new_fed_not_degraded().await;
+    let client = fed.new_client().await;
+    let bitcoin = fixtures.bitcoin();
+    let wallet = client.get_first_module::<WalletClientModule>()?;
+
+    let address = bitcoin.get_new_address().await.as_unchecked().clone();
+
+    assert_eq!(
+        wallet
+            .send(
+                Account::Secondary,
+                address,
+                Amount::from_sat(10_000),
                 None,
                 serde_json::Value::Null,
             )
             .await
             .err(),
-        Some(SendError::WrongNetwork),
+        Some(SendError::AccountNotSupported),
+    );
+
+    assert_eq!(
+        wallet.receive(Account::Secondary).await.err(),
+        Some(ReceiveError::AccountNotSupported),
     );
 
     Ok(())
@@ -277,7 +315,13 @@ async fn send_below_the_dust_limit_is_rejected() -> anyhow::Result<()> {
     assert_eq!(
         client
             .get_first_module::<WalletClientModule>()?
-            .send(address, Amount::from_sat(1), None, serde_json::Value::Null)
+            .send(
+                Account::Primary,
+                address,
+                Amount::from_sat(1),
+                None,
+                serde_json::Value::Null
+            )
             .await
             .err(),
         Some(SendError::DustValue),
@@ -295,7 +339,8 @@ mod db {
     use fedimint_core::db::{
         Database, DatabaseVersion, DatabaseVersionKeyV0, IDatabaseTransactionOpsCoreTyped,
     };
-    use fedimint_core::{OutPoint, PeerId, TransactionId};
+    use fedimint_core::encoding::{Decodable, Encodable};
+    use fedimint_core::{OutPoint, PeerId, TransactionId, impl_db_record};
     use fedimint_logging::TracingSetup;
     use fedimint_server_core::DynServerModuleInit;
     use fedimint_testing::db::{
@@ -303,9 +348,7 @@ mod db {
         validate_migrations_server,
     };
     use fedimint_walletv2_client::WalletClientModule;
-    use fedimint_walletv2_client::db::{
-        self, NextOutputIndexKey, ValidAddressIndexKey, ValidAddressIndexPrefix,
-    };
+    use fedimint_walletv2_client::db::{self, NextOutputIndexKey, ValidAddressIndexPrefix};
     use fedimint_walletv2_common::{FederationWallet, TxInfo, WalletCommonInit};
     use fedimint_walletv2_server::db::{
         BlockCountVoteKey, BlockCountVotePrefix, DbKeyPrefix, FederationWalletKey, FeeRateVoteKey,
@@ -689,11 +732,23 @@ mod db {
 
         dbtx.insert_new_entry(&NextOutputIndexKey, &3).await;
 
-        dbtx.insert_new_entry(&ValidAddressIndexKey(0), &()).await;
-        dbtx.insert_new_entry(&ValidAddressIndexKey(1), &()).await;
+        dbtx.insert_new_entry(&ValidAddressIndexKeyV0(0), &()).await;
+        dbtx.insert_new_entry(&ValidAddressIndexKeyV0(1), &()).await;
 
         dbtx.commit_tx().await;
     }
+
+    /// The v0 shape of the address-index key: the index alone, before accounts
+    /// split the table. Spelt out here so the snapshot keeps producing v0
+    /// bytes now that the live key leads with an account.
+    #[derive(Clone, Debug, Encodable, Decodable)]
+    struct ValidAddressIndexKeyV0(u64);
+
+    impl_db_record!(
+        key = ValidAddressIndexKeyV0,
+        value = (),
+        db_prefix = db::DbKeyPrefix::ValidAddressIndex
+    );
 
     #[tokio::test(flavor = "multi_thread")]
     async fn snapshot_client_db_migrations() -> anyhow::Result<()> {
@@ -718,29 +773,27 @@ mod db {
 
                 for prefix in db::DbKeyPrefix::iter() {
                     match prefix {
+                        // The accounts migration drops the cursor rather than
+                        // re-keying it, so the scanner replays the federation's
+                        // output stream from zero and re-derives every index.
                         db::DbKeyPrefix::NextOutputIndex => {
-                            let index = dbtx
-                                .get_value(&NextOutputIndexKey)
-                                .await
-                                .context("the seeded next output index must still decode")?;
-
                             ensure!(
-                                index == 3,
-                                "the next output index must round-trip unchanged, got {index}"
+                                dbtx.get_value(&NextOutputIndexKey).await.is_none(),
+                                "the scan cursor must be cleared so the rescan starts from zero"
                             );
                         }
                         db::DbKeyPrefix::ValidAddressIndex => {
                             let indices = dbtx
                                 .find_by_prefix(&ValidAddressIndexPrefix)
                                 .await
-                                .map(|(key, ())| key.0)
                                 .collect::<Vec<_>>()
                                 .await;
 
                             ensure!(
-                                indices == vec![0, 1],
-                                "both seeded valid address indices must round-trip unchanged, \
-                                 got {indices:?}"
+                                indices.is_empty(),
+                                "the pre-accounts address indices must be dropped for the \
+                                 rescan to re-derive them per account, got {} entries",
+                                indices.len()
                             );
                         }
                     }


### PR DESCRIPTION
Ports the account feature from picomint: five balances inside a single federation client. An account is purely client-side — a hop in the derivation tree and a leading component on the few client tables that hold per-account state. The federation cannot tell them apart.

`Account::Primary` derives exactly where every released client already derives, so no existing wallet's money moves. The set is fixed at five: every account exists from the moment a client is built, so nothing creates one, and a restored seed is scanned on all of them.

## Client API changes

Every entry point that touches account-scoped state now takes an `Account` explicitly. `Account` has **no `Default` impl** on purpose — an omitted argument is a compile error rather than a silent write to the wrong balance. This is source-breaking by design; seeds, wire format and databases stay compatible.

**Core plumbing**
- `TransactionBuilder::new(account)` — was argument-less, and no longer derives `Default`. The account it carries is what the primary module funds from and credits change back to, and it is recorded against the operation when the operation is created.
- `ClientModule::create_final_inputs_and_outputs(…, account)` and `ClientModule::get_balance(…, account)` — trait signature changes, so out-of-tree modules need updating.
- `ClientContext::manual_operation_start(operation_id, account, …)` and `add_operation_log_entry_dbtx(…, account, …)`: an operation's account is fixed at creation.
- `DynGlobalClientContext::claim_inputs` and `fund_output` are unchanged in shape: a state machine's claims and refunds go to its operation's account, looked up rather than passed. `DynGlobalClientContext::account(dbtx)` exposes it for event tagging.
- `PrimaryModuleSupport` gains an `AccountSupport`, and `ClientContext::supports_account(unit, account)` asks the primary module whether it can hold a balance for an account at all.
- `FeeQuoteRequest` gains an `account` field; a quote runs the real balancing against that account's inventory.

**Client**
- `Client::get_balance_for_btc(account)`, `get_balance_for_unit(unit, account)`, `subscribe_balance_changes(unit, account)`. The subscription is per-account and deduplicates, so a change in one account emits nothing on another's stream.
- The `get_balance` and `subscribe_balance_changes` RPCs take an optional `account` (defaulting to primary), so existing callers are unaffected.
- uniffi: `get_balance(account)` and `subscribe_balance_changes(unit, account)`; `Account` crosses the FFI as its name.

**Modules**
- mintv2: `send`, `receive`, `get_count_by_denomination`, and both fee quotes take an account. New `send_max(account, …)` hands out everything an account holds as one bundle — this is how funds move between accounts: `send_max` one, `receive` into another.
- lnv2: `send`, `receive`, `generate_lnurl`, `spendable_amount` and both fee quotes take an account. Each account has its own receive and lnurl keys, so a wallet has five lightning addresses.
- walletv2: `receive(account)` (now fallible), `send(account, …)`, `send_fee_quote` and `max_sendable_amount` take an account.
- The v1 mint and dummy modules advertise `AccountSupport::PrimaryOnly`. lnv2 and walletv2 refuse a non-primary account up front on such a federation — before an lnurl, invoice or address is handed out, since a contract or deposit bound to an account the primary module cannot fund a claim for would strand the payer's money.

## Storage and compatibility

The client core keeps one table mapping an operation to its account, written when the operation is created and only for non-primary accounts, so an absent row reads as primary — which is also the only account any pre-existing operation could have belonged to. State machines read their account off that row instead of carrying it, so **no state machine changes shape and none is migrated**.

mintv2 keys its notes by account and walletv2 its address indices; both migrate at v0→v1, the former re-keying every note as primary's, the latter dropping its scan cursor so the scanner replays and re-derives per account. lnv2 has no per-account tables and needs no migration.

Module event payloads gain a `#[serde(default)]` account, so entries written before accounts still decode as primary.

Recovery is unchanged in cost: mintv2's tweak filter stays derived from the module root rather than per account, so one pre-grinder serves the whole wallet and a scan still runs a single filter check per output — only the ~1/65536 that pass are tried against each account's nonces. Recovered notes are credited through one operation per account.

Accounts are a v2-stack feature; v1 federations remain single-account.
