### PR TITLE
fix(server): drive the p2p send and receive halves concurrently

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -39,12 +39,61 @@ jobs:
                 -- \
               nix build -L .#release.quickFuzz
 
+  large-federation:
+    if: github.repository == 'fedimint/fedimint'
+    name: "19 guardian federation (${{ matrix.stack }})"
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      # `run-with-nix-workspace-ci.sh` takes over the shared target dir, so keep
+      # the two stacks sequential rather than racing them on one runner.
+      max-parallel: 1
+      matrix:
+        include:
+          - stack: iroh
+            enable-iroh: "true"
+          - stack: tls
+            enable-iroh: "false"
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Prepare
+        uses: ./.github/actions/prepare
+      - uses: dpc/nix-installer-action@c6e05d595d5ed6d6b7c46e42409ca2a126efe13d # dpc/jj-vqymqvyntouw
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
+        with:
+          name: fedimint
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+        continue-on-error: true
+      - uses: ./.github/actions/pin-nix-flake-inputs
+
+      - name: DKG and startup with 19 guardians
+        run: |
+          # `test-ci-all` runs this at 7 guardians on every PR. Large
+          # federations exercise p2p paths that only show up with more peers
+          # and more concurrent data in flight, so they get a daily run at a
+          # size no PR pays for.
+          # the default tmp dir is too long (/home/ubuntu/actions-runner/_work/_temp/)
+          env \
+            TMPDIR=/tmp \
+            CARGO_PROFILE=ci \
+            FM_ENABLE_IROH=${{ matrix.enable-iroh }} \
+            FM_IROH_DHT_ENABLE=false \
+            FM_IROH_NEXT_ENABLE=false \
+            FM_IROH_RELAYS_ENABLE=false \
+            FM_IROH_N0_DISCOVERY_ENABLE=false \
+            FM_IROH_PKARR_RESOLVER_ENABLE=false \
+            FM_IROH_PKARR_PUBLISHER_ENABLE=false \
+            nix develop -c \
+            env -u RUSTC_WRAPPER \
+            scripts/tests/run-with-nix-workspace-ci.sh ./scripts/tests/large-setup-test.sh 19
+
   notifications:
     if: always() && github.repository == 'fedimint/fedimint'
     name: "Notifications"
     timeout-minutes: 1
     runs-on: [self-hosted, linux, x64]
-    needs: [ audit, fuzz ]
+    needs: [ audit, fuzz, large-federation ]
 
     steps:
     - name: Discord notifications on failure

--- a/fedimint-server/src/net/p2p.rs
+++ b/fedimint-server/src/net/p2p.rs
@@ -270,6 +270,22 @@ enum P2PConnectionSMState<M> {
     Connected(DynP2PConnection<M>),
 }
 
+/// How often live connection metadata (currently only the round-trip time) is
+/// re-published while a connection stays up.
+const METADATA_REFRESH_INTERVAL: Duration = Duration::from_secs(10);
+
+/// Why the send half of the connection stopped.
+enum SendHalt<M> {
+    /// The state machine is shutting down.
+    Shutdown,
+    /// The connection failed and should be re-established.
+    Failed(anyhow::Error),
+    /// The peer opened a replacement connection that supersedes this one.
+    Replaced(DynP2PConnection<M>),
+    /// The connection exceeded the maximum age and should be re-established.
+    MaxAge,
+}
+
 impl<M: Send + 'static> P2PConnectionStateMachine<M> {
     async fn state_transition(mut self) -> Option<Self> {
         match self.state {
@@ -288,17 +304,8 @@ impl<M: Send + 'static> P2PConnectionStateMachine<M> {
                 // Subscribe before taking the snapshot so an update racing with
                 // the snapshot remains queued for the connected transition.
                 let status_updates = connection.connection_status_updates();
-                let status = P2PConnectionStatus {
-                    conn_type: connection
-                        .connection_type()
-                        .or_else(|| self.common.connector.connection_type(self.common.peer_id)),
-                    rtt: connection.rtt(),
-                };
 
-                self.common.status_sender.send_replace(P2PConnectionState {
-                    connected: Some(status),
-                    last_error: None,
-                });
+                self.common.refresh_status(&connection);
 
                 self.common
                     .transition_connected(connection, status_updates)
@@ -315,58 +322,170 @@ impl<M: Send + 'static> P2PConnectionStateMachine<M> {
 impl<M: Send + 'static> P2PConnectionSMCommon<M> {
     async fn transition_connected(
         &mut self,
-        mut connection: DynP2PConnection<M>,
+        connection: DynP2PConnection<M>,
         mut status_updates: Option<DynConnectionStatusUpdates>,
     ) -> Option<P2PConnectionSMState<M>> {
-        tokio::select! {
-            Some(()) = async {
-                match status_updates.as_mut() {
-                    Some(status_updates) => status_updates.next().await,
-                    None => std::future::pending().await,
-                }
-            } => {
-                Some(P2PConnectionSMState::Connected(connection))
-            },
-            () = async {
-                match self.connection_deadline {
-                    Some(deadline) => sleep_until(deadline).await,
-                    None => std::future::pending().await,
-                }
-            } => {
-                Some(self.disconnect(anyhow!("Connection exceeded the maximum age")))
-            },
-            message = self.outgoing_receiver.recv() => {
-                Some(self.send_message(connection, message.ok()?).await)
-            },
-            connection = self.incoming_connections.recv() => {
-                info!(target: LOG_NET_PEER, "Connected to peer");
+        // The send and receive halves are driven as two long-lived futures that
+        // are never cancelled part-way through a message. Multiplexing a single
+        // send and a single receive in one `select!` meant that a send parked on
+        // transport flow control could no longer poll `receive`, so two peers
+        // that both started writing a message larger than the transport window
+        // deadlocked permanently and silently.
+        //
+        // Interleaving reads inside the parked send is *not* sufficient: it just
+        // turns a write/write deadlock into a read/read one. The halves have to
+        // be genuinely concurrent.
+        //
+        // Replacement connections and the max-age deadline are observed inside
+        // the send half, between messages, so they can never cancel a send that
+        // is already in flight.
+        let send_loop = Self::send_loop(
+            &connection,
+            &self.outgoing_receiver,
+            &self.incoming_connections,
+            self.connection_deadline,
+            &self.our_id_str,
+            &self.peer_id_str,
+        );
+        let receive_loop = Self::receive_loop(
+            &connection,
+            &self.incoming_sender,
+            &self.our_id_str,
+            &self.peer_id_str,
+        );
 
-                self.connection_deadline = self.max_connection_age.map(|age| Instant::now() + age);
+        tokio::pin!(send_loop, receive_loop);
 
-                Some(P2PConnectionSMState::Connected(connection.ok()?))
-            },
-            message = connection.receive() => {
-                let mut message = match message {
-                    Ok(message) => message,
-                    Err(e) => return Some(self.disconnect(e)),
-                };
-
-                match message.read_to_end().await {
-                    Ok(message) => {
-                        PEER_MESSAGES_COUNT
-                            .with_label_values(&[self.our_id_str.as_str(), self.peer_id_str.as_str(), "incoming"])
-                            .inc();
-
-                        if self.incoming_sender.try_send(message).is_err() {
-                            debug!(target: LOG_NET_PEER, "Incoming message channel is full");
+        loop {
+            tokio::select! {
+                halt = &mut send_loop => {
+                    return match halt {
+                        SendHalt::Shutdown => None,
+                        SendHalt::Failed(e) => Some(self.disconnect(e)),
+                        SendHalt::MaxAge => {
+                            Some(self.disconnect(anyhow!("Connection exceeded the maximum age")))
                         }
-                    },
-                    Err(e) => return Some(self.disconnect(e)),
-                }
+                        SendHalt::Replaced(connection) => {
+                            info!(target: LOG_NET_PEER, "Connected to peer");
 
-                Some(P2PConnectionSMState::Connected(connection))
-            },
+                            self.connection_deadline =
+                                self.max_connection_age.map(|age| Instant::now() + age);
+
+                            Some(P2PConnectionSMState::Connected(connection))
+                        }
+                    };
+                },
+                e = &mut receive_loop => {
+                    return Some(self.disconnect(e));
+                },
+                Some(()) = async {
+                    match status_updates.as_mut() {
+                        Some(status_updates) => status_updates.next().await,
+                        None => std::future::pending().await,
+                    }
+                } => {
+                    self.refresh_status(&connection);
+                },
+                () = sleep(METADATA_REFRESH_INTERVAL) => {
+                    // Connection metadata used to be refreshed as a side effect
+                    // of every message, which the long-lived halves no longer
+                    // provide. Only `rtt` needs this; transport changes still
+                    // arrive on the status update stream above.
+                    self.refresh_status(&connection);
+                },
+            }
         }
+    }
+
+    /// Drains the outgoing queue onto the connection. Replacement connections
+    /// and the max-age deadline are observed here, between sends, so they can
+    /// never cancel the non-cancel-safe `send` and silently drop a message
+    /// that the DKG would not resend. Only a failure of the connection itself
+    /// can still lose the message in flight; the networking layer is
+    /// unreliable by design.
+    async fn send_loop(
+        connection: &DynP2PConnection<M>,
+        outgoing_receiver: &Receiver<M>,
+        incoming_connections: &Receiver<DynP2PConnection<M>>,
+        connection_deadline: Option<Instant>,
+        our_id_str: &str,
+        peer_id_str: &str,
+    ) -> SendHalt<M> {
+        loop {
+            // All branches are cancel-safe: `recv` on an async channel does not
+            // take an item unless it completes and the timer holds no state.
+            let message = tokio::select! {
+                message = outgoing_receiver.recv() => match message {
+                    Ok(message) => message,
+                    Err(..) => return SendHalt::Shutdown,
+                },
+                connection = incoming_connections.recv() => return match connection {
+                    Ok(connection) => SendHalt::Replaced(connection),
+                    Err(..) => SendHalt::Shutdown,
+                },
+                () = async {
+                    match connection_deadline {
+                        Some(deadline) => sleep_until(deadline).await,
+                        None => std::future::pending().await,
+                    }
+                } => return SendHalt::MaxAge,
+            };
+
+            PEER_MESSAGES_COUNT
+                .with_label_values(&[our_id_str, peer_id_str, "outgoing"])
+                .inc();
+
+            if let Err(e) = connection.send(message).await {
+                return SendHalt::Failed(e);
+            }
+        }
+    }
+
+    /// Drains the connection into the incoming queue. Only returns when the
+    /// connection fails.
+    async fn receive_loop(
+        connection: &DynP2PConnection<M>,
+        incoming_sender: &Sender<M>,
+        our_id_str: &str,
+        peer_id_str: &str,
+    ) -> anyhow::Error {
+        loop {
+            let mut frame = match connection.receive().await {
+                Ok(frame) => frame,
+                Err(e) => return e,
+            };
+
+            match frame.read_to_end().await {
+                Ok(message) => {
+                    PEER_MESSAGES_COUNT
+                        .with_label_values(&[our_id_str, peer_id_str, "incoming"])
+                        .inc();
+
+                    if incoming_sender.try_send(message).is_err() {
+                        debug!(target: LOG_NET_PEER, "Incoming message channel is full");
+                    }
+                }
+                Err(e) => return e,
+            }
+        }
+    }
+
+    /// Publishes a fresh metadata snapshot for the live connection.
+    ///
+    /// Refreshing in place rather than re-entering the connected state means a
+    /// send already in flight is never cancelled by a status event.
+    fn refresh_status(&self, connection: &DynP2PConnection<M>) {
+        let status = P2PConnectionStatus {
+            conn_type: connection
+                .connection_type()
+                .or_else(|| self.connector.connection_type(self.peer_id)),
+            rtt: connection.rtt(),
+        };
+
+        self.status_sender.send_replace(P2PConnectionState {
+            connected: Some(status),
+            last_error: None,
+        });
     }
 
     fn disconnect(&self, error: anyhow::Error) -> P2PConnectionSMState<M> {
@@ -386,26 +505,6 @@ impl<M: Send + 'static> P2PConnectionSMCommon<M> {
             backoff: api_networking_backoff(),
             last_error: Some(last_error),
         }
-    }
-
-    async fn send_message(
-        &mut self,
-        mut connection: DynP2PConnection<M>,
-        peer_message: M,
-    ) -> P2PConnectionSMState<M> {
-        PEER_MESSAGES_COUNT
-            .with_label_values(&[
-                self.our_id_str.as_str(),
-                self.peer_id_str.as_str(),
-                "outgoing",
-            ])
-            .inc();
-
-        if let Err(e) = connection.send(peer_message).await {
-            return self.disconnect(e);
-        }
-
-        P2PConnectionSMState::Connected(connection)
     }
 
     async fn transition_disconnected(

--- a/fedimint-server/src/net/p2p/tests.rs
+++ b/fedimint-server/src/net/p2p/tests.rs
@@ -16,7 +16,7 @@ use super::{
     P2PConnectionSMCommon, P2PConnectionSMState, P2PConnectionState, P2PConnectionStateMachine,
 };
 use crate::net::p2p_connection::{
-    DynConnectionStatusUpdates, DynIP2PFrame, DynP2PConnection, IP2PConnection,
+    DynConnectionStatusUpdates, DynIP2PFrame, DynP2PConnection, IP2PConnection, IP2PFrame,
 };
 use crate::net::p2p_connector::{DynP2PConnector, IP2PConnector};
 
@@ -97,11 +97,11 @@ impl FakeConnection {
 
 #[async_trait]
 impl IP2PConnection<u64> for FakeConnection {
-    async fn send(&mut self, _message: u64) -> anyhow::Result<()> {
+    async fn send(&self, _message: u64) -> anyhow::Result<()> {
         Ok(())
     }
 
-    async fn receive(&mut self) -> anyhow::Result<DynIP2PFrame<u64>> {
+    async fn receive(&self) -> anyhow::Result<DynIP2PFrame<u64>> {
         self.control.disconnect.notified().await;
         Err(anyhow!("fake connection disconnected"))
     }
@@ -209,7 +209,7 @@ impl StatusMachineHarness {
         });
         let connector: DynP2PConnector<u64> = Arc::new(PendingConnector { fallback });
         let mut state_machine = P2PConnectionStateMachine {
-            state: P2PConnectionSMState::Connected(Box::new(connection)),
+            state: P2PConnectionSMState::Connected(Arc::new(connection)),
             common: P2PConnectionSMCommon {
                 incoming_sender,
                 outgoing_receiver,
@@ -309,10 +309,14 @@ async fn subscribes_before_snapshot_to_close_status_update_race() {
     control.update_status_during_next_snapshot(ConnectionType::Direct);
     let mut harness = StatusMachineHarness::spawn(FakeConnection::new(control.clone()));
 
+    // An update emitted while the initial snapshot is taken must still be seen.
+    // The connected state now holds one subscription for the lifetime of the
+    // connection and refreshes in place, rather than re-entering (and so
+    // re-subscribing) once per status event.
     harness
         .wait_for_status(ExpectedStatus::Connected(ConnectionType::Direct))
         .await;
-    assert!(control.subscriptions() >= 2);
+    assert!(control.subscriptions() >= 1);
 }
 
 #[tokio::test]
@@ -326,7 +330,7 @@ async fn superseded_connection_events_do_not_replace_current_status() {
     let new_control = FakeConnectionControl::new(ConnectionType::Direct);
     harness
         .connection_sender
-        .send(Box::new(FakeConnection::new(new_control)))
+        .send(Arc::new(FakeConnection::new(new_control)))
         .await
         .expect("state machine receives replacement connection");
     harness
@@ -377,4 +381,233 @@ async fn closed_status_stream_does_not_spin() {
     control.disconnect();
     harness.wait_for_status(ExpectedStatus::Disconnected).await;
     assert_eq!(harness.current_status(), None);
+}
+
+/// A frame that yields a single pre-baked message.
+struct FakeFrame(u64);
+
+#[async_trait]
+impl IP2PFrame<u64> for FakeFrame {
+    async fn read_to_end(&mut self) -> anyhow::Result<u64> {
+        Ok(self.0)
+    }
+}
+
+/// A connection whose `send` cannot complete until `receive` has been served at
+/// least once. This is the shape of transport flow control: the peer has to
+/// drain our stream before our write can finish.
+struct FlowControlledConnection {
+    /// Granted by `receive`, awaited by `send`.
+    window: Arc<Notify>,
+    frames: async_channel::Receiver<u64>,
+    /// Number of sends that made it past the window wait.
+    sends_completed: Arc<AtomicUsize>,
+}
+
+#[async_trait]
+impl IP2PConnection<u64> for FlowControlledConnection {
+    async fn send(&self, _message: u64) -> anyhow::Result<()> {
+        self.window.notified().await;
+
+        self.sends_completed.fetch_add(1, Ordering::Relaxed);
+
+        Ok(())
+    }
+
+    async fn receive(&self) -> anyhow::Result<DynIP2PFrame<u64>> {
+        let message = self
+            .frames
+            .recv()
+            .await
+            .map_err(|_| anyhow!("frame channel closed"))?;
+
+        self.window.notify_one();
+
+        Ok(FakeFrame(message).into_dyn())
+    }
+
+    fn rtt(&self) -> Option<Duration> {
+        None
+    }
+
+    fn connection_type(&self) -> Option<ConnectionType> {
+        Some(ConnectionType::Direct)
+    }
+}
+
+/// Regression test for a p2p deadlock: when send and receive were multiplexed
+/// in a single `select!`, a send parked on transport flow control could no
+/// longer poll `receive`, so the window never reopened. Two peers that both
+/// started writing an oversized message hung forever, silently.
+#[tokio::test]
+async fn receives_while_a_send_is_parked_on_flow_control() {
+    let (frame_sender, frames) = async_channel::bounded(1);
+    let (connection_sender, incoming_connections) = async_channel::bounded(1);
+    let (outgoing_sender, outgoing_receiver) = async_channel::bounded(1);
+    let (incoming_sender, incoming_receiver) = async_channel::bounded(1);
+    let (status_sender, _status_receiver) = watch::channel(P2PConnectionState {
+        connected: None,
+        last_error: None,
+    });
+
+    let sends_completed = Arc::new(AtomicUsize::new(0));
+
+    let connection = FlowControlledConnection {
+        window: Arc::new(Notify::new()),
+        frames,
+        sends_completed: sends_completed.clone(),
+    };
+
+    let mut state_machine = P2PConnectionStateMachine {
+        state: P2PConnectionSMState::Connected(Arc::new(connection)),
+        common: P2PConnectionSMCommon {
+            incoming_sender,
+            outgoing_receiver,
+            our_id: PeerId::from(1),
+            our_id_str: "1".to_owned(),
+            peer_id: PeerId::from(0),
+            peer_id_str: "0".to_owned(),
+            connector: Arc::new(PendingConnector { fallback: None }),
+            incoming_connections,
+            status_sender,
+            max_connection_age: None,
+            connection_deadline: None,
+        },
+    };
+
+    let task = runtime::spawn("p2p-flow-control-test", async move {
+        while let Some(next) = state_machine.state_transition().await {
+            state_machine = next;
+        }
+    });
+
+    // Park a send first, so the connection is mid-write when the peer's frame
+    // arrives. Only a receive can unblock it.
+    outgoing_sender.send(7).await.expect("outgoing queued");
+    frame_sender.send(9).await.expect("frame queued");
+
+    let received = timeout(Duration::from_secs(5), incoming_receiver.recv())
+        .await
+        .expect("receive must be served while the send is parked")
+        .expect("incoming channel is open");
+
+    assert_eq!(received, 9);
+
+    // The send can only get past the window wait because the receive was
+    // served, so a completed send proves both halves made progress.
+    timeout(Duration::from_secs(5), async {
+        while sends_completed.load(Ordering::Relaxed) == 0 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("parked send completes once the window reopens");
+
+    // If the closed frame channel is observed before the closed outgoing
+    // channel, the machine transitions to Disconnected instead of shutting
+    // down; the connection channel must be closed too for the task to end.
+    drop(frame_sender);
+    drop(outgoing_sender);
+    drop(connection_sender);
+    let _ = task.await;
+}
+
+/// A replacement connection that arrives while a send is parked must not
+/// cancel the in-flight send: the already dequeued message would be silently
+/// lost, and e.g. the DKG sends every message exactly once.
+#[tokio::test]
+async fn replacement_connection_does_not_cancel_in_flight_send() {
+    let (frame_sender, frames) = async_channel::bounded(1);
+    let (connection_sender, incoming_connections) = async_channel::bounded(1);
+    let (outgoing_sender, outgoing_receiver) = async_channel::bounded(1);
+    let (incoming_sender, _incoming_receiver) = async_channel::bounded(1);
+    let (status_sender, mut status_receiver) = watch::channel(P2PConnectionState {
+        connected: None,
+        last_error: None,
+    });
+
+    let sends_completed = Arc::new(AtomicUsize::new(0));
+
+    let connection = FlowControlledConnection {
+        window: Arc::new(Notify::new()),
+        frames,
+        sends_completed: sends_completed.clone(),
+    };
+
+    let mut state_machine = P2PConnectionStateMachine {
+        state: P2PConnectionSMState::Connected(Arc::new(connection)),
+        common: P2PConnectionSMCommon {
+            incoming_sender,
+            outgoing_receiver,
+            our_id: PeerId::from(1),
+            our_id_str: "1".to_owned(),
+            peer_id: PeerId::from(0),
+            peer_id_str: "0".to_owned(),
+            connector: Arc::new(PendingConnector { fallback: None }),
+            incoming_connections,
+            status_sender,
+            max_connection_age: None,
+            connection_deadline: None,
+        },
+    };
+
+    let task = runtime::spawn("p2p-replacement-test", async move {
+        while let Some(next) = state_machine.state_transition().await {
+            state_machine = next;
+        }
+    });
+
+    // Park a send on flow control and wait until the message is dequeued, so
+    // the send is in flight before the replacement connection arrives.
+    outgoing_sender.send(7).await.expect("outgoing queued");
+    timeout(Duration::from_secs(5), async {
+        while !outgoing_sender.is_empty() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("send is dequeued and in flight");
+
+    connection_sender
+        .send(Arc::new(FakeConnection::new(FakeConnectionControl::new(
+            ConnectionType::Relay,
+        ))))
+        .await
+        .expect("replacement queued");
+
+    // Serving a receive reopens the window; the parked send must still be
+    // alive to complete despite the queued replacement.
+    frame_sender.send(9).await.expect("frame queued");
+    timeout(Duration::from_secs(5), async {
+        while sends_completed.load(Ordering::Relaxed) == 0 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("in-flight send completes despite the queued replacement");
+
+    // Only then does the replacement connection take over.
+    timeout(Duration::from_secs(5), async {
+        loop {
+            if status_receiver
+                .borrow_and_update()
+                .connected
+                .as_ref()
+                .is_some_and(|status| status.conn_type == Some(ConnectionType::Relay))
+            {
+                return;
+            }
+            status_receiver
+                .changed()
+                .await
+                .expect("status sender remains alive");
+        }
+    })
+    .await
+    .expect("replacement connection takes over after the send completes");
+
+    drop(frame_sender);
+    drop(outgoing_sender);
+    drop(connection_sender);
+    let _ = task.await;
 }

--- a/fedimint-server/src/net/p2p_connection.rs
+++ b/fedimint-server/src/net/p2p_connection.rs
@@ -2,7 +2,9 @@
 mod tests;
 
 use std::io::Cursor;
+use std::marker::PhantomData;
 use std::pin::Pin;
+use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Context;
@@ -11,6 +13,7 @@ use bytes::{Bytes, BytesMut};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_server_core::dashboard_ui::ConnectionType;
+use futures::stream::{SplitSink, SplitStream};
 use futures::{SinkExt, Stream, StreamExt};
 use iroh_next::endpoint::{Connection as IrohV1Connection, RecvStream as IrohV1RecvStream};
 use serde::Serialize;
@@ -21,9 +24,9 @@ use tokio_util::codec::{Framed, LengthDelimitedCodec};
 
 /// Maximum size of a p2p message in bytes. The largest message we expect to
 /// receive is a signed session outcome.
-const MAX_P2P_MESSAGE_SIZE: usize = 10_000_000;
+pub const MAX_P2P_MESSAGE_SIZE: usize = 10_000_000;
 
-pub type DynP2PConnection<M> = Box<dyn IP2PConnection<M>>;
+pub type DynP2PConnection<M> = Arc<dyn IP2PConnection<M>>;
 
 pub type DynIP2PFrame<M> = Box<dyn IP2PFrame<M>>;
 
@@ -46,14 +49,24 @@ pub trait IP2PFrame<M>: Send + 'static {
 }
 
 #[async_trait]
-pub trait IP2PConnection<M>: Send + 'static {
+pub trait IP2PConnection<M>: Send + Sync + 'static {
     /// Send a message over the connection. This is *not* required to be
     /// cancel-safe.
-    async fn send(&mut self, message: M) -> anyhow::Result<()>;
+    ///
+    /// Takes `&self` so that the send and receive halves can be driven
+    /// concurrently. A send parked on transport flow control must never stop
+    /// the peer's stream from being drained, or two peers that are both
+    /// sending an oversized message deadlock permanently.
+    ///
+    /// While `send` and `receive` may run concurrently with each other, each
+    /// of them must have at most one caller at a time: a second concurrent
+    /// `receive` would steal frames from the first and silently reorder the
+    /// message stream.
+    async fn send(&self, message: M) -> anyhow::Result<()>;
 
     /// Receive a p2p frame from the connection. This is *required* to be
-    /// cancel-safe.
-    async fn receive(&mut self) -> anyhow::Result<DynIP2PFrame<M>>;
+    /// cancel-safe. See [`Self::send`] for the concurrency contract.
+    async fn receive(&self) -> anyhow::Result<DynIP2PFrame<M>>;
 
     /// Get the round-trip time of the connection.
     fn rtt(&self) -> Option<Duration>;
@@ -78,7 +91,7 @@ pub trait IP2PConnection<M>: Send + 'static {
     where
         Self: Sized,
     {
-        Box::new(self)
+        Arc::new(self)
     }
 }
 
@@ -98,23 +111,63 @@ where
     }
 }
 
+type TlsFramed = Framed<TlsStream<TcpStream>, LengthDelimitedCodec>;
+
+/// A TLS p2p connection.
+///
+/// A single `Framed` cannot serve both directions at once, so the sink and
+/// stream halves are split and guarded separately. That is what lets a send
+/// parked on socket buffers coexist with a concurrent receive.
+pub struct TlsP2PConnection<M> {
+    sink: tokio::sync::Mutex<SplitSink<TlsFramed, Bytes>>,
+    stream: tokio::sync::Mutex<SplitStream<TlsFramed>>,
+    // `fn(M) -> M` keeps the struct `Send + Sync` regardless of `M`, which is
+    // never stored, only sent.
+    _message: PhantomData<fn(M) -> M>,
+}
+
+impl<M> TlsP2PConnection<M> {
+    pub fn new(framed: TlsFramed) -> Self {
+        let (sink, stream) = framed.split();
+
+        Self {
+            sink: tokio::sync::Mutex::new(sink),
+            stream: tokio::sync::Mutex::new(stream),
+            _message: PhantomData,
+        }
+    }
+}
+
 #[async_trait]
-impl<M> IP2PConnection<M> for Framed<TlsStream<TcpStream>, LengthDelimitedCodec>
+impl<M> IP2PConnection<M> for TlsP2PConnection<M>
 where
     M: Encodable + Decodable + Serialize + DeserializeOwned + Send + 'static,
 {
-    async fn send(&mut self, message: M) -> anyhow::Result<()> {
+    async fn send(&self, message: M) -> anyhow::Result<()> {
         let mut bytes = Vec::new();
 
         bincode::serialize_into(&mut bytes, &message)?;
 
-        SinkExt::send(self, Bytes::from_owner(bytes)).await?;
+        // The locks are never contended by contract — see the trait doc — so
+        // a second concurrent caller fails loudly instead of queuing behind
+        // the lock and interleaving with the first.
+        let mut sink = self
+            .sink
+            .try_lock()
+            .expect("send has at most one caller at a time");
+
+        SinkExt::send(&mut *sink, Bytes::from_owner(bytes)).await?;
 
         Ok(())
     }
 
-    async fn receive(&mut self) -> anyhow::Result<DynIP2PFrame<M>> {
-        let message = self
+    async fn receive(&self) -> anyhow::Result<DynIP2PFrame<M>> {
+        let mut stream = self
+            .stream
+            .try_lock()
+            .expect("receive has at most one caller at a time");
+
+        let message = stream
             .next()
             .await
             .context("Framed stream is closed")??
@@ -155,7 +208,7 @@ impl<M> IP2PConnection<M> for iroh::endpoint::Connection
 where
     M: Encodable + Decodable + Serialize + DeserializeOwned + Send + 'static,
 {
-    async fn send(&mut self, message: M) -> anyhow::Result<()> {
+    async fn send(&self, message: M) -> anyhow::Result<()> {
         let mut bytes = Vec::new();
 
         bincode::serialize_into(&mut bytes, &message)?;
@@ -168,7 +221,7 @@ where
         Ok(())
     }
 
-    async fn receive(&mut self) -> anyhow::Result<DynIP2PFrame<M>> {
+    async fn receive(&self) -> anyhow::Result<DynIP2PFrame<M>> {
         Ok(self.accept_uni().await?.into_dyn())
     }
 
@@ -200,7 +253,7 @@ impl<M> IP2PConnection<M> for IrohV1Connection
 where
     M: Encodable + Decodable + Serialize + DeserializeOwned + Send + 'static,
 {
-    async fn send(&mut self, message: M) -> anyhow::Result<()> {
+    async fn send(&self, message: M) -> anyhow::Result<()> {
         let mut bytes = Vec::new();
 
         bincode::serialize_into(&mut bytes, &message)?;
@@ -214,7 +267,7 @@ where
         Ok(())
     }
 
-    async fn receive(&mut self) -> anyhow::Result<DynIP2PFrame<M>> {
+    async fn receive(&self) -> anyhow::Result<DynIP2PFrame<M>> {
         Ok(self.accept_uni().await?.into_dyn())
     }
 

--- a/fedimint-server/src/net/p2p_connector/iroh/tests.rs
+++ b/fedimint-server/src/net/p2p_connector/iroh/tests.rs
@@ -82,8 +82,7 @@ async fn production_connectors_exchange_messages_over_direct_override() -> anyho
         <IrohConnector as IP2PConnector<u64>>::connect(&connector_a, peer_b),
         <IrohConnector as IP2PConnector<u64>>::accept(&connector_b),
     )?;
-    let (authenticated_peer, mut incoming) = incoming;
-    let mut outgoing = outgoing;
+    let (authenticated_peer, incoming) = incoming;
     assert_eq!(authenticated_peer, peer_a);
 
     outgoing.send(42).await?;

--- a/fedimint-server/src/net/p2p_connector/tls.rs
+++ b/fedimint-server/src/net/p2p_connector/tls.rs
@@ -20,7 +20,9 @@ use tokio_util::codec::LengthDelimitedCodec;
 
 use super::IP2PConnector;
 use super::iroh::parse_p2p;
-use crate::net::p2p_connection::{DynP2PConnection, IP2PConnection as _};
+use crate::net::p2p_connection::{
+    DynP2PConnection, IP2PConnection as _, MAX_P2P_MESSAGE_SIZE, TlsP2PConnection,
+};
 
 #[derive(Debug, Clone)]
 pub struct TlsConfig {
@@ -146,9 +148,10 @@ where
 
         let framed = LengthDelimitedCodec::builder()
             .length_field_type::<u64>()
+            .max_frame_length(MAX_P2P_MESSAGE_SIZE)
             .new_framed(TlsStream::Client(tls));
 
-        Ok(framed.into_dyn())
+        Ok(TlsP2PConnection::new(framed).into_dyn())
     }
 
     async fn accept(&self) -> anyhow::Result<(PeerId, DynP2PConnection<M>)> {
@@ -174,9 +177,10 @@ where
 
         let framed = LengthDelimitedCodec::builder()
             .length_field_type::<u64>()
+            .max_frame_length(MAX_P2P_MESSAGE_SIZE)
             .new_framed(TlsStream::Server(tls));
 
-        Ok((auth_peer, framed.into_dyn()))
+        Ok((auth_peer, TlsP2PConnection::new(framed).into_dyn()))
     }
 
     fn connection_type(&self, _peer: PeerId) -> Option<ConnectionType> {

--- a/scripts/tests/large-setup-test.sh
+++ b/scripts/tests/large-setup-test.sh
@@ -9,9 +9,14 @@ build_workspace
 add_target_dir_to_path
 make_fm_test_marker
 
-export FM_FED_SIZE=7
+# The federation size is the first script argument (default 7, the per-PR
+# `test-ci-all` size; the daily check passes 19) rather than an env override,
+# so an FM_FED_SIZE exported for a devimint environment cannot silently
+# shrink the check. Remaining arguments are forwarded to devimint.
+export FM_FED_SIZE="${1:-7}"
+if [ $# -gt 0 ]; then shift; fi
 
->&2 echo "Testing ${FM_FED_SIZE} peer dkg"
+>&2 echo "Testing ${FM_FED_SIZE} peer dkg (FM_ENABLE_IROH=${FM_ENABLE_IROH:-unset})"
 
 env \
   RUST_LOG="${RUST_LOG:-info,jsonrpsee-client=off}" \


### PR DESCRIPTION
## Summary

Fixes the p2p deadlock in #9091: two peers that both begin writing a message larger than the transport's flow-control window hang forever, silently. The connected state now drives the send and receive halves as two genuinely concurrent long-lived futures, so a write parked on flow control can no longer stop us from draining the peer. A second commit adds a daily CI job that runs a 19 guardian federation.

## Details

`P2PConnectionStateMachine::transition_connected` multiplexed a single send and a single receive in one `tokio::select!`. Once a peer parked inside `send_message(..).await` — which happens as soon as one message exceeds the window — that task could no longer poll `connection.receive()`. The peer was in the same state for the same reason, so neither drained the other's stream. The connection stayed open, keep-alives kept flowing, `max_idle_timeout` never fired, and nothing was logged on either side: it presents as a federation that quietly stops making progress.

The fix drives a send loop and a receive loop that are never cancelled part-way through a message. That requires the connection to be usable from both halves at once:

- `IP2PConnection::send`/`receive` take `&self` and the trait gains a `Sync` bound.
- `DynP2PConnection` becomes an `Arc`.
- The TLS connection is split into its sink and stream halves behind separate mutexes — one `Framed` cannot serve both directions. Both iroh impls were already `&self`-compatible.

Connection metadata used to be refreshed as a side effect of every message, which long-lived halves no longer provide. Transport changes still arrive on the existing status-update stream; `rtt` gets a 10 s timer. Both refresh **in place** rather than re-entering the connected state, so a send already in flight is never cancelled by a status event.

One variant that looks right and is not: keeping the fused `select!` and draining incoming frames alongside the parked send. That converts a write/write deadlock into a read/read one — each peer blocks in `read_to_end` of the other's message and stops polling its own write. The halves have to be genuinely concurrent, not interleaved within one task.

This is the structural fix, so it also covers the TLS transport, where the same defect bites at ~2.5–3 MB and there is no window knob to turn (`SO_RCVBUF` is capped by `net.core.rmem_max`). Sizing the iroh QUIC windows to `MAX_P2P_MESSAGE_SIZE` is still worth doing on top as defence in depth — it is not in this PR.

## Reviewing

- The `&self` + `Arc` change to `IP2PConnection` is the widest part of the diff and touches the trait every transport implements. Worth checking the TLS split is right: `receive` is still required to be cancel-safe, and `Framed`'s `StreamExt::next` is.
- Refreshing status in place rather than re-entering the connected state is a deliberate behaviour change. It is what keeps a parked send from being cancelled by an unrelated status event, but it means `rtt` is now only as fresh as the 10 s timer instead of per-message. `subscribes_before_snapshot_to_close_status_update_race` was relaxed from `>= 2` subscriptions to `>= 1` for this reason — the connection now holds one subscription for its whole lifetime, which is strictly simpler than re-subscribing per event.
- The daily job runs both p2p stacks sequentially, since `run-with-nix-workspace-ci.sh` takes over the shared target dir. If the runner can afford it, they could go parallel.

## Testing

`receives_while_a_send_is_parked_on_flow_control` is a deterministic regression test built on a fake connection whose `send` only completes once `receive` has been served. It times out against the previous structure and passes against this one — verified both ways.

Also verified end to end against a real devimint federation on the Iroh transport, forcing an all-to-all DKG message of a given size across every peer:

| guardians | payload | before | after |
|---|---|---|---|
| 13 | 1,200,000 B | 13/13 ok | 13/13 ok |
| 13 | 1,300,000 B | **0/13, hung ≥180 s** | 13/13 ok |
| 19 | 1,300,000 B | **0/19, hung ≥170 s** | — |
| 13 | 5,000,000 B | — | 13/13 ok in ~7 s |

The `before` failures reproduce the production symptom exactly: `Still waiting for peer message peer=2`, naming only the lowest missing peer, with zero disconnects and CPU decaying to ~5%.

For context on why this had not been hit at DKG time in practice: unmodified 13/16/19 guardian federations all complete DKG fine (25.7 s / 38.3 s / 61.4 s), with a largest p2p message of 1,750 / 2,134 / 2,518 B. DKG message size is `128·n + 86` bytes — every message is a polynomial commitment of length `threshold`, and mintv2 runs one `run_dkg_g2` per denomination sequentially — so reaching the 1.25 MB window through guardian count alone would take ~9,800 guardians. Payload size is what crosses the threshold, not peer count.

`cargo clippy -p fedimint-server --all-targets` clean, `cargo test -p fedimint-server --lib net::` green (14 tests), `cargo check -p fedimintd -p devimint` clean, `just final-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQkYZiCQyD8QVadFxeLGsN
