### PR TITLE
feat(server): allow DKG across patch releases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3409,6 +3409,7 @@ dependencies = [
  "rand 0.8.5",
  "scopeguard",
  "secp256k1",
+ "semver",
  "serde",
  "serde_json",
  "serdect 0.2.0",

--- a/devimint/src/envs.rs
+++ b/devimint/src/envs.rs
@@ -120,6 +120,19 @@ pub const FM_DEVIMINT_CMD_INHERIT_STDERR_ENV: &str = "FM_DEVIMINT_CMD_INHERIT_ST
 /// Force devimint to run a test with a deprecated configuration
 pub const FM_DEVIMINT_RUN_DEPRECATED_TESTS_ENV: &str = "FM_DEVIMINT_RUN_DEPRECATED_TESTS";
 
+/// Expected vendor when devimint compares `fedimintd --version` with DKG/setup.
+///
+/// `fedimintd --version` is its Cargo package version, so it does not include
+/// the optional vendor passed to `fedimintd::run` at runtime. DKG/setup reports
+/// the normalized version with `+vendor`; set this environment variable so
+/// devimint can reconstruct and compare that semantic version exactly. This
+/// preserves testing of exact vendor identity instead of stripping SemVer build
+/// metadata.
+///
+/// `_ENV` names this Rust constant; the environment variable is
+/// `FM_EXPECTED_FEDIMINTD_VENDOR`.
+pub const FM_EXPECTED_FEDIMINTD_VENDOR_ENV: &str = "FM_EXPECTED_FEDIMINTD_VENDOR";
+
 /// Devimint's "data dir" (think `/usr/devimint/`).
 ///
 /// "Static" because we use "data dir" for the directory `devimint` puts all the

--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -41,6 +41,7 @@ use crate::federation::Client;
 use crate::util::{LoadTestTool, ProcessManager, almost_equal, poll};
 use crate::version_constants::{
     VERSION_0_10_0_ALPHA, VERSION_0_11_0_ALPHA, VERSION_0_12_0_ALPHA, VERSION_0_13_0_ALPHA,
+    ensure_expected_fedimintd_version,
 };
 use crate::{DevFed, Gatewayd, LightningNode, Lnd, cmd, dev_fed};
 
@@ -1246,10 +1247,8 @@ pub async fn cli_tests(dev_fed: DevFed) -> Result<()> {
         .unwrap()
         .to_owned();
 
-    assert_eq!(
-        semver::Version::parse(&peer_0_fedimintd_version)?,
-        fedimintd_version
-    );
+    ensure_expected_fedimintd_version(&peer_0_fedimintd_version, fedimintd_version)
+        .expect("peer should report the expected fedimintd version");
 
     info!("Checking initial announcements...");
 

--- a/devimint/src/version_constants.rs
+++ b/devimint/src/version_constants.rs
@@ -1,6 +1,41 @@
+use std::env;
 use std::sync::LazyLock;
 
-use semver::Version;
+use semver::{BuildMetadata, Version};
+
+use crate::envs::FM_EXPECTED_FEDIMINTD_VENDOR_ENV;
+
+/// Add the exact expected vendor identity to a fedimintd release version.
+pub fn version_with_vendor(mut version: Version, vendor: Option<&str>) -> anyhow::Result<Version> {
+    version.build = match vendor {
+        Some(vendor) => {
+            anyhow::ensure!(!vendor.is_empty(), "Fedimintd vendor must not be empty");
+            BuildMetadata::new(vendor)?
+        }
+        None => BuildMetadata::EMPTY,
+    };
+    Ok(version)
+}
+
+/// Check a reported fedimintd version against this devimint invocation.
+pub fn ensure_expected_fedimintd_version(
+    reported_version: &str,
+    version: Version,
+) -> anyhow::Result<()> {
+    let expected_vendor = match env::var(FM_EXPECTED_FEDIMINTD_VENDOR_ENV) {
+        Ok(vendor) => Some(vendor),
+        Err(env::VarError::NotPresent) => None,
+        Err(error) => return Err(error.into()),
+    };
+    let expected_version = version_with_vendor(version, expected_vendor.as_deref())?;
+    let reported_version = Version::parse(reported_version)?;
+
+    anyhow::ensure!(
+        reported_version == expected_version,
+        "Fedimintd reported version {reported_version}, expected {expected_version}"
+    );
+    Ok(())
+}
 
 pub static VERSION_0_10_0_ALPHA: LazyLock<Version> =
     LazyLock::new(|| Version::parse("0.10.0-alpha").expect("version is parsable"));
@@ -10,3 +45,37 @@ pub static VERSION_0_12_0_ALPHA: LazyLock<Version> =
     LazyLock::new(|| Version::parse("0.12.0-alpha").expect("version is parsable"));
 pub static VERSION_0_13_0_ALPHA: LazyLock<Version> =
     LazyLock::new(|| Version::parse("0.13.0-alpha").expect("version is parsable"));
+
+#[cfg(test)]
+mod tests {
+    use super::version_with_vendor;
+
+    #[test]
+    fn version_with_vendor_requires_exact_optional_identity() {
+        let upstream = semver::Version::parse("0.11.1-rc.1").expect("valid version");
+        let reported_upstream = semver::Version::parse("0.11.1-rc.1").expect("valid version");
+        let reported_fedi = semver::Version::parse("0.11.1-rc.1+fedi").expect("valid version");
+        let reported_acme = semver::Version::parse("0.11.1-rc.1+acme").expect("valid version");
+
+        assert_eq!(
+            version_with_vendor(upstream.clone(), None).expect("valid upstream version"),
+            reported_upstream
+        );
+        assert_eq!(
+            version_with_vendor(upstream.clone(), Some("fedi")).expect("valid vendor"),
+            reported_fedi
+        );
+        assert_ne!(
+            version_with_vendor(upstream, Some("fedi")).expect("valid vendor"),
+            reported_acme
+        );
+    }
+
+    #[test]
+    fn version_with_vendor_rejects_invalid_build_metadata() {
+        let upstream = semver::Version::parse("0.11.1").expect("valid version");
+
+        assert!(version_with_vendor(upstream.clone(), Some("")).is_err());
+        assert!(version_with_vendor(upstream, Some("not valid")).is_err());
+    }
+}

--- a/fedimint-core/Cargo.toml
+++ b/fedimint-core/Cargo.toml
@@ -55,6 +55,7 @@ n0-future = { workspace = true }
 rand = { workspace = true }
 scopeguard = { workspace = true }
 secp256k1 = { workspace = true, features = ["global-context", "rand-std"] }
+semver = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serdect = { workspace = true }

--- a/fedimint-core/src/setup_code.rs
+++ b/fedimint-core/src/setup_code.rs
@@ -6,6 +6,7 @@ use serde::Serialize;
 use crate::core::ModuleKind;
 use crate::encoding::{Decodable, Encodable};
 use crate::util::SafeUrl;
+use crate::version::DkgVersion;
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Encodable, Decodable, Serialize)]
 /// Connection information sent between peers in order to start config gen
@@ -26,8 +27,12 @@ pub struct PeerSetupCode {
     pub federation_size: Option<u32>,
     /// Bitcoin network configured locally by the guardian
     pub network: Network,
-    /// Fedimint `x.y.z` cargo release version running on this peer
-    pub fedimint_version: String,
+    /// Normalized Fedimint `x.y.z` release version with optional vendor suffix
+    ///
+    /// Its consensus encoding remains the historical string encoding so setup
+    /// codes generated before this field became semantically typed still
+    /// decode.
+    pub fedimint_version: DkgVersion,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Encodable, Decodable, Serialize)]

--- a/fedimint-core/src/version.rs
+++ b/fedimint-core/src/version.rs
@@ -1,3 +1,9 @@
+use semver::{BuildMetadata, Prerelease, Version};
+use serde::{Serialize, Serializer};
+
+use crate::encoding::{Decodable, DecodeError, Encodable};
+use crate::module::registry::ModuleDecoderRegistry;
+
 /// Get the  cargo package version of `fedimint-core`
 pub fn cargo_pkg() -> &'static str {
     env!("CARGO_PKG_VERSION")
@@ -14,6 +20,96 @@ pub fn release_version(version: &str) -> &str {
         .split(['-', '+'])
         .next()
         .expect("split always returns at least one item")
+}
+
+/// A validated Fedimint version projected for DKG compatibility.
+///
+/// DKG ignores patch and pre-release components, but requires exact equality
+/// of the major version, minor version, and optional vendor string. The vendor
+/// string is encoded as SemVer build metadata.
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+pub struct DkgVersion {
+    /// The normalized semantic release version sent in setup codes.
+    setup_code_version: Box<Version>,
+}
+
+/// The semantic identity used to decide whether two guardians can run DKG.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct DkgVersionCompatibility {
+    /// The Fedimint major version.
+    major: u64,
+    /// The Fedimint minor version.
+    minor: u64,
+    /// The exact optional vendor identity.
+    vendor: Option<BuildMetadata>,
+}
+
+impl DkgVersion {
+    /// Parse a semantic version and derive its setup-code and DKG forms.
+    pub fn parse(version: &str) -> Result<Self, semver::Error> {
+        let mut setup_code_version = Version::parse(version)?;
+        setup_code_version.pre = Prerelease::EMPTY;
+
+        Ok(Self {
+            setup_code_version: Box::new(setup_code_version),
+        })
+    }
+
+    /// Return the normalized release version stored in a setup code.
+    pub fn setup_code_version(&self) -> &Version {
+        &self.setup_code_version
+    }
+
+    /// Return the major.minor and exact optional vendor identity for DKG.
+    pub fn compatibility_version(&self) -> DkgVersionCompatibility {
+        DkgVersionCompatibility {
+            major: self.setup_code_version.major,
+            minor: self.setup_code_version.minor,
+            vendor: (!self.setup_code_version.build.is_empty())
+                .then(|| self.setup_code_version.build.clone()),
+        }
+    }
+}
+
+impl std::fmt::Display for DkgVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.setup_code_version.fmt(f)
+    }
+}
+
+impl Serialize for DkgVersion {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.collect_str(self)
+    }
+}
+
+impl Encodable for DkgVersion {
+    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        self.to_string().consensus_encode(writer)
+    }
+}
+
+impl Decodable for DkgVersion {
+    fn consensus_decode_partial_from_finite_reader<D: std::io::Read>(
+        d: &mut D,
+        modules: &ModuleDecoderRegistry,
+    ) -> Result<Self, DecodeError> {
+        let version = String::consensus_decode_partial_from_finite_reader(d, modules)?;
+        Self::parse(&version).map_err(DecodeError::from_err)
+    }
+}
+
+impl std::fmt::Display for DkgVersionCompatibility {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}.{}", self.major, self.minor)?;
+        if let Some(vendor) = &self.vendor {
+            write!(f, "+{vendor}")?;
+        }
+        Ok(())
+    }
 }
 
 /// Get the git hash version of `fedimint-core`

--- a/fedimint-core/src/version/tests.rs
+++ b/fedimint-core/src/version/tests.rs
@@ -1,4 +1,6 @@
-use super::release_version;
+use super::{DkgVersion, release_version};
+use crate::encoding::{Decodable, Encodable};
+use crate::module::registry::ModuleDecoderRegistry;
 
 #[test]
 fn release_version_ignores_pre_release_and_build_metadata() {
@@ -7,4 +9,73 @@ fn release_version_ignores_pre_release_and_build_metadata() {
     assert_eq!(release_version("1.2.3-rc.1"), "1.2.3");
     assert_eq!(release_version("1.2.3+vendor-a"), "1.2.3");
     assert_eq!(release_version("1.2.3-alpha.1+vendor-a"), "1.2.3");
+}
+
+#[test]
+fn dkg_version_ignores_patch_and_pre_release_but_preserves_vendor() {
+    let version = DkgVersion::parse("1.2.3-alpha.1+vendor-a").expect("valid version");
+
+    assert_eq!(version.setup_code_version().to_string(), "1.2.3+vendor-a");
+    assert_eq!(version.compatibility_version().to_string(), "1.2+vendor-a");
+
+    let patch_skew = DkgVersion::parse("1.2.4-beta+vendor-a").expect("valid version");
+    assert_eq!(
+        version.compatibility_version(),
+        patch_skew.compatibility_version()
+    );
+}
+
+#[test]
+fn dkg_version_distinguishes_vendor_identity() {
+    let upstream = DkgVersion::parse("1.2.3").expect("valid version");
+    let vendor_a = DkgVersion::parse("1.2.3+vendor-a").expect("valid version");
+    let vendor_b = DkgVersion::parse("1.2.3+vendor-b").expect("valid version");
+
+    assert_ne!(
+        upstream.compatibility_version(),
+        vendor_a.compatibility_version()
+    );
+    assert_ne!(
+        vendor_a.compatibility_version(),
+        vendor_b.compatibility_version()
+    );
+}
+
+#[test]
+fn dkg_version_rejects_malformed_versions() {
+    for version in ["", "1", "1.2", "1.2.3.4", "1.02.3", "1.2.x", "v1.2.3"] {
+        assert!(
+            DkgVersion::parse(version).is_err(),
+            "{version:?} should be rejected"
+        );
+    }
+}
+
+#[test]
+fn dkg_version_preserves_historical_string_encodings() {
+    let version = DkgVersion::parse("1.2.3-alpha.1+vendor-a").expect("valid version");
+    let encoded = version.consensus_encode_to_vec();
+
+    assert_eq!(
+        encoded,
+        "1.2.3+vendor-a".to_owned().consensus_encode_to_vec()
+    );
+    assert_eq!(
+        DkgVersion::consensus_decode_whole(&encoded, &ModuleDecoderRegistry::default())
+            .expect("valid encoded version"),
+        version
+    );
+    assert_eq!(
+        serde_json::to_string(&version).expect("version serializes"),
+        "\"1.2.3+vendor-a\""
+    );
+}
+
+#[test]
+fn dkg_version_rejects_malformed_string_encoding() {
+    let encoded = "fedimint-code-version".to_owned().consensus_encode_to_vec();
+
+    assert!(
+        DkgVersion::consensus_decode_whole(&encoded, &ModuleDecoderRegistry::default()).is_err()
+    );
 }

--- a/fedimint-server/src/config/mod.rs
+++ b/fedimint-server/src/config/mod.rs
@@ -124,8 +124,14 @@ pub struct ServerConfigPrivate {
 
 #[derive(Debug, Clone, Serialize, Deserialize, Encodable)]
 pub struct ServerConfigConsensus {
-    /// The normalized `x.y.z` release version used for consensus config
-    /// checksums
+    /// The compatibility version used for consensus config checksums
+    ///
+    /// Newly generated configs use `major.minor` plus an exact optional vendor
+    /// suffix; restored legacy configs can contain `major.minor.patch`.
+    ///
+    /// This remains a string because it is persisted in consensus-config JSON
+    /// and its string consensus encoding contributes to the federation ID.
+    /// Changing the field type or encoding would break existing configurations.
     pub code_version: String,
     /// Agreed on core consensus version
     pub version: CoreConsensusVersion,
@@ -325,7 +331,13 @@ impl ServerConfig {
         code_version: String,
     ) -> Self {
         let consensus = ServerConfigConsensus {
-            code_version: fedimint_core::version::release_version(&code_version).to_owned(),
+            // Setup validates untrusted code versions before config generation.
+            // Keep this lower-level API usable by test helpers that use opaque
+            // version strings, as it was before DKG compatibility was added.
+            code_version: fedimint_core::version::DkgVersion::parse(&code_version).map_or_else(
+                |_| fedimint_core::version::release_version(&code_version).to_owned(),
+                |version| version.compatibility_version().to_string(),
+            ),
             version: CORE_CONSENSUS_VERSION,
             broadcast_public_keys,
             broadcast_rounds_per_session: if is_running_in_test_env() {
@@ -873,3 +885,6 @@ impl ConfigGenParams {
             .collect()
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/fedimint-server/src/config/setup.rs
+++ b/fedimint-server/src/config/setup.rs
@@ -26,6 +26,7 @@ use fedimint_core::module::{
     admin_api_endpoint, public_api_endpoint,
 };
 use fedimint_core::setup_code::PeerEndpoints;
+use fedimint_core::version::DkgVersion;
 use fedimint_core::{PeerId, base32, runtime};
 use fedimint_server_core::setup_ui::ISetupApi;
 use iroh::SecretKey;
@@ -88,8 +89,8 @@ pub struct LocalParams {
     federation_size: Option<u32>,
     /// Bitcoin network configured locally
     network: bitcoin::Network,
-    /// Fedimint `x.y.z` cargo release version configured locally
-    fedimint_version: String,
+    /// Normalized Fedimint version used for setup and DKG compatibility
+    fedimint_version: DkgVersion,
 }
 
 impl LocalParams {
@@ -109,14 +110,13 @@ impl LocalParams {
 
 fn ensure_fedimint_version_matches(
     peer_setup_code: &PeerSetupCode,
-    local_fedimint_version: &str,
+    local_fedimint_version: &DkgVersion,
 ) -> anyhow::Result<()> {
-    let peer_fedimint_version =
-        fedimint_core::version::release_version(&peer_setup_code.fedimint_version);
-
     ensure!(
-        peer_fedimint_version == local_fedimint_version,
-        "Guardian uses Fedimint version {peer_fedimint_version} but we use {local_fedimint_version}",
+        peer_setup_code.fedimint_version.compatibility_version()
+            == local_fedimint_version.compatibility_version(),
+        "Guardian uses Fedimint version {} but we use {local_fedimint_version}",
+        peer_setup_code.fedimint_version,
     );
 
     Ok(())
@@ -133,7 +133,9 @@ pub struct SetupApi {
     db: Database,
     /// Triggers config generation or config restore
     sender: Sender<ConfigGenOutcome>,
-    /// Version of the running fedimintd binary
+    /// Exact running version exposed by the setup API and recorded after setup
+    ///
+    /// Compatibility checks parse this boundary value into [`DkgVersion`].
     code_version_str: String,
     /// Git hash of the running fedimintd binary
     code_version_hash: String,
@@ -367,6 +369,9 @@ impl ISetupApi for SetupApi {
             "A restore is already in progress"
         );
 
+        let fedimint_version =
+            DkgVersion::parse(&self.code_version_str).context("Invalid local Fedimint version")?;
+
         let lp = if self.settings.enable_iroh {
             let iroh_api_sk = if let Ok(var) = std::env::var(FM_IROH_API_SECRET_KEY_OVERRIDE_ENV) {
                 SecretKey::from_str(&var)
@@ -396,8 +401,7 @@ impl ISetupApi for SetupApi {
                 enabled_modules,
                 federation_size,
                 network: self.settings.network,
-                fedimint_version: fedimint_core::version::release_version(&self.code_version_str)
-                    .to_owned(),
+                fedimint_version: fedimint_version.clone(),
             }
         } else {
             let (tls_cert, tls_key) =
@@ -427,8 +431,7 @@ impl ISetupApi for SetupApi {
                 enabled_modules,
                 federation_size,
                 network: self.settings.network,
-                fedimint_version: fedimint_core::version::release_version(&self.code_version_str)
-                    .to_owned(),
+                fedimint_version,
             }
         };
 
@@ -813,7 +816,7 @@ mod tests {
     use bitcoin::Network;
     use fedimint_core::db::IRawDatabaseExt;
     use fedimint_core::db::mem_impl::MemDatabase;
-    use tokio::sync::mpsc;
+    use tokio::sync::mpsc::{self, Receiver};
 
     use super::*;
 
@@ -822,29 +825,39 @@ mod tests {
     }
 
     fn setup_api_with_version(network: Network, version: &str) -> SetupApi {
-        let (sender, _receiver) = mpsc::channel(1);
+        setup_api_with_version_and_receiver(network, version).0
+    }
+
+    fn setup_api_with_version_and_receiver(
+        network: Network,
+        version: &str,
+    ) -> (SetupApi, Receiver<ConfigGenOutcome>) {
+        let (sender, receiver) = mpsc::channel(1);
         let bind = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0);
 
-        SetupApi::new(
-            ConfigGenSettings {
-                p2p_bind: bind,
-                api_bind: bind,
-                ui_bind: bind,
-                p2p_url: None,
-                api_url: None,
-                enable_iroh: true,
-                iroh_dns: None,
-                iroh_relays: Vec::new(),
-                network,
-                available_modules: BTreeSet::new(),
-                default_modules: BTreeSet::new(),
-            },
-            MemDatabase::new().into_database(),
-            sender,
-            version.to_owned(),
-            String::new(),
-            None,
-            None,
+        (
+            SetupApi::new(
+                ConfigGenSettings {
+                    p2p_bind: bind,
+                    api_bind: bind,
+                    ui_bind: bind,
+                    p2p_url: None,
+                    api_url: None,
+                    enable_iroh: true,
+                    iroh_dns: None,
+                    iroh_relays: Vec::new(),
+                    network,
+                    available_modules: BTreeSet::new(),
+                    default_modules: BTreeSet::new(),
+                },
+                MemDatabase::new().into_database(),
+                sender,
+                version.to_owned(),
+                String::new(),
+                None,
+                None,
+            ),
+            receiver,
         )
     }
 
@@ -855,6 +868,10 @@ mod tests {
         api.set_local_parameters(name.to_string(), None, None, None, None)
             .await
             .expect("setting local parameters should succeed")
+    }
+
+    fn decode_setup_code(setup_code: &str) -> PeerSetupCode {
+        base32::decode_prefixed(FEDIMINT_PREFIX, setup_code).expect("setup code should decode")
     }
 
     #[tokio::test]
@@ -937,9 +954,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn rejects_peer_setup_code_with_different_fedimint_version() {
+    async fn rejects_peer_setup_code_from_different_fedimint_minor() {
         let api = setup_api_with_version(Network::Regtest, "1.2.3-alpha");
-        let peer_api = setup_api_with_version(Network::Regtest, "1.2.4-beta");
+        let peer_api = setup_api_with_version(Network::Regtest, "1.3.0-beta");
 
         setup_code(&api, "local").await;
         let peer_code = setup_code(&peer_api, "peer").await;
@@ -947,34 +964,72 @@ mod tests {
         let err = api
             .add_peer_setup_code(peer_code)
             .await
-            .expect_err("peer setup code with different Fedimint version should be rejected");
+            .expect_err("peer setup code from a different Fedimint minor should be rejected");
 
         assert!(
             err.to_string()
-                .contains("Guardian uses Fedimint version 1.2.4 but we use 1.2.3")
+                .contains("Guardian uses Fedimint version 1.3.0 but we use 1.2.3")
         );
     }
 
     #[tokio::test]
-    async fn accepts_peer_setup_code_with_same_release_fedimint_version() {
-        let api = setup_api_with_version(Network::Regtest, "1.2.3-alpha");
-        let peer_api = setup_api_with_version(Network::Regtest, "1.2.3-beta");
+    async fn accepts_peer_setup_code_from_same_vendor_with_patch_skew() {
+        let api = setup_api_with_version(Network::Regtest, "1.2.3-alpha+fedi");
+        let peer_api = setup_api_with_version(Network::Regtest, "1.2.4-beta+fedi");
 
-        setup_code(&api, "local").await;
+        let local_code = setup_code(&api, "local").await;
         let peer_code = setup_code(&peer_api, "peer").await;
+        let peer_setup_code = decode_setup_code(&peer_code);
 
         let added_peer = api
             .add_peer_setup_code(peer_code)
             .await
-            .expect("peer setup code with same Fedimint release version should be accepted");
+            .expect("peer setup code from the same Fedimint minor should be accepted");
 
         assert_eq!(added_peer, "peer");
+        assert_eq!(
+            decode_setup_code(&local_code).fedimint_version.to_string(),
+            "1.2.3+fedi"
+        );
+        assert_eq!(peer_setup_code.fedimint_version.to_string(), "1.2.4+fedi");
     }
 
     #[tokio::test]
-    async fn rejects_wrong_fedimint_version_during_dkg() {
+    async fn rejects_peer_setup_code_from_different_fedimint_vendor() {
+        for (local_version, peer_version) in [("1.2.3+fedi", "1.2.4"), ("1.2.3+fedi", "1.2.4+acme")]
+        {
+            let api = setup_api_with_version(Network::Regtest, local_version);
+            let peer_api = setup_api_with_version(Network::Regtest, peer_version);
+
+            setup_code(&api, "local").await;
+            let peer_code = setup_code(&peer_api, "peer").await;
+
+            let err = api
+                .add_peer_setup_code(peer_code)
+                .await
+                .expect_err("peer setup code from a different vendor should be rejected");
+
+            assert!(
+                err.to_string()
+                    .contains(&format!("Guardian uses Fedimint version {peer_version}"))
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn rejects_malformed_local_fedimint_version() {
+        let malformed_local = setup_api_with_version(Network::Regtest, "fedimint-code-version");
+        let err = malformed_local
+            .set_local_parameters("local".to_owned(), None, None, None, None)
+            .await
+            .expect_err("malformed local version should be rejected");
+        assert!(err.to_string().contains("Invalid local Fedimint version"));
+    }
+
+    #[tokio::test]
+    async fn rejects_different_fedimint_minor_during_dkg() {
         let api = setup_api_with_version(Network::Regtest, "1.2.3-alpha");
-        let peer_api = setup_api_with_version(Network::Regtest, "1.2.4-beta");
+        let peer_api = setup_api_with_version(Network::Regtest, "1.3.0-beta");
 
         setup_code(&api, "local").await;
         let peer_code = setup_code(&peer_api, "peer").await;
@@ -986,11 +1041,67 @@ mod tests {
         let err = api
             .start_dkg()
             .await
-            .expect_err("DKG should reject peer setup code with different Fedimint version");
+            .expect_err("DKG should reject a peer from a different Fedimint minor");
 
         assert!(
             err.to_string()
-                .contains("Guardian uses Fedimint version 1.2.4 but we use 1.2.3")
+                .contains("Guardian uses Fedimint version 1.3.0 but we use 1.2.3")
         );
+    }
+
+    #[tokio::test]
+    async fn accepts_same_vendor_patch_versions_during_dkg() {
+        let (api, mut receiver) =
+            setup_api_with_version_and_receiver(Network::Regtest, "1.2.3-alpha+fedi");
+        api.set_local_parameters(
+            "local".to_owned(),
+            Some("test federation".to_owned()),
+            None,
+            None,
+            Some(4),
+        )
+        .await
+        .expect("setting local parameters should succeed");
+
+        for (name, version) in [
+            ("peer-1", "1.2.4-beta+fedi"),
+            ("peer-2", "1.2.5+fedi"),
+            ("peer-3", "1.2.6-rc.1+fedi"),
+        ] {
+            let peer_api = setup_api_with_version(Network::Regtest, version);
+            let peer_code = setup_code(&peer_api, name).await;
+            let peer_code = decode_setup_code(&peer_code);
+            api.state.lock().await.setup_codes.insert(peer_code);
+        }
+
+        api.start_dkg()
+            .await
+            .expect("DKG should accept peers from the same Fedimint minor");
+        receiver
+            .recv()
+            .await
+            .expect("DKG parameters should be sent");
+    }
+
+    #[tokio::test]
+    async fn rejects_different_fedimint_vendor_during_dkg() {
+        for (local_version, peer_version) in [("1.2.3+fedi", "1.2.4"), ("1.2.3+fedi", "1.2.4+acme")]
+        {
+            let api = setup_api_with_version(Network::Regtest, local_version);
+            let peer_api = setup_api_with_version(Network::Regtest, peer_version);
+
+            setup_code(&api, "local").await;
+            let peer_code = decode_setup_code(&setup_code(&peer_api, "peer").await);
+            api.state.lock().await.setup_codes.insert(peer_code);
+
+            let err = api
+                .start_dkg()
+                .await
+                .expect_err("DKG should reject a peer from a different vendor");
+            assert!(
+                err.to_string()
+                    .contains(&format!("Guardian uses Fedimint version {peer_version}"))
+            );
+        }
     }
 }

--- a/fedimint-server/src/config/tests.rs
+++ b/fedimint-server/src/config/tests.rs
@@ -1,0 +1,63 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use fedimint_core::{PeerId, secp256k1};
+use rand::rngs::OsRng;
+
+use super::{ConfigGenParams, ServerConfig};
+
+fn server_config_with_code_version(code_version: &str) -> ServerConfig {
+    let (broadcast_secret_key, _) = secp256k1::generate_keypair(&mut OsRng);
+
+    ServerConfig::from(
+        ConfigGenParams {
+            identity: PeerId::from(0),
+            tls_key: None,
+            iroh_api_sk: None,
+            iroh_p2p_sk: None,
+            peers: BTreeMap::new(),
+            meta: BTreeMap::new(),
+            disable_base_fees: false,
+            enabled_modules: BTreeSet::new(),
+            network: bitcoin::Network::Regtest,
+        },
+        PeerId::from(0),
+        BTreeMap::new(),
+        broadcast_secret_key,
+        BTreeMap::new(),
+        code_version.to_owned(),
+    )
+}
+
+#[test]
+fn server_config_uses_dkg_compatibility_identity_as_consensus_code_version() {
+    let patch_3 = server_config_with_code_version("1.2.3-alpha+fedi");
+    let patch_4 = server_config_with_code_version("1.2.4+fedi");
+    let upstream = server_config_with_code_version("1.2.4");
+    let other_vendor = server_config_with_code_version("1.2.4+acme");
+    let next_minor = server_config_with_code_version("1.3.0");
+
+    assert_eq!(patch_3.consensus.code_version, "1.2+fedi");
+    assert_eq!(
+        patch_3.consensus.code_version,
+        patch_4.consensus.code_version
+    );
+    assert_ne!(
+        patch_3.consensus.code_version,
+        upstream.consensus.code_version
+    );
+    assert_ne!(
+        patch_3.consensus.code_version,
+        other_vendor.consensus.code_version
+    );
+    assert_ne!(
+        patch_3.consensus.code_version,
+        next_minor.consensus.code_version
+    );
+}
+
+#[test]
+fn server_config_accepts_opaque_test_code_versions() {
+    let config = server_config_with_code_version("fedimint-code-version");
+
+    assert_eq!(config.consensus.code_version, "fedimint");
+}

--- a/fedimint-testing-core/src/config.rs
+++ b/fedimint-testing-core/src/config.rs
@@ -62,7 +62,10 @@ pub fn local_config_gen_params(
                 enabled_modules: None,
                 federation_size: None,
                 network: bitcoin::Network::Regtest,
-                fedimint_version: fedimint_core::version::cargo_pkg_release().to_owned(),
+                fedimint_version: fedimint_core::version::DkgVersion::parse(
+                    fedimint_core::version::cargo_pkg_release(),
+                )
+                .expect("cargo package release is a valid semantic version"),
             };
             (*peer, params)
         })

--- a/fedimintd/src/lib.rs
+++ b/fedimintd/src/lib.rs
@@ -310,11 +310,13 @@ impl ServerOpts {
 ///   (`fedimintd version-hash`). See `fedimint-build` crate for easy way to
 ///   obtain it.
 ///
-/// * `code_version_vendor_suffix` - An optional suffix that will be appended to
-///   the internal fedimint release version, to distinguish binaries built by
-///   different vendors, usually with a different set of modules. The suffix is
-///   informational in setup/DKG: compatibility and consensus config generation
-///   use the normalized `x.y.z` release version.
+/// * `code_version_vendor_suffix` - An optional vendor string appended to the
+///   internal Fedimint release version, to distinguish binaries built by
+///   different vendors, usually with a different set of modules. It is encoded
+///   as `SemVer` build metadata and therefore must contain dot-separated,
+///   non-empty identifiers with only ASCII alphanumeric characters and hyphens.
+///   Setup/DKG compatibility and consensus config generation require the same
+///   exact optional vendor string as well as the same `major.minor` series.
 #[allow(clippy::too_many_lines)]
 pub async fn run(
     module_init_registry: ServerModuleInitRegistry,
@@ -381,6 +383,8 @@ pub async fn run(
         || fedimint_version.to_string(),
         |suffix| format!("{fedimint_version}+{suffix}"),
     );
+    fedimint_core::version::DkgVersion::parse(&code_version_str)
+        .context("Invalid Fedimint version vendor string")?;
 
     let timing_total_runtime = timing::TimeReporter::new("total-runtime").info();
 


### PR DESCRIPTION
*Posted by Tau/OpenAI*

### Summary

Allow guardians on different patch or prerelease releases within one Fedimint major.minor series to complete setup and DKG only when their exact optional vendor identity matches. The previous code required matching `major.minor.patch` while discarding prerelease and vendor metadata; the new code ignores patch and prerelease but carries and compares the exact optional SemVer build-metadata vendor. Setup code and in-memory DKG state now use a validated semantic `DkgVersion`, while their existing string wire representation stays compatible.

| Guardian versions | Result | Compatibility identity |
| --- | --- | --- |
| `0.11.0` + `0.11.1` | accepted | both `0.11` with no vendor |
| `0.11.0+fedi` + `0.11.1-rc.1+fedi` | accepted | both `0.11+fedi` |
| `0.11.0` + `0.11.1+fedi` | rejected | no vendor vs `fedi` |
| `0.11.0+fedi` + `0.11.1+acme` | rejected | `fedi` vs `acme` |

Closes #9087.

### Details

`DkgVersion` validates version values at the setup-code boundary and explicitly preserves the prior string consensus encoding and JSON form. Existing setup codes therefore remain decodable, but malformed version strings fail at decoding. `ServerConfigConsensus.code_version` intentionally remains a `String`: it is persisted in consensus-config JSON and its existing string consensus encoding contributes to the federation ID, so changing its representation would break restored configurations and compatibility.

Devimint now accepts `FM_EXPECTED_FEDIMINTD_VENDOR` to test the vendor boundary. Fedi exports `fedi`; its test comparison keeps exact semantic-version equality rather than stripping vendor metadata. The separate Linked Specs bootstrap PR #9094 remains independent of this code change.
