### PR TITLE
docs: bootstrap Linked Specs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,8 @@
 # CLAUDE.md
 
+This project uses the Linked Specs convention; consult the `linked-specs`
+skill before working with specs or governed code.
+
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 Additional agent-specific instructions (e.g. for CI-driven code review) can be found in `.github/agents/`.

--- a/flake.lock
+++ b/flake.lock
@@ -414,6 +414,29 @@
         "type": "github"
       }
     },
+    "linked-specs-skills": {
+      "inputs": {
+        "flakebox": [
+          "flakebox"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1788064855,
+        "narHash": "sha256-ttHQzcWlE99gbV4Ty2S6+3uMEyghmJTKuWvqAWKO5Mw=",
+        "ref": "refs/heads/master",
+        "rev": "9292a771c1b36b78d6790ab316c61a69452fb9c9",
+        "revCount": 109,
+        "type": "git",
+        "url": "https://radicle.dpc.pw/z2HR882B4c4mTdAgdt4SozpdeTuMf.git"
+      },
+      "original": {
+        "type": "git",
+        "url": "https://radicle.dpc.pw/z2HR882B4c4mTdAgdt4SozpdeTuMf.git"
+      }
+    },
     "nix-bundle": {
       "inputs": {
         "nixpkgs": [
@@ -542,6 +565,7 @@
         "fenix": "fenix_2",
         "flake-utils": "flake-utils_5",
         "flakebox": "flakebox_2",
+        "linked-specs-skills": "linked-specs-skills",
         "nixpkgs": "nixpkgs_4",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "wild": "wild"

--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,11 @@
       inputs.nixpkgs.follows = "nixpkgs-unstable";
       inputs.fenix.follows = "fenix";
     };
+    linked-specs-skills = {
+      url = "git+https://radicle.dpc.pw/z2HR882B4c4mTdAgdt4SozpdeTuMf.git";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.flakebox.follows = "flakebox";
+    };
     wild = {
       url = "github:davidlattimore/wild/0.9.0";
       inputs.nixpkgs.follows = "nixpkgs-unstable";
@@ -41,6 +46,7 @@
       nixpkgs-unstable,
       flake-utils,
       flakebox,
+      linked-specs-skills,
       cargo-deluxe,
       advisory-db,
       bundlers,
@@ -107,6 +113,48 @@
         stdenv = pkgs.stdenv;
 
         cargoCrap = flakebox.packages.${system}.cargo-crap;
+
+        projectSkillNames = [
+          "linked-specs"
+          "linked-specs-updating"
+          "linked-specs-review"
+        ];
+
+        linkProjectSkills = pkgs.writeShellScriptBin "link-project-skills" ''
+          set -eu
+
+          root=$1
+          skills_dir="$root/.agents/skills"
+          source_dir="${linked-specs-skills.packages.${system}.skills}/share/agents/skills"
+          ${pkgs.coreutils}/bin/mkdir -p "$skills_dir"
+
+          for name in ${pkgs.lib.escapeShellArgs projectSkillNames}; do
+            target="$skills_dir/$name"
+            if [ -e "$target" ] && [ ! -L "$target" ]; then
+              printf 'refusing to replace non-symlink: %s\n' "$target" >&2
+              exit 1
+            fi
+
+            tmp="$(${pkgs.coreutils}/bin/mktemp "$skills_dir/.link-project-skill.XXXXXX")"
+            trap '${pkgs.coreutils}/bin/rm -f "$tmp"' EXIT HUP INT TERM
+            ${pkgs.coreutils}/bin/rm -f "$tmp"
+            ${pkgs.coreutils}/bin/ln -s "$source_dir/$name" "$tmp"
+            ${pkgs.coreutils}/bin/mv -Tf "$tmp" "$target"
+            trap - EXIT HUP INT TERM
+          done
+
+          if exclude_file="$(${pkgs.git}/bin/git -C "$root" rev-parse --path-format=absolute --git-path info/exclude 2>/dev/null)"; then
+            ${pkgs.coreutils}/bin/mkdir -p "$(${pkgs.coreutils}/bin/dirname "$exclude_file")"
+            ${pkgs.coreutils}/bin/touch "$exclude_file"
+
+            for name in ${pkgs.lib.escapeShellArgs projectSkillNames}; do
+              pattern="/.agents/skills/$name"
+              if ! ${pkgs.gnugrep}/bin/grep -Fxq "$pattern" "$exclude_file"; then
+                printf '%s\n' "$pattern" >>"$exclude_file"
+              fi
+            done
+          fi
+        '';
 
         flakeboxLib = flakebox.lib.mkLib pkgs {
           # customizations will go here in the future
@@ -365,6 +413,8 @@
                 shellHook = ''
                   export REPO_ROOT="$(git rev-parse --show-toplevel)"
                   export PATH="$REPO_ROOT/bin:$PATH"
+
+                  ${linkProjectSkills}/bin/link-project-skills "$REPO_ROOT" || exit $?
 
                   # workaround https://github.com/rust-lang/cargo/issues/11020
                   cargo_cmd_bins=( $(ls $HOME/.cargo/bin/cargo-{clippy,udeps,llvm-cov} 2>/dev/null) )

--- a/specs/ARCH-fedimint.md
+++ b/specs/ARCH-fedimint.md
@@ -1,0 +1,16 @@
+# ARCH-fedimint: Fedimint architecture
+
+Fedimint is a modular framework for federated applications. Its primary deployment is a federation of guardian processes that jointly execute deterministic consensus and expose APIs to clients; the default modules provide Chaumian e-cash, Bitcoin on-chain custody, and Lightning payments.
+
+## System boundaries
+
+- `fedimintd` assembles server modules and runs one guardian. Before a federation exists, guardians exchange setup information and jointly generate configuration and cryptographic key material. After setup, guardian-to-guardian networking orders core and module consensus items, and every honest guardian applies the same ordered outcomes to its local database.
+- `fedimint-core`, `fedimint-server-core`, and `fedimint-client-module` define shared encodings, configuration, module interfaces, and common infrastructure. `fedimint-server` owns setup, networking integration, consensus execution, and server configuration; `fedimint-client` owns persistent client operations and module state machines.
+- Modules normally separate common wire and configuration types from client and server implementations. The daemon and clients select implementations through module registries, while a federation's generated consensus configuration fixes the enabled module instances.
+- Clients use federation configuration to query multiple guardians, submit transactions, and drive durable module operations. Gateways are federation clients that also connect to external Lightning nodes and mediate Lightning payments; they are not guardians and do not participate in federation consensus.
+
+## Configuration boundary
+
+Guardian setup converts operator-selected parameters and exchanged peer setup codes into private, local, and consensus server configuration. The consensus portion must be identical across guardians and determines the federation and module configuration visible to clients. [SPEC-dkg-version-compatibility](SPEC-dkg-version-compatibility.md) constrains which daemon builds may participate in one setup ceremony and how that decision is reflected in the generated consensus configuration.
+
+See the [project overview](../README.md), [deployment guide](../docs/deploying.md), [modular architecture](../docs/modular-architecture.md), and [networking notes](../docs/networking.md) for operational and implementation detail.

--- a/specs/SPEC-dkg-version-compatibility.md
+++ b/specs/SPEC-dkg-version-compatibility.md
@@ -1,0 +1,25 @@
+# SPEC-dkg-version-compatibility: DKG version compatibility
+
+## Status
+
+Guardian setup currently strips prerelease and build metadata, exchanges `major.minor.patch`, requires exact equality of that release version, and stores the same release version in `ServerConfigConsensus::code_version`; it therefore neither preserves vendor identity nor permits patch skew. The compatibility contract below is the agreed target tracked by [#9087](https://github.com/fedimint/fedimint/issues/9087) and [#9092](https://github.com/fedimint/fedimint/pull/9092), but is not yet implemented.
+
+## Record justification
+
+The contract spans daemon version construction, `PeerSetupCode` exchange, `SetupApi` admission and start checks, and `ServerConfigConsensus::code_version` checksumming, so no single implementation artifact can coherently own the end-to-end compatibility rule.
+
+## Compatibility contract
+
+For a new federation setup, each guardian identifies its running build with a valid semantic version. Setup codes carry the normalized `major.minor.patch` release plus the exact optional vendor string encoded as SemVer build metadata; prerelease metadata is omitted so the displayed value remains useful for diagnosing a rejected peer.
+
+Two guardians are DKG-compatible exactly when their major and minor versions match and their optional vendor strings are equal. Patch and prerelease differences do not affect compatibility. An absent vendor string is distinct from every specified vendor string, and vendor strings compare exactly.
+
+A guardian must validate its local version and reject a malformed or incompatible peer version when the peer setup code is added. It must revalidate every collected setup-code version immediately before starting DKG so stale or otherwise bypassed setup state cannot enter configuration generation.
+
+Newly generated `ServerConfigConsensus::code_version` values must use the same compatibility identity as the early setup and start-DKG checks. Guardians admitted under patch or prerelease skew must therefore derive the same consensus-config checksum, while guardians from another major/minor series or vendor identity must not be admitted merely because their remaining configuration agrees.
+
+This contract applies when every participating binary implements this compatibility projection. Already-shipped binaries that use another projection for setup admission or the consensus-config checksum are not retroactively compatible.
+
+This contract governs new setup and DKG only. It does not rewrite persisted configurations, promise compatibility for the setup API itself, or define compatibility for upgrading an operating federation.
+
+This specification refines the setup boundary in [ARCH-fedimint](ARCH-fedimint.md).


### PR DESCRIPTION
*Posted by Tau/OpenAI*

### Summary

Fedimint adopts Linked Specs. The development shell exposes exactly `linked-specs`, `linked-specs-updating`, and `linked-specs-review` as explicit generated `.agents/skills/<name>` links. Root guidance points agents to the convention, and this change adds `ARCH-fedimint` plus the status-bearing `SPEC-dkg-version-compatibility`.

### Details

The DKG SPEC accurately separates current master behavior from the agreed #9087/#9092 transition. It can land independently because it records the contract and its status without claiming that transition has already landed.

Validation passed format, final lint, Nix parse and metadata checks, and isolated clean-root dev-shell verification of exactly the three expected links, excluded generated paths, and non-symlink refusal. Offline Markdown links and independent normal and Linked Specs reviews also passed. SelfCI's cargo-crap failure reproduces identically on master; all other SelfCI stages passed.
