### PR TITLE
fix(ln): wait for the offer before recording a recurring receive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4069,6 +4069,7 @@ version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
+ "axum 0.8.9",
  "bitcoin_hashes",
  "fedimint-client",
  "fedimint-client-module",

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -1809,7 +1809,8 @@ impl LightningClientModule {
             self.client_ctx
                 .make_client_inputs(ClientInputBundle::new_no_sm(vec![client_input])),
         );
-        let extra_meta = serde_json::to_value(extra_meta).expect("extra_meta is serializable");
+        let extra_meta =
+            serde_json::to_value(extra_meta).context("Failed to serialize extra metadata")?;
         let operation_meta_gen = move |change_range: OutPointRange| LightningOperationMeta {
             variant: LightningOperationMetaVariant::Claim {
                 out_points: change_range.into_iter().collect(),
@@ -2046,7 +2047,8 @@ impl LightningClientModule {
 
         let tx =
             TransactionBuilder::new().with_outputs(self.client_ctx.make_client_outputs(output));
-        let extra_meta = serde_json::to_value(extra_meta).expect("extra_meta is serializable");
+        let extra_meta =
+            serde_json::to_value(extra_meta).context("Failed to serialize extra metadata")?;
         let operation_meta_gen = {
             let invoice = invoice.clone();
             move |change_range: OutPointRange| LightningOperationMeta {

--- a/modules/fedimint-ln-client/src/receive.rs
+++ b/modules/fedimint-ln-client/src/receive.rs
@@ -326,7 +326,7 @@ impl LightningReceiveConfirmedInvoice {
     }
 }
 
-fn has_invoice_expired(
+pub(crate) fn has_invoice_expired(
     invoice: &Bolt11Invoice,
     now_epoch: Duration,
     clock_skew_tolerance: Duration,

--- a/modules/fedimint-ln-client/src/recurring/mod.rs
+++ b/modules/fedimint-ln-client/src/recurring/mod.rs
@@ -38,8 +38,9 @@ use tokio::select;
 use tokio::sync::Notify;
 use tracing::{debug, trace, warn};
 
+use crate::api::LnFederationApi;
 use crate::db::{RecurringPaymentCodeKey, RecurringPaymentCodeKeyPrefix};
-use crate::receive::LightningReceiveError;
+use crate::receive::{LightningReceiveError, has_invoice_expired};
 use crate::{
     LightningClientModule, LightningClientStateMachines, LightningOperationMeta,
     LightningOperationMetaVariant, LnReceiveState, tweak_user_key, tweak_user_secret_key,
@@ -234,7 +235,82 @@ impl LightningClientModule {
         invoice_idx: u64,
         invoice: lightning_invoice::Bolt11Invoice,
     ) {
+        const CLOCK_SKEW_TOLERANCE: Duration = Duration::from_mins(1);
+
         // TODO: validate invoice hash etc.
+        let operation_id = OperationId(*invoice.payment_hash().as_ref());
+        let offer_in_consensus = match client
+            .self_ref()
+            .module_api
+            .offer_exists(*invoice.payment_hash())
+            .await
+        {
+            Ok(exists) => exists,
+            Err(err) => {
+                warn!(
+                    target: LOG_CLIENT_RECURRING,
+                    ?operation_id,
+                    invoice_index=%invoice_idx,
+                    err = %err.fmt_compact(),
+                    "Could not query incoming contract offer, will retry"
+                );
+                return;
+            }
+        };
+
+        // funding consumes the offer, so a paid invoice shows no offer, only
+        // its funded contract, and the receive still has to claim it
+        let contract_funded = if offer_in_consensus {
+            false
+        } else {
+            match client
+                .self_ref()
+                .module_api
+                .fetch_contract((*invoice.payment_hash()).into())
+                .await
+            {
+                Ok(contract) => contract.is_some(),
+                Err(err) => {
+                    warn!(
+                        target: LOG_CLIENT_RECURRING,
+                        ?operation_id,
+                        invoice_index=%invoice_idx,
+                        err = %err.fmt_compact(),
+                        "Could not query incoming contract, will retry"
+                    );
+                    return;
+                }
+            }
+        };
+        let record_receive = offer_in_consensus || contract_funded;
+
+        if !record_receive {
+            if !has_invoice_expired(
+                &invoice,
+                fedimint_core::time::duration_since_epoch(),
+                CLOCK_SKEW_TOLERANCE,
+            ) {
+                // recurringd serves new invoices before their offer transaction
+                // clears consensus, so a missing offer usually means it is in flight
+                debug!(
+                    target: LOG_CLIENT_RECURRING,
+                    ?operation_id,
+                    invoice_index=%invoice_idx,
+                    "Incoming contract offer not in consensus yet, will retry"
+                );
+                return;
+            }
+
+            // recurringd hands invoices to payers only after the offer confirms,
+            // so expired with no offer and no contract means never paid
+            warn!(
+                target: LOG_CLIENT_RECURRING,
+                ?operation_id,
+                invoice_index=%invoice_idx,
+                "Recurring invoice expired without an incoming contract offer, skipping it"
+            );
+        }
+
         let mut dbtx = client.module_db().begin_transaction().await;
         let old_payment_code_entry = dbtx
             .get_value(&crate::db::RecurringPaymentCodeKey {
@@ -256,17 +332,17 @@ impl LightningClientModule {
         .await;
 
         // We want to increment the invoice counter even if the operation creation
-        // fails. This should never happen and if it does, we'd rather miss an invoice
-        // than get stuck in an infinite loop.
+        // fails. We'd rather miss an invoice than get stuck in an infinite loop.
         let mut dbtx_nc = dbtx.to_ref_nc();
-        if let Ok(operation_id) = Self::create_recurring_receive_operation(
-            client,
-            &mut dbtx_nc,
-            &old_payment_code_entry,
-            invoice_idx,
-            invoice,
-        )
-        .await
+        if record_receive
+            && let Ok(operation_id) = Self::create_recurring_receive_operation(
+                client,
+                &mut dbtx_nc,
+                &old_payment_code_entry,
+                invoice_idx,
+                invoice,
+            )
+            .await
         {
             client
                 .log_event(
@@ -278,11 +354,6 @@ impl LightningClientModule {
                     },
                 )
                 .await;
-        } else {
-            debug_assert!(
-                false,
-                "Recurring invoice operation creation failed, this should never happen"
-            );
         }
         drop(dbtx_nc);
 

--- a/modules/fedimint-ln-tests/Cargo.toml
+++ b/modules/fedimint-ln-tests/Cargo.toml
@@ -13,6 +13,7 @@ path = "tests/tests.rs"
 
 [dependencies]
 anyhow = { workspace = true }
+axum = { workspace = true }
 bitcoin_hashes = { workspace = true }
 fedimint-client = { workspace = true }
 fedimint-client-module = { workspace = true }

--- a/modules/fedimint-ln-tests/tests/tests.rs
+++ b/modules/fedimint-ln-tests/tests/tests.rs
@@ -1,8 +1,12 @@
+use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::bail;
 use assert_matches::assert_matches;
+use axum::extract::{Path, State};
+use axum::routing::{get, put};
+use axum::{Json, Router};
 use bitcoin_hashes::{Hash, sha256};
 use fedimint_client::transaction::{
     ClientOutput, ClientOutputBundle, ClientOutputSM, TransactionBuilder, TxSubmissionStates,
@@ -13,7 +17,7 @@ use fedimint_client_module::oplog::OperationLogEntry;
 use fedimint_core::core::{IntoDynInstance, OperationId};
 use fedimint_core::module::{AmountUnit, Amounts, CommonModuleInit as _};
 use fedimint_core::util::backoff_util::aggressive_backoff_long;
-use fedimint_core::util::{BoxStream, NextOrPending, retry};
+use fedimint_core::util::{BoxStream, NextOrPending, SafeUrl, retry};
 use fedimint_core::{Amount, sats, secp256k1};
 use fedimint_dummy_client::{DummyClientInit, DummyClientModule};
 use fedimint_dummy_server::DummyInit;
@@ -23,11 +27,12 @@ use fedimint_ln_client::receive::{
     LightningReceiveError, LightningReceiveStateMachine, LightningReceiveStates,
     LightningReceiveSubmittedOffer,
 };
+use fedimint_ln_client::recurring::RecurringPaymentProtocol;
 use fedimint_ln_client::{
     InternalPayState, LightningClientInit, LightningClientModule, LightningClientStateMachines,
     LightningOperationMeta, LightningOperationMetaVariant, LnPayState, LnReceiveState,
     MockGatewayConnection, OutgoingLightningPayment, PayType, ReceivingKey,
-    create_incoming_contract_output,
+    create_incoming_contract_output, tweak_user_key,
 };
 use fedimint_ln_common::contracts::incoming::IncomingContractOffer;
 use fedimint_ln_common::contracts::{EncryptedPreimage, PreimageKey};
@@ -43,6 +48,7 @@ use lightning_invoice::{
 };
 use rand::rngs::OsRng;
 use secp256k1::Keypair;
+use tokio::sync::{mpsc, watch};
 
 pub async fn ln_operation(
     client: &ClientHandleArc,
@@ -145,6 +151,378 @@ async fn await_client_tx_accepted(
         .next()
         .await
         .expect("tx either accepted or rejected")
+}
+
+#[derive(Clone)]
+struct MockRecurringdState {
+    invoices: watch::Receiver<BTreeMap<u64, Bolt11Invoice>>,
+    requested_indices: mpsc::UnboundedSender<u64>,
+}
+
+async fn await_mock_recurring_invoice(
+    Path((_, invoice_index)): Path<(String, u64)>,
+    State(state): State<MockRecurringdState>,
+) -> Json<Bolt11Invoice> {
+    let _ = state.requested_indices.send(invoice_index);
+    let mut invoices = state.invoices.clone();
+    loop {
+        if let Some(invoice) = invoices.borrow().get(&invoice_index).cloned() {
+            return Json(invoice);
+        }
+        invoices
+            .changed()
+            .await
+            .expect("test keeps the invoice sender alive");
+    }
+}
+
+#[allow(clippy::literal_string_with_formatting_args)]
+async fn spawn_mock_recurringd(
+    state: MockRecurringdState,
+) -> anyhow::Result<(SafeUrl, tokio::task::JoinHandle<()>)> {
+    let router = Router::new()
+        .route(
+            "/lnv1/paycodes",
+            put(|| async {
+                Json(serde_json::json!({
+                    "recurring_payment_code": "LNURL test payment code"
+                }))
+            }),
+        )
+        .route(
+            "/lnv1/paycodes/recipient/{root_key}/generated/{invoice_index}",
+            get(await_mock_recurring_invoice),
+        )
+        .with_state(state);
+    let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0)).await?;
+    let api = SafeUrl::parse(&format!("http://{}/", listener.local_addr()?))?;
+    let task = tokio::spawn(async move {
+        axum::serve(listener, router)
+            .await
+            .expect("mock recurringd server failed");
+    });
+    Ok((api, task))
+}
+
+fn recurring_invoice_for_index(
+    root_key: secp256k1::PublicKey,
+    invoice_index: u64,
+    amount: Amount,
+    timestamp: Duration,
+    expiry_time: Duration,
+) -> anyhow::Result<(Bolt11Invoice, sha256::Hash, [u8; 33])> {
+    let secp = secp256k1::Secp256k1::new();
+    let invoice_key = tweak_user_key(&secp, root_key, invoice_index);
+    let preimage_key: [u8; 33] = invoice_key.serialize();
+    let preimage = sha256::Hash::hash(&preimage_key);
+    let payment_hash = sha256::Hash::hash(&preimage.to_byte_array());
+    let (node_secret_key, node_public_key) = secp.generate_keypair(&mut OsRng);
+    let invoice = InvoiceBuilder::new(Currency::Regtest)
+        .amount_milli_satoshis(amount.msats)
+        .description("recurring receive".to_owned())
+        .payment_hash(payment_hash)
+        .payment_secret(PaymentSecret([0; 32]))
+        .duration_since_epoch(timestamp)
+        .min_final_cltv_expiry_delta(18)
+        .payee_pub_key(node_public_key)
+        .expiry_time(expiry_time)
+        .build_signed(|message| secp.sign_ecdsa_recoverable(message, &node_secret_key))?;
+    Ok((invoice, payment_hash, preimage_key))
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn recurring_receive_waits_for_offer() -> anyhow::Result<()> {
+    let (invoice_tx, invoice_rx) = watch::channel(BTreeMap::new());
+    let (requested_tx, _requested_rx) = mpsc::unbounded_channel();
+    let (recurringd_api, recurringd_task) = spawn_mock_recurringd(MockRecurringdState {
+        invoices: invoice_rx,
+        requested_indices: requested_tx,
+    })
+    .await?;
+
+    let fixtures = fixtures();
+    let fed = fixtures.new_fed_degraded().await;
+    let client = fed.new_client().await;
+    let ln_module = client.get_first_module::<LightningClientModule>()?;
+    let payment_code = ln_module
+        .register_recurring_payment_code(
+            RecurringPaymentProtocol::LNURL,
+            recurringd_api,
+            "[[\"text/plain\", \"test\"]]",
+        )
+        .await?;
+
+    let invoice_index = 1;
+    let amount = sats(100);
+    let (invoice, payment_hash, preimage_key) = recurring_invoice_for_index(
+        payment_code.root_keypair.public_key(),
+        invoice_index,
+        amount,
+        fedimint_core::time::duration_since_epoch(),
+        Duration::from_secs(3600),
+    )?;
+    invoice_tx.send_replace(BTreeMap::from([(invoice_index, invoice)]));
+
+    // give the poller several 1s cycles, otherwise the assertions below pass
+    // vacuously before it ever processed the invoice
+    tokio::time::sleep(Duration::from_secs(3)).await;
+    let operation_id = OperationId(*payment_hash.as_ref());
+    assert!(
+        ln_module
+            .subscribe_ln_recurring_receive(operation_id)
+            .await
+            .is_err()
+    );
+    assert!(!ln_module.api.offer_exists(payment_hash).await?);
+
+    let offer_output = LightningOutput::new_v0_offer(IncomingContractOffer {
+        amount,
+        hash: payment_hash,
+        encrypted_preimage: EncryptedPreimage::new(
+            &PreimageKey(preimage_key),
+            &ln_module.cfg.threshold_pub_key,
+        ),
+        expiry_time: None,
+    });
+    let offer_operation_id = OperationId::new_random();
+    let offer_tx = TransactionBuilder::new().with_outputs(
+        ClientOutputBundle::new_no_sm(vec![ClientOutput {
+            output: offer_output,
+            amounts: Amounts::ZERO,
+        }])
+        .into_dyn(ln_module.id),
+    );
+    client
+        .finalize_and_submit_transaction(
+            offer_operation_id,
+            LightningCommonInit::KIND.as_str(),
+            |_| (),
+            offer_tx,
+        )
+        .await?;
+    await_client_tx_accepted(
+        client
+            .transaction_updates(offer_operation_id)
+            .await
+            .update_stream,
+    )
+    .await
+    .expect("offer transaction should be accepted");
+
+    let mut receive_updates = retry(
+        "recurring receive operation created",
+        aggressive_backoff_long(),
+        || async { ln_module.subscribe_ln_recurring_receive(operation_id).await },
+    )
+    .await?
+    .into_stream();
+    assert_eq!(receive_updates.ok().await?, LnReceiveState::Created);
+    assert_matches!(
+        receive_updates.ok().await?,
+        LnReceiveState::WaitingForPayment { .. }
+    );
+
+    recurringd_task.abort();
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn recurring_receive_skips_expired_offerless_invoice() -> anyhow::Result<()> {
+    let (invoice_tx, invoice_rx) = watch::channel(BTreeMap::new());
+    let (requested_tx, mut requested_rx) = mpsc::unbounded_channel();
+    let (recurringd_api, recurringd_task) = spawn_mock_recurringd(MockRecurringdState {
+        invoices: invoice_rx,
+        requested_indices: requested_tx,
+    })
+    .await?;
+
+    let fixtures = fixtures();
+    let fed = fixtures.new_fed_degraded().await;
+    let client = fed.new_client().await;
+    let ln_module = client.get_first_module::<LightningClientModule>()?;
+    let payment_code = ln_module
+        .register_recurring_payment_code(
+            RecurringPaymentProtocol::LNURL,
+            recurringd_api,
+            "[[\"text/plain\", \"test\"]]",
+        )
+        .await?;
+
+    // expired long enough ago to clear the client's clock skew tolerance
+    let stale_timestamp = fedimint_core::time::duration_since_epoch()
+        .checked_sub(Duration::from_secs(600))
+        .expect("current time is after unix epoch");
+    let (invoice, payment_hash, _) = recurring_invoice_for_index(
+        payment_code.root_keypair.public_key(),
+        1,
+        sats(100),
+        stale_timestamp,
+        Duration::from_secs(1),
+    )?;
+    invoice_tx.send_replace(BTreeMap::from([(1, invoice)]));
+
+    // the poller only requests index 2 after persisting the skip of index 1
+    tokio::time::timeout(Duration::from_secs(30), async {
+        loop {
+            if requested_rx.recv().await.expect("mock stays alive") == 2 {
+                break;
+            }
+        }
+    })
+    .await?;
+
+    let operation_id = OperationId(*payment_hash.as_ref());
+    assert!(
+        ln_module
+            .subscribe_ln_recurring_receive(operation_id)
+            .await
+            .is_err()
+    );
+    assert!(!ln_module.api.offer_exists(payment_hash).await?);
+
+    recurringd_task.abort();
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn recurring_receive_claims_paid_invoice() -> anyhow::Result<()> {
+    let (invoice_tx, invoice_rx) = watch::channel(BTreeMap::new());
+    let (requested_tx, _requested_rx) = mpsc::unbounded_channel();
+    let (recurringd_api, recurringd_task) = spawn_mock_recurringd(MockRecurringdState {
+        invoices: invoice_rx,
+        requested_indices: requested_tx,
+    })
+    .await?;
+
+    let fixtures = fixtures();
+    let fed = fixtures.new_fed_degraded().await;
+    let (client, payer) = fed.two_clients().await;
+    let ln_module = client.get_first_module::<LightningClientModule>()?;
+    let payment_code = ln_module
+        .register_recurring_payment_code(
+            RecurringPaymentProtocol::LNURL,
+            recurringd_api,
+            "[[\"text/plain\", \"test\"]]",
+        )
+        .await?;
+
+    let invoice_index = 1;
+    let amount = sats(100);
+    let (invoice, payment_hash, preimage_key) = recurring_invoice_for_index(
+        payment_code.root_keypair.public_key(),
+        invoice_index,
+        amount,
+        fedimint_core::time::duration_since_epoch(),
+        Duration::from_secs(3600),
+    )?;
+
+    let offer_output = LightningOutput::new_v0_offer(IncomingContractOffer {
+        amount,
+        hash: payment_hash,
+        encrypted_preimage: EncryptedPreimage::new(
+            &PreimageKey(preimage_key),
+            &ln_module.cfg.threshold_pub_key,
+        ),
+        expiry_time: None,
+    });
+    let offer_operation_id = OperationId::new_random();
+    let offer_tx = TransactionBuilder::new().with_outputs(
+        ClientOutputBundle::new_no_sm(vec![ClientOutput {
+            output: offer_output,
+            amounts: Amounts::ZERO,
+        }])
+        .into_dyn(ln_module.id),
+    );
+    client
+        .finalize_and_submit_transaction(
+            offer_operation_id,
+            LightningCommonInit::KIND.as_str(),
+            |_| (),
+            offer_tx,
+        )
+        .await?;
+    await_client_tx_accepted(
+        client
+            .transaction_updates(offer_operation_id)
+            .await
+            .update_stream,
+    )
+    .await
+    .expect("offer transaction should be accepted");
+
+    let payer_dummy = payer.get_first_module::<DummyClientModule>()?;
+    payer_dummy
+        .mock_receive(sats(1000), AmountUnit::BITCOIN)
+        .await?;
+    let payer_ln = payer.get_first_module::<LightningClientModule>()?;
+    let secp = secp256k1::Secp256k1::new();
+    let redeem_key = Keypair::new(&secp, &mut OsRng);
+    let (incoming_output, contract_amount, _contract_id) =
+        create_incoming_contract_output(&payer_ln.api, payment_hash, amount, &redeem_key).await?;
+    let funding_operation_id = OperationId::new_random();
+    let funding_tx = TransactionBuilder::new().with_outputs(
+        ClientOutputBundle::new_no_sm(vec![ClientOutput {
+            output: LightningOutput::V0(incoming_output),
+            amounts: Amounts::new_bitcoin(contract_amount),
+        }])
+        .into_dyn(payer_ln.id),
+    );
+    payer
+        .finalize_and_submit_transaction(
+            funding_operation_id,
+            LightningCommonInit::KIND.as_str(),
+            |_| (),
+            funding_tx,
+        )
+        .await?;
+    await_client_tx_accepted(
+        payer
+            .transaction_updates(funding_operation_id)
+            .await
+            .update_stream,
+    )
+    .await
+    .expect("funding transaction should be accepted");
+
+    // hold the invoice back until the offer is consumed, or the poller
+    // records an ordinary unpaid receive and the test goes vacuous
+    retry(
+        "offer consumed by funding",
+        aggressive_backoff_long(),
+        || async {
+            if ln_module.api.offer_exists(payment_hash).await? {
+                bail!("offer still exists");
+            }
+            Ok(())
+        },
+    )
+    .await?;
+
+    invoice_tx.send_replace(BTreeMap::from([(invoice_index, invoice)]));
+
+    let operation_id = OperationId(*payment_hash.as_ref());
+    let mut receive_updates = retry(
+        "recurring receive operation created",
+        aggressive_backoff_long(),
+        || async { ln_module.subscribe_ln_recurring_receive(operation_id).await },
+    )
+    .await?
+    .into_stream();
+    tokio::time::timeout(Duration::from_secs(60), async {
+        loop {
+            match receive_updates.ok().await? {
+                LnReceiveState::Claimed => return Ok(()),
+                LnReceiveState::Canceled { reason } => {
+                    bail!("recurring receive canceled: {reason}")
+                }
+                _ => {}
+            }
+        }
+    })
+    .await??;
+
+    recurringd_task.abort();
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
Follow-up to the review on #9036. The offer registration there raced recurringd's in-flight offer transaction, so this keeps the safe hardening and replaces registration with waiting.

The client records a recurring receive in `ConfirmedInvoice` without checking that the offer exists. That state is wrong while recurringd's offer transaction is still in flight, and permanently wrong in the rare case where consensus rejects it.

- before recording a recurring receive, the client checks whether the offer is in consensus. A missing offer on an unexpired invoice usually means the offer transaction is still in flight, so the client leaves the invoice index untouched and retries instead of submitting a competing offer
- a funded contract with no offer means the invoice was already paid: funding consumes the offer, so a receive paid while the recipient's client was offline wakes up to exactly this state. The client records the receive so its state machine claims the contract
- an invoice that expired with neither an offer nor a funded contract is skipped. recurringd hands invoices to payers only after offer confirmation, so nothing was ever payable
- an inconclusive federation read also leaves the invoice index untouched for retry instead of skipping the invoice
- an operation-creation failure logs a warning instead of tripping a `debug_assert!` that is a no-op in release builds
- `extra_meta` serialization failures return an error instead of panicking the client

## Testing

The branch is a test-first pair, so both the bug and the fix reproduce from the commits. The tests drive a mock recurringd that serves invoices whose offer state the test controls: no offer, offer landing late, or offer already consumed by a payer's funding.

- at the test commit (client unchanged) `recurring_receive_waits_for_offer` and `recurring_receive_skips_expired_offerless_invoice` fail: the client records a receive for an offer-less invoice, the precondition for the #9036 race. `recurring_receive_claims_paid_invoice` passes, unconditional recording handles the paid case
- at HEAD all three pass
- an offer-only gate without the funded-contract check fails `recurring_receive_claims_paid_invoice` with the receive never recorded, which is why the gate is offer-or-contract rather than offer alone. 8bbe9966f1d carries that variant with the same tests for anyone who wants to rerun it

<details><summary>test transcripts</summary>

test commit only, client at master:

```
test recurring_receive_skips_expired_offerless_invoice ... FAILED
test recurring_receive_claims_paid_invoice ... ok
test recurring_receive_waits_for_offer ... FAILED
thread 'recurring_receive_skips_expired_offerless_invoice' panicked at modules/fedimint-ln-tests/tests/tests.rs:375:
assertion failed: ln_module.subscribe_ln_recurring_receive(operation_id).await.is_err()
thread 'recurring_receive_waits_for_offer' panicked at modules/fedimint-ln-tests/tests/tests.rs:270:
assertion failed: ln_module.subscribe_ln_recurring_receive(operation_id).await.is_err()
test result: FAILED. 1 passed; 2 failed
```

HEAD:

```
test result: ok. 3 passed; 0 failed; finished in 4.68s
```

offer-only gate (8bbe9966f1d) plus `recurring_receive_claims_paid_invoice`:

```
test recurring_receive_claims_paid_invoice ... FAILED
Error: Operation not found
test result: FAILED. 0 passed; 1 failed; finished in 129.58s
```

</details>
