### PR TITLE
feat(walletv2): Walletv2 Mempool and Confirmation Progress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5176,6 +5176,7 @@ dependencies = [
  "serde",
  "strum 0.27.1",
  "strum_macros 0.27.1",
+ "tokio",
  "tracing",
 ]
 

--- a/fedimint-server-bitcoin-rpc/src/bitcoind.rs
+++ b/fedimint-server-bitcoin-rpc/src/bitcoind.rs
@@ -1,5 +1,5 @@
 use anyhow::anyhow;
-use bitcoin::{BlockHash, Transaction};
+use bitcoin::{BlockHash, Transaction, Txid};
 use bitcoincore_rpc::Error::JsonRpc;
 use bitcoincore_rpc::bitcoincore_rpc_json::EstimateMode;
 use bitcoincore_rpc::jsonrpc::Error::Rpc;
@@ -95,6 +95,24 @@ impl IServerBitcoinRpc for BitcoindClient {
         Ok(Some(
             block_in_place(|| self.client.get_blockchain_info())?.verification_progress,
         ))
+    }
+
+    async fn get_mempool_txids(&self) -> anyhow::Result<Option<Vec<Txid>>> {
+        block_in_place(|| self.client.get_raw_mempool())
+            .map(Some)
+            .map_err(anyhow::Error::from)
+    }
+
+    async fn get_mempool_tx(&self, txid: &Txid) -> anyhow::Result<Option<Transaction>> {
+        // Bitcoin Core resolves the mempool before the block index, so this
+        // works without `txindex`. Error code -5 is the node saying it has no
+        // such transaction, which for a mempool read is an ordinary outcome:
+        // the transaction was mined or evicted since it was listed.
+        match block_in_place(|| self.client.get_raw_transaction(txid, None)) {
+            Ok(tx) => Ok(Some(tx)),
+            Err(JsonRpc(Rpc(e))) if e.code == -5 => Ok(None),
+            Err(e) => Err(e.into()),
+        }
     }
 
     async fn get_chain_id(&self) -> anyhow::Result<ChainId> {

--- a/fedimint-server-bitcoin-rpc/src/esplora.rs
+++ b/fedimint-server-bitcoin-rpc/src/esplora.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::sync::OnceLock;
 
 use anyhow::Context;
-use bitcoin::{BlockHash, Transaction};
+use bitcoin::{BlockHash, Transaction, Txid};
 use fedimint_core::envs::BitcoinRpcConfig;
 use fedimint_core::util::SafeUrl;
 use fedimint_core::{ChainId, Feerate};
@@ -93,6 +93,20 @@ impl IServerBitcoinRpc for EsploraClient {
     }
 
     async fn get_sync_progress(&self) -> anyhow::Result<Option<f64>> {
+        Ok(None)
+    }
+
+    /// Esplora has no API for reading the mempool as a whole.
+    ///
+    /// It exposes the full list of mempool txids, but nothing that returns
+    /// their outputs in bulk, so filtering the mempool by script would take one
+    /// request per transaction on every scan. Its other mempool endpoints are
+    /// per-address, which is of no use to a guardian that deliberately does not
+    /// know which addresses belong to which client.
+    ///
+    /// Reporting no visibility is the honest answer; callers degrade to
+    /// confirmation-only progress.
+    async fn get_mempool_txids(&self) -> anyhow::Result<Option<Vec<Txid>>> {
         Ok(None)
     }
 

--- a/fedimint-server-bitcoin-rpc/src/lib.rs
+++ b/fedimint-server-bitcoin-rpc/src/lib.rs
@@ -4,7 +4,7 @@ pub mod metrics;
 pub mod tracked;
 
 use anyhow::Result;
-use bitcoin::{BlockHash, Transaction};
+use bitcoin::{BlockHash, Transaction, Txid};
 use fedimint_core::envs::BitcoinRpcConfig;
 use fedimint_core::util::{FmtCompactAnyhow, SafeUrl};
 use fedimint_core::{ChainId, Feerate};
@@ -133,6 +133,18 @@ impl IServerBitcoinRpc for BitcoindClientWithFallback {
     async fn get_sync_progress(&self) -> Result<Option<f64>> {
         // We're always in sync, just like esplora
         self.esplora_client.get_sync_progress().await
+    }
+
+    // Mempool reads have no esplora fallback: esplora cannot serve them at all,
+    // so a failing bitcoind means no mempool visibility rather than a degraded
+    // one. Callers treat the error the same way they treat `None`.
+
+    async fn get_mempool_txids(&self) -> Result<Option<Vec<Txid>>> {
+        self.bitcoind_client.get_mempool_txids().await
+    }
+
+    async fn get_mempool_tx(&self, txid: &Txid) -> Result<Option<Transaction>> {
+        self.bitcoind_client.get_mempool_tx(txid).await
     }
 
     async fn get_chain_id(&self) -> Result<ChainId> {

--- a/fedimint-server-bitcoin-rpc/src/tracked.rs
+++ b/fedimint-server-bitcoin-rpc/src/tracked.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use bitcoin::{Block, BlockHash, Transaction};
+use bitcoin::{Block, BlockHash, Transaction, Txid};
 use fedimint_core::envs::BitcoinRpcConfig;
 use fedimint_core::time::now;
 use fedimint_core::util::{FmtCompactResultAnyhow as _, SafeUrl};
@@ -113,6 +113,22 @@ impl IServerBitcoinRpc for ServerBitcoinRpcTracked {
             self,
             "get_sync_progress",
             self.inner.get_sync_progress().await
+        )
+    }
+
+    async fn get_mempool_txids(&self) -> Result<Option<Vec<Txid>>> {
+        tracked_call!(
+            self,
+            "get_mempool_txids",
+            self.inner.get_mempool_txids().await
+        )
+    }
+
+    async fn get_mempool_tx(&self, txid: &Txid) -> Result<Option<Transaction>> {
+        tracked_call!(
+            self,
+            "get_mempool_tx",
+            self.inner.get_mempool_tx(txid).await
         )
     }
 

--- a/fedimint-server-core/src/bitcoin_rpc.rs
+++ b/fedimint-server-core/src/bitcoin_rpc.rs
@@ -128,6 +128,20 @@ impl ServerBitcoinRpcMonitor {
         self.status_receiver.borrow().clone()
     }
 
+    /// Returns a receiver that can be awaited to be notified whenever the
+    /// status is refreshed.
+    ///
+    /// This lets a consumer react to the monitor's own polling cadence instead
+    /// of running an independent timer, which would otherwise read a status
+    /// that is already up to one update interval stale before sleeping again.
+    ///
+    /// Note the monitor republishes on every update interval regardless of
+    /// whether the status actually changed, so the receiver fires once per
+    /// interval rather than only on a real change.
+    pub fn subscribe_status(&self) -> watch::Receiver<Option<ServerBitcoinRpcStatus>> {
+        self.status_receiver.clone()
+    }
+
     pub async fn get_block(&self, hash: &BlockHash) -> Result<Block> {
         ensure!(
             self.status_receiver.borrow().is_some(),

--- a/fedimint-server-core/src/bitcoin_rpc.rs
+++ b/fedimint-server-core/src/bitcoin_rpc.rs
@@ -2,8 +2,8 @@ use std::fmt::Debug;
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
-use anyhow::{Result, ensure};
-use fedimint_core::bitcoin::{Block, BlockHash, Network, Transaction};
+use anyhow::{Context, Result, ensure};
+use fedimint_core::bitcoin::{Block, BlockHash, Network, Transaction, Txid};
 use fedimint_core::envs::BitcoinRpcConfig;
 use fedimint_core::task::TaskGroup;
 use fedimint_core::util::{FmtCompactAnyhow as _, SafeUrl};
@@ -151,6 +151,27 @@ impl ServerBitcoinRpcMonitor {
         self.rpc.get_block(hash).await
     }
 
+    /// See [`IServerBitcoinRpc::get_mempool_txids`]; `None` means the backend
+    /// has no mempool visibility, not that the mempool is empty.
+    pub async fn get_mempool_txids(&self) -> Result<Option<Vec<Txid>>> {
+        ensure!(
+            self.status_receiver.borrow().is_some(),
+            "Not connected to bitcoin backend"
+        );
+
+        self.rpc.get_mempool_txids().await
+    }
+
+    /// See [`IServerBitcoinRpc::get_mempool_tx`].
+    pub async fn get_mempool_tx(&self, txid: &Txid) -> Result<Option<Transaction>> {
+        ensure!(
+            self.status_receiver.borrow().is_some(),
+            "Not connected to bitcoin backend"
+        );
+
+        self.rpc.get_mempool_tx(txid).await
+    }
+
     pub async fn get_block_hash(&self, height: u64) -> Result<BlockHash> {
         ensure!(
             self.status_receiver.borrow().is_some(),
@@ -261,6 +282,31 @@ pub trait IServerBitcoinRpc: Debug + Send + Sync + 'static {
     /// Returns the node's estimated chain sync percentage as a float between
     /// 0.0 and 1.0, or `None` if the node doesn't support this feature.
     async fn get_sync_progress(&self) -> Result<Option<f64>>;
+
+    /// Returns the ids of every transaction in the node's mempool, or `None`
+    /// if the backend cannot enumerate it.
+    ///
+    /// Enumerating the mempool is only possible on backends that expose the
+    /// whole of it. Esplora deliberately returns `None`: its mempool APIs are
+    /// per-address, and resolving a full mempool through them would take one
+    /// request per transaction.
+    ///
+    /// Callers must treat `None` as "this backend has no mempool visibility",
+    /// never as "the mempool is empty".
+    async fn get_mempool_txids(&self) -> Result<Option<Vec<Txid>>> {
+        Ok(None)
+    }
+
+    /// Returns a transaction from the node's mempool.
+    ///
+    /// `None` means either that the backend cannot serve mempool transactions
+    /// or that this transaction is no longer in the mempool, which is expected
+    /// when it is mined or evicted between listing and fetching it.
+    async fn get_mempool_tx(&self, txid: &Txid) -> Result<Option<Transaction>> {
+        let _ = txid;
+
+        Ok(None)
+    }
 
     /// Returns the chain ID (block hash at height 1)
     ///

--- a/fedimint-server-core/src/bitcoin_rpc.rs
+++ b/fedimint-server-core/src/bitcoin_rpc.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
-use anyhow::{Context, Result, ensure};
+use anyhow::{Result, ensure};
 use fedimint_core::bitcoin::{Block, BlockHash, Network, Transaction, Txid};
 use fedimint_core::envs::BitcoinRpcConfig;
 use fedimint_core::task::TaskGroup;

--- a/fedimint-testing/src/btc/mock.rs
+++ b/fedimint-testing/src/btc/mock.rs
@@ -3,7 +3,7 @@ use std::iter::repeat_n;
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use async_trait::async_trait;
 use bitcoin::absolute::LockTime;
 use bitcoin::block::{Header as BlockHeader, Version};
@@ -41,6 +41,12 @@ struct FakeBitcoinTestInner {
     scripts: BTreeMap<ScriptBuf, Vec<Transaction>>,
     /// Tracks the block height a transaction was included
     txid_to_block_height: BTreeMap<Txid, usize>,
+    /// Makes every mempool transaction fetch fail, to model a backend that goes
+    /// away partway through a guardian's mempool scan.
+    ///
+    /// Listing the mempool is deliberately left working, so a scan still sees
+    /// which transactions exist and fails only when fetching them.
+    fail_mempool_tx_fetches: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -63,6 +69,7 @@ impl FakeBitcoinTest {
             proofs: BTreeMap::new(),
             scripts: BTreeMap::new(),
             txid_to_block_height: BTreeMap::new(),
+            fail_mempool_tx_fetches: false,
         };
         let res = FakeBitcoinTest {
             inner: std::sync::RwLock::new(inner).into(),
@@ -311,6 +318,13 @@ impl BitcoinTest for FakeBitcoinTest {
             .find(|tx| tx.compute_txid() == *txid)
             .map(std::borrow::ToOwned::to_owned)
     }
+
+    fn fail_mempool_tx_fetches(&self, failing: bool) {
+        self.inner
+            .write()
+            .expect("RwLock poisoned")
+            .fail_mempool_tx_fetches = failing;
+    }
 }
 
 #[async_trait]
@@ -425,10 +439,16 @@ impl IServerBitcoinRpc for FakeBitcoinTest {
     }
 
     async fn get_mempool_tx(&self, txid: &bitcoin::Txid) -> Result<Option<bitcoin::Transaction>> {
-        Ok(self
-            .inner
-            .read()
-            .unwrap()
+        let inner = self.inner.read().unwrap();
+
+        // Bitcoin Core reports "no such transaction" as `Ok(None)`, so an error
+        // here models the backend itself failing rather than the transaction
+        // having left the mempool.
+        if inner.fail_mempool_tx_fetches {
+            bail!("Mempool transaction fetches are failing");
+        }
+
+        Ok(inner
             .pending
             .iter()
             .find(|tx| tx.compute_txid() == *txid)

--- a/fedimint-testing/src/btc/mock.rs
+++ b/fedimint-testing/src/btc/mock.rs
@@ -176,6 +176,26 @@ impl BitcoinTest for FakeBitcoinTest {
         }
     }
 
+    async fn send_without_mining(&self, address: &Address, amount: bitcoin::Amount) -> Transaction {
+        let mut inner = self.inner.write().unwrap();
+
+        let transaction = FakeBitcoinTest::new_transaction(
+            vec![TxOut {
+                value: amount,
+                script_pubkey: address.script_pubkey(),
+            }],
+            inner.blocks.len() as u32,
+        );
+
+        inner
+            .addresses
+            .insert(transaction.compute_txid(), amount.into());
+
+        inner.pending.push(transaction.clone());
+
+        transaction
+    }
+
     async fn send_and_mine_block(
         &self,
         address: &Address,
@@ -386,6 +406,33 @@ impl IServerBitcoinRpc for FakeBitcoinTest {
 
     async fn get_feerate(&self) -> Result<Option<Feerate>> {
         Ok(Some(Feerate { sats_per_kvb: 2000 }))
+    }
+
+    /// Models a backend that can enumerate its mempool, as bitcoind can.
+    ///
+    /// Esplora-backed guardians return `None` here instead, so tests that need
+    /// to cover the no-visibility path cannot use this fixture.
+    async fn get_mempool_txids(&self) -> Result<Option<Vec<bitcoin::Txid>>> {
+        Ok(Some(
+            self.inner
+                .read()
+                .unwrap()
+                .pending
+                .iter()
+                .map(bitcoin::Transaction::compute_txid)
+                .collect(),
+        ))
+    }
+
+    async fn get_mempool_tx(&self, txid: &bitcoin::Txid) -> Result<Option<bitcoin::Transaction>> {
+        Ok(self
+            .inner
+            .read()
+            .unwrap()
+            .pending
+            .iter()
+            .find(|tx| tx.compute_txid() == *txid)
+            .cloned())
     }
 
     async fn submit_transaction(&self, transaction: bitcoin::Transaction) -> anyhow::Result<()> {

--- a/fedimint-testing/src/btc/mod.rs
+++ b/fedimint-testing/src/btc/mod.rs
@@ -32,6 +32,14 @@ pub trait BitcoinTest {
         amount: bitcoin::Amount,
     ) -> (TxOutProof, Transaction);
 
+    /// Send some bitcoin to an address and leave the transaction unconfirmed in
+    /// the mempool.
+    ///
+    /// The counterpart to [`BitcoinTest::send_and_mine_block`], for exercising
+    /// behaviour that depends on a transaction being seen before it is mined.
+    /// Mine a block afterwards to confirm it.
+    async fn send_without_mining(&self, address: &Address, amount: bitcoin::Amount) -> Transaction;
+
     /// Returns a new address.
     async fn get_new_address(&self) -> Address;
 

--- a/fedimint-testing/src/btc/mod.rs
+++ b/fedimint-testing/src/btc/mod.rs
@@ -62,4 +62,21 @@ pub trait BitcoinTest {
 
     /// Returns a transaction with the provided txid if it exists in the mempool
     async fn get_mempool_tx(&self, txid: &Txid) -> Option<bitcoin::Transaction>;
+
+    /// Makes every subsequent mempool transaction fetch by a guardian fail,
+    /// until called again with `false`.
+    ///
+    /// Lets a test drive a guardian's mempool scan into failing partway
+    /// through, which is otherwise only reachable by breaking a real node.
+    /// Listing the mempool keeps working, so the guardian still learns which
+    /// transactions exist and only the fetches fail.
+    ///
+    /// Only the mock backend can do this, so a test that calls it must skip
+    /// itself on real daemons via `Fixtures::is_real_test`.
+    fn fail_mempool_tx_fetches(&self, _failing: bool) {
+        panic!(
+            "Only the mock bitcoin backend can fail mempool fetches; \
+             guard this test with `Fixtures::is_real_test`"
+        );
+    }
 }

--- a/fedimint-testing/src/btc/real.rs
+++ b/fedimint-testing/src/btc/real.rs
@@ -213,6 +213,18 @@ impl BitcoinTest for RealBitcoinTestNoLock {
         }
     }
 
+    async fn send_without_mining(&self, address: &Address, amount: bitcoin::Amount) -> Transaction {
+        let id = self
+            .client
+            .send_to_address(address, amount)
+            .expect(Self::ERROR);
+
+        // No block is mined, so this resolves out of the mempool.
+        self.client
+            .get_raw_transaction(&id, None)
+            .expect(Self::ERROR)
+    }
+
     async fn send_and_mine_block(
         &self,
         address: &Address,
@@ -377,6 +389,11 @@ impl BitcoinTest for RealBitcoinTest {
         self.inner.prepare_funding_wallet().await;
     }
 
+    async fn send_without_mining(&self, address: &Address, amount: bitcoin::Amount) -> Transaction {
+        let _lock = self.lock_exclusive().await;
+        self.inner.send_without_mining(address, amount).await
+    }
+
     async fn send_and_mine_block(
         &self,
         address: &Address,
@@ -433,6 +450,10 @@ impl BitcoinTest for RealBitcoinTestLocked {
 
     async fn prepare_funding_wallet(&self) {
         self.inner.prepare_funding_wallet().await;
+    }
+
+    async fn send_without_mining(&self, address: &Address, amount: bitcoin::Amount) -> Transaction {
+        self.inner.send_without_mining(address, amount).await
     }
 
     async fn send_and_mine_block(

--- a/modules/fedimint-walletv2-client/src/api.rs
+++ b/modules/fedimint-walletv2-client/src/api.rs
@@ -209,16 +209,32 @@ where
         }))
         .await;
 
-        let mut block_count = 0;
+        let responses: Vec<PendingOutputs> = responses.into_iter().flatten().collect();
+
+        // Heights are absolute, so confirmations can be computed against any
+        // guardian's tip. Which tip to trust is the question: taking the
+        // highest would let a single peer inflate everyone's progress, so pick
+        // the same way the module itself picks a block count, the highest value
+        // a threshold of peers have reached.
+        //
+        // Falling back to the highest reported tip keeps progress working on a
+        // federation where fewer than a threshold of guardians are upgraded far
+        // enough to serve this endpoint at all.
+        let mut counts: Vec<u64> = responses.iter().map(|r| r.block_count).collect();
+
+        counts.sort_unstable();
+        counts.reverse();
+
+        let block_count = counts
+            .get(self.all_peers().to_num_peers().threshold() - 1)
+            .or_else(|| counts.first())
+            .copied()
+            .unwrap_or(0);
+
         let mut mempool_visibility = false;
         let mut outputs: BTreeMap<bitcoin::OutPoint, PendingOutput> = BTreeMap::new();
 
-        for response in responses.into_iter().flatten() {
-            // Take the highest tip any guardian reports so that a peer lagging
-            // by a block does not walk back a confirmation count we already
-            // showed the user.
-            block_count = block_count.max(response.block_count);
-
+        for response in responses {
             // One guardian that can see a mempool is enough to report unmined
             // peg-ins for the whole federation.
             mempool_visibility |= response.mempool_visibility;

--- a/modules/fedimint-walletv2-client/src/api.rs
+++ b/modules/fedimint-walletv2-client/src/api.rs
@@ -10,10 +10,12 @@ use fedimint_core::task::{MaybeSend, MaybeSync};
 use fedimint_core::{NumPeersExt, OutPoint, PeerId, apply, async_trait_maybe_send};
 use fedimint_walletv2_common::endpoint_constants::{
     CONSENSUS_BLOCK_COUNT_ENDPOINT, CONSENSUS_FEERATE_ENDPOINT, FEDERATION_WALLET_ENDPOINT,
-    OUTPUT_INFO_SLICE_ENDPOINT, PENDING_TRANSACTION_CHAIN_ENDPOINT, RECEIVE_FEE_ENDPOINT,
-    SEND_FEE_ENDPOINT, TRANSACTION_CHAIN_ENDPOINT, TRANSACTION_ID_ENDPOINT,
+    OUTPUT_INFO_SLICE_ENDPOINT, PENDING_OUTPUTS_ENDPOINT, PENDING_TRANSACTION_CHAIN_ENDPOINT,
+    RECEIVE_FEE_ENDPOINT, SEND_FEE_ENDPOINT, TRANSACTION_CHAIN_ENDPOINT, TRANSACTION_ID_ENDPOINT,
 };
-use fedimint_walletv2_common::{FederationWallet, OutputInfo, TxInfo};
+use fedimint_walletv2_common::{
+    FederationWallet, OutputInfo, PendingOutput, PendingOutputs, TxInfo,
+};
 
 /// Renders each peer's fee answer so a divergence error names the odd one out.
 fn describe_fee_quotes(quotes: &BTreeMap<PeerId, Option<bitcoin::Amount>>) -> String {
@@ -50,6 +52,16 @@ pub trait WalletFederationApi {
     ) -> FederationResult<Vec<OutputInfo>>;
 
     async fn tx_id(&self, outpoint: OutPoint) -> Option<bitcoin::Txid>;
+
+    /// Fetches the guardians' local views of mined but not yet final receive
+    /// outputs, merged into a single view.
+    ///
+    /// This is advisory data used to display peg-in progress. It is
+    /// deliberately not requested via threshold consensus: guardians observe
+    /// the chain tip independently and will legitimately disagree by a block,
+    /// so a consensus request would simply never resolve. Peers that error,
+    /// including guardians too old to know the endpoint, are skipped.
+    async fn pending_outputs(&self) -> PendingOutputs;
 }
 
 #[apply(async_trait_maybe_send!)]
@@ -184,5 +196,46 @@ where
             ApiRequestErased::new(outpoint),
         )
         .await
+    }
+
+    async fn pending_outputs(&self) -> PendingOutputs {
+        let responses = futures::future::join_all(self.all_peers().iter().map(|peer| async move {
+            self.request_single_peer::<PendingOutputs>(
+                PENDING_OUTPUTS_ENDPOINT.to_string(),
+                ApiRequestErased::new(()),
+                *peer,
+            )
+            .await
+        }))
+        .await;
+
+        let mut block_count = 0;
+        let mut outputs: BTreeMap<bitcoin::OutPoint, PendingOutput> = BTreeMap::new();
+
+        for response in responses.into_iter().flatten() {
+            // Take the highest tip any guardian reports so that a peer lagging
+            // by a block does not walk back a confirmation count we already
+            // showed the user.
+            block_count = block_count.max(response.block_count);
+
+            for output in response.outputs {
+                // Guardians can disagree on the height of an outpoint across a
+                // reorg. Keep the deepest height, which yields the lower
+                // confirmation count, so progress is never overstated.
+                outputs
+                    .entry(output.outpoint)
+                    .and_modify(|existing| {
+                        if output.height > existing.height {
+                            existing.height = output.height;
+                        }
+                    })
+                    .or_insert(output);
+            }
+        }
+
+        PendingOutputs {
+            block_count,
+            outputs: outputs.into_values().collect(),
+        }
     }
 }

--- a/modules/fedimint-walletv2-client/src/api.rs
+++ b/modules/fedimint-walletv2-client/src/api.rs
@@ -53,8 +53,12 @@ pub trait WalletFederationApi {
 
     async fn tx_id(&self, outpoint: OutPoint) -> Option<bitcoin::Txid>;
 
-    /// Fetches the guardians' local views of mined but not yet final receive
-    /// outputs, merged into a single view.
+    /// Fetches the guardians' local views of the receive outputs they can see
+    /// but the federation has not recorded yet - mempool candidates plus the
+    /// recent-block window - merged into a single view.
+    ///
+    /// Entries are retained for a short while past finality, so an outpoint
+    /// appearing here does not mean the deposit is still unclaimed.
     ///
     /// This is advisory data used to display peg-in progress. It is
     /// deliberately not requested via threshold consensus: guardians observe

--- a/modules/fedimint-walletv2-client/src/api.rs
+++ b/modules/fedimint-walletv2-client/src/api.rs
@@ -210,6 +210,7 @@ where
         .await;
 
         let mut block_count = 0;
+        let mut mempool_visibility = false;
         let mut outputs: BTreeMap<bitcoin::OutPoint, PendingOutput> = BTreeMap::new();
 
         for response in responses.into_iter().flatten() {
@@ -218,16 +219,25 @@ where
             // showed the user.
             block_count = block_count.max(response.block_count);
 
+            // One guardian that can see a mempool is enough to report unmined
+            // peg-ins for the whole federation.
+            mempool_visibility |= response.mempool_visibility;
+
             for output in response.outputs {
-                // Guardians can disagree on the height of an outpoint across a
-                // reorg. Keep the deepest height, which yields the lower
-                // confirmation count, so progress is never overstated.
                 outputs
                     .entry(output.outpoint)
                     .and_modify(|existing| {
-                        if output.height > existing.height {
-                            existing.height = output.height;
-                        }
+                        existing.height = match (existing.height, output.height) {
+                            // A guardian that has seen the transaction mined is
+                            // ahead of one that still has it in its mempool, so
+                            // a known height always wins over none.
+                            (None, height) | (height, None) => height,
+                            // Guardians can disagree on the height of an
+                            // outpoint across a reorg. Keep the deepest, which
+                            // yields the lower confirmation count, so progress
+                            // is never overstated.
+                            (Some(existing), Some(new)) => Some(existing.max(new)),
+                        };
                     })
                     .or_insert(output);
             }
@@ -236,6 +246,7 @@ where
         PendingOutputs {
             block_count,
             outputs: outputs.into_values().collect(),
+            mempool_visibility,
         }
     }
 }

--- a/modules/fedimint-walletv2-client/src/db.rs
+++ b/modules/fedimint-walletv2-client/src/db.rs
@@ -45,13 +45,13 @@ impl_db_lookup!(
     query_prefix = ValidAddressIndexPrefix
 );
 
-/// A peg-in to one of our addresses that has been mined but is not yet deep
-/// enough for the federation to have recorded it in its consensus output log.
+/// A peg-in to one of our addresses that the federation can see but has not yet
+/// recorded in its consensus output log.
 ///
 /// This table is rebuilt wholesale on every scan rather than appended to. The
 /// underlying data is advisory and revocable: an entry must disappear if a
-/// reorg unmines it, or once the output graduates into the consensus output log
-/// and the real receive operation takes over.
+/// reorg unmines it or the mempool drops it, and once the output graduates into
+/// the consensus output log the real receive operation takes over.
 #[derive(Clone, Debug, Encodable, Decodable, Serialize)]
 pub struct PendingReceiveKey(pub u64);
 
@@ -59,8 +59,9 @@ pub struct PendingReceiveKey(pub u64);
 pub struct PendingReceive {
     pub outpoint: bitcoin::OutPoint,
     pub value: bitcoin::Amount,
-    /// Height of the block that mined the peg-in.
-    pub height: u64,
+    /// Height of the block that mined the peg-in, or `None` while it is only
+    /// in a guardian's mempool.
+    pub height: Option<u64>,
     /// Chain tip the confirmation count is relative to, as reported by the
     /// federation when this entry was written.
     pub block_count: u64,
@@ -69,8 +70,10 @@ pub struct PendingReceive {
 impl PendingReceive {
     /// Confirmations using the standard Bitcoin convention, where the block
     /// that mines a transaction counts as the first confirmation.
-    pub fn confirmations(&self) -> u64 {
-        self.block_count.saturating_sub(self.height)
+    ///
+    /// `None` for a peg-in that is still unmined.
+    pub fn confirmations(&self) -> Option<u64> {
+        Some(self.block_count.saturating_sub(self.height?))
     }
 }
 

--- a/modules/fedimint-walletv2-client/src/db.rs
+++ b/modules/fedimint-walletv2-client/src/db.rs
@@ -8,7 +8,6 @@ use strum_macros::EnumIter;
 pub enum DbKeyPrefix {
     NextOutputIndex = 0x31,
     ValidAddressIndex = 0x32,
-    PendingReceive = 0x33,
 }
 
 impl std::fmt::Display for DbKeyPrefix {
@@ -41,67 +40,4 @@ pub struct ValidAddressIndexPrefix;
 impl_db_lookup!(
     key = ValidAddressIndexKey,
     query_prefix = ValidAddressIndexPrefix
-);
-
-/// A peg-in to one of our addresses that the federation can see but has not yet
-/// recorded in its consensus output log.
-///
-/// Keyed per outpoint rather than per address, because nothing stops an address
-/// being paid more than once: [`receive`] hands out the same address until a
-/// deposit is detected at it, so two deposits before the first is seen is an
-/// ordinary flow. Collapsing them would silently drop one from the progress
-/// view.
-///
-/// This table is rebuilt wholesale on every scan rather than appended to. The
-/// underlying data is advisory and revocable: an entry must disappear if a
-/// reorg unmines it or the mempool drops it, and once the output graduates into
-/// the consensus output log the real receive operation takes over.
-///
-/// [`receive`]: crate::WalletClientModule::receive
-#[derive(Clone, Debug, Encodable, Decodable, Serialize)]
-pub struct PendingReceiveKey {
-    /// Encoded first so that [`PendingReceiveAddressPrefix`] can range over
-    /// every deposit to one address.
-    pub address_index: u64,
-    pub outpoint: bitcoin::OutPoint,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq, Encodable, Decodable, Serialize)]
-pub struct PendingReceive {
-    pub value: bitcoin::Amount,
-    /// Height of the block that mined the peg-in, or `None` while it is only
-    /// in a guardian's mempool.
-    pub height: Option<u64>,
-    /// Chain tip the confirmation count is relative to, as reported by the
-    /// federation when this entry was written.
-    pub block_count: u64,
-}
-
-impl PendingReceive {
-    /// Confirmations using the standard Bitcoin convention, where the block
-    /// that mines a transaction counts as the first confirmation.
-    ///
-    /// `None` for a peg-in that is still unmined.
-    pub fn confirmations(&self) -> Option<u64> {
-        Some(self.block_count.saturating_sub(self.height?))
-    }
-}
-
-impl_db_record!(
-    key = PendingReceiveKey,
-    value = PendingReceive,
-    db_prefix = DbKeyPrefix::PendingReceive
-);
-
-#[derive(Clone, Debug, Encodable, Decodable, Serialize)]
-pub struct PendingReceivePrefix;
-
-/// Ranges over every pending deposit to a single receive address.
-#[derive(Clone, Debug, Encodable, Decodable, Serialize)]
-pub struct PendingReceiveAddressPrefix(pub u64);
-
-impl_db_lookup!(
-    key = PendingReceiveKey,
-    query_prefix = PendingReceivePrefix,
-    query_prefix = PendingReceiveAddressPrefix,
 );

--- a/modules/fedimint-walletv2-client/src/db.rs
+++ b/modules/fedimint-walletv2-client/src/db.rs
@@ -1,3 +1,4 @@
+use fedimint_core::core::OperationId;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::{impl_db_lookup, impl_db_record};
 use serde::Serialize;
@@ -8,6 +9,8 @@ use strum_macros::EnumIter;
 pub enum DbKeyPrefix {
     NextOutputIndex = 0x31,
     ValidAddressIndex = 0x32,
+    PendingReceive = 0x33,
+    ReceiveOperation = 0x34,
 }
 
 impl std::fmt::Display for DbKeyPrefix {
@@ -40,4 +43,66 @@ pub struct ValidAddressIndexPrefix;
 impl_db_lookup!(
     key = ValidAddressIndexKey,
     query_prefix = ValidAddressIndexPrefix
+);
+
+/// A peg-in to one of our addresses that has been mined but is not yet deep
+/// enough for the federation to have recorded it in its consensus output log.
+///
+/// This table is rebuilt wholesale on every scan rather than appended to. The
+/// underlying data is advisory and revocable: an entry must disappear if a
+/// reorg unmines it, or once the output graduates into the consensus output log
+/// and the real receive operation takes over.
+#[derive(Clone, Debug, Encodable, Decodable, Serialize)]
+pub struct PendingReceiveKey(pub u64);
+
+#[derive(Clone, Debug, Eq, PartialEq, Encodable, Decodable, Serialize)]
+pub struct PendingReceive {
+    pub outpoint: bitcoin::OutPoint,
+    pub value: bitcoin::Amount,
+    /// Height of the block that mined the peg-in.
+    pub height: u64,
+    /// Chain tip the confirmation count is relative to, as reported by the
+    /// federation when this entry was written.
+    pub block_count: u64,
+}
+
+impl PendingReceive {
+    /// Confirmations using the standard Bitcoin convention, where the block
+    /// that mines a transaction counts as the first confirmation.
+    pub fn confirmations(&self) -> u64 {
+        self.block_count.saturating_sub(self.height)
+    }
+}
+
+impl_db_record!(
+    key = PendingReceiveKey,
+    value = PendingReceive,
+    db_prefix = DbKeyPrefix::PendingReceive
+);
+
+#[derive(Clone, Debug, Encodable, Decodable, Serialize)]
+pub struct PendingReceivePrefix;
+
+impl_db_lookup!(key = PendingReceiveKey, query_prefix = PendingReceivePrefix);
+
+/// Links a receive address index to the operation claiming it.
+///
+/// Written atomically with the creation of the receive operation, so that
+/// progress for an address can be resolved with a point lookup instead of a
+/// scan over the event log.
+#[derive(Clone, Debug, Encodable, Decodable, Serialize)]
+pub struct ReceiveOperationKey(pub u64);
+
+impl_db_record!(
+    key = ReceiveOperationKey,
+    value = OperationId,
+    db_prefix = DbKeyPrefix::ReceiveOperation
+);
+
+#[derive(Clone, Debug, Encodable, Decodable, Serialize)]
+pub struct ReceiveOperationPrefix;
+
+impl_db_lookup!(
+    key = ReceiveOperationKey,
+    query_prefix = ReceiveOperationPrefix
 );

--- a/modules/fedimint-walletv2-client/src/db.rs
+++ b/modules/fedimint-walletv2-client/src/db.rs
@@ -1,4 +1,3 @@
-use fedimint_core::core::OperationId;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::{impl_db_lookup, impl_db_record};
 use serde::Serialize;
@@ -10,7 +9,6 @@ pub enum DbKeyPrefix {
     NextOutputIndex = 0x31,
     ValidAddressIndex = 0x32,
     PendingReceive = 0x33,
-    ReceiveOperation = 0x34,
 }
 
 impl std::fmt::Display for DbKeyPrefix {
@@ -48,16 +46,28 @@ impl_db_lookup!(
 /// A peg-in to one of our addresses that the federation can see but has not yet
 /// recorded in its consensus output log.
 ///
+/// Keyed per outpoint rather than per address, because nothing stops an address
+/// being paid more than once: [`receive`] hands out the same address until a
+/// deposit is detected at it, so two deposits before the first is seen is an
+/// ordinary flow. Collapsing them would silently drop one from the progress
+/// view.
+///
 /// This table is rebuilt wholesale on every scan rather than appended to. The
 /// underlying data is advisory and revocable: an entry must disappear if a
 /// reorg unmines it or the mempool drops it, and once the output graduates into
 /// the consensus output log the real receive operation takes over.
+///
+/// [`receive`]: crate::WalletClientModule::receive
 #[derive(Clone, Debug, Encodable, Decodable, Serialize)]
-pub struct PendingReceiveKey(pub u64);
+pub struct PendingReceiveKey {
+    /// Encoded first so that [`PendingReceiveAddressPrefix`] can range over
+    /// every deposit to one address.
+    pub address_index: u64,
+    pub outpoint: bitcoin::OutPoint,
+}
 
 #[derive(Clone, Debug, Eq, PartialEq, Encodable, Decodable, Serialize)]
 pub struct PendingReceive {
-    pub outpoint: bitcoin::OutPoint,
     pub value: bitcoin::Amount,
     /// Height of the block that mined the peg-in, or `None` while it is only
     /// in a guardian's mempool.
@@ -86,26 +96,12 @@ impl_db_record!(
 #[derive(Clone, Debug, Encodable, Decodable, Serialize)]
 pub struct PendingReceivePrefix;
 
-impl_db_lookup!(key = PendingReceiveKey, query_prefix = PendingReceivePrefix);
-
-/// Links a receive address index to the operation claiming it.
-///
-/// Written atomically with the creation of the receive operation, so that
-/// progress for an address can be resolved with a point lookup instead of a
-/// scan over the event log.
+/// Ranges over every pending deposit to a single receive address.
 #[derive(Clone, Debug, Encodable, Decodable, Serialize)]
-pub struct ReceiveOperationKey(pub u64);
-
-impl_db_record!(
-    key = ReceiveOperationKey,
-    value = OperationId,
-    db_prefix = DbKeyPrefix::ReceiveOperation
-);
-
-#[derive(Clone, Debug, Encodable, Decodable, Serialize)]
-pub struct ReceiveOperationPrefix;
+pub struct PendingReceiveAddressPrefix(pub u64);
 
 impl_db_lookup!(
-    key = ReceiveOperationKey,
-    query_prefix = ReceiveOperationPrefix
+    key = PendingReceiveKey,
+    query_prefix = PendingReceivePrefix,
+    query_prefix = PendingReceiveAddressPrefix,
 );

--- a/modules/fedimint-walletv2-client/src/lib.rs
+++ b/modules/fedimint-walletv2-client/src/lib.rs
@@ -18,11 +18,14 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::anyhow;
+use anyhow::{Context as _, anyhow};
 use api::WalletFederationApi;
 use bitcoin::address::NetworkUnchecked;
 use bitcoin::{Address, ScriptBuf};
-use db::{NextOutputIndexKey, ValidAddressIndexKey, ValidAddressIndexPrefix};
+use db::{
+    NextOutputIndexKey, PendingReceive, PendingReceiveKey, PendingReceivePrefix,
+    ReceiveOperationKey, ValidAddressIndexKey, ValidAddressIndexPrefix,
+};
 use events::{ReceivePaymentEvent, SendPaymentEvent};
 use fedimint_api_client::api::{DynModuleApi, FederationResult};
 use fedimint_client::DynGlobalClientContext;
@@ -45,16 +48,18 @@ use fedimint_core::module::{
     AmountUnit, Amounts, ApiVersion, CommonModuleInit, ModuleCommon, ModuleInit, MultiApiVersion,
 };
 use fedimint_core::task::{TaskGroup, TaskHandle, sleep};
+use fedimint_core::util::FmtCompactAnyhow as _;
 use fedimint_core::{Amount, OutPoint, TransactionId, apply, async_trait_maybe_send};
 use fedimint_derive_secret::{ChildId, DerivableSecret};
 use fedimint_eventlog::{Event, EventLogId};
 use fedimint_logging::LOG_CLIENT_MODULE_WALLETV2;
 use fedimint_walletv2_common::config::WalletClientConfig;
 use fedimint_walletv2_common::{
-    KIND, OutputInfo, StandardScript, TxInfo, WalletCommonInit, WalletInput, WalletInputV0,
-    WalletModuleTypes, WalletOutput, WalletOutputV0, descriptor, is_potential_receive,
+    CONFIRMATION_FINALITY_DELAY, KIND, OutputInfo, StandardScript, TxInfo, WalletCommonInit,
+    WalletInput, WalletInputV0, WalletModuleTypes, WalletOutput, WalletOutputV0, descriptor,
+    is_potential_receive,
 };
-use futures::StreamExt;
+use futures::{Stream, StreamExt};
 use receive_sm::{ReceiveSMCommon, ReceiveSMState, ReceiveStateMachine};
 use secp256k1::Keypair;
 use send_sm::{SendSMCommon, SendSMState, SendStateMachine};
@@ -112,6 +117,38 @@ pub enum FinalReceiveOperationState {
     Success,
     /// The federation rejected the claiming transaction.
     Aborted,
+}
+
+/// Progress of an incoming peg-in to one of our addresses.
+///
+/// The [`ReceiveProgress::Confirming`] variant is derived from advisory,
+/// non-consensus data reported by individual guardians, so it is **not**
+/// authoritative and may move backwards: a reorg can unmine a peg-in and return
+/// the stream to [`ReceiveProgress::AwaitingTransaction`]. Only
+/// [`ReceiveProgress::Claiming`] and later reflect federation consensus. Do not
+/// treat anything before that as money received.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ReceiveProgress {
+    /// No transaction paying the address has been mined yet.
+    ///
+    /// Note this does not distinguish "nothing sent" from "sent but still in
+    /// the mempool"; guardians only report mined outputs.
+    AwaitingTransaction,
+    /// A transaction paying the address has been mined but is not yet deep
+    /// enough for the federation to act on it.
+    Confirming {
+        value: bitcoin::Amount,
+        outpoint: bitcoin::OutPoint,
+        /// Confirmations counting the block that mined the transaction as the
+        /// first, matching what a block explorer displays.
+        confirmations: u64,
+        /// Confirmations needed before the federation records the output.
+        required: u64,
+    },
+    /// The federation has recorded the output and the client is claiming it.
+    Claiming,
+    /// The peg-in has been claimed and the ecash issued.
+    Claimed,
 }
 
 #[derive(Debug, Clone)]
@@ -211,6 +248,7 @@ impl ClientModuleInit for WalletClientInit {
         };
 
         module.spawn_output_scanner(args.task_group(), args.client_span());
+        module.spawn_pending_receive_scanner(args.task_group(), args.client_span());
 
         Ok(module)
     }
@@ -550,6 +588,135 @@ impl WalletClientModule {
         Ok(final_state.expect("Stream contains one final state"))
     }
 
+    /// Resolves one of our receive addresses back to the index it was derived
+    /// at.
+    ///
+    /// Only addresses handed out by [`Self::receive`] resolve; the set of valid
+    /// indices is small, so this is a short scan rather than a stored reverse
+    /// index.
+    async fn address_index(&self, address: &Address) -> Option<u64> {
+        let script = address.script_pubkey();
+
+        let indices: Vec<u64> = self
+            .db
+            .begin_transaction_nc()
+            .await
+            .find_by_prefix(&ValidAddressIndexPrefix)
+            .await
+            .map(|entry| entry.0.0)
+            .collect()
+            .await;
+
+        indices
+            .into_iter()
+            .find(|index| self.derive_address(*index).script_pubkey() == script)
+    }
+
+    /// The current progress of an incoming peg-in to `address`.
+    ///
+    /// See [`ReceiveProgress`] for why everything short of
+    /// [`ReceiveProgress::Claiming`] is advisory and may move backwards.
+    ///
+    /// Errors if `address` was not handed out by [`Self::receive`].
+    pub async fn receive_progress(&self, address: &Address) -> anyhow::Result<ReceiveProgress> {
+        let address_index = self
+            .address_index(address)
+            .await
+            .context("Address was not derived by this client")?;
+
+        Ok(self.receive_progress_by_index(address_index).await)
+    }
+
+    async fn receive_progress_by_index(&self, address_index: u64) -> ReceiveProgress {
+        let mut dbtx = self.db.begin_transaction_nc().await;
+
+        if dbtx
+            .get_value(&ReceiveOperationKey(address_index))
+            .await
+            .is_some()
+        {
+            return ReceiveProgress::Claiming;
+        }
+
+        // The module counts finality from the block after the one that mined the
+        // transaction, so a peg-in is claimable one standard confirmation later
+        // than the delay itself.
+        let required = CONFIRMATION_FINALITY_DELAY + 1;
+
+        match dbtx.get_value(&PendingReceiveKey(address_index)).await {
+            Some(pending) => ReceiveProgress::Confirming {
+                value: pending.value,
+                outpoint: pending.outpoint,
+                // Guardians keep reporting an output for a while after it turns
+                // final, so that progress does not blank out before the claim
+                // begins. Clamp so a progress display cannot run past its own
+                // target during that overlap.
+                confirmations: pending.confirmations().min(required),
+                required,
+            },
+            None => ReceiveProgress::AwaitingTransaction,
+        }
+    }
+
+    /// Streams the progress of an incoming peg-in to `address`, yielding only
+    /// on change.
+    ///
+    /// The stream ends once the peg-in is claimed. It is driven by polling
+    /// rather than server push, so updates arrive within roughly the client's
+    /// scan interval of the federation observing them.
+    ///
+    /// Errors if `address` was not handed out by [`Self::receive`].
+    pub async fn subscribe_receive_progress(
+        &self,
+        address: &Address,
+    ) -> anyhow::Result<impl Stream<Item = ReceiveProgress> + use<>> {
+        let address_index = self
+            .address_index(address)
+            .await
+            .context("Address was not derived by this client")?;
+
+        let module = self.clone();
+
+        Ok(async_stream::stream! {
+            let mut last: Option<ReceiveProgress> = None;
+
+            loop {
+                let progress = module.receive_progress_by_index(address_index).await;
+
+                if progress == ReceiveProgress::Claiming {
+                    if last != Some(ReceiveProgress::Claiming) {
+                        yield ReceiveProgress::Claiming;
+                        last = Some(ReceiveProgress::Claiming);
+                    }
+
+                    let operation_id = module
+                        .db
+                        .begin_transaction_nc()
+                        .await
+                        .get_value(&ReceiveOperationKey(address_index))
+                        .await
+                        .expect("Receive operation was present a moment ago");
+
+                    // An aborted claim is retried as a fresh operation against
+                    // the still unspent output, so fall back to polling and
+                    // pick the new operation up once it is recorded.
+                    if let Ok(FinalReceiveOperationState::Success) = module
+                        .await_final_receive_operation_state(operation_id)
+                        .await
+                    {
+                        yield ReceiveProgress::Claimed;
+                        return;
+                    }
+                } else if last.as_ref() != Some(&progress) {
+                    yield progress.clone();
+                    last = Some(progress);
+                }
+
+                sleep(fedimint_walletv2_common::sleep_duration()).await;
+            }
+        })
+    }
+
     /// Returns the highest valid receive address index that the background
     /// scanner has derived so far, or `None` if it has not derived one yet.
     async fn valid_index(&self) -> Option<u64> {
@@ -793,6 +960,12 @@ impl WalletClientModule {
             )
             .await;
 
+        // Recorded alongside the event so that receive progress for this
+        // address resolves with a point lookup. A retry after an aborted claim
+        // overwrites this with the new operation.
+        dbtx.insert_entry(&ReceiveOperationKey(address_index), &operation_id)
+            .await;
+
         dbtx.commit_tx().await;
 
         Some((operation_id, range.txid()))
@@ -837,6 +1010,106 @@ impl WalletClientModule {
                 sleep(fedimint_walletv2_common::sleep_duration()).await;
             }
         });
+    }
+
+    /// Tracks peg-ins that are mined but not yet final, so a user who has just
+    /// sent bitcoin sees confirmation progress instead of nothing at all.
+    ///
+    /// Kept separate from the output scanner because the two answer different
+    /// questions on different cadences: that one walks an append-only consensus
+    /// log and may not rewind, whereas this one mirrors a revocable view of the
+    /// chain tip and must be free to drop entries again.
+    fn spawn_pending_receive_scanner(&self, task_group: &TaskGroup, client_span: &tracing::Span) {
+        let module = self.clone();
+
+        task_group.spawn_cancellable_with_span(
+            client_span.clone(),
+            "pending-receive-scanner",
+            async move {
+                loop {
+                    if let Err(err) = module.check_pending_receives().await {
+                        warn!(
+                            target: LOG_CLIENT_MODULE_WALLETV2,
+                            err = %err.fmt_compact_anyhow(),
+                            "Failed to fetch pending receives"
+                        );
+                    }
+
+                    sleep(fedimint_walletv2_common::sleep_duration()).await;
+                }
+            },
+        );
+    }
+
+    /// Refreshes the pending receive table from the guardians' local views.
+    ///
+    /// The table is rebuilt wholesale rather than appended to: entries have to
+    /// disappear when a reorg unmines a peg-in, or when the output becomes
+    /// final and the real receive operation takes over.
+    async fn check_pending_receives(&self) -> anyhow::Result<()> {
+        let pending = self.module_api.pending_outputs().await;
+
+        let address_map: BTreeMap<ScriptBuf, u64> = self
+            .db
+            .begin_transaction_nc()
+            .await
+            .find_by_prefix(&ValidAddressIndexPrefix)
+            .await
+            .map(|entry| entry.0.0)
+            .map(|index| (self.derive_address(index).script_pubkey(), index))
+            .collect()
+            .await;
+
+        let matched: BTreeMap<u64, PendingReceive> = pending
+            .outputs
+            .iter()
+            .filter_map(|output| {
+                let address_index = address_map.get(&output.script)?;
+
+                Some((
+                    *address_index,
+                    PendingReceive {
+                        outpoint: output.outpoint,
+                        value: output.value,
+                        height: output.height,
+                        block_count: pending.block_count,
+                    },
+                ))
+            })
+            .collect();
+
+        let mut dbtx = self.db.begin_transaction().await;
+
+        let existing: Vec<u64> = dbtx
+            .find_by_prefix(&PendingReceivePrefix)
+            .await
+            .map(|entry| entry.0.0)
+            .collect()
+            .await;
+
+        for address_index in existing
+            .into_iter()
+            .filter(|index| !matched.contains_key(index))
+        {
+            dbtx.remove_entry(&PendingReceiveKey(address_index)).await;
+        }
+
+        for (address_index, pending_receive) in &matched {
+            dbtx.insert_entry(&PendingReceiveKey(*address_index), pending_receive)
+                .await;
+        }
+
+        dbtx.commit_tx_result().await?;
+
+        debug!(
+            target: LOG_CLIENT_MODULE_WALLETV2,
+            block_count = pending.block_count,
+            reported_num = pending.outputs.len(),
+            matched_num = matched.len(),
+            "Scanning for pending receives"
+        );
+
+        Ok(())
     }
 
     async fn check_outputs(&self, handle: &TaskHandle) -> anyhow::Result<bool> {

--- a/modules/fedimint-walletv2-client/src/lib.rs
+++ b/modules/fedimint-walletv2-client/src/lib.rs
@@ -147,6 +147,11 @@ pub enum ReceiveProgress {
     /// to act on it.
     Confirming {
         value: bitcoin::Amount,
+        /// Height of the block that mined the deposit.
+        ///
+        /// Reported as the guardians saw it, so a reorg can move a deposit to a
+        /// different height or back to being unseen entirely.
+        height: u64,
         /// Confirmations counting the block that mined the transaction as the
         /// first, matching what a block explorer displays.
         confirmations: u64,
@@ -716,19 +721,18 @@ impl WalletClientModule {
         // than the delay itself.
         let required = CONFIRMATION_FINALITY_DELAY + 1;
 
-        // Confirmations count the block that mined the deposit as the first,
-        // matching what a block explorer displays.
-        match output
-            .height
-            .map(|height| block_count.saturating_sub(height))
-        {
-            Some(confirmations) => ReceiveProgress::Confirming {
+        match output.height {
+            Some(height) => ReceiveProgress::Confirming {
                 value: output.value,
+                height,
+                // Confirmations count the block that mined the deposit as the
+                // first, matching what a block explorer displays.
+                //
                 // Guardians keep reporting an output for a while after it turns
                 // final, so that progress does not blank out before the claim
                 // begins. Clamp so a progress display cannot run past its own
                 // target during that overlap.
-                confirmations: confirmations.min(required),
+                confirmations: block_count.saturating_sub(height).min(required),
                 required,
             },
             None => ReceiveProgress::Mempool {

--- a/modules/fedimint-walletv2-client/src/lib.rs
+++ b/modules/fedimint-walletv2-client/src/lib.rs
@@ -22,10 +22,7 @@ use anyhow::{Context as _, anyhow};
 use api::WalletFederationApi;
 use bitcoin::address::NetworkUnchecked;
 use bitcoin::{Address, ScriptBuf};
-use db::{
-    NextOutputIndexKey, PendingReceive, PendingReceiveAddressPrefix, PendingReceiveKey,
-    PendingReceivePrefix, ValidAddressIndexKey, ValidAddressIndexPrefix,
-};
+use db::{NextOutputIndexKey, ValidAddressIndexKey, ValidAddressIndexPrefix};
 use events::{ReceivePaymentEvent, SendPaymentEvent};
 use fedimint_api_client::api::{DynModuleApi, FederationResult};
 use fedimint_client::DynGlobalClientContext;
@@ -48,16 +45,15 @@ use fedimint_core::module::{
     AmountUnit, Amounts, ApiVersion, CommonModuleInit, ModuleCommon, ModuleInit, MultiApiVersion,
 };
 use fedimint_core::task::{TaskGroup, TaskHandle, sleep};
-use fedimint_core::util::FmtCompactAnyhow as _;
 use fedimint_core::{Amount, OutPoint, TransactionId, apply, async_trait_maybe_send};
 use fedimint_derive_secret::{ChildId, DerivableSecret};
 use fedimint_eventlog::{Event, EventLogId};
 use fedimint_logging::LOG_CLIENT_MODULE_WALLETV2;
 use fedimint_walletv2_common::config::WalletClientConfig;
 use fedimint_walletv2_common::{
-    CONFIRMATION_FINALITY_DELAY, KIND, OutputInfo, StandardScript, TxInfo, WalletCommonInit,
-    WalletInput, WalletInputV0, WalletModuleTypes, WalletOutput, WalletOutputV0, descriptor,
-    is_potential_receive,
+    CONFIRMATION_FINALITY_DELAY, KIND, OutputInfo, PendingOutput, StandardScript, TxInfo,
+    WalletCommonInit, WalletInput, WalletInputV0, WalletModuleTypes, WalletOutput, WalletOutputV0,
+    descriptor, is_potential_receive,
 };
 use futures::{Stream, StreamExt};
 use receive_sm::{ReceiveSMCommon, ReceiveSMState, ReceiveStateMachine};
@@ -262,7 +258,6 @@ impl ClientModuleInit for WalletClientInit {
         };
 
         module.spawn_output_scanner(args.task_group(), args.client_span());
-        module.spawn_pending_receive_scanner(args.task_group(), args.client_span());
 
         Ok(module)
     }
@@ -633,31 +628,30 @@ impl WalletClientModule {
     /// may move backwards. Use [`Self::subscribe_receive_progress`] to follow a
     /// deposit through to being claimed.
     ///
+    /// Each call queries the federation, so poll it sparingly;
+    /// [`Self::subscribe_receive_progress`] is the better fit for following a
+    /// deposit.
+    ///
     /// Errors if no deposit at `outpoint` is known to this client, which
     /// includes one that has been reorged out or evicted since it was last
-    /// seen.
+    /// seen, and one paying an address this client did not derive.
     pub async fn receive_progress(
         &self,
         outpoint: bitcoin::OutPoint,
     ) -> anyhow::Result<ReceiveProgress> {
-        // The pending table holds only a handful of live entries, so finding a
-        // deposit by outpoint alone is a short scan rather than a second index.
-        let pending: Vec<(bitcoin::OutPoint, PendingReceive)> = self
-            .db
-            .begin_transaction_nc()
-            .await
-            .find_by_prefix(&PendingReceivePrefix)
-            .await
-            .map(|(key, pending)| (key.outpoint, pending))
-            .collect()
-            .await;
+        let pending = self.module_api.pending_outputs().await;
 
-        let (_, pending) = pending
-            .into_iter()
-            .find(|(reported, _)| *reported == outpoint)
-            .context("No deposit at this outpoint")?;
+        // Guardians report every output passing the receive filter, most of
+        // which belong to other clients, so ownership is established by matching
+        // the script against our own addresses.
+        let ours = self.address_map().await;
 
-        Ok(Self::pending_progress(&pending))
+        pending
+            .outputs
+            .iter()
+            .find(|output| output.outpoint == outpoint && ours.contains_key(&output.script))
+            .map(|output| Self::pending_progress(output, pending.block_count))
+            .context("No deposit of ours at this outpoint")
     }
 
     /// The progress of every deposit to `address` the federation has seen,
@@ -672,37 +666,64 @@ impl WalletClientModule {
         &self,
         address: &Address,
     ) -> anyhow::Result<Vec<(bitcoin::OutPoint, ReceiveProgress)>> {
-        let address_index = self
-            .address_index(address)
+        self.address_index(address)
             .await
             .context("Address was not derived by this client")?;
 
-        Ok(self.address_receive_progress_by_index(address_index).await)
+        Ok(self.deposits_paying(&address.script_pubkey()).await)
     }
 
-    async fn address_receive_progress_by_index(
+    /// Every deposit the federation currently reports against `script`.
+    async fn deposits_paying(
         &self,
-        address_index: u64,
+        script: &ScriptBuf,
     ) -> Vec<(bitcoin::OutPoint, ReceiveProgress)> {
+        let pending = self.module_api.pending_outputs().await;
+
+        let mut deposits: Vec<(bitcoin::OutPoint, ReceiveProgress)> = pending
+            .outputs
+            .iter()
+            .filter(|output| output.script == *script)
+            .map(|output| {
+                (
+                    output.outpoint,
+                    Self::pending_progress(output, pending.block_count),
+                )
+            })
+            .collect();
+
+        deposits.sort_by_key(|(outpoint, _)| *outpoint);
+
+        deposits
+    }
+
+    /// The scripts of every receive address derived so far, by index.
+    async fn address_map(&self) -> BTreeMap<ScriptBuf, u64> {
         self.db
             .begin_transaction_nc()
             .await
-            .find_by_prefix(&PendingReceiveAddressPrefix(address_index))
+            .find_by_prefix(&ValidAddressIndexPrefix)
             .await
-            .map(|(key, pending)| (key.outpoint, Self::pending_progress(&pending)))
+            .map(|entry| entry.0.0)
+            .map(|index| (self.derive_address(index).script_pubkey(), index))
             .collect()
             .await
     }
 
-    fn pending_progress(pending: &PendingReceive) -> ReceiveProgress {
+    fn pending_progress(output: &PendingOutput, block_count: u64) -> ReceiveProgress {
         // The module counts finality from the block after the one that mined the
         // transaction, so a peg-in is claimable one standard confirmation later
         // than the delay itself.
         let required = CONFIRMATION_FINALITY_DELAY + 1;
 
-        match pending.confirmations() {
+        // Confirmations count the block that mined the deposit as the first,
+        // matching what a block explorer displays.
+        match output
+            .height
+            .map(|height| block_count.saturating_sub(height))
+        {
             Some(confirmations) => ReceiveProgress::Confirming {
-                value: pending.value,
+                value: output.value,
                 // Guardians keep reporting an output for a while after it turns
                 // final, so that progress does not blank out before the claim
                 // begins. Clamp so a progress display cannot run past its own
@@ -711,7 +732,7 @@ impl WalletClientModule {
                 required,
             },
             None => ReceiveProgress::Mempool {
-                value: pending.value,
+                value: output.value,
             },
         }
     }
@@ -741,19 +762,19 @@ impl WalletClientModule {
         address: &Address,
         position: EventLogId,
     ) -> anyhow::Result<impl Stream<Item = Vec<(bitcoin::OutPoint, ReceiveProgress)>> + use<>> {
-        let address_index = self
-            .address_index(address)
+        self.address_index(address)
             .await
             .context("Address was not derived by this client")?;
 
         let module = self.clone();
+        let script = address.script_pubkey();
 
         Ok(async_stream::stream! {
             let mut last: Option<Vec<(bitcoin::OutPoint, ReceiveProgress)>> = None;
             let mut seen: BTreeSet<bitcoin::OutPoint> = BTreeSet::new();
 
             loop {
-                let progress = module.address_receive_progress_by_index(address_index).await;
+                let progress = module.deposits_paying(&script).await;
 
                 seen.extend(progress.iter().map(|(outpoint, _)| *outpoint));
 
@@ -1090,117 +1111,6 @@ impl WalletClientModule {
                 sleep(fedimint_walletv2_common::sleep_duration()).await;
             }
         });
-    }
-
-    /// Tracks peg-ins that are mined but not yet final, so a user who has just
-    /// sent bitcoin sees confirmation progress instead of nothing at all.
-    ///
-    /// Kept separate from the output scanner because the two answer different
-    /// questions on different cadences: that one walks an append-only consensus
-    /// log and may not rewind, whereas this one mirrors a revocable view of the
-    /// chain tip and must be free to drop entries again.
-    fn spawn_pending_receive_scanner(&self, task_group: &TaskGroup, client_span: &tracing::Span) {
-        let module = self.clone();
-
-        task_group.spawn_cancellable_with_span(
-            client_span.clone(),
-            "pending-receive-scanner",
-            async move {
-                loop {
-                    if let Err(err) = module.check_pending_receives().await {
-                        warn!(
-                            target: LOG_CLIENT_MODULE_WALLETV2,
-                            err = %err.fmt_compact_anyhow(),
-                            "Failed to fetch pending receives"
-                        );
-                    }
-
-                    sleep(fedimint_walletv2_common::sleep_duration()).await;
-                }
-            },
-        );
-    }
-
-    /// Refreshes the pending receive table from the guardians' local views.
-    ///
-    /// The table is rebuilt wholesale rather than appended to: entries have to
-    /// disappear when a reorg unmines a peg-in, or when the output becomes
-    /// final and the real receive operation takes over.
-    async fn check_pending_receives(&self) -> anyhow::Result<()> {
-        let pending = self.module_api.pending_outputs().await;
-
-        let address_map: BTreeMap<ScriptBuf, u64> = self
-            .db
-            .begin_transaction_nc()
-            .await
-            .find_by_prefix(&ValidAddressIndexPrefix)
-            .await
-            .map(|entry| entry.0.0)
-            .map(|index| (self.derive_address(index).script_pubkey(), index))
-            .collect()
-            .await;
-
-        // Keyed per outpoint, so an address paid more than once keeps one entry
-        // per payment instead of the last one overwriting the rest.
-        let matched: BTreeMap<(u64, bitcoin::OutPoint), PendingReceive> = pending
-            .outputs
-            .iter()
-            .filter_map(|output| {
-                let address_index = address_map.get(&output.script)?;
-
-                Some((
-                    (*address_index, output.outpoint),
-                    PendingReceive {
-                        value: output.value,
-                        height: output.height,
-                        block_count: pending.block_count,
-                    },
-                ))
-            })
-            .collect();
-
-        let mut dbtx = self.db.begin_transaction().await;
-
-        let existing: Vec<(u64, bitcoin::OutPoint)> = dbtx
-            .find_by_prefix(&PendingReceivePrefix)
-            .await
-            .map(|(key, _)| (key.address_index, key.outpoint))
-            .collect()
-            .await;
-
-        for (address_index, outpoint) in existing
-            .into_iter()
-            .filter(|key| !matched.contains_key(key))
-        {
-            dbtx.remove_entry(&PendingReceiveKey {
-                address_index,
-                outpoint,
-            })
-            .await;
-        }
-
-        for ((address_index, outpoint), pending_receive) in &matched {
-            dbtx.insert_entry(
-                &PendingReceiveKey {
-                    address_index: *address_index,
-                    outpoint: *outpoint,
-                },
-                pending_receive,
-            )
-            .await;
-        }
-
-        dbtx.commit_tx_result().await?;
-
-        debug!(
-            target: LOG_CLIENT_MODULE_WALLETV2,
-            block_count = pending.block_count,
-            reported_num = pending.outputs.len(),
-            matched_num = matched.len(),
-            "Scanning for pending receives"
-        );
-
-        Ok(())
     }
 
     async fn check_outputs(&self, handle: &TaskHandle) -> anyhow::Result<bool> {

--- a/modules/fedimint-walletv2-client/src/lib.rs
+++ b/modules/fedimint-walletv2-client/src/lib.rs
@@ -23,8 +23,8 @@ use api::WalletFederationApi;
 use bitcoin::address::NetworkUnchecked;
 use bitcoin::{Address, ScriptBuf};
 use db::{
-    NextOutputIndexKey, PendingReceive, PendingReceiveKey, PendingReceivePrefix,
-    ReceiveOperationKey, ValidAddressIndexKey, ValidAddressIndexPrefix,
+    NextOutputIndexKey, PendingReceive, PendingReceiveAddressPrefix, PendingReceiveKey,
+    PendingReceivePrefix, ValidAddressIndexKey, ValidAddressIndexPrefix,
 };
 use events::{ReceivePaymentEvent, SendPaymentEvent};
 use fedimint_api_client::api::{DynModuleApi, FederationResult};
@@ -119,48 +119,49 @@ pub enum FinalReceiveOperationState {
     Aborted,
 }
 
-/// Progress of an incoming peg-in to one of our addresses.
+/// Progress of a single incoming peg-in.
 ///
-/// The [`ReceiveProgress::Confirming`] variant is derived from advisory,
-/// non-consensus data reported by individual guardians, so it is **not**
-/// authoritative and may move backwards: a reorg can unmine a peg-in and return
-/// the stream to [`ReceiveProgress::AwaitingTransaction`]. Only
-/// [`ReceiveProgress::Claiming`] and later reflect federation consensus. Do not
-/// treat anything before that as money received.
+/// Each variant describes one deposit, identified by the outpoint it is looked
+/// up or paired with. An address that has been paid more than once has one of
+/// these per payment rather than a combined view, so nothing is aggregated
+/// away.
+///
+/// There is no "nothing has arrived" variant: a deposit no guardian has seen
+/// has no outpoint to describe it, so absence is expressed by
+/// [`WalletClientModule::address_receive_progress`] returning an empty list.
+///
+/// [`ReceiveProgress::Mempool`] and [`ReceiveProgress::Confirming`] are derived
+/// from advisory, non-consensus data reported by individual guardians, so they
+/// are **not** authoritative and may move backwards: a reorg or an eviction can
+/// take a deposit back to being unseen entirely. Only
+/// [`ReceiveProgress::Claimed`] means money has actually been received.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ReceiveProgress {
-    /// No guardian has seen a transaction paying the address.
-    ///
-    /// This does not always mean nothing was sent. A federation whose guardians
-    /// all run a bitcoin backend that cannot enumerate a mempool stays here
-    /// until the peg-in is mined, so it also covers "sent, but nobody can see
-    /// it yet".
-    AwaitingTransaction,
-    /// A transaction paying the address is in a guardian's mempool but is not
-    /// mined.
+    /// The deposit is in a guardian's mempool but is not mined.
     ///
     /// The weakest signal there is: an unmined transaction can be replaced or
-    /// evicted, and this state can revert to
-    /// [`ReceiveProgress::AwaitingTransaction`]. Treat it as "we have seen your
-    /// payment", never as money received.
-    Mempool {
-        value: bitcoin::Amount,
-        outpoint: bitcoin::OutPoint,
-    },
-    /// A transaction paying the address has been mined but is not yet deep
-    /// enough for the federation to act on it.
+    /// evicted, and a deposit in this state can disappear again. Treat it as
+    /// "we have seen your payment", never as money received.
+    ///
+    /// Only guardians whose bitcoin backend can enumerate a mempool report
+    /// these, so on a federation without one a deposit stays unseen until it is
+    /// mined.
+    Mempool { value: bitcoin::Amount },
+    /// The deposit has been mined but is not yet deep enough for the federation
+    /// to act on it.
     Confirming {
         value: bitcoin::Amount,
-        outpoint: bitcoin::OutPoint,
         /// Confirmations counting the block that mined the transaction as the
         /// first, matching what a block explorer displays.
         confirmations: u64,
         /// Confirmations needed before the federation records the output.
         required: u64,
     },
-    /// The federation has recorded the output and the client is claiming it.
-    Claiming,
-    /// The peg-in has been claimed and the ecash issued.
+    /// The deposit has been claimed and its ecash issued.
+    ///
+    /// Only [`WalletClientModule::subscribe_receive_progress`] reports this,
+    /// since establishing it means waiting on the receive operation itself
+    /// rather than reading the guardians' pending view.
     Claimed,
 }
 
@@ -625,45 +626,83 @@ impl WalletClientModule {
             .find(|index| self.derive_address(*index).script_pubkey() == script)
     }
 
-    /// The current progress of an incoming peg-in to `address`.
+    /// The current progress of the deposit at `outpoint`.
     ///
-    /// See [`ReceiveProgress`] for why everything short of
-    /// [`ReceiveProgress::Claiming`] is advisory and may move backwards.
+    /// Reads only the guardians' pending view, so it never reports
+    /// [`ReceiveProgress::Claimed`]; everything it does report is advisory and
+    /// may move backwards. Use [`Self::subscribe_receive_progress`] to follow a
+    /// deposit through to being claimed.
+    ///
+    /// Errors if no deposit at `outpoint` is known to this client, which
+    /// includes one that has been reorged out or evicted since it was last
+    /// seen.
+    pub async fn receive_progress(
+        &self,
+        outpoint: bitcoin::OutPoint,
+    ) -> anyhow::Result<ReceiveProgress> {
+        // The pending table holds only a handful of live entries, so finding a
+        // deposit by outpoint alone is a short scan rather than a second index.
+        let pending: Vec<(bitcoin::OutPoint, PendingReceive)> = self
+            .db
+            .begin_transaction_nc()
+            .await
+            .find_by_prefix(&PendingReceivePrefix)
+            .await
+            .map(|(key, pending)| (key.outpoint, pending))
+            .collect()
+            .await;
+
+        let (_, pending) = pending
+            .into_iter()
+            .find(|(reported, _)| *reported == outpoint)
+            .context("No deposit at this outpoint")?;
+
+        Ok(Self::pending_progress(&pending))
+    }
+
+    /// The progress of every deposit to `address` the federation has seen,
+    /// ordered by outpoint.
+    ///
+    /// An empty list means no guardian has reported a payment to the address
+    /// yet. That is not proof nothing was sent: an unmined deposit is only
+    /// visible to guardians whose bitcoin backend can enumerate a mempool.
     ///
     /// Errors if `address` was not handed out by [`Self::receive`].
-    pub async fn receive_progress(&self, address: &Address) -> anyhow::Result<ReceiveProgress> {
+    pub async fn address_receive_progress(
+        &self,
+        address: &Address,
+    ) -> anyhow::Result<Vec<(bitcoin::OutPoint, ReceiveProgress)>> {
         let address_index = self
             .address_index(address)
             .await
             .context("Address was not derived by this client")?;
 
-        Ok(self.receive_progress_by_index(address_index).await)
+        Ok(self.address_receive_progress_by_index(address_index).await)
     }
 
-    async fn receive_progress_by_index(&self, address_index: u64) -> ReceiveProgress {
-        let mut dbtx = self.db.begin_transaction_nc().await;
-
-        if dbtx
-            .get_value(&ReceiveOperationKey(address_index))
+    async fn address_receive_progress_by_index(
+        &self,
+        address_index: u64,
+    ) -> Vec<(bitcoin::OutPoint, ReceiveProgress)> {
+        self.db
+            .begin_transaction_nc()
             .await
-            .is_some()
-        {
-            return ReceiveProgress::Claiming;
-        }
+            .find_by_prefix(&PendingReceiveAddressPrefix(address_index))
+            .await
+            .map(|(key, pending)| (key.outpoint, Self::pending_progress(&pending)))
+            .collect()
+            .await
+    }
 
+    fn pending_progress(pending: &PendingReceive) -> ReceiveProgress {
         // The module counts finality from the block after the one that mined the
         // transaction, so a peg-in is claimable one standard confirmation later
         // than the delay itself.
         let required = CONFIRMATION_FINALITY_DELAY + 1;
 
-        let Some(pending) = dbtx.get_value(&PendingReceiveKey(address_index)).await else {
-            return ReceiveProgress::AwaitingTransaction;
-        };
-
         match pending.confirmations() {
             Some(confirmations) => ReceiveProgress::Confirming {
                 value: pending.value,
-                outpoint: pending.outpoint,
                 // Guardians keep reporting an output for a while after it turns
                 // final, so that progress does not blank out before the claim
                 // begins. Clamp so a progress display cannot run past its own
@@ -673,23 +712,35 @@ impl WalletClientModule {
             },
             None => ReceiveProgress::Mempool {
                 value: pending.value,
-                outpoint: pending.outpoint,
             },
         }
     }
 
-    /// Streams the progress of an incoming peg-in to `address`, yielding only
-    /// on change.
+    /// Streams the progress of every deposit to `address`, yielding the full
+    /// per-deposit list whenever any of it changes, and ending once every
+    /// deposit it saw has been claimed.
     ///
-    /// The stream ends once the peg-in is claimed. It is driven by polling
-    /// rather than server push, so updates arrive within roughly the client's
-    /// scan interval of the federation observing them.
+    /// Yields an empty list until the first deposit appears. Confirmation
+    /// progress comes from polling the guardians' pending view, so updates
+    /// arrive within roughly the client's scan interval of the federation
+    /// observing them. Once no deposit is still gaining confirmations, the
+    /// stream waits on the receive operations themselves and yields a final
+    /// all-[`ReceiveProgress::Claimed`] list.
+    ///
+    /// `position` must be an event log position read *before* `address` was
+    /// handed out, the same way [`Self::await_receive`] is used, so that the
+    /// claims for these deposits fall at or after it.
+    ///
+    /// Because [`Self::await_receive`] matches the next receive of *any*
+    /// address, a deposit to a different address claimed in the meantime is
+    /// counted here too. Subscribing to one address at a time avoids that.
     ///
     /// Errors if `address` was not handed out by [`Self::receive`].
     pub async fn subscribe_receive_progress(
         &self,
         address: &Address,
-    ) -> anyhow::Result<impl Stream<Item = ReceiveProgress> + use<>> {
+        position: EventLogId,
+    ) -> anyhow::Result<impl Stream<Item = Vec<(bitcoin::OutPoint, ReceiveProgress)>> + use<>> {
         let address_index = self
             .address_index(address)
             .await
@@ -698,42 +749,57 @@ impl WalletClientModule {
         let module = self.clone();
 
         Ok(async_stream::stream! {
-            let mut last: Option<ReceiveProgress> = None;
+            let mut last: Option<Vec<(bitcoin::OutPoint, ReceiveProgress)>> = None;
+            let mut seen: BTreeSet<bitcoin::OutPoint> = BTreeSet::new();
 
             loop {
-                let progress = module.receive_progress_by_index(address_index).await;
+                let progress = module.address_receive_progress_by_index(address_index).await;
 
-                if progress == ReceiveProgress::Claiming {
-                    if last != Some(ReceiveProgress::Claiming) {
-                        yield ReceiveProgress::Claiming;
-                        last = Some(ReceiveProgress::Claiming);
-                    }
+                seen.extend(progress.iter().map(|(outpoint, _)| *outpoint));
 
-                    let operation_id = module
-                        .db
-                        .begin_transaction_nc()
-                        .await
-                        .get_value(&ReceiveOperationKey(address_index))
-                        .await
-                        .expect("Receive operation was present a moment ago");
-
-                    // An aborted claim is retried as a fresh operation against
-                    // the still unspent output, so fall back to polling and
-                    // pick the new operation up once it is recorded.
-                    if let Ok(FinalReceiveOperationState::Success) = module
-                        .await_final_receive_operation_state(operation_id)
-                        .await
-                    {
-                        yield ReceiveProgress::Claimed;
-                        return;
-                    }
-                } else if last.as_ref() != Some(&progress) {
+                if last.as_ref() != Some(&progress) {
                     yield progress.clone();
-                    last = Some(progress);
+
+                    last = Some(progress.clone());
+                }
+
+                // Stop polling once nothing is still gaining confirmations,
+                // which covers a deposit sitting at the depth the federation
+                // claims at and one that has already dropped out of the pending
+                // window, as happens when several blocks arrive at once.
+                let advancing = progress.iter().any(|(_, state)| match state {
+                    ReceiveProgress::Mempool { .. } => true,
+                    ReceiveProgress::Confirming {
+                        confirmations,
+                        required,
+                        ..
+                    } => confirmations < required,
+                    ReceiveProgress::Claimed => false,
+                });
+
+                if !seen.is_empty() && !advancing {
+                    break;
                 }
 
                 sleep(fedimint_walletv2_common::sleep_duration()).await;
             }
+
+            // The pending view cannot tell a claimed deposit from a reorged
+            // one, so the receive operations settle it.
+            let mut position = position;
+
+            for _ in 0..seen.len() {
+                let Ok((_, next)) = module.await_receive(position).await else {
+                    return;
+                };
+
+                position = next;
+            }
+
+            yield seen
+                .into_iter()
+                .map(|outpoint| (outpoint, ReceiveProgress::Claimed))
+                .collect();
         })
     }
 
@@ -980,12 +1046,6 @@ impl WalletClientModule {
             )
             .await;
 
-        // Recorded alongside the event so that receive progress for this
-        // address resolves with a point lookup. A retry after an aborted claim
-        // overwrites this with the new operation.
-        dbtx.insert_entry(&ReceiveOperationKey(address_index), &operation_id)
-            .await;
-
         dbtx.commit_tx().await;
 
         Some((operation_id, range.txid()))
@@ -1080,16 +1140,17 @@ impl WalletClientModule {
             .collect()
             .await;
 
-        let matched: BTreeMap<u64, PendingReceive> = pending
+        // Keyed per outpoint, so an address paid more than once keeps one entry
+        // per payment instead of the last one overwriting the rest.
+        let matched: BTreeMap<(u64, bitcoin::OutPoint), PendingReceive> = pending
             .outputs
             .iter()
             .filter_map(|output| {
                 let address_index = address_map.get(&output.script)?;
 
                 Some((
-                    *address_index,
+                    (*address_index, output.outpoint),
                     PendingReceive {
-                        outpoint: output.outpoint,
                         value: output.value,
                         height: output.height,
                         block_count: pending.block_count,
@@ -1100,23 +1161,33 @@ impl WalletClientModule {
 
         let mut dbtx = self.db.begin_transaction().await;
 
-        let existing: Vec<u64> = dbtx
+        let existing: Vec<(u64, bitcoin::OutPoint)> = dbtx
             .find_by_prefix(&PendingReceivePrefix)
             .await
-            .map(|entry| entry.0.0)
+            .map(|(key, _)| (key.address_index, key.outpoint))
             .collect()
             .await;
 
-        for address_index in existing
+        for (address_index, outpoint) in existing
             .into_iter()
-            .filter(|index| !matched.contains_key(index))
+            .filter(|key| !matched.contains_key(key))
         {
-            dbtx.remove_entry(&PendingReceiveKey(address_index)).await;
+            dbtx.remove_entry(&PendingReceiveKey {
+                address_index,
+                outpoint,
+            })
+            .await;
         }
 
-        for (address_index, pending_receive) in &matched {
-            dbtx.insert_entry(&PendingReceiveKey(*address_index), pending_receive)
-                .await;
+        for ((address_index, outpoint), pending_receive) in &matched {
+            dbtx.insert_entry(
+                &PendingReceiveKey {
+                    address_index: *address_index,
+                    outpoint: *outpoint,
+                },
+                pending_receive,
+            )
+            .await;
         }
 
         dbtx.commit_tx_result().await?;

--- a/modules/fedimint-walletv2-client/src/lib.rs
+++ b/modules/fedimint-walletv2-client/src/lib.rs
@@ -129,11 +129,24 @@ pub enum FinalReceiveOperationState {
 /// treat anything before that as money received.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ReceiveProgress {
-    /// No transaction paying the address has been mined yet.
+    /// No guardian has seen a transaction paying the address.
     ///
-    /// Note this does not distinguish "nothing sent" from "sent but still in
-    /// the mempool"; guardians only report mined outputs.
+    /// This does not always mean nothing was sent. A federation whose guardians
+    /// all run a bitcoin backend that cannot enumerate a mempool stays here
+    /// until the peg-in is mined, so it also covers "sent, but nobody can see
+    /// it yet".
     AwaitingTransaction,
+    /// A transaction paying the address is in a guardian's mempool but is not
+    /// mined.
+    ///
+    /// The weakest signal there is: an unmined transaction can be replaced or
+    /// evicted, and this state can revert to
+    /// [`ReceiveProgress::AwaitingTransaction`]. Treat it as "we have seen your
+    /// payment", never as money received.
+    Mempool {
+        value: bitcoin::Amount,
+        outpoint: bitcoin::OutPoint,
+    },
     /// A transaction paying the address has been mined but is not yet deep
     /// enough for the federation to act on it.
     Confirming {
@@ -643,18 +656,25 @@ impl WalletClientModule {
         // than the delay itself.
         let required = CONFIRMATION_FINALITY_DELAY + 1;
 
-        match dbtx.get_value(&PendingReceiveKey(address_index)).await {
-            Some(pending) => ReceiveProgress::Confirming {
+        let Some(pending) = dbtx.get_value(&PendingReceiveKey(address_index)).await else {
+            return ReceiveProgress::AwaitingTransaction;
+        };
+
+        match pending.confirmations() {
+            Some(confirmations) => ReceiveProgress::Confirming {
                 value: pending.value,
                 outpoint: pending.outpoint,
                 // Guardians keep reporting an output for a while after it turns
                 // final, so that progress does not blank out before the claim
                 // begins. Clamp so a progress display cannot run past its own
                 // target during that overlap.
-                confirmations: pending.confirmations().min(required),
+                confirmations: confirmations.min(required),
                 required,
             },
-            None => ReceiveProgress::AwaitingTransaction,
+            None => ReceiveProgress::Mempool {
+                value: pending.value,
+                outpoint: pending.outpoint,
+            },
         }
     }
 

--- a/modules/fedimint-walletv2-client/src/lib.rs
+++ b/modules/fedimint-walletv2-client/src/lib.rs
@@ -55,7 +55,7 @@ use fedimint_walletv2_common::{
     WalletCommonInit, WalletInput, WalletInputV0, WalletModuleTypes, WalletOutput, WalletOutputV0,
     descriptor, is_potential_receive,
 };
-use futures::{Stream, StreamExt};
+use futures::StreamExt;
 use receive_sm::{ReceiveSMCommon, ReceiveSMState, ReceiveStateMachine};
 use secp256k1::Keypair;
 use send_sm::{SendSMCommon, SendSMState, SendStateMachine};
@@ -126,11 +126,12 @@ pub enum FinalReceiveOperationState {
 /// has no outpoint to describe it, so absence is expressed by
 /// [`WalletClientModule::address_receive_progress`] returning an empty list.
 ///
-/// [`ReceiveProgress::Mempool`] and [`ReceiveProgress::Confirming`] are derived
-/// from advisory, non-consensus data reported by individual guardians, so they
-/// are **not** authoritative and may move backwards: a reorg or an eviction can
-/// take a deposit back to being unseen entirely. Only
-/// [`ReceiveProgress::Claimed`] means money has actually been received.
+/// Every variant is derived from advisory, non-consensus data reported by
+/// individual guardians, so none of them is authoritative and progress may move
+/// backwards: a reorg or an eviction can take a deposit back to being unseen
+/// entirely. No variant means money has been received - a deposit is only
+/// actually claimed once [`WalletClientModule::await_receive`] returns, and an
+/// output is deliberately still reported here for a short while after that.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ReceiveProgress {
     /// The deposit is in a guardian's mempool but is not mined.
@@ -158,12 +159,6 @@ pub enum ReceiveProgress {
         /// Confirmations needed before the federation records the output.
         required: u64,
     },
-    /// The deposit has been claimed and its ecash issued.
-    ///
-    /// Only [`WalletClientModule::subscribe_receive_progress`] reports this,
-    /// since establishing it means waiting on the receive operation itself
-    /// rather than reading the guardians' pending view.
-    Claimed,
 }
 
 #[derive(Debug, Clone)]
@@ -628,14 +623,12 @@ impl WalletClientModule {
 
     /// The current progress of the deposit at `outpoint`.
     ///
-    /// Reads only the guardians' pending view, so it never reports
-    /// [`ReceiveProgress::Claimed`]; everything it does report is advisory and
-    /// may move backwards. Use [`Self::subscribe_receive_progress`] to follow a
-    /// deposit through to being claimed.
+    /// Reads only the guardians' pending view, which is advisory and may move
+    /// backwards, and which cannot tell a claimed deposit from a reorged one.
+    /// Use [`Self::await_receive`] to establish that a deposit has actually
+    /// been claimed.
     ///
-    /// Each call queries the federation, so poll it sparingly;
-    /// [`Self::subscribe_receive_progress`] is the better fit for following a
-    /// deposit.
+    /// Each call queries the federation, so poll it sparingly.
     ///
     /// Errors if no deposit at `outpoint` is known to this client, which
     /// includes one that has been reorged out or evicted since it was last
@@ -739,93 +732,6 @@ impl WalletClientModule {
                 value: output.value,
             },
         }
-    }
-
-    /// Streams the progress of every deposit to `address`, yielding the full
-    /// per-deposit list whenever any of it changes, and ending once every
-    /// deposit it saw has been claimed.
-    ///
-    /// Yields an empty list until the first deposit appears. Confirmation
-    /// progress comes from polling the guardians' pending view, so updates
-    /// arrive within roughly the client's scan interval of the federation
-    /// observing them. Once no deposit is still gaining confirmations, the
-    /// stream waits on the receive operations themselves and yields a final
-    /// all-[`ReceiveProgress::Claimed`] list.
-    ///
-    /// `position` must be an event log position read *before* `address` was
-    /// handed out, the same way [`Self::await_receive`] is used, so that the
-    /// claims for these deposits fall at or after it.
-    ///
-    /// Because [`Self::await_receive`] matches the next receive of *any*
-    /// address, a deposit to a different address claimed in the meantime is
-    /// counted here too. Subscribing to one address at a time avoids that.
-    ///
-    /// Errors if `address` was not handed out by [`Self::receive`].
-    pub async fn subscribe_receive_progress(
-        &self,
-        address: &Address,
-        position: EventLogId,
-    ) -> anyhow::Result<impl Stream<Item = Vec<(bitcoin::OutPoint, ReceiveProgress)>> + use<>> {
-        self.address_index(address)
-            .await
-            .context("Address was not derived by this client")?;
-
-        let module = self.clone();
-        let script = address.script_pubkey();
-
-        Ok(async_stream::stream! {
-            let mut last: Option<Vec<(bitcoin::OutPoint, ReceiveProgress)>> = None;
-            let mut seen: BTreeSet<bitcoin::OutPoint> = BTreeSet::new();
-
-            loop {
-                let progress = module.deposits_paying(&script).await;
-
-                seen.extend(progress.iter().map(|(outpoint, _)| *outpoint));
-
-                if last.as_ref() != Some(&progress) {
-                    yield progress.clone();
-
-                    last = Some(progress.clone());
-                }
-
-                // Stop polling once nothing is still gaining confirmations,
-                // which covers a deposit sitting at the depth the federation
-                // claims at and one that has already dropped out of the pending
-                // window, as happens when several blocks arrive at once.
-                let advancing = progress.iter().any(|(_, state)| match state {
-                    ReceiveProgress::Mempool { .. } => true,
-                    ReceiveProgress::Confirming {
-                        confirmations,
-                        required,
-                        ..
-                    } => confirmations < required,
-                    ReceiveProgress::Claimed => false,
-                });
-
-                if !seen.is_empty() && !advancing {
-                    break;
-                }
-
-                sleep(fedimint_walletv2_common::sleep_duration()).await;
-            }
-
-            // The pending view cannot tell a claimed deposit from a reorged
-            // one, so the receive operations settle it.
-            let mut position = position;
-
-            for _ in 0..seen.len() {
-                let Ok((_, next)) = module.await_receive(position).await else {
-                    return;
-                };
-
-                position = next;
-            }
-
-            yield seen
-                .into_iter()
-                .map(|outpoint| (outpoint, ReceiveProgress::Claimed))
-                .collect();
-        })
     }
 
     /// Returns the highest valid receive address index that the background

--- a/modules/fedimint-walletv2-client/src/lib.rs
+++ b/modules/fedimint-walletv2-client/src/lib.rs
@@ -124,7 +124,7 @@ pub enum FinalReceiveOperationState {
 ///
 /// There is no "nothing has arrived" variant: a deposit no guardian has seen
 /// has no outpoint to describe it, so absence is expressed by
-/// [`WalletClientModule::address_receive_progress`] returning an empty list.
+/// [`WalletClientModule::address_receive_progress`] reporting no deposits.
 ///
 /// Every variant is derived from advisory, non-consensus data reported by
 /// individual guardians, so none of them is authoritative and progress may move
@@ -159,6 +159,30 @@ pub enum ReceiveProgress {
         /// Confirmations needed before the federation records the output.
         required: u64,
     },
+}
+
+/// What the federation currently reports about the deposits to one address.
+///
+/// Returned by [`WalletClientModule::address_receive_progress`]. The two fields
+/// are only meaningful together: they come from a single query, so the
+/// visibility flag describes exactly the view the deposits were read from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AddressReceiveProgress {
+    /// One entry per deposit the guardians can see, ordered by outpoint.
+    pub deposits: Vec<(bitcoin::OutPoint, ReceiveProgress)>,
+    /// Whether any guardian could enumerate a mempool for this query.
+    ///
+    /// When this is false nobody can report an unmined deposit, so empty
+    /// `deposits` are not evidence that nothing was sent - the federation is
+    /// simply blind to the payment until it is mined. A guardian reports false
+    /// if its bitcoin backend is esplora, if it has turned its mempool scan
+    /// off, or if it could not read its mempool this round; one guardian that
+    /// can see a mempool is enough to make this true for everyone.
+    ///
+    /// A wallet showing a receive screen wants this to choose between "we have
+    /// not seen your payment yet" and "waiting for the first confirmation",
+    /// which are very different things to tell a user who has just paid.
+    pub mempool_visibility: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -655,15 +679,16 @@ impl WalletClientModule {
     /// The progress of every deposit to `address` the federation has seen,
     /// ordered by outpoint.
     ///
-    /// An empty list means no guardian has reported a payment to the address
-    /// yet. That is not proof nothing was sent: an unmined deposit is only
-    /// visible to guardians whose bitcoin backend can enumerate a mempool.
+    /// Empty deposits mean no guardian has reported a payment to the address
+    /// yet. That is only proof nothing was sent if
+    /// [`AddressReceiveProgress::mempool_visibility`] is true, since an unmined
+    /// deposit is invisible to a federation that cannot read a mempool.
     ///
     /// Errors if `address` was not handed out by [`Self::receive`].
     pub async fn address_receive_progress(
         &self,
         address: &Address,
-    ) -> anyhow::Result<Vec<(bitcoin::OutPoint, ReceiveProgress)>> {
+    ) -> anyhow::Result<AddressReceiveProgress> {
         self.address_index(address)
             .await
             .context("Address was not derived by this client")?;
@@ -672,10 +697,7 @@ impl WalletClientModule {
     }
 
     /// Every deposit the federation currently reports against `script`.
-    async fn deposits_paying(
-        &self,
-        script: &ScriptBuf,
-    ) -> Vec<(bitcoin::OutPoint, ReceiveProgress)> {
+    async fn deposits_paying(&self, script: &ScriptBuf) -> AddressReceiveProgress {
         let pending = self.module_api.pending_outputs().await;
 
         let mut deposits: Vec<(bitcoin::OutPoint, ReceiveProgress)> = pending
@@ -692,7 +714,10 @@ impl WalletClientModule {
 
         deposits.sort_by_key(|(outpoint, _)| *outpoint);
 
-        deposits
+        AddressReceiveProgress {
+            deposits,
+            mempool_visibility: pending.mempool_visibility,
+        }
     }
 
     /// The scripts of every receive address derived so far, by index.

--- a/modules/fedimint-walletv2-common/src/endpoint_constants.rs
+++ b/modules/fedimint-walletv2-common/src/endpoint_constants.rs
@@ -7,3 +7,4 @@ pub const TRANSACTION_ID_ENDPOINT: &str = "transaction_id";
 pub const OUTPUT_INFO_SLICE_ENDPOINT: &str = "output_info_slice";
 pub const PENDING_TRANSACTION_CHAIN_ENDPOINT: &str = "pending_transaction_chain";
 pub const TRANSACTION_CHAIN_ENDPOINT: &str = "transaction_chain";
+pub const PENDING_OUTPUTS_ENDPOINT: &str = "pending_outputs";

--- a/modules/fedimint-walletv2-common/src/lib.rs
+++ b/modules/fedimint-walletv2-common/src/lib.rs
@@ -31,6 +31,11 @@ pub const KIND: ModuleKind = ModuleKind::from_static_str("walletv2");
 
 pub const MODULE_CONSENSUS_VERSION: ModuleConsensusVersion = ModuleConsensusVersion::new(1, 0);
 
+/// Number of confirmations required for a transaction to be considered as
+/// final by the federation. The block that mines the transaction does
+/// not count towards the number of confirmations.
+pub const CONFIRMATION_FINALITY_DELAY: u64 = 6;
+
 /// Returns a sleep duration of 1 second in test environments or 60 seconds in
 /// production. Used for polling intervals where faster feedback is needed
 /// during testing.
@@ -102,6 +107,43 @@ pub struct OutputInfo {
     pub value: bitcoin::Amount,
     pub spent: bool,
     pub outpoint: Option<bitcoin::OutPoint>,
+}
+
+/// An output passing the probabilistic receive filter that has been mined, but
+/// is not yet deep enough to have entered the federation's consensus output
+/// log.
+///
+/// This is advisory, non-consensus data: it is derived from a single guardian's
+/// local view of the chain tip and may be revoked by a reorg. It exists purely
+/// so a client can show a peg-in's confirmation progress instead of nothing at
+/// all while it waits out the module's confirmation finality delay.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct PendingOutput {
+    pub script: ScriptBuf,
+    pub outpoint: bitcoin::OutPoint,
+    pub value: bitcoin::Amount,
+    /// Height of the block that mined this output.
+    pub height: u64,
+}
+
+/// A guardian's local view of the mined-but-not-yet-final receive outputs,
+/// together with the block count that view was derived from.
+///
+/// The block count is returned alongside the outputs so that a client computes
+/// confirmations against a single consistent view rather than mixing a height
+/// from one guardian with a chain tip from another.
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct PendingOutputs {
+    /// The responding guardian's local block count, or `0` if its bitcoin
+    /// backend is unavailable.
+    ///
+    /// An output's confirmations are `block_count - height`, which counts the
+    /// block that mined it as the first confirmation. Note this is offset by
+    /// one from [`CONFIRMATION_FINALITY_DELAY`], which does not count the
+    /// mining block, so a peg-in becomes claimable at
+    /// `CONFIRMATION_FINALITY_DELAY + 1` confirmations.
+    pub block_count: u64,
+    pub outputs: Vec<PendingOutput>,
 }
 
 #[derive(Debug)]

--- a/modules/fedimint-walletv2-common/src/lib.rs
+++ b/modules/fedimint-walletv2-common/src/lib.rs
@@ -109,21 +109,27 @@ pub struct OutputInfo {
     pub outpoint: Option<bitcoin::OutPoint>,
 }
 
-/// An output passing the probabilistic receive filter that has been mined, but
-/// is not yet deep enough to have entered the federation's consensus output
-/// log.
+/// An output passing the probabilistic receive filter that a guardian can see,
+/// but which is not yet deep enough to have entered the federation's consensus
+/// output log.
 ///
 /// This is advisory, non-consensus data: it is derived from a single guardian's
-/// local view of the chain tip and may be revoked by a reorg. It exists purely
-/// so a client can show a peg-in's confirmation progress instead of nothing at
-/// all while it waits out the module's confirmation finality delay.
+/// local view of the chain and its mempool, and may be revoked by a reorg, an
+/// eviction or a replacement. It exists purely so a client can show a peg-in's
+/// progress instead of nothing at all while it waits out the module's
+/// confirmation finality delay.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PendingOutput {
     pub script: ScriptBuf,
     pub outpoint: bitcoin::OutPoint,
     pub value: bitcoin::Amount,
-    /// Height of the block that mined this output.
-    pub height: u64,
+    /// Height of the block that mined this output, or `None` while it is only
+    /// in the guardian's mempool.
+    ///
+    /// A mempool output is the weakest signal the federation offers: it is not
+    /// mined, not final, and can vanish entirely. Only guardians whose bitcoin
+    /// backend can enumerate a mempool report these at all.
+    pub height: Option<u64>,
 }
 
 /// A guardian's local view of the mined-but-not-yet-final receive outputs,
@@ -137,13 +143,19 @@ pub struct PendingOutputs {
     /// The responding guardian's local block count, or `0` if its bitcoin
     /// backend is unavailable.
     ///
-    /// An output's confirmations are `block_count - height`, which counts the
-    /// block that mined it as the first confirmation. Note this is offset by
-    /// one from [`CONFIRMATION_FINALITY_DELAY`], which does not count the
+    /// A mined output's confirmations are `block_count - height`, which counts
+    /// the block that mined it as the first confirmation. Note this is offset
+    /// by one from [`CONFIRMATION_FINALITY_DELAY`], which does not count the
     /// mining block, so a peg-in becomes claimable at
     /// `CONFIRMATION_FINALITY_DELAY + 1` confirmations.
     pub block_count: u64,
     pub outputs: Vec<PendingOutput>,
+    /// Whether this guardian's bitcoin backend can enumerate a mempool.
+    ///
+    /// Distinguishes "no unmined peg-ins" from "this guardian cannot see the
+    /// mempool at all", which an esplora-backed guardian never can. Without it
+    /// a client could not tell an empty mempool from a blind guardian.
+    pub mempool_visibility: bool,
 }
 
 #[derive(Debug)]

--- a/modules/fedimint-walletv2-common/src/lib.rs
+++ b/modules/fedimint-walletv2-common/src/lib.rs
@@ -132,8 +132,17 @@ pub struct PendingOutput {
     pub height: Option<u64>,
 }
 
-/// A guardian's local view of the mined-but-not-yet-final receive outputs,
-/// together with the block count that view was derived from.
+/// A guardian's local, advisory view of the receive outputs it can see but the
+/// federation has not recorded yet, together with the block count that view was
+/// derived from.
+///
+/// Two kinds of output land here: candidates sitting in the guardian's mempool,
+/// and the receive outputs of the handful of blocks below its local chain tip.
+/// That block window is measured against the guardian's own tip rather than the
+/// consensus block count, so an output keeps being reported for a while *after*
+/// it becomes final - deliberately, so that a progress display does not blank
+/// out in the gap between finality and the claim landing. Presence here
+/// therefore does not mean a deposit is still unclaimed.
 ///
 /// The block count is returned alongside the outputs so that a client computes
 /// confirmations against a single consistent view rather than mixing a height

--- a/modules/fedimint-walletv2-server/Cargo.toml
+++ b/modules/fedimint-walletv2-server/Cargo.toml
@@ -32,4 +32,5 @@ secp256k1 = { workspace = true }
 serde = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
+tokio = { workspace = true }
 tracing = { workspace = true }

--- a/modules/fedimint-walletv2-server/src/envs.rs
+++ b/modules/fedimint-walletv2-server/src/envs.rs
@@ -1,0 +1,9 @@
+/// Set to 1/true to stop this guardian from scanning its mempool for pending
+/// receives.
+///
+/// Enumerating a mempool costs one transaction fetch per mempool entry the
+/// guardian has not already cached, which on a busy mainnet node is a large
+/// burst of RPC work every time the cache is cold. A guardian that would rather
+/// not pay for it can turn the mempool half of the pending view off and report
+/// confirmations only, exactly as an esplora-backed guardian already does.
+pub const FM_WALLETV2_DISABLE_MEMPOOL_SCAN_ENV: &str = "FM_WALLETV2_DISABLE_MEMPOOL_SCAN";

--- a/modules/fedimint-walletv2-server/src/lib.rs
+++ b/modules/fedimint-walletv2-server/src/lib.rs
@@ -296,7 +296,26 @@ async fn scan_pending_receives(
 
     scan_pending_blocks(btc_rpc, pks_hash, status.block_count, &mut cache.blocks).await?;
 
-    let mempool_visibility = scan_pending_mempool(btc_rpc, pks_hash, &mut cache.mempool).await?;
+    // A failed mempool read degrades to reporting no mempool visibility rather
+    // than failing the whole scan. Propagating would discard the mined progress
+    // gathered above, which is both the stronger signal and still available:
+    // with an esplora fallback the block scan can succeed while the mempool
+    // read, which only bitcoind can serve, does not.
+    let mempool_visibility = match scan_pending_mempool(btc_rpc, pks_hash, &mut cache.mempool).await
+    {
+        Ok(visibility) => visibility,
+        Err(err) => {
+            debug!(
+                target: LOG_MODULE_WALLETV2,
+                err = %err.fmt_compact_anyhow(),
+                "Error scanning mempool for pending receives, reporting confirmations only"
+            );
+
+            cache.mempool.clear();
+
+            false
+        }
+    };
 
     let mined = cache
         .blocks

--- a/modules/fedimint-walletv2-server/src/lib.rs
+++ b/modules/fedimint-walletv2-server/src/lib.rs
@@ -157,6 +157,46 @@ async fn pending_txs_unordered(dbtx: &mut DatabaseTransaction<'_>) -> Vec<Federa
 /// height and tagged with the hash they were derived from.
 type BlockCache = BTreeMap<u64, (bitcoin::BlockHash, Vec<PendingOutput>)>;
 
+/// Filtered receive outputs of the transactions currently in the mempool.
+///
+/// Every transaction is kept, including those with no matching outputs, so that
+/// a scan only fetches transactions it has never seen. On a busy mainnet node
+/// this holds on the order of tens of thousands of empty entries, which is a
+/// few megabytes and far cheaper than refetching the mempool each scan.
+type MempoolCache = BTreeMap<Txid, Vec<PendingOutput>>;
+
+/// State the pending receive scanner carries between runs.
+#[derive(Default)]
+struct PendingCache {
+    blocks: BlockCache,
+    mempool: MempoolCache,
+}
+
+/// Returns the receive outputs of `tx` that pass the probabilistic filter.
+fn filtered_receive_outputs(
+    tx: &Transaction,
+    pks_hash: &sha256::Hash,
+    height: Option<u64>,
+) -> Vec<PendingOutput> {
+    let txid = tx.compute_txid();
+
+    tx.output
+        .iter()
+        .enumerate()
+        .filter(|(_, tx_out)| is_potential_receive(&tx_out.script_pubkey, pks_hash))
+        .map(|(vout, tx_out)| PendingOutput {
+            script: tx_out.script_pubkey.clone(),
+            outpoint: bitcoin::OutPoint {
+                txid,
+                vout: u32::try_from(vout)
+                    .expect("Bitcoin transaction has more than u32::MAX outputs"),
+            },
+            value: tx_out.value,
+            height,
+        })
+        .collect()
+}
+
 /// Collects the receive outputs of the most recently mined blocks.
 ///
 /// Scans the last [`MAX_PENDING_DEPTH`] blocks below the guardian's local chain
@@ -168,21 +208,18 @@ type BlockCache = BTreeMap<u64, (bitcoin::BlockHash, Vec<PendingOutput>)>;
 /// Blocks are only fetched when the hash at a height is absent from `cache` or
 /// differs from the cached one, which keeps the steady state cost at one block
 /// fetch per new block and makes reorgs within the window self-repairing.
-async fn scan_pending_receives(
+async fn scan_pending_blocks(
     btc_rpc: &ServerBitcoinRpcMonitor,
     pks_hash: &sha256::Hash,
+    block_count: u64,
     cache: &mut BlockCache,
-) -> anyhow::Result<PendingOutputs> {
-    let status = btc_rpc
-        .status()
-        .context("Bitcoin backend is not connected")?;
-
-    let start = status.block_count.saturating_sub(MAX_PENDING_DEPTH);
+) -> anyhow::Result<()> {
+    let start = block_count.saturating_sub(MAX_PENDING_DEPTH);
 
     // Drop the blocks that have fallen out of the window as the chain advanced.
-    cache.retain(|height, _| (start..status.block_count).contains(height));
+    cache.retain(|height, _| (start..block_count).contains(height));
 
-    for height in start..status.block_count {
+    for height in start..block_count {
         let block_hash = btc_rpc.get_block_hash(height).await?;
 
         if cache
@@ -197,39 +234,87 @@ async fn scan_pending_receives(
         let outputs = block
             .txdata
             .iter()
-            .flat_map(|tx| {
-                let txid = tx.compute_txid();
-
-                tx.output
-                    .iter()
-                    .enumerate()
-                    .filter(|(_, tx_out)| is_potential_receive(&tx_out.script_pubkey, pks_hash))
-                    .map(move |(vout, tx_out)| PendingOutput {
-                        script: tx_out.script_pubkey.clone(),
-                        outpoint: bitcoin::OutPoint {
-                            txid,
-                            vout: u32::try_from(vout)
-                                .expect("Bitcoin transaction has more than u32::MAX outputs"),
-                        },
-                        value: tx_out.value,
-                        height,
-                    })
-                    .collect::<Vec<PendingOutput>>()
-            })
+            .flat_map(|tx| filtered_receive_outputs(tx, pks_hash, Some(height)))
             .collect::<Vec<PendingOutput>>();
 
         cache.insert(height, (block_hash, outputs));
     }
 
-    let outputs = cache
+    Ok(())
+}
+
+/// Collects the receive outputs of the transactions in the node's mempool.
+///
+/// Returns whether the backend has mempool visibility at all. Esplora cannot
+/// enumerate a mempool, so its guardians report `false` and simply never
+/// surface unmined peg-ins.
+///
+/// Only transactions absent from `cache` are fetched, and entries that have
+/// left the mempool are dropped, so eviction and replacement are handled by
+/// rebuilding the retained set rather than by tracking them explicitly. A
+/// transaction that disappears between being listed and being fetched is
+/// skipped rather than treated as an error, since that is the ordinary outcome
+/// of it being mined mid-scan.
+async fn scan_pending_mempool(
+    btc_rpc: &ServerBitcoinRpcMonitor,
+    pks_hash: &sha256::Hash,
+    cache: &mut MempoolCache,
+) -> anyhow::Result<bool> {
+    let Some(txids) = btc_rpc.get_mempool_txids().await? else {
+        cache.clear();
+
+        return Ok(false);
+    };
+
+    let txids: BTreeSet<Txid> = txids.into_iter().collect();
+
+    cache.retain(|txid, _| txids.contains(txid));
+
+    for txid in txids {
+        if cache.contains_key(&txid) {
+            continue;
+        }
+
+        if let Some(tx) = btc_rpc.get_mempool_tx(&txid).await? {
+            cache.insert(txid, filtered_receive_outputs(&tx, pks_hash, None));
+        }
+    }
+
+    Ok(true)
+}
+
+/// Collects every receive output a guardian can see but the federation has not
+/// yet recorded, from both the recent blocks and the mempool.
+async fn scan_pending_receives(
+    btc_rpc: &ServerBitcoinRpcMonitor,
+    pks_hash: &sha256::Hash,
+    cache: &mut PendingCache,
+) -> anyhow::Result<PendingOutputs> {
+    let status = btc_rpc
+        .status()
+        .context("Bitcoin backend is not connected")?;
+
+    scan_pending_blocks(btc_rpc, pks_hash, status.block_count, &mut cache.blocks).await?;
+
+    let mempool_visibility = scan_pending_mempool(btc_rpc, pks_hash, &mut cache.mempool).await?;
+
+    let mined = cache
+        .blocks
         .values()
-        .flat_map(|(_, outputs)| outputs.iter().cloned())
+        .flat_map(|(_, outputs)| outputs.iter().cloned());
+
+    // A transaction mined between the two scans appears in both; the mined
+    // entry is the stronger signal, so it wins on the client side by way of the
+    // per-outpoint merge preferring a known height.
+    let outputs = mined
+        .chain(cache.mempool.values().flatten().cloned())
         .collect::<Vec<PendingOutput>>();
 
     debug!(
         target: LOG_MODULE_WALLETV2,
         block_count = status.block_count,
-        window = status.block_count.saturating_sub(start),
+        mempool_visibility,
+        mempool_txs_num = cache.mempool.len(),
         pending_outputs_num = outputs.len(),
         "Scanned for pending receives"
     );
@@ -237,6 +322,7 @@ async fn scan_pending_receives(
     Ok(PendingOutputs {
         block_count: status.block_count,
         outputs,
+        mempool_visibility,
     })
 }
 
@@ -1080,11 +1166,9 @@ impl Wallet {
         task_group: &TaskGroup,
     ) {
         task_group.spawn_cancellable("scan_pending_receives", async move {
-            // Filtered outputs of every block in the pending window, keyed by
-            // height. Re-fetching a block is only necessary when the hash at a
-            // height changes, which is also how a reorg within the window
-            // repairs itself.
-            let mut cache: BlockCache = BTreeMap::new();
+            // Carried across scans so that each one only fetches blocks and
+            // mempool transactions it has not already seen.
+            let mut cache = PendingCache::default();
 
             // Follow the monitor's own refresh cadence rather than an
             // independent timer, so we never scan a chain tip that is already

--- a/modules/fedimint-walletv2-server/src/lib.rs
+++ b/modules/fedimint-walletv2-server/src/lib.rs
@@ -1132,8 +1132,10 @@ pub struct Wallet {
     cfg: WalletConfig,
     db: Database,
     btc_rpc: ServerBitcoinRpcMonitor,
-    /// Local, non-consensus view of receive outputs that have been mined but
-    /// are not yet deep enough to enter the consensus output log.
+    /// Local, non-consensus view of the receive outputs this guardian can see
+    /// ahead of the consensus output log: mempool candidates plus the receive
+    /// outputs of the last [`MAX_PENDING_DEPTH`] blocks, the latter retained
+    /// past finality so that clients see continuous progress.
     ///
     /// Maintained by the `scan_pending_receives` background task and read by
     /// the pending outputs endpoint. This is intentionally in-memory only: it
@@ -1169,8 +1171,8 @@ impl Wallet {
         }
     }
 
-    /// Maintains [`Wallet::pending_outputs`] by scanning the blocks just below
-    /// the guardian's local chain tip.
+    /// Maintains [`Wallet::pending_outputs`] by scanning both the blocks just
+    /// below the guardian's local chain tip and its mempool.
     ///
     /// This deliberately runs outside of consensus. Most of this window sits
     /// above the consensus block count precisely because the federation does

--- a/modules/fedimint-walletv2-server/src/lib.rs
+++ b/modules/fedimint-walletv2-server/src/lib.rs
@@ -64,17 +64,20 @@ use fedimint_server_core::{
     ConfigGenModuleArgs, EnvVarDoc, ServerModule, ServerModuleInit, ServerModuleInitArgs,
 };
 pub use fedimint_walletv2_common as common;
+/// Re-exported for existing callers; the constant lives in the common crate so
+/// that the client can render peg-in confirmation progress against it.
+pub use fedimint_walletv2_common::CONFIRMATION_FINALITY_DELAY;
 use fedimint_walletv2_common::config::{
     FeeConsensus, WalletClientConfig, WalletConfig, WalletConfigPrivate,
 };
 use fedimint_walletv2_common::endpoint_constants::{
     CONSENSUS_BLOCK_COUNT_ENDPOINT, CONSENSUS_FEERATE_ENDPOINT, FEDERATION_WALLET_ENDPOINT,
-    OUTPUT_INFO_SLICE_ENDPOINT, PENDING_TRANSACTION_CHAIN_ENDPOINT, RECEIVE_FEE_ENDPOINT,
-    SEND_FEE_ENDPOINT, TRANSACTION_CHAIN_ENDPOINT, TRANSACTION_ID_ENDPOINT,
+    OUTPUT_INFO_SLICE_ENDPOINT, PENDING_OUTPUTS_ENDPOINT, PENDING_TRANSACTION_CHAIN_ENDPOINT,
+    RECEIVE_FEE_ENDPOINT, SEND_FEE_ENDPOINT, TRANSACTION_CHAIN_ENDPOINT, TRANSACTION_ID_ENDPOINT,
 };
 use fedimint_walletv2_common::{
-    FederationWallet, MODULE_CONSENSUS_VERSION, TxInfo, WalletInputError, WalletOutputError,
-    descriptor, is_potential_receive, tweak_public_key,
+    FederationWallet, MODULE_CONSENSUS_VERSION, PendingOutput, PendingOutputs, TxInfo,
+    WalletInputError, WalletOutputError, descriptor, is_potential_receive, tweak_public_key,
 };
 use futures::StreamExt;
 use miniscript::descriptor::Wsh;
@@ -83,6 +86,7 @@ use secp256k1::ecdsa::Signature;
 use secp256k1::{PublicKey, Scalar, SecretKey};
 use serde::{Deserialize, Serialize};
 use strum::IntoEnumIterator;
+use tokio::sync::watch;
 use tracing::{debug, info};
 
 use crate::db::{
@@ -93,11 +97,6 @@ use crate::metrics::{
     WALLET_BLOCK_COUNT, WALLET_INOUT_FEES_SATS, WALLET_INOUT_SATS, WALLET_PEGIN_FEES_SATS,
     WALLET_PEGIN_SATS, WALLET_PEGOUT_FEES_SATS, WALLET_PEGOUT_SATS,
 };
-
-/// Number of confirmations required for a transaction to be considered as
-/// final by the federation. The block that mines the transaction does
-/// not count towards the number of confirmations.
-pub const CONFIRMATION_FINALITY_DELAY: u64 = 6;
 
 /// Maximum number of blocks the consensus block count can advance in a single
 /// consensus item to limit the work done in one `process_consensus_item` step.
@@ -110,6 +109,17 @@ const TEST_MAX_BLOCK_COUNT_INCREMENT: u64 = 100;
 /// Minimum fee rate vote of 1 sat/vB to ensure we never propose a fee rate
 /// below what Bitcoin Core will relay.
 const MIN_FEERATE_VOTE_SATS_PER_KVB: u64 = 1000;
+
+/// Number of blocks below the local chain tip that the pending receive scanner
+/// reports on.
+///
+/// Only the first [`CONFIRMATION_FINALITY_DELAY`] blocks of this window are
+/// strictly necessary, since deeper outputs are already in the consensus output
+/// log. The window deliberately extends past that so a peg-in keeps being
+/// reported for a while after it becomes final: a client needs a moment to
+/// notice the consensus entry and start its claim, and without the overlap its
+/// progress display would briefly fall back to reporting nothing at all.
+const MAX_PENDING_DEPTH: u64 = 2 * CONFIRMATION_FINALITY_DELAY;
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Encodable, Decodable)]
 pub struct FederationTx {
@@ -141,6 +151,93 @@ async fn pending_txs_unordered(dbtx: &mut DatabaseTransaction<'_>) -> Vec<Federa
         .await;
 
     unsigned.into_iter().chain(unconfirmed).collect()
+}
+
+/// Filtered receive outputs of the blocks in the pending window, keyed by
+/// height and tagged with the hash they were derived from.
+type BlockCache = BTreeMap<u64, (bitcoin::BlockHash, Vec<PendingOutput>)>;
+
+/// Collects the receive outputs of the most recently mined blocks.
+///
+/// Scans the last [`MAX_PENDING_DEPTH`] blocks below the guardian's local chain
+/// tip. The window is relative to the tip rather than to the consensus block
+/// count, so the work stays bounded even if the federation's consensus block
+/// count is lagging badly, and so a peg-in keeps being reported for a while
+/// after it becomes final.
+///
+/// Blocks are only fetched when the hash at a height is absent from `cache` or
+/// differs from the cached one, which keeps the steady state cost at one block
+/// fetch per new block and makes reorgs within the window self-repairing.
+async fn scan_pending_receives(
+    btc_rpc: &ServerBitcoinRpcMonitor,
+    pks_hash: &sha256::Hash,
+    cache: &mut BlockCache,
+) -> anyhow::Result<PendingOutputs> {
+    let status = btc_rpc
+        .status()
+        .context("Bitcoin backend is not connected")?;
+
+    let start = status.block_count.saturating_sub(MAX_PENDING_DEPTH);
+
+    // Drop the blocks that have fallen out of the window as the chain advanced.
+    cache.retain(|height, _| (start..status.block_count).contains(height));
+
+    for height in start..status.block_count {
+        let block_hash = btc_rpc.get_block_hash(height).await?;
+
+        if cache
+            .get(&height)
+            .is_some_and(|(cached_hash, _)| *cached_hash == block_hash)
+        {
+            continue;
+        }
+
+        let block = btc_rpc.get_block(&block_hash).await?;
+
+        let outputs = block
+            .txdata
+            .iter()
+            .flat_map(|tx| {
+                let txid = tx.compute_txid();
+
+                tx.output
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, tx_out)| is_potential_receive(&tx_out.script_pubkey, pks_hash))
+                    .map(move |(vout, tx_out)| PendingOutput {
+                        script: tx_out.script_pubkey.clone(),
+                        outpoint: bitcoin::OutPoint {
+                            txid,
+                            vout: u32::try_from(vout)
+                                .expect("Bitcoin transaction has more than u32::MAX outputs"),
+                        },
+                        value: tx_out.value,
+                        height,
+                    })
+                    .collect::<Vec<PendingOutput>>()
+            })
+            .collect::<Vec<PendingOutput>>();
+
+        cache.insert(height, (block_hash, outputs));
+    }
+
+    let outputs = cache
+        .values()
+        .flat_map(|(_, outputs)| outputs.iter().cloned())
+        .collect::<Vec<PendingOutput>>();
+
+    debug!(
+        target: LOG_MODULE_WALLETV2,
+        block_count = status.block_count,
+        window = status.block_count.saturating_sub(start),
+        pending_outputs_num = outputs.len(),
+        "Scanned for pending receives"
+    );
+
+    Ok(PendingOutputs {
+        block_count: status.block_count,
+        outputs,
+    })
 }
 
 #[derive(Debug, Clone)]
@@ -906,11 +1003,21 @@ impl ServerModule for Wallet {
                     Ok(module.tx_chain(&mut dbtx).await)
                 }
             },
+            public_api_endpoint! {
+                PENDING_OUTPUTS_ENDPOINT,
+                ApiVersion::new(0, 2),
+                async |module: &Wallet, _context, _params: ()| -> PendingOutputs {
+                    // Deliberately reads local, non-consensus state rather than
+                    // the database. Clients must not request this via threshold
+                    // consensus; see the client side api for details.
+                    Ok(module.pending_outputs.borrow().clone())
+                }
+            },
         ]
     }
 
     fn supported_api_versions(&self) -> MultiApiVersion {
-        MultiApiVersion::try_from_iter([ApiVersion::new(0, 1)])
+        MultiApiVersion::try_from_iter([ApiVersion::new(0, 2)])
             .expect("walletv2 declares one API version per major version")
     }
 }
@@ -920,6 +1027,15 @@ pub struct Wallet {
     cfg: WalletConfig,
     db: Database,
     btc_rpc: ServerBitcoinRpcMonitor,
+    /// Local, non-consensus view of receive outputs that have been mined but
+    /// are not yet deep enough to enter the consensus output log.
+    ///
+    /// Maintained by the `scan_pending_receives` background task and read by
+    /// the pending outputs endpoint. This is intentionally in-memory only: it
+    /// is per-guardian divergent data that has no business in the consensus
+    /// database, and it is cheap to rebuild from a handful of blocks on
+    /// restart.
+    pending_outputs: watch::Receiver<PendingOutputs>,
 }
 
 impl Wallet {
@@ -931,11 +1047,74 @@ impl Wallet {
     ) -> Wallet {
         Self::spawn_broadcast_unconfirmed_txs_task(btc_rpc.clone(), db.clone(), task_group);
 
+        let (pending_sender, pending_outputs) = watch::channel(PendingOutputs::default());
+
+        Self::spawn_pending_receive_scanner(
+            btc_rpc.clone(),
+            cfg.consensus.bitcoin_pks.consensus_hash(),
+            pending_sender,
+            task_group,
+        );
+
         Wallet {
             cfg,
             btc_rpc,
             db: db.clone(),
+            pending_outputs,
         }
+    }
+
+    /// Maintains [`Wallet::pending_outputs`] by scanning the blocks just below
+    /// the guardian's local chain tip.
+    ///
+    /// This deliberately runs outside of consensus. Most of this window sits
+    /// above the consensus block count precisely because the federation does
+    /// not consider those blocks final yet, and each guardian sees a slightly
+    /// different tip, so nothing derived here may ever influence consensus
+    /// state. It exists only so clients can render peg-in progress rather than
+    /// showing nothing for the hour it takes a deposit to become claimable.
+    fn spawn_pending_receive_scanner(
+        btc_rpc: ServerBitcoinRpcMonitor,
+        pks_hash: sha256::Hash,
+        sender: watch::Sender<PendingOutputs>,
+        task_group: &TaskGroup,
+    ) {
+        task_group.spawn_cancellable("scan_pending_receives", async move {
+            // Filtered outputs of every block in the pending window, keyed by
+            // height. Re-fetching a block is only necessary when the hash at a
+            // height changes, which is also how a reorg within the window
+            // repairs itself.
+            let mut cache: BlockCache = BTreeMap::new();
+
+            // Follow the monitor's own refresh cadence rather than an
+            // independent timer, so we never scan a chain tip that is already
+            // stale by up to a full update interval.
+            let mut status = btc_rpc.subscribe_status();
+
+            loop {
+                match scan_pending_receives(&btc_rpc, &pks_hash, &mut cache).await {
+                    Ok(pending) => {
+                        sender.send_replace(pending);
+                    }
+                    Err(err) => {
+                        // This view is advisory, so a guardian that cannot
+                        // reach its bitcoin backend degrades to reporting
+                        // nothing pending rather than failing.
+                        debug!(
+                            target: LOG_MODULE_WALLETV2,
+                            err = %err.fmt_compact_anyhow(),
+                            "Error scanning for pending receives"
+                        );
+
+                        sender.send_replace(PendingOutputs::default());
+                    }
+                }
+
+                if status.changed().await.is_err() {
+                    break;
+                }
+            }
+        });
     }
 
     fn spawn_broadcast_unconfirmed_txs_task(

--- a/modules/fedimint-walletv2-server/src/lib.rs
+++ b/modules/fedimint-walletv2-server/src/lib.rs
@@ -11,6 +11,7 @@
 #![allow(clippy::too_many_lines)]
 
 pub mod db;
+pub mod envs;
 mod metrics;
 
 use std::collections::{BTreeMap, BTreeSet};
@@ -32,6 +33,7 @@ use db::{
     SignaturesKey, SignaturesPrefix, SignaturesTxidPrefix, SpentOutputKey, SpentOutputPrefix,
     TxInfoIndexKey, TxInfoIndexPrefix,
 };
+use envs::FM_WALLETV2_DISABLE_MEMPOOL_SCAN_ENV;
 use fedimint_core::config::{
     ServerModuleConfig, ServerModuleConsensusConfig, TypedServerModuleConfig,
     TypedServerModuleConsensusConfig,
@@ -42,7 +44,7 @@ use fedimint_core::db::{
 };
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::envs::{
-    FM_ENABLE_MODULE_WALLETV2_ENV, is_env_var_set_opt, is_running_in_test_env,
+    FM_ENABLE_MODULE_WALLETV2_ENV, is_env_var_set, is_env_var_set_opt, is_running_in_test_env,
 };
 use fedimint_core::module::audit::Audit;
 use fedimint_core::module::{
@@ -243,11 +245,37 @@ async fn scan_pending_blocks(
     Ok(())
 }
 
-/// Collects the receive outputs of the transactions in the node's mempool.
+/// The outcome of one pass over the guardian's mempool.
 ///
-/// Returns whether the backend has mempool visibility at all. Esplora cannot
-/// enumerate a mempool, so its guardians report `false` and simply never
-/// surface unmined peg-ins.
+/// A pass never fails outright, because the mempool is only ever the weakest
+/// half of the pending view: losing it must not cost the mined half, which is
+/// the stronger signal and is gathered from a backend that may well still be
+/// working.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MempoolScan {
+    /// Every transaction the backend listed is now in the cache.
+    Complete,
+    /// The backend listed its mempool, but the pass gave up partway through
+    /// fetching transactions from it.
+    ///
+    /// What is cached was still pruned against that fresh listing, so every
+    /// entry in it is real and the set is merely short of a few transactions.
+    /// That is indistinguishable to a client from a deposit that has not
+    /// arrived yet, so a partial pass is still reported.
+    Partial,
+    /// This pass learned nothing about the mempool, either because the backend
+    /// cannot enumerate one or because listing it failed.
+    Unavailable,
+}
+
+impl MempoolScan {
+    /// Whether the cache this pass leaves behind may be reported to clients.
+    fn visible(self) -> bool {
+        matches!(self, Self::Complete | Self::Partial)
+    }
+}
+
+/// Collects the receive outputs of the transactions in the node's mempool.
 ///
 /// Only transactions absent from `cache` are fetched, and entries that have
 /// left the mempool are dropped, so eviction and replacement are handled by
@@ -255,15 +283,32 @@ async fn scan_pending_blocks(
 /// transaction that disappears between being listed and being fetched is
 /// skipped rather than treated as an error, since that is the ordinary outcome
 /// of it being mined mid-scan.
+///
+/// `cache` is never emptied on failure. Refilling it costs one fetch per
+/// mempool transaction, so discarding it because a single call failed would
+/// turn a transient error into repeated bursts of RPC work; whether its
+/// contents may be *reported* is what the returned [`MempoolScan`] decides.
 async fn scan_pending_mempool(
     btc_rpc: &ServerBitcoinRpcMonitor,
     pks_hash: &sha256::Hash,
     cache: &mut MempoolCache,
-) -> anyhow::Result<bool> {
-    let Some(txids) = btc_rpc.get_mempool_txids().await? else {
-        cache.clear();
+) -> MempoolScan {
+    let txids = match btc_rpc.get_mempool_txids().await {
+        Ok(Some(txids)) => txids,
+        // The backend has no mempool to enumerate, as esplora never does.
+        Ok(None) => return MempoolScan::Unavailable,
+        // Without a fresh listing the cache cannot be pruned, so it may hold
+        // transactions that have since been mined or evicted. Report nothing
+        // from it until a listing succeeds and prunes it again.
+        Err(err) => {
+            debug!(
+                target: LOG_MODULE_WALLETV2,
+                err = %err.fmt_compact_anyhow(),
+                "Error listing the mempool, reporting confirmations only"
+            );
 
-        return Ok(false);
+            return MempoolScan::Unavailable;
+        }
     };
 
     let txids: BTreeSet<Txid> = txids.into_iter().collect();
@@ -275,19 +320,43 @@ async fn scan_pending_mempool(
             continue;
         }
 
-        if let Some(tx) = btc_rpc.get_mempool_tx(&txid).await? {
-            cache.insert(txid, filtered_receive_outputs(&tx, pks_hash, None));
+        match btc_rpc.get_mempool_tx(&txid).await {
+            Ok(Some(tx)) => {
+                cache.insert(txid, filtered_receive_outputs(&tx, pks_hash, None));
+            }
+            // The transaction left the mempool between being listed and being
+            // fetched, so its absence from the cache is correct.
+            Ok(None) => {}
+            // A node that has the transaction but declines to return it answers
+            // with code `-5`, which the backend already reports as `Ok(None)`,
+            // so an error here is the backend itself failing and every
+            // remaining fetch would fail the same way. Abandon the pass rather
+            // than walk the rest of the mempool collecting the same error, and
+            // report what was gathered: everything fetched so far stays cached,
+            // so the next pass resumes from here instead of starting over.
+            Err(err) => {
+                debug!(
+                    target: LOG_MODULE_WALLETV2,
+                    %txid,
+                    err = %err.fmt_compact_anyhow(),
+                    "Error fetching a mempool transaction, reporting a partial mempool"
+                );
+
+                return MempoolScan::Partial;
+            }
         }
     }
 
-    Ok(true)
+    MempoolScan::Complete
 }
 
 /// Collects every receive output a guardian can see but the federation has not
-/// yet recorded, from both the recent blocks and the mempool.
+/// yet recorded, from the recent blocks and, unless `scan_mempool` is off, the
+/// mempool.
 async fn scan_pending_receives(
     btc_rpc: &ServerBitcoinRpcMonitor,
     pks_hash: &sha256::Hash,
+    scan_mempool: bool,
     cache: &mut PendingCache,
 ) -> anyhow::Result<PendingOutputs> {
     let status = btc_rpc
@@ -296,25 +365,14 @@ async fn scan_pending_receives(
 
     scan_pending_blocks(btc_rpc, pks_hash, status.block_count, &mut cache.blocks).await?;
 
-    // A failed mempool read degrades to reporting no mempool visibility rather
-    // than failing the whole scan. Propagating would discard the mined progress
-    // gathered above, which is both the stronger signal and still available:
-    // with an esplora fallback the block scan can succeed while the mempool
-    // read, which only bitcoind can serve, does not.
-    let mempool_visibility = match scan_pending_mempool(btc_rpc, pks_hash, &mut cache.mempool).await
-    {
-        Ok(visibility) => visibility,
-        Err(err) => {
-            debug!(
-                target: LOG_MODULE_WALLETV2,
-                err = %err.fmt_compact_anyhow(),
-                "Error scanning mempool for pending receives, reporting confirmations only"
-            );
-
-            cache.mempool.clear();
-
-            false
-        }
+    // The mempool pass never fails the whole scan. Propagating would discard
+    // the mined progress gathered above, which is both the stronger signal and
+    // still available: with an esplora fallback the block scan can succeed
+    // while the mempool read, which only bitcoind can serve, does not.
+    let mempool = if scan_mempool {
+        scan_pending_mempool(btc_rpc, pks_hash, &mut cache.mempool).await
+    } else {
+        MempoolScan::Unavailable
     };
 
     let mined = cache
@@ -322,17 +380,24 @@ async fn scan_pending_receives(
         .values()
         .flat_map(|(_, outputs)| outputs.iter().cloned());
 
+    // The cache survives a pass that could not report from it, so that a
+    // transient failure does not force a refetch of the whole mempool next
+    // time; what is reported is decided here instead of by emptying it.
+    let unmined = mempool
+        .visible()
+        .then(|| cache.mempool.values().flatten().cloned())
+        .into_iter()
+        .flatten();
+
     // A transaction mined between the two scans appears in both; the mined
     // entry is the stronger signal, so it wins on the client side by way of the
     // per-outpoint merge preferring a known height.
-    let outputs = mined
-        .chain(cache.mempool.values().flatten().cloned())
-        .collect::<Vec<PendingOutput>>();
+    let outputs = mined.chain(unmined).collect::<Vec<PendingOutput>>();
 
     debug!(
         target: LOG_MODULE_WALLETV2,
         block_count = status.block_count,
-        mempool_visibility,
+        ?mempool,
         mempool_txs_num = cache.mempool.len(),
         pending_outputs_num = outputs.len(),
         "Scanned for pending receives"
@@ -341,7 +406,7 @@ async fn scan_pending_receives(
     Ok(PendingOutputs {
         block_count: status.block_count,
         outputs,
-        mempool_visibility,
+        mempool_visibility: mempool.visible(),
     })
 }
 
@@ -484,10 +549,18 @@ impl ServerModuleInit for WalletInit {
     }
 
     fn get_documented_env_vars(&self) -> Vec<EnvVarDoc> {
-        vec![EnvVarDoc {
-            name: FM_ENABLE_MODULE_WALLETV2_ENV,
-            description: "Set to 0/false to disable the WalletV2 module. Enabled by default.",
-        }]
+        vec![
+            EnvVarDoc {
+                name: FM_ENABLE_MODULE_WALLETV2_ENV,
+                description: "Set to 0/false to disable the WalletV2 module. Enabled by default.",
+            },
+            EnvVarDoc {
+                name: FM_WALLETV2_DISABLE_MEMPOOL_SCAN_ENV,
+                description: "Set to 1/true to stop scanning the mempool for pending receives. \
+                              Peg-in progress is then only reported once a deposit is mined, as \
+                              it already is on an esplora backend. Enabled by default.",
+            },
+        ]
     }
 
     async fn init(&self, args: &ServerModuleInitArgs<Self>) -> anyhow::Result<Self::Module> {
@@ -1186,6 +1259,11 @@ impl Wallet {
         sender: watch::Sender<PendingOutputs>,
         task_group: &TaskGroup,
     ) {
+        // Read once rather than per scan: it selects how this guardian behaves
+        // for its whole run, and a guardian that has opted out should not be
+        // paying an env lookup on every chain tip either.
+        let scan_mempool = !is_env_var_set(FM_WALLETV2_DISABLE_MEMPOOL_SCAN_ENV);
+
         task_group.spawn_cancellable("scan_pending_receives", async move {
             // Carried across scans so that each one only fetches blocks and
             // mempool transactions it has not already seen.
@@ -1197,7 +1275,7 @@ impl Wallet {
             let mut status = btc_rpc.subscribe_status();
 
             loop {
-                match scan_pending_receives(&btc_rpc, &pks_hash, &mut cache).await {
+                match scan_pending_receives(&btc_rpc, &pks_hash, scan_mempool, &mut cache).await {
                     Ok(pending) => {
                         sender.send_replace(pending);
                     }

--- a/modules/fedimint-walletv2-tests/tests/tests.rs
+++ b/modules/fedimint-walletv2-tests/tests/tests.rs
@@ -154,9 +154,14 @@ async fn await_federation_total_value(
     }
 }
 
-/// A peg-in should report confirmation progress while it waits out the
-/// finality delay, rather than leaving the user with no feedback at all
-/// between broadcasting and the ecash being issued.
+/// A peg-in should report progress while it waits out the finality delay,
+/// rather than leaving the user with no feedback at all between broadcasting
+/// and the ecash being issued.
+///
+/// Also covers an address paid twice: `receive` hands out the same address
+/// until a deposit is detected at it, so two deposits to one address is an
+/// ordinary flow and each must be tracked separately rather than one
+/// overwriting the other.
 #[tokio::test(flavor = "multi_thread")]
 async fn receive_reports_confirmation_progress() -> anyhow::Result<()> {
     let fixtures = fixtures();
@@ -167,23 +172,35 @@ async fn receive_reports_confirmation_progress() -> anyhow::Result<()> {
     initialize_consensus(&client, &bitcoin).await?;
 
     let module = client.get_first_module::<WalletClientModule>()?;
+
+    // Read before handing out the address, so that the claims for both deposits
+    // fall at or after this position.
+    let position = client.get_next_event_log_id().await;
+
     let address = module.receive().await;
 
-    assert_eq!(
-        module.receive_progress(&address).await?,
-        ReceiveProgress::AwaitingTransaction,
-        "An address with nothing sent to it is not awaiting confirmations"
+    assert!(
+        module.address_receive_progress(&address).await?.is_empty(),
+        "An address with nothing sent to it has no deposits to report"
     );
 
-    info!("Broadcast the deposit without mining it...");
+    info!("Broadcast the first deposit without mining it...");
 
-    let tx = bitcoin
+    let mined_tx = bitcoin
         .send_without_mining(&address, Amount::from_int_btc(1))
         .await;
 
     // Guardians report the unmined deposit straight out of their mempools,
     // which is the whole point: the user gets feedback before the first block.
-    await_receive_mempool(&client, &address, tx.compute_txid()).await?;
+    let mined_outpoint = await_receive_mempool(&client, &address, mined_tx.compute_txid()).await?;
+
+    // The per-deposit lookup must agree with the address-wide one.
+    assert_eq!(
+        module.receive_progress(mined_outpoint).await?,
+        ReceiveProgress::Mempool {
+            value: Amount::from_int_btc(1)
+        },
+    );
 
     bitcoin.mine_blocks(1).await;
 
@@ -197,46 +214,162 @@ async fn receive_reports_confirmation_progress() -> anyhow::Result<()> {
         "Progress should count up to the depth at which the federation claims"
     );
 
-    info!("Mine the deposit to finality and confirm the claim takes over...");
+    info!("Send a second deposit to the same address and leave it unmined...");
 
-    await_finality_delay(&client, &bitcoin).await?;
+    let unmined_tx = bitcoin
+        .send_without_mining(&address, Amount::from_int_btc(2))
+        .await;
 
-    let mut progress = pin!(module.subscribe_receive_progress(&address).await?);
+    let unmined_outpoint = await_deposit_count(&client, &address, 2)
+        .await?
+        .into_iter()
+        .find_map(|(outpoint, _)| (outpoint.txid == unmined_tx.compute_txid()).then_some(outpoint))
+        .expect("The second deposit must be reported against its own transaction");
+
+    // The two deposits sit at different stages, so neither may mask the other.
+    let progress = module.address_receive_progress(&address).await?;
+
+    let mined = lookup_progress(&progress, mined_outpoint);
+    let unmined = lookup_progress(&progress, unmined_outpoint);
+
+    assert_eq!(
+        unmined,
+        ReceiveProgress::Mempool {
+            value: Amount::from_int_btc(2)
+        },
+        "The unmined deposit must be reported from the mempool, with its own value"
+    );
+
+    match mined {
+        ReceiveProgress::Confirming {
+            value,
+            confirmations,
+            required,
+        } => {
+            assert_eq!(
+                value,
+                Amount::from_int_btc(1),
+                "Each deposit reports its own value, not a combined one"
+            );
+            assert!(
+                (1..required).contains(&confirmations),
+                "The mined deposit is confirming, got {confirmations} of {required}"
+            );
+        }
+        state => panic!("The mined deposit should still be confirming, got {state:?}"),
+    }
+
+    assert_eq!(
+        module.receive_progress(mined_outpoint).await?,
+        mined,
+        "The per-deposit lookup must agree with the address-wide one"
+    );
+
+    info!("Mine both deposits to finality and confirm they are claimed...");
+
+    // The second deposit is still unmined, so it is mined by the first of these
+    // blocks and needs the full delay on top of that. Mining only the delay
+    // would leave it one block short of claimable forever.
+    let consensus_block_count = module.block_count().await?;
+
+    bitcoin.mine_blocks(CONFIRMATION_FINALITY_DELAY + 1).await;
+
+    await_consensus_block_count(
+        &client,
+        consensus_block_count + CONFIRMATION_FINALITY_DELAY + 1,
+    )
+    .await?;
+
+    let mut progress = pin!(
+        module
+            .subscribe_receive_progress(&address, position)
+            .await?
+    );
 
     loop {
         match progress.next().await {
-            Some(ReceiveProgress::Claimed) => break,
-            Some(state) => info!("Receive progress: {state:?}"),
-            None => panic!("Progress stream ended before the peg-in was claimed"),
+            Some(states)
+                if states.len() == 2
+                    && states
+                        .iter()
+                        .all(|(_, state)| *state == ReceiveProgress::Claimed) =>
+            {
+                break;
+            }
+            Some(states) => info!("Receive progress: {states:?}"),
+            None => panic!("Progress stream ended before both peg-ins were claimed"),
         }
     }
 
     Ok(())
 }
 
+/// Returns the progress reported for `outpoint`, panicking if it is absent.
+fn lookup_progress(
+    progress: &[(bitcoin::OutPoint, ReceiveProgress)],
+    outpoint: bitcoin::OutPoint,
+) -> ReceiveProgress {
+    progress
+        .iter()
+        .find(|(reported, _)| *reported == outpoint)
+        .map(|(_, state)| state.clone())
+        .unwrap_or_else(|| panic!("No progress reported for {outpoint}, got {progress:?}"))
+}
+
+/// Polls until the address reports exactly `count` deposits.
+async fn await_deposit_count(
+    client: &ClientHandleArc,
+    address: &bitcoin::Address,
+    count: usize,
+) -> anyhow::Result<Vec<(bitcoin::OutPoint, ReceiveProgress)>> {
+    loop {
+        let progress = client
+            .get_first_module::<WalletClientModule>()?
+            .address_receive_progress(address)
+            .await?;
+
+        assert!(
+            progress.len() <= count,
+            "More deposits reported than were sent: {progress:?}"
+        );
+
+        if progress.len() == count {
+            return Ok(progress);
+        }
+
+        sleep_in_test(
+            format!("Waiting for the address to report {count} deposits"),
+            Duration::from_secs(1),
+        )
+        .await;
+    }
+}
+
 /// Polls receive progress until the unmined peg-in is visible in the
-/// guardians' mempools, asserting it is reported against the expected
-/// transaction and value.
+/// guardians' mempools, returning its outpoint.
+///
+/// Asserts it is reported against the expected transaction and value, and as
+/// exactly one deposit.
 async fn await_receive_mempool(
     client: &ClientHandleArc,
     address: &bitcoin::Address,
     txid: bitcoin::Txid,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<bitcoin::OutPoint> {
     loop {
         let progress = client
             .get_first_module::<WalletClientModule>()?
-            .receive_progress(address)
+            .address_receive_progress(address)
             .await?;
 
-        match progress {
-            ReceiveProgress::Mempool { value, outpoint } => {
-                assert_eq!(value, Amount::from_int_btc(1));
+        match progress.as_slice() {
+            [(outpoint, ReceiveProgress::Mempool { value })] => {
+                assert_eq!(*value, Amount::from_int_btc(1));
                 assert_eq!(outpoint.txid, txid);
 
-                return Ok(());
+                return Ok(*outpoint);
             }
-            ReceiveProgress::AwaitingTransaction => {}
-            state => panic!("Peg-in reached {state:?} while still unmined"),
+            [] => {}
+            states => panic!("Peg-in reached {states:?} while still unmined"),
         }
 
         sleep_in_test(
@@ -260,26 +393,30 @@ async fn await_receive_confirmations(
     loop {
         let progress = client
             .get_first_module::<WalletClientModule>()?
-            .receive_progress(address)
+            .address_receive_progress(address)
             .await?;
 
-        match progress {
-            ReceiveProgress::Confirming {
-                value,
-                confirmations,
-                required,
-                ..
-            } => {
-                assert_eq!(value, Amount::from_int_btc(1));
+        match progress.as_slice() {
+            [
+                (
+                    _,
+                    ReceiveProgress::Confirming {
+                        value,
+                        confirmations,
+                        required,
+                    },
+                ),
+            ] => {
+                assert_eq!(*value, Amount::from_int_btc(1));
 
-                if confirmations >= min {
-                    return Ok(required);
+                if *confirmations >= min {
+                    return Ok(*required);
                 }
             }
             // Still legitimate here: the scanner may not have observed the new
             // block yet, so the peg-in can briefly read as unmined.
-            ReceiveProgress::AwaitingTransaction | ReceiveProgress::Mempool { .. } => {}
-            state => panic!("Peg-in reached {state:?} before the finality delay elapsed"),
+            [] | [(_, ReceiveProgress::Mempool { .. })] => {}
+            states => panic!("Peg-in reached {states:?} before the finality delay elapsed"),
         }
 
         sleep_in_test(
@@ -440,8 +577,8 @@ mod db {
     };
     use fedimint_walletv2_client::WalletClientModule;
     use fedimint_walletv2_client::db::{
-        self, NextOutputIndexKey, PendingReceivePrefix, ReceiveOperationPrefix,
-        ValidAddressIndexKey, ValidAddressIndexPrefix,
+        self, NextOutputIndexKey, PendingReceivePrefix, ValidAddressIndexKey,
+        ValidAddressIndexPrefix,
     };
     use fedimint_walletv2_common::{FederationWallet, TxInfo, WalletCommonInit};
     use fedimint_walletv2_server::db::{
@@ -893,19 +1030,6 @@ mod db {
                             ensure!(
                                 pending.is_empty(),
                                 "no pending receives must be present, got {pending:?}"
-                            );
-                        }
-                        db::DbKeyPrefix::ReceiveOperation => {
-                            let operations = dbtx
-                                .find_by_prefix(&ReceiveOperationPrefix)
-                                .await
-                                .map(|(key, _)| key.0)
-                                .collect::<Vec<_>>()
-                                .await;
-
-                            ensure!(
-                                operations.is_empty(),
-                                "no receive operations must be present, got {operations:?}"
                             );
                         }
                     }

--- a/modules/fedimint-walletv2-tests/tests/tests.rs
+++ b/modules/fedimint-walletv2-tests/tests/tests.rs
@@ -577,8 +577,7 @@ mod db {
     };
     use fedimint_walletv2_client::WalletClientModule;
     use fedimint_walletv2_client::db::{
-        self, NextOutputIndexKey, PendingReceivePrefix, ValidAddressIndexKey,
-        ValidAddressIndexPrefix,
+        self, NextOutputIndexKey, ValidAddressIndexKey, ValidAddressIndexPrefix,
     };
     use fedimint_walletv2_common::{FederationWallet, TxInfo, WalletCommonInit};
     use fedimint_walletv2_server::db::{
@@ -1015,21 +1014,6 @@ mod db {
                                 indices == vec![0, 1],
                                 "both seeded valid address indices must round-trip unchanged, \
                                  got {indices:?}"
-                            );
-                        }
-                        // Both tables below track peg-in progress and are
-                        // rebuilt at runtime, so a migrated database must not
-                        // carry any entries over.
-                        db::DbKeyPrefix::PendingReceive => {
-                            let pending = dbtx
-                                .find_by_prefix(&PendingReceivePrefix)
-                                .await
-                                .collect::<Vec<_>>()
-                                .await;
-
-                            ensure!(
-                                pending.is_empty(),
-                                "no pending receives must be present, got {pending:?}"
                             );
                         }
                     }

--- a/modules/fedimint-walletv2-tests/tests/tests.rs
+++ b/modules/fedimint-walletv2-tests/tests/tests.rs
@@ -16,7 +16,7 @@ use fedimint_walletv2_client::events::{
     SendPaymentUpdateEvent,
 };
 use fedimint_walletv2_client::{
-    FinalSendOperationState, SendError, WalletClientInit, WalletClientModule,
+    FinalSendOperationState, ReceiveProgress, SendError, WalletClientInit, WalletClientModule,
 };
 use fedimint_walletv2_common::KIND;
 use fedimint_walletv2_server::{CONFIRMATION_FINALITY_DELAY, WalletInit};
@@ -148,6 +148,99 @@ async fn await_federation_total_value(
 
         sleep_in_test(
             format!("Waiting for federation total value of {current_value} to reach {min_value}"),
+            Duration::from_secs(1),
+        )
+        .await;
+    }
+}
+
+/// A peg-in should report confirmation progress while it waits out the
+/// finality delay, rather than leaving the user with no feedback at all
+/// between broadcasting and the ecash being issued.
+#[tokio::test(flavor = "multi_thread")]
+async fn receive_reports_confirmation_progress() -> anyhow::Result<()> {
+    let fixtures = fixtures();
+    let fed = fixtures.new_fed_not_degraded().await;
+    let client = fed.new_client().await;
+    let bitcoin = fixtures.bitcoin();
+
+    initialize_consensus(&client, &bitcoin).await?;
+
+    let module = client.get_first_module::<WalletClientModule>()?;
+    let address = module.receive().await;
+
+    assert_eq!(
+        module.receive_progress(&address).await?,
+        ReceiveProgress::AwaitingTransaction,
+        "An address with nothing sent to it is not awaiting confirmations"
+    );
+
+    bitcoin
+        .send_and_mine_block(&address, Amount::from_int_btc(1))
+        .await;
+
+    // The deposit is now mined but still short of the finality delay, so the
+    // federation has not recorded it and only the advisory view can see it.
+    let confirmations = await_receive_confirmations(&client, &address, 1).await?;
+
+    assert_eq!(
+        confirmations,
+        CONFIRMATION_FINALITY_DELAY + 1,
+        "Progress should count up to the depth at which the federation claims"
+    );
+
+    info!("Mine the deposit to finality and confirm the claim takes over...");
+
+    await_finality_delay(&client, &bitcoin).await?;
+
+    let mut progress = pin!(module.subscribe_receive_progress(&address).await?);
+
+    loop {
+        match progress.next().await {
+            Some(ReceiveProgress::Claimed) => break,
+            Some(state) => info!("Receive progress: {state:?}"),
+            None => panic!("Progress stream ended before the peg-in was claimed"),
+        }
+    }
+
+    Ok(())
+}
+
+/// Polls receive progress until the peg-in is at least `min` confirmations
+/// deep, returning the `required` depth it is counting towards.
+///
+/// Asserts along the way that a mined-but-not-final peg-in is never reported as
+/// claimable, and that its reported value matches what was sent.
+async fn await_receive_confirmations(
+    client: &ClientHandleArc,
+    address: &bitcoin::Address,
+    min: u64,
+) -> anyhow::Result<u64> {
+    loop {
+        let progress = client
+            .get_first_module::<WalletClientModule>()?
+            .receive_progress(address)
+            .await?;
+
+        match progress {
+            ReceiveProgress::Confirming {
+                value,
+                confirmations,
+                required,
+                ..
+            } => {
+                assert_eq!(value, Amount::from_int_btc(1));
+
+                if confirmations >= min {
+                    return Ok(required);
+                }
+            }
+            ReceiveProgress::AwaitingTransaction => {}
+            state => panic!("Peg-in reached {state:?} before the finality delay elapsed"),
+        }
+
+        sleep_in_test(
+            format!("Waiting for the peg-in to reach {min} confirmations"),
             Duration::from_secs(1),
         )
         .await;
@@ -304,7 +397,8 @@ mod db {
     };
     use fedimint_walletv2_client::WalletClientModule;
     use fedimint_walletv2_client::db::{
-        self, NextOutputIndexKey, ValidAddressIndexKey, ValidAddressIndexPrefix,
+        self, NextOutputIndexKey, PendingReceivePrefix, ReceiveOperationPrefix,
+        ValidAddressIndexKey, ValidAddressIndexPrefix,
     };
     use fedimint_walletv2_common::{FederationWallet, TxInfo, WalletCommonInit};
     use fedimint_walletv2_server::db::{
@@ -741,6 +835,34 @@ mod db {
                                 indices == vec![0, 1],
                                 "both seeded valid address indices must round-trip unchanged, \
                                  got {indices:?}"
+                            );
+                        }
+                        // Both tables below track peg-in progress and are
+                        // rebuilt at runtime, so a migrated database must not
+                        // carry any entries over.
+                        db::DbKeyPrefix::PendingReceive => {
+                            let pending = dbtx
+                                .find_by_prefix(&PendingReceivePrefix)
+                                .await
+                                .collect::<Vec<_>>()
+                                .await;
+
+                            ensure!(
+                                pending.is_empty(),
+                                "no pending receives must be present, got {pending:?}"
+                            );
+                        }
+                        db::DbKeyPrefix::ReceiveOperation => {
+                            let operations = dbtx
+                                .find_by_prefix(&ReceiveOperationPrefix)
+                                .await
+                                .map(|(key, _)| key.0)
+                                .collect::<Vec<_>>()
+                                .await;
+
+                            ensure!(
+                                operations.is_empty(),
+                                "no receive operations must be present, got {operations:?}"
                             );
                         }
                     }

--- a/modules/fedimint-walletv2-tests/tests/tests.rs
+++ b/modules/fedimint-walletv2-tests/tests/tests.rs
@@ -204,6 +204,10 @@ async fn receive_reports_confirmation_progress() -> anyhow::Result<()> {
 
     bitcoin.mine_blocks(1).await;
 
+    // The tip is the block that just mined the deposit, and `get_block_count`
+    // returns a count rather than a height.
+    let mined_height = bitcoin.get_block_count().await - 1;
+
     // The deposit is now mined but still short of the finality delay, so the
     // federation has not recorded it and only the advisory view can see it.
     let confirmations = await_receive_confirmations(&client, &address, 1).await?;
@@ -243,6 +247,7 @@ async fn receive_reports_confirmation_progress() -> anyhow::Result<()> {
     match mined {
         ReceiveProgress::Confirming {
             value,
+            height,
             confirmations,
             required,
         } => {
@@ -254,6 +259,10 @@ async fn receive_reports_confirmation_progress() -> anyhow::Result<()> {
             assert!(
                 (1..required).contains(&confirmations),
                 "The mined deposit is confirming, got {confirmations} of {required}"
+            );
+            assert_eq!(
+                height, mined_height,
+                "The deposit must report the height of the block that mined it"
             );
         }
         state => panic!("The mined deposit should still be confirming, got {state:?}"),
@@ -404,6 +413,7 @@ async fn await_receive_confirmations(
                         value,
                         confirmations,
                         required,
+                        ..
                     },
                 ),
             ] => {

--- a/modules/fedimint-walletv2-tests/tests/tests.rs
+++ b/modules/fedimint-walletv2-tests/tests/tests.rs
@@ -175,9 +175,17 @@ async fn receive_reports_confirmation_progress() -> anyhow::Result<()> {
         "An address with nothing sent to it is not awaiting confirmations"
     );
 
-    bitcoin
-        .send_and_mine_block(&address, Amount::from_int_btc(1))
+    info!("Broadcast the deposit without mining it...");
+
+    let tx = bitcoin
+        .send_without_mining(&address, Amount::from_int_btc(1))
         .await;
+
+    // Guardians report the unmined deposit straight out of their mempools,
+    // which is the whole point: the user gets feedback before the first block.
+    await_receive_mempool(&client, &address, tx.compute_txid()).await?;
+
+    bitcoin.mine_blocks(1).await;
 
     // The deposit is now mined but still short of the finality delay, so the
     // federation has not recorded it and only the advisory view can see it.
@@ -204,6 +212,39 @@ async fn receive_reports_confirmation_progress() -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+/// Polls receive progress until the unmined peg-in is visible in the
+/// guardians' mempools, asserting it is reported against the expected
+/// transaction and value.
+async fn await_receive_mempool(
+    client: &ClientHandleArc,
+    address: &bitcoin::Address,
+    txid: bitcoin::Txid,
+) -> anyhow::Result<()> {
+    loop {
+        let progress = client
+            .get_first_module::<WalletClientModule>()?
+            .receive_progress(address)
+            .await?;
+
+        match progress {
+            ReceiveProgress::Mempool { value, outpoint } => {
+                assert_eq!(value, Amount::from_int_btc(1));
+                assert_eq!(outpoint.txid, txid);
+
+                return Ok(());
+            }
+            ReceiveProgress::AwaitingTransaction => {}
+            state => panic!("Peg-in reached {state:?} while still unmined"),
+        }
+
+        sleep_in_test(
+            "Waiting for the peg-in to appear in the mempool",
+            Duration::from_secs(1),
+        )
+        .await;
+    }
 }
 
 /// Polls receive progress until the peg-in is at least `min` confirmations
@@ -235,7 +276,9 @@ async fn await_receive_confirmations(
                     return Ok(required);
                 }
             }
-            ReceiveProgress::AwaitingTransaction => {}
+            // Still legitimate here: the scanner may not have observed the new
+            // block yet, so the peg-in can briefly read as unmined.
+            ReceiveProgress::AwaitingTransaction | ReceiveProgress::Mempool { .. } => {}
             state => panic!("Peg-in reached {state:?} before the finality delay elapsed"),
         }
 

--- a/modules/fedimint-walletv2-tests/tests/tests.rs
+++ b/modules/fedimint-walletv2-tests/tests/tests.rs
@@ -9,6 +9,7 @@ use fedimint_core::task::sleep_in_test;
 use fedimint_dummy_client::DummyClientInit;
 use fedimint_dummy_server::DummyInit;
 use fedimint_eventlog::{Event, EventLogEntry, EventLogId};
+use fedimint_logging::LOG_TEST;
 use fedimint_testing::btc::BitcoinTest;
 use fedimint_testing::fixtures::Fixtures;
 use fedimint_walletv2_client::events::{
@@ -22,7 +23,7 @@ use fedimint_walletv2_client::{
 use fedimint_walletv2_common::KIND;
 use fedimint_walletv2_server::{CONFIRMATION_FINALITY_DELAY, WalletInit};
 use futures::StreamExt;
-use tracing::info;
+use tracing::{info, warn};
 
 #[derive(Debug)]
 enum WalletEvent {
@@ -181,7 +182,11 @@ async fn receive_reports_confirmation_progress() -> anyhow::Result<()> {
     let address = module.receive().await;
 
     assert!(
-        module.address_receive_progress(&address).await?.is_empty(),
+        module
+            .address_receive_progress(&address)
+            .await?
+            .deposits
+            .is_empty(),
         "An address with nothing sent to it has no deposits to report"
     );
 
@@ -232,7 +237,7 @@ async fn receive_reports_confirmation_progress() -> anyhow::Result<()> {
         .expect("The second deposit must be reported against its own transaction");
 
     // The two deposits sit at different stages, so neither may mask the other.
-    let progress = module.address_receive_progress(&address).await?;
+    let progress = module.address_receive_progress(&address).await?.deposits;
 
     let mined = lookup_progress(&progress, mined_outpoint);
     let unmined = lookup_progress(&progress, unmined_outpoint);
@@ -305,6 +310,120 @@ async fn receive_reports_confirmation_progress() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// A guardian whose backend starts failing partway through a mempool scan must
+/// keep reporting the deposits it had already cached.
+///
+/// The scan caches one transaction per mempool entry it has never seen, so
+/// discarding the cache on a transient error would both hide deposits the
+/// guardian can still account for and force the whole mempool to be refetched
+/// on the next pass. A pass that fails is reported as far as it got instead: an
+/// unfetched deposit is indistinguishable to a client from one that has not
+/// been broadcast yet, so the federation keeps its mempool visibility.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_failed_mempool_fetch_keeps_the_deposits_already_seen() -> anyhow::Result<()> {
+    if Fixtures::is_real_test() {
+        warn!(
+            target: LOG_TEST,
+            "Skipping test as only the mock bitcoin backend can fail a mempool fetch"
+        );
+
+        return Ok(());
+    }
+
+    let fixtures = fixtures();
+    let fed = fixtures.new_fed_not_degraded().await;
+    let client = fed.new_client().await;
+    let bitcoin = fixtures.bitcoin();
+
+    initialize_consensus(&client, &bitcoin).await?;
+
+    let module = client.get_first_module::<WalletClientModule>()?;
+
+    let address = module.receive().await;
+
+    info!("Broadcast a deposit and wait for the guardians to cache it...");
+
+    let cached = bitcoin
+        .send_without_mining(&address, Amount::from_int_btc(1))
+        .await;
+
+    let cached_outpoint = await_receive_mempool(&client, &address, cached.compute_txid()).await?;
+
+    info!("Break every mempool fetch, then broadcast a second deposit...");
+
+    // Listing the mempool keeps working, so from here each scan sees both
+    // transactions, keeps the one it has already cached and fails to fetch the
+    // new one.
+    bitcoin.fail_mempool_tx_fetches(true);
+
+    let unfetchable = bitcoin
+        .send_without_mining(&address, Amount::from_int_btc(2))
+        .await;
+
+    // The guardians rescan on their bitcoin monitor's interval, which is 100ms
+    // under test, so this covers many failing passes rather than a single one.
+    for _ in 0..20 {
+        let progress = module.address_receive_progress(&address).await?;
+
+        assert_eq!(
+            lookup_progress(&progress.deposits, cached_outpoint),
+            ReceiveProgress::Mempool {
+                value: Amount::from_int_btc(1)
+            },
+            "A failing scan must not drop the deposit the guardians had already cached"
+        );
+
+        assert!(
+            progress.mempool_visibility,
+            "A scan that fails partway through still saw a mempool, so it must keep reporting one"
+        );
+
+        assert!(
+            !progress
+                .deposits
+                .iter()
+                .any(|(outpoint, _)| outpoint.txid == unfetchable.compute_txid()),
+            "The deposit whose transaction could not be fetched must not be reported"
+        );
+
+        sleep_in_test(
+            "Letting the guardians run failing mempool scans",
+            Duration::from_millis(100),
+        )
+        .await;
+    }
+
+    info!("Let fetches succeed again and confirm the second deposit is picked up...");
+
+    bitcoin.fail_mempool_tx_fetches(false);
+
+    let deposits = await_deposit_count(&client, &address, 2).await?;
+
+    assert_eq!(
+        lookup_progress(&deposits, cached_outpoint),
+        ReceiveProgress::Mempool {
+            value: Amount::from_int_btc(1)
+        },
+        "The recovered scan must still report the originally cached deposit"
+    );
+
+    let recovered = deposits
+        .iter()
+        .find_map(|(outpoint, state)| {
+            (outpoint.txid == unfetchable.compute_txid()).then(|| state.clone())
+        })
+        .expect("The second deposit is reported once its transaction can be fetched");
+
+    assert_eq!(
+        recovered,
+        ReceiveProgress::Mempool {
+            value: Amount::from_int_btc(2)
+        }
+    );
+
+    Ok(())
+}
+
 /// Returns the progress reported for `outpoint`, panicking if it is absent.
 fn lookup_progress(
     progress: &[(bitcoin::OutPoint, ReceiveProgress)],
@@ -330,12 +449,12 @@ async fn await_deposit_count(
             .await?;
 
         assert!(
-            progress.len() <= count,
+            progress.deposits.len() <= count,
             "More deposits reported than were sent: {progress:?}"
         );
 
-        if progress.len() == count {
-            return Ok(progress);
+        if progress.deposits.len() == count {
+            return Ok(progress.deposits);
         }
 
         sleep_in_test(
@@ -362,7 +481,12 @@ async fn await_receive_mempool(
             .address_receive_progress(address)
             .await?;
 
-        match progress.as_slice() {
+        assert!(
+            progress.mempool_visibility,
+            "The mock backend can enumerate its mempool, so the federation must see one"
+        );
+
+        match progress.deposits.as_slice() {
             [(outpoint, ReceiveProgress::Mempool { value })] => {
                 assert_eq!(*value, Amount::from_int_btc(1));
                 assert_eq!(outpoint.txid, txid);
@@ -397,7 +521,7 @@ async fn await_receive_confirmations(
             .address_receive_progress(address)
             .await?;
 
-        match progress.as_slice() {
+        match progress.deposits.as_slice() {
             [
                 (
                     _,

--- a/modules/fedimint-walletv2-tests/tests/tests.rs
+++ b/modules/fedimint-walletv2-tests/tests/tests.rs
@@ -16,7 +16,8 @@ use fedimint_walletv2_client::events::{
     SendPaymentUpdateEvent,
 };
 use fedimint_walletv2_client::{
-    FinalSendOperationState, ReceiveProgress, SendError, WalletClientInit, WalletClientModule,
+    FinalReceiveOperationState, FinalSendOperationState, ReceiveProgress, SendError,
+    WalletClientInit, WalletClientModule,
 };
 use fedimint_walletv2_common::KIND;
 use fedimint_walletv2_server::{CONFIRMATION_FINALITY_DELAY, WalletInit};
@@ -289,26 +290,17 @@ async fn receive_reports_confirmation_progress() -> anyhow::Result<()> {
     )
     .await?;
 
-    let mut progress = pin!(
-        module
-            .subscribe_receive_progress(&address, position)
-            .await?
-    );
+    // The advisory view cannot tell a claimed deposit from a reorged one, and
+    // keeps reporting an output for a while after it turns final, so the receive
+    // operations themselves settle it. Only these two deposits exist, so waiting
+    // for two successful receives covers both.
+    let (state, position) = module.await_receive(position).await?;
 
-    loop {
-        match progress.next().await {
-            Some(states)
-                if states.len() == 2
-                    && states
-                        .iter()
-                        .all(|(_, state)| *state == ReceiveProgress::Claimed) =>
-            {
-                break;
-            }
-            Some(states) => info!("Receive progress: {states:?}"),
-            None => panic!("Progress stream ended before both peg-ins were claimed"),
-        }
-    }
+    assert_eq!(state, FinalReceiveOperationState::Success);
+
+    let (state, _) = module.await_receive(position).await?;
+
+    assert_eq!(state, FinalReceiveOperationState::Success);
 
     Ok(())
 }


### PR DESCRIPTION
Walletv2 has a nice property that all "pending receives" are kept by the guardians, because clients only ever send peg-ins to addresses that match a hash filter.

However, right now there is a UX issue where the user does not know that the guardians can see their deposit until the finality delay has passed. Users are sometimes worried that their funds are gone, because no ecash has been issued yet, but in reality they just need to wait for more blocks.

Ecash App solves this problem in a privacy degrading way - it simply polls esplora for the status of the peg-in. To solve this, instead of polling esplora, we can simply ask the guardians for their mempool/confirmation subset and filter client side if we seeing a pending deposit.

This PR adds this functionality in two commits, first commit adding progress updates for confirmations before the finality delay, and the second commit adding progress updates for transactions that are added to the mempool.

Two unfortunate downsides of the mempool approach:
1) On startup it requires scanning the current mempool for existing pending receives
2) Esplora is not supported currently. If one guardian runs Bitcoind though, every client will get updates to the mempool.