### PR TITLE
chore(core): give DecodeError structured variants and drop anyhow from fedimint-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4792,6 +4792,7 @@ dependencies = [
 name = "fedimint-server-tests"
 version = "0.13.0-alpha"
 dependencies = [
+ "anyhow",
  "bitcoin",
  "fedimint-api-client",
  "fedimint-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3511,7 +3511,6 @@ dependencies = [
 name = "fedimint-derive-secret"
 version = "0.13.0-alpha"
 dependencies = [
- "anyhow",
  "bitcoin_hashes",
  "bls12_381",
  "fedimint-core",
@@ -3549,7 +3548,6 @@ dependencies = [
 name = "fedimint-dummy-common"
 version = "0.13.0-alpha"
 dependencies = [
- "anyhow",
  "fedimint-core",
  "serde",
  "thiserror 2.0.18",
@@ -3592,7 +3590,6 @@ dependencies = [
 name = "fedimint-empty-common"
 version = "0.13.0-alpha"
 dependencies = [
- "anyhow",
  "fedimint-core",
  "serde",
  "thiserror 2.0.18",
@@ -3637,7 +3634,6 @@ dependencies = [
 name = "fedimint-fountain"
 version = "0.13.0-alpha"
 dependencies = [
- "anyhow",
  "assert_matches",
  "bitcoin_hashes",
  "fedimint-core",
@@ -3687,7 +3683,6 @@ dependencies = [
 name = "fedimint-gateway-common"
 version = "0.13.0-alpha"
 dependencies = [
- "anyhow",
  "bitcoin",
  "clap",
  "fedimint-api-client",
@@ -4982,7 +4977,6 @@ dependencies = [
 name = "fedimint-unknown-common"
 version = "0.13.0-alpha"
 dependencies = [
- "anyhow",
  "fedimint-core",
  "serde",
  "thiserror 2.0.18",

--- a/crypto/derive-secret/Cargo.toml
+++ b/crypto/derive-secret/Cargo.toml
@@ -16,7 +16,6 @@ name = "fedimint_derive_secret"
 path = "src/lib.rs"
 
 [dependencies]
-anyhow = { workspace = true }
 bitcoin_hashes = { workspace = true }
 bls12_381 = { workspace = true }
 fedimint-core = { workspace = true }

--- a/fedimint-client/src/backup.rs
+++ b/fedimint-client/src/backup.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::io;
 use std::io::{Cursor, Write};
 
-use anyhow::{Context, Result, bail, ensure};
+use anyhow::{Result, bail, ensure};
 use bitcoin::secp256k1::{Keypair, PublicKey, Secp256k1, SignOnly};
 use fedimint_api_client::api::DynGlobalApi;
 use fedimint_client_module::module::recovery::DynModuleBackup;
@@ -12,7 +12,7 @@ use fedimint_core::core::backup::{
     BACKUP_REQUEST_MAX_PAYLOAD_SIZE_BYTES, BackupRequest, SignedBackupRequest,
 };
 use fedimint_core::db::IDatabaseTransactionOpsCoreTyped;
-use fedimint_core::encoding::{Decodable, DecodeError, Encodable};
+use fedimint_core::encoding::{Decodable, DecodeContext as _, DecodeError, Encodable};
 use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_core::module::serde_json;
 use fedimint_derive_secret::DerivableSecret;

--- a/fedimint-client/src/client.rs
+++ b/fedimint-client/src/client.rs
@@ -506,7 +506,7 @@ impl Client {
         Ok(match client_secret {
             Some(client_secret) => Some(
                 T::consensus_decode_whole(&client_secret, &ModuleRegistry::default())
-                    .map_err(|e| anyhow!("Decoding failed: {e}"))?,
+                    .context("Decoding failed")?,
             ),
             None => None,
         })

--- a/fedimint-client/src/db.rs
+++ b/fedimint-client/src/db.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::time::SystemTime;
 
-use anyhow::{anyhow, bail};
+use anyhow::{Context as _, bail};
 use bitcoin::hex::DisplayHex as _;
 use fedimint_api_client::api::ApiVersionSet;
 use fedimint_client_module::db::ClientModuleMigrationFn;
@@ -1064,7 +1064,7 @@ pub async fn get_decoded_client_secret<T: Decodable>(db: &Database) -> anyhow::R
     match client_secret {
         Some(client_secret) => {
             T::consensus_decode_whole(&client_secret, &ModuleRegistry::default())
-                .map_err(|e| anyhow!("Decoding failed: {e}"))
+                .context("Decoding failed")
         }
         None => bail!("Encoded client secret not present in DB"),
     }

--- a/fedimint-client/src/sm/executor.rs
+++ b/fedimint-client/src/sm/executor.rs
@@ -1091,9 +1091,7 @@ impl Decodable for InactiveStateKeyBytes {
         let operation_id = OperationId::consensus_decode_partial(reader, modules)?;
         let module_instance_id = ModuleInstanceId::consensus_decode_partial(reader, modules)?;
         let mut bytes = Vec::new();
-        reader
-            .read_to_end(&mut bytes)
-            .map_err(DecodeError::from_err)?;
+        reader.read_to_end(&mut bytes)?;
 
         let mut instance_bytes = ModuleInstanceId::consensus_encode_to_vec(&module_instance_id);
         instance_bytes.append(&mut bytes);
@@ -1185,9 +1183,7 @@ impl Decodable for ActiveStateKeyBytes {
         let operation_id = OperationId::consensus_decode_partial(reader, modules)?;
         let module_instance_id = ModuleInstanceId::consensus_decode_partial(reader, modules)?;
         let mut bytes = Vec::new();
-        reader
-            .read_to_end(&mut bytes)
-            .map_err(DecodeError::from_err)?;
+        reader.read_to_end(&mut bytes)?;
 
         let mut instance_bytes = ModuleInstanceId::consensus_encode_to_vec(&module_instance_id);
         instance_bytes.append(&mut bytes);

--- a/fedimint-core/src/base32.rs
+++ b/fedimint-core/src/base32.rs
@@ -206,7 +206,6 @@ fn decode_prefixed_reports_the_whole_decode_chain() {
 
     use crate::encoding::Encodable;
     use crate::invite_code::InviteCode;
-    use crate::util::FmtCompact as _;
 
     // Dropping the last byte of a valid invite code cuts off mid-federation-id, so
     // the reader runs out of input partway through the consensus decode instead of

--- a/fedimint-core/src/base32.rs
+++ b/fedimint-core/src/base32.rs
@@ -4,6 +4,7 @@ use thiserror::Error;
 
 use crate::encoding::{Decodable, DecodeError, Encodable};
 use crate::module::registry::ModuleDecoderRegistry;
+use crate::util::FmtCompact as _;
 
 /// Lowercase RFC 4648 Base32hex alphabet (32 characters).
 const RFC4648: [u8; 32] = *b"0123456789abcdefghijklmnopqrstuv";
@@ -125,10 +126,22 @@ pub enum PrefixedDecodeError {
     InvalidPrefix { expected: String },
     /// The payload is not valid base 32.
     #[error("Invalid base32 payload: {0}")]
-    Base32Decode(#[from] Base32DecodeError),
+    Base32Decode(Base32DecodeError),
     /// The decoded bytes are not a valid consensus encoding of the target type.
-    #[error("Invalid consensus encoding in base32 payload: {0}")]
-    ConsensusDecode(#[from] DecodeError),
+    #[error("Invalid consensus encoding in base32 payload: {}", .0.fmt_compact())]
+    ConsensusDecode(DecodeError),
+}
+
+impl From<DecodeError> for PrefixedDecodeError {
+    fn from(source: DecodeError) -> Self {
+        Self::ConsensusDecode(source)
+    }
+}
+
+impl From<Base32DecodeError> for PrefixedDecodeError {
+    fn from(source: Base32DecodeError) -> Self {
+        Self::Base32Decode(source)
+    }
 }
 
 #[test]
@@ -185,4 +198,42 @@ fn decode_prefixed_bytes_rejects_wrong_prefix() {
         decode_prefixed_bytes("fed", "xyz00"),
         Err(PrefixedDecodeError::InvalidPrefix { expected }) if expected == "fed"
     ));
+}
+
+#[test]
+fn decode_prefixed_reports_the_whole_decode_chain() {
+    use std::str::FromStr;
+
+    use crate::encoding::Encodable;
+    use crate::invite_code::InviteCode;
+    use crate::util::FmtCompact as _;
+
+    // Dropping the last byte of a valid invite code cuts off mid-federation-id, so
+    // the reader runs out of input partway through the consensus decode instead of
+    // failing on the very first byte.
+    let invite_code_str = "fed11qgqpu8rhwden5te0vejkg6tdd9h8gepwd4cxcumxv4jzuen0duhsqqfqh6nl7sgk72caxfx8khtfnn8y436q3nhyrkev3qp8ugdhdllnh86qmp42pm";
+    let invite = InviteCode::from_str(invite_code_str).expect("valid invite code");
+    let bytes = invite.consensus_encode_to_vec();
+    let encoded = encode_prefixed_bytes(FEDIMINT_PREFIX, &bytes[..bytes.len() - 1]);
+
+    let err =
+        decode_prefixed::<InviteCode>(FEDIMINT_PREFIX, &encoded).expect_err("payload is truncated");
+    let text = err.to_string();
+    let err_fmt_compact = err.fmt_compact().to_string();
+    let PrefixedDecodeError::ConsensusDecode(inner) = err else {
+        panic!("a truncated payload is a decode error: {err:?}");
+    };
+
+    assert_eq!(
+        text,
+        format!(
+            "Invalid consensus encoding in base32 payload: {}",
+            inner.fmt_compact()
+        )
+    );
+    assert_ne!(inner.fmt_compact().to_string(), inner.to_string());
+    assert_eq!(
+        err_fmt_compact, text,
+        "no source, so nothing is printed twice"
+    );
 }

--- a/fedimint-core/src/config.rs
+++ b/fedimint-core/src/config.rs
@@ -31,6 +31,7 @@ use crate::module::{
     SerdeModuleEncoding,
 };
 use crate::session_outcome::SignedSessionOutcome;
+use crate::util::FmtCompact as _;
 use crate::{PeerId, maybe_add_send_sync, secp256k1};
 
 // TODO: make configurable
@@ -919,7 +920,7 @@ impl<'de> Deserialize<'de> for DkgMessageG1 {
             &String::deserialize(deserializer)?,
             &ModuleDecoderRegistry::default(),
         )
-        .map_err(serde::de::Error::custom)
+        .map_err(|e| serde::de::Error::custom(e.fmt_compact()))
     }
 }
 
@@ -943,7 +944,7 @@ impl<'de> Deserialize<'de> for DkgMessageG2 {
             &String::deserialize(deserializer)?,
             &ModuleDecoderRegistry::default(),
         )
-        .map_err(serde::de::Error::custom)
+        .map_err(|e| serde::de::Error::custom(e.fmt_compact()))
     }
 }
 

--- a/fedimint-core/src/config.rs
+++ b/fedimint-core/src/config.rs
@@ -6,7 +6,6 @@ use std::hash::Hash;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
-use anyhow::Context;
 use bitcoin::hashes::sha256::HashEngine;
 use bitcoin::hashes::{Hash as BitcoinHash, hex, sha256};
 use bls12_381::Scalar;
@@ -26,7 +25,7 @@ use threshold_crypto::{G1Projective, G2Projective};
 use tracing::warn;
 
 use crate::core::DynClientConfig;
-use crate::encoding::{Decodable, DecodeError};
+use crate::encoding::{Decodable, DecodeContext as _, DecodeError};
 use crate::module::{
     CoreConsensusVersion, DynCommonModuleInit, IDynCommonModuleInit, ModuleConsensusVersion,
     SerdeModuleEncoding,

--- a/fedimint-core/src/config/tests.rs
+++ b/fedimint-core/src/config/tests.rs
@@ -234,3 +234,31 @@ fn load_from_file_reads_valid_json() {
         serde_json::json!({ "answer": 42 })
     );
 }
+
+#[test]
+fn dkg_message_deserialize_reports_the_whole_decode_chain() {
+    use crate::config::DkgMessageG1;
+    use crate::encoding::Decodable;
+    use crate::module::registry::ModuleDecoderRegistry;
+    use crate::util::FmtCompact as _;
+
+    // Variant 1 (`Commitment`) whose one payload byte announces a one-element
+    // vector and then ends, so the reader runs out of input inside the variant
+    // rather than on the first byte.
+    let hex = "010101";
+    let expected = DkgMessageG1::consensus_decode_hex(hex, &ModuleDecoderRegistry::default())
+        .expect_err("payload is truncated");
+    assert_ne!(
+        expected.fmt_compact().to_string(),
+        expected.to_string(),
+        "the decode error has more than one layer, and the message shows all of them"
+    );
+
+    let err = serde_json::from_str::<DkgMessageG1>(&format!("\"{hex}\""))
+        .expect_err("payload is truncated");
+    assert!(
+        err.to_string()
+            .starts_with(&expected.fmt_compact().to_string()),
+        "{err}"
+    );
+}

--- a/fedimint-core/src/core.rs
+++ b/fedimint-core/src/core.rs
@@ -305,10 +305,7 @@ impl DecoderBuilder {
                 };
                 let typed_val =
                     Type::consensus_decode_partial(&mut reader, decoders).map_err(|err| {
-                        let err: anyhow::Error = err.into();
-                        DecodeError::new_custom(
-                            err.context(format!("while decoding Dyn type module_id={instance}")),
-                        )
+                        err.context(format!("while decoding Dyn type module_id={instance}"))
                     })?;
                 let dyn_val = typed_val.into_dyn(instance);
                 let any_val: Box<dyn Any> = Box::new(dyn_val);
@@ -364,15 +361,11 @@ impl Decoder {
         let left = reader.limit();
 
         if left != 0 {
-            return Err(fedimint_core::encoding::DecodeError::new_custom(
-                anyhow::anyhow!(
-                    "Dyn type did not consume all bytes during decoding; module_id={}; expected={}; left={}; type={}",
-                    module_id,
-                    total_len,
-                    left,
-                    std::any::type_name::<DynType>(),
-                ),
-            ));
+            return Err(fedimint_core::encoding::DecodeError::custom(format!(
+                "Dyn type did not consume all bytes during decoding; module_id={module_id}; \
+                 expected={total_len}; left={left}; type={}",
+                std::any::type_name::<DynType>(),
+            )));
         }
 
         Ok(val)

--- a/fedimint-core/src/db/mod.rs
+++ b/fedimint-core/src/db/mod.rs
@@ -1938,7 +1938,7 @@ where
         }
 
         <Self as crate::encoding::Decodable>::consensus_decode_whole(&data[1..], modules)
-            .map_err(|decode_error| DecodingError::Other(decode_error.0.into()))
+            .map_err(DecodingError::from)
     }
 }
 
@@ -1950,7 +1950,7 @@ where
         data: &[u8],
         modules: &ModuleDecoderRegistry,
     ) -> std::result::Result<Self, DecodingError> {
-        T::consensus_decode_whole(data, modules).map_err(|e| DecodingError::Other(e.0.into()))
+        T::consensus_decode_whole(data, modules).map_err(DecodingError::from)
     }
 
     fn to_bytes(&self) -> Vec<u8> {
@@ -2108,6 +2108,9 @@ pub enum DecodingError {
     WrongLength { expected: usize, found: usize },
     #[error("Other decoding error")]
     Other(#[source] Box<dyn Error + Send + Sync>),
+    /// The bytes are not a valid consensus encoding of the record type.
+    #[error("Invalid consensus encoding")]
+    Decode(#[from] DecodeError),
 }
 
 impl DecodingError {

--- a/fedimint-core/src/db/tests.rs
+++ b/fedimint-core/src/db/tests.rs
@@ -2,9 +2,10 @@ use tokio::sync::oneshot;
 
 use super::mem_impl::MemDatabase;
 use super::{
-    Database, GlobalDBTxAccessToken, IDatabaseTransactionOpsCoreTyped, IRawDatabaseExt, TestKey,
-    TestVal, future_returns_shortly,
+    Database, DatabaseKey, DatabaseRecord, DecodingError, GlobalDBTxAccessToken,
+    IDatabaseTransactionOpsCoreTyped, IRawDatabaseExt, TestKey, TestVal, future_returns_shortly,
 };
+use crate::module::registry::ModuleDecoderRegistry;
 use crate::runtime::spawn;
 
 async fn waiter(db: &Database, key: TestKey) -> tokio::task::JoinHandle<TestVal> {
@@ -218,4 +219,13 @@ async fn test_prefix_global_dbtx_panics_on_wrong_access_token() {
 
     let mut tx = db.begin_transaction().await;
     let _tx = tx.global_dbtx(GlobalDBTxAccessToken::from_prefix(&[1]));
+}
+
+#[test]
+fn key_with_a_truncated_payload_is_a_decode_error() {
+    // The prefix byte alone is a well-formed prefix followed by no payload.
+    let bytes = [TestKey::DB_PREFIX];
+    let err = TestKey::from_bytes(&bytes, &ModuleDecoderRegistry::default())
+        .expect_err("a u64 cannot be decoded from zero bytes");
+    assert!(matches!(err, DecodingError::Decode(_)), "{err:?}");
 }

--- a/fedimint-core/src/encoding/as_base64.rs
+++ b/fedimint-core/src/encoding/as_base64.rs
@@ -25,5 +25,10 @@ where
             })?,
         &ModuleRegistry::default(),
     )
-    .map_err(|e| serde::de::Error::custom(format!("decodable deserialization failed: {e:#}")))
+    .map_err(|e| {
+        serde::de::Error::custom(format!(
+            "decodable deserialization failed: {}",
+            crate::util::FmtCompact::fmt_compact(&e)
+        ))
+    })
 }

--- a/fedimint-core/src/encoding/as_hex.rs
+++ b/fedimint-core/src/encoding/as_hex.rs
@@ -29,8 +29,14 @@ pub fn deserialize<'de, T: Decodable, D>(de: D) -> Result<T, D::Error>
 where
     D: serde::de::Deserializer<'de>,
 {
-    Decodable::consensus_decode_hex(&String::deserialize(de)?, &ModuleRegistry::default())
-        .map_err(|e| serde::de::Error::custom(format!("decodable deserialization failed: {e:#}")))
+    Decodable::consensus_decode_hex(&String::deserialize(de)?, &ModuleRegistry::default()).map_err(
+        |e| {
+            serde::de::Error::custom(format!(
+                "decodable deserialization failed: {}",
+                crate::util::FmtCompact::fmt_compact(&e)
+            ))
+        },
+    )
 }
 
 #[macro_export]
@@ -63,7 +69,10 @@ macro_rules! deserialize_as_encodable_hex {
                     &Default::default(),
                 )
                 .map_err(|e| {
-                    serde::de::Error::custom(format!("decodable deserialization failed: {e:#}"))
+                    serde::de::Error::custom(format!(
+                        "decodable deserialization failed: {}",
+                        $crate::util::FmtCompact::fmt_compact(&e)
+                    ))
                 })
             }
         }
@@ -76,4 +85,49 @@ macro_rules! serde_as_encodable_hex {
         $crate::serialize_as_encodable_hex!($name);
         $crate::deserialize_as_encodable_hex!($name);
     };
+}
+
+#[cfg(test)]
+mod tests {
+    use fedimint_derive::{Decodable, Encodable};
+
+    use crate::encoding::Decodable as _;
+    use crate::module::registry::ModuleRegistry;
+    use crate::util::FmtCompact as _;
+
+    #[derive(Debug, Encodable, Decodable, Eq, PartialEq)]
+    struct TestStruct {
+        vec: Vec<u8>,
+        num: u32,
+    }
+
+    #[derive(Debug, serde::Deserialize)]
+    struct Wrapper {
+        #[serde(with = "crate::encoding::as_hex", rename = "inner")]
+        _inner: TestStruct,
+    }
+
+    #[test_log::test]
+    fn deserialize_reports_the_whole_decode_chain() {
+        // `vec` decodes as one element (7); `num` then has no bytes left, so this
+        // fails deep inside the derived decoder, not at the hex-parsing layer.
+        let err = serde_json::from_str::<Wrapper>(r#"{"inner":"0107"}"#)
+            .expect_err("payload is truncated");
+
+        let expected = TestStruct::consensus_decode_hex("0107", &ModuleRegistry::default())
+            .expect_err("payload is truncated");
+
+        assert!(
+            err.to_string().starts_with(&format!(
+                "decodable deserialization failed: {}",
+                expected.fmt_compact()
+            )),
+            "{err}"
+        );
+        assert_ne!(
+            expected.fmt_compact().to_string(),
+            expected.to_string(),
+            "the decode error has more than one layer and the message shows all of them"
+        );
+    }
 }

--- a/fedimint-core/src/encoding/btc.rs
+++ b/fedimint-core/src/encoding/btc.rs
@@ -5,6 +5,7 @@ use anyhow::format_err;
 use bitcoin::address::NetworkUnchecked;
 use bitcoin::hashes::Hash as BitcoinHash;
 use hex::{FromHex, ToHex};
+use lightning::ln::msgs;
 use lightning::util::ser::{BigSize, Readable, Writeable};
 use miniscript::{Descriptor, MiniscriptKey};
 use serde::{Deserialize, Serialize};
@@ -12,6 +13,23 @@ use serde::{Deserialize, Serialize};
 use crate::encoding::{Decodable, DecodeError, Encodable};
 use crate::get_network_for_address;
 use crate::module::registry::ModuleDecoderRegistry;
+
+/// Keeps a rust-bitcoin reader failure distinguishable as [`DecodeError::Io`].
+fn from_bitcoin_encode_error(error: bitcoin::consensus::encode::Error) -> DecodeError {
+    match error {
+        bitcoin::consensus::encode::Error::Io(io) => DecodeError::Io(io.into()),
+        other => DecodeError::from_err(other),
+    }
+}
+
+/// Keeps a PSBT reader failure distinguishable as [`DecodeError::Io`].
+fn from_psbt_error(error: bitcoin::psbt::Error) -> DecodeError {
+    match error {
+        bitcoin::psbt::Error::Io(io) => DecodeError::Io(io.into()),
+        bitcoin::psbt::Error::ConsensusEncoding(inner) => from_bitcoin_encode_error(inner),
+        other => DecodeError::from_err(other),
+    }
+}
 
 macro_rules! impl_encode_decode_bridge {
     ($btc_type:ty) => {
@@ -36,7 +54,7 @@ macro_rules! impl_encode_decode_bridge {
                 bitcoin::consensus::Decodable::consensus_decode_from_finite_reader(
                     &mut SimpleBitcoinRead(d),
                 )
-                .map_err(crate::encoding::DecodeError::from_err)
+                .map_err(from_bitcoin_encode_error)
             }
         }
     };
@@ -62,8 +80,7 @@ impl crate::encoding::Decodable for bitcoin::psbt::Psbt {
         d: &mut D,
         _modules: &ModuleDecoderRegistry,
     ) -> Result<Self, crate::encoding::DecodeError> {
-        Self::deserialize_from_reader(&mut BufBitcoinReader::new(d))
-            .map_err(crate::encoding::DecodeError::from_err)
+        Self::deserialize_from_reader(&mut BufBitcoinReader::new(d)).map_err(from_psbt_error)
     }
 }
 
@@ -95,7 +112,7 @@ impl crate::encoding::Decodable for bitcoin::Txid {
         bitcoin::consensus::Decodable::consensus_decode_from_finite_reader(&mut SimpleBitcoinRead(
             d,
         ))
-        .map_err(crate::encoding::DecodeError::from_err)
+        .map_err(from_bitcoin_encode_error)
     }
 
     fn consensus_decode_hex(
@@ -317,8 +334,13 @@ impl Decodable for BigSize {
         r: &mut R,
         _modules: &ModuleDecoderRegistry,
     ) -> Result<Self, DecodeError> {
-        Self::read(&mut SimpleBitcoinRead(r))
-            .map_err(|e| DecodeError::new_custom(anyhow::anyhow!("BigSize decoding error: {e:?}")))
+        Self::read(&mut SimpleBitcoinRead(r)).map_err(|error| match error {
+            msgs::DecodeError::ShortRead => {
+                DecodeError::Io(std::io::ErrorKind::UnexpectedEof.into())
+            }
+            msgs::DecodeError::Io(kind) => DecodeError::Io(bitcoin_io::Error::from(kind).into()),
+            other => DecodeError::custom(format!("BigSize decoding error: {other:?}")),
+        })
     }
 }
 
@@ -447,7 +469,7 @@ mod tests {
     use crate::db::DatabaseValue;
     use crate::encoding::btc::NetworkLegacyEncodingWrapper;
     use crate::encoding::tests::{test_roundtrip, test_roundtrip_expected};
-    use crate::encoding::{Decodable, Encodable};
+    use crate::encoding::{Decodable, DecodeError, Encodable};
 
     #[test_log::test]
     fn block_hash_roundtrip() {
@@ -615,5 +637,34 @@ mod tests {
             .parse::<lightning_invoice::Bolt11Invoice>()
             .unwrap();
         test_roundtrip(&invoice);
+    }
+
+    #[test_log::test]
+    fn truncated_outpoint_is_an_io_error() {
+        let outpoint = bitcoin::OutPoint {
+            txid: bitcoin::Txid::from_str(
+                "51f7ed2f23e58cc6e139e715e9ce304a1e858416edc9079dd7b74fa8d2efc09a",
+            )
+            .unwrap(),
+            vout: 0,
+        };
+        let mut encoded = outpoint.consensus_encode_to_vec();
+        encoded.truncate(encoded.len() - 1);
+
+        let err =
+            bitcoin::OutPoint::consensus_decode_whole(&encoded, &ModuleDecoderRegistry::default())
+                .expect_err("35 of 36 bytes are not a full outpoint");
+        assert!(matches!(err, DecodeError::Io(_)), "{err:?}");
+    }
+
+    #[test_log::test]
+    fn empty_psbt_input_is_an_io_error() {
+        // The PSBT magic is read through rust-bitcoin's consensus decoder, so a short
+        // read arrives wrapped in `ConsensusEncoding` rather than as a
+        // top-level `Io`.
+        let err =
+            bitcoin::psbt::Psbt::consensus_decode_whole(&[], &ModuleDecoderRegistry::default())
+                .expect_err("empty input is not a psbt");
+        assert!(matches!(err, DecodeError::Io(_)), "{err:?}");
     }
 }

--- a/fedimint-core/src/encoding/btc.rs
+++ b/fedimint-core/src/encoding/btc.rs
@@ -1,7 +1,6 @@
 use std::io::{Error, Write};
 use std::str::FromStr;
 
-use anyhow::format_err;
 use bitcoin::address::NetworkUnchecked;
 use bitcoin::hashes::Hash as BitcoinHash;
 use hex::{FromHex, ToHex};
@@ -119,9 +118,7 @@ impl crate::encoding::Decodable for bitcoin::Txid {
         hex: &str,
         modules: &ModuleDecoderRegistry,
     ) -> Result<Self, DecodeError> {
-        let mut bytes = Vec::<u8>::from_hex(hex)
-            .map_err(anyhow::Error::from)
-            .map_err(DecodeError::new_custom)?;
+        let mut bytes = Vec::<u8>::from_hex(hex).map_err(DecodeError::from_err)?;
 
         // Just Bitcoin things: transaction hashes are encoded reverse
         bytes.reverse();
@@ -180,9 +177,8 @@ impl Decodable for NetworkLegacyEncodingWrapper {
     ) -> Result<Self, DecodeError> {
         let num = u32::consensus_decode_partial(d, modules)?;
         let magic = bitcoin::p2p::Magic::from_bytes(num.to_le_bytes());
-        let network = bitcoin::Network::from_magic(magic).ok_or_else(|| {
-            DecodeError::new_custom(format_err!("Unknown network magic: {magic:x}"))
-        })?;
+        let network = bitcoin::Network::from_magic(magic)
+            .ok_or_else(|| DecodeError::custom(format!("Unknown network magic: {magic:x}")))?;
         Ok(Self(network))
     }
 }
@@ -200,7 +196,7 @@ impl Decodable for bitcoin::Network {
         Self::from_magic(bitcoin::p2p::Magic::from_bytes(
             Decodable::consensus_decode_partial(d, modules)?,
         ))
-        .ok_or_else(|| DecodeError::new_custom(format_err!("Unknown network magic")))
+        .ok_or_else(|| DecodeError::from_str("Unknown network magic"))
     }
 }
 
@@ -241,8 +237,8 @@ impl Decodable for bitcoin::Address<NetworkUnchecked> {
         let network = NetworkLegacyEncodingWrapper::consensus_decode_partial(&mut d, modules)?.0;
         let script_pk = bitcoin::ScriptBuf::consensus_decode_partial(&mut d, modules)?;
 
-        let address = bitcoin::Address::from_script(&script_pk, network)
-            .map_err(|e| DecodeError::new_custom(e.into()))?;
+        let address =
+            bitcoin::Address::from_script(&script_pk, network).map_err(DecodeError::from_err)?;
 
         Ok(address.into_unchecked())
     }

--- a/fedimint-core/src/encoding/collections.rs
+++ b/fedimint-core/src/encoding/collections.rs
@@ -215,7 +215,7 @@ where
             }
             let v = V::consensus_decode_partial_from_finite_reader(d, modules)?;
             if res.insert(k, v).is_some() {
-                return Err(DecodeError(anyhow::format_err!("Duplicate key")));
+                return Err(DecodeError::from_str("Duplicate key"));
             }
         }
         Ok(res)
@@ -251,7 +251,7 @@ where
                 return Err(DecodeError::from_str("Non-canonical encoding"));
             }
             if !res.insert(k) {
-                return Err(DecodeError(anyhow::format_err!("Duplicate key")));
+                return Err(DecodeError::from_str("Duplicate key"));
             }
         }
         Ok(res)

--- a/fedimint-core/src/encoding/collections.rs
+++ b/fedimint-core/src/encoding/collections.rs
@@ -62,8 +62,7 @@ where
                 let chunk_size = core::cmp::min(len, CHUNK_SIZE);
                 let chunk_end = chunk_start + chunk_size;
                 bytes.resize(chunk_end, 0u8);
-                d.read_exact(&mut bytes[chunk_start..chunk_end])
-                    .map_err(DecodeError::from_err)?;
+                d.read_exact(&mut bytes[chunk_start..chunk_end])?;
                 len -= chunk_size;
             }
 
@@ -163,8 +162,7 @@ where
 
         if TypeId::of::<T>() == TypeId::of::<u8>() {
             let mut bytes = [0u8; SIZE];
-            d.read_exact(bytes.as_mut_slice())
-                .map_err(DecodeError::from_err)?;
+            d.read_exact(bytes.as_mut_slice())?;
 
             // unsafe: we've just checked that T is `u8` so the transmute here is a no-op
             return Ok(unsafe { horribe_array_transmute_workaround(bytes) });

--- a/fedimint-core/src/encoding/mod.rs
+++ b/fedimint-core/src/encoding/mod.rs
@@ -1458,4 +1458,45 @@ mod tests {
         .expect_err("31 bytes are not a transaction id");
         assert!(matches!(err, DecodeError::Io(_)), "{err:?}");
     }
+
+    #[test]
+    fn derived_decode_names_the_failing_field_and_keeps_the_io_root() {
+        // `vec` decodes as one element (7); `num` then has no bytes left.
+        let err = TestStruct::consensus_decode_whole(&[1, 7], &ModuleDecoderRegistry::default())
+            .expect_err("payload is truncated");
+
+        let DecodeError::Context { context, source } = &err else {
+            panic!("the failing field's context is the outer layer: {err:?}");
+        };
+        assert_eq!(
+            context,
+            "Decoding named block field: TestStruct{ ... num ... }"
+        );
+        assert!(matches!(**source, DecodeError::Io(_)), "{source:?}");
+    }
+
+    #[test]
+    fn derived_decode_reports_unknown_variants_structurally() {
+        let unknown_variant = DefaultEnum::Default {
+            variant: 42,
+            bytes: vec![0, 1, 2, 3],
+        };
+        let mut encoding = vec![];
+        unknown_variant
+            .consensus_encode(&mut encoding)
+            .expect("encodes");
+
+        let err = NoDefaultEnum::consensus_decode_whole(&encoding, &ModuleRegistry::default())
+            .expect_err("variant 42 does not exist");
+        assert!(
+            matches!(
+                err,
+                DecodeError::InvalidVariant {
+                    variant: 42,
+                    type_name: "NoDefaultEnum"
+                }
+            ),
+            "{err:?}"
+        );
+    }
 }

--- a/fedimint-core/src/encoding/mod.rs
+++ b/fedimint-core/src/encoding/mod.rs
@@ -237,14 +237,11 @@ pub trait Decodable: Sized {
         let left = r.limit();
 
         if left != 0 {
-            return Err(fedimint_core::encoding::DecodeError::new_custom(
-                anyhow::anyhow!(
-                    "Type did not consume all bytes during decoding; expected={}; left={}; type={}",
-                    total_len,
-                    left,
-                    std::any::type_name::<Self>(),
-                ),
-            ));
+            return Err(fedimint_core::encoding::DecodeError::custom(format!(
+                "Type did not consume all bytes during decoding; expected={total_len}; \
+                 left={left}; type={}",
+                std::any::type_name::<Self>(),
+            )));
         }
         Ok(res)
     }
@@ -273,9 +270,7 @@ pub trait Decodable: Sized {
         hex: &str,
         modules: &ModuleDecoderRegistry,
     ) -> Result<Self, DecodeError> {
-        let bytes = Vec::<u8>::from_hex(hex)
-            .map_err(anyhow::Error::from)
-            .map_err(DecodeError::new_custom)?;
+        let bytes = Vec::<u8>::from_hex(hex).map_err(DecodeError::from_err)?;
         Decodable::consensus_decode_whole(&bytes, modules)
     }
 }
@@ -361,24 +356,7 @@ pub fn with_decoding_context<T>(
     result: Result<T, DecodeError>,
     context: &'static str,
 ) -> Result<T, DecodeError> {
-    DecodeContext::context(result, context)
-}
-
-impl Encodable for SafeUrl {
-    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<(), Error> {
-        self.to_string().consensus_encode(writer)
-    }
-}
-
-impl Decodable for SafeUrl {
-    fn consensus_decode_partial_from_finite_reader<D: std::io::Read>(
-        d: &mut D,
-        modules: &ModuleDecoderRegistry,
-    ) -> Result<Self, DecodeError> {
-        String::consensus_decode_partial_from_finite_reader(d, modules)?
-            .parse::<Self>()
-            .map_err(DecodeError::from_err)
-    }
+    result.context(context)
 }
 
 /// Failure to consensus-decode a value.
@@ -507,6 +485,23 @@ where
         F: FnOnce() -> C,
     {
         self.map_err(|error| error.into().context(context()))
+    }
+}
+
+impl Encodable for SafeUrl {
+    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<(), Error> {
+        self.to_string().consensus_encode(writer)
+    }
+}
+
+impl Decodable for SafeUrl {
+    fn consensus_decode_partial_from_finite_reader<D: std::io::Read>(
+        d: &mut D,
+        modules: &ModuleDecoderRegistry,
+    ) -> Result<Self, DecodeError> {
+        String::consensus_decode_partial_from_finite_reader(d, modules)?
+            .parse::<Self>()
+            .map_err(DecodeError::from_err)
     }
 }
 
@@ -1373,6 +1368,18 @@ mod tests {
         // bitcoin structures are not lexicographically sortable so we cannot
         // test them here. in future we may crate a wrapper type that is
         // lexicographically sortable to use when needed
+    }
+
+    #[test]
+    fn whole_decode_rejects_trailing_bytes_with_a_message() {
+        let err = u8::consensus_decode_whole(&[1, 2], &ModuleDecoderRegistry::default())
+            .expect_err("one byte too many");
+        assert!(matches!(err, DecodeError::Custom { .. }), "{err:?}");
+        assert!(
+            err.to_string()
+                .starts_with("Type did not consume all bytes during decoding"),
+            "{err}"
+        );
     }
 
     #[test]

--- a/fedimint-core/src/encoding/mod.rs
+++ b/fedimint-core/src/encoding/mod.rs
@@ -430,22 +430,6 @@ impl DecodeError {
             source: Box::new(self),
         }
     }
-
-    /// Transitional constructor for decode bodies still built on `anyhow`; the
-    /// chain is flattened into the message. Removed once no caller is left.
-    // Takes the error by value because callers pass it to `Result::map_err`.
-    #[allow(clippy::needless_pass_by_value)]
-    pub fn new_custom(e: anyhow::Error) -> Self {
-        Self::custom(format!("{e:#}"))
-    }
-}
-
-/// Transitional: lets `?` convert an `anyhow::Error` in decode bodies that
-/// have not moved to [`DecodeContext`] yet. Removed once no caller is left.
-impl From<anyhow::Error> for DecodeError {
-    fn from(e: anyhow::Error) -> Self {
-        Self::new_custom(e)
-    }
 }
 
 /// Adds the context of a decoding step to a failed result.

--- a/fedimint-core/src/encoding/mod.rs
+++ b/fedimint-core/src/encoding/mod.rs
@@ -526,7 +526,7 @@ macro_rules! impl_encode_decode_num_as_plain {
                 _modules: &ModuleDecoderRegistry,
             ) -> Result<Self, crate::encoding::DecodeError> {
                 let mut bytes = [0u8; (<$num_type>::BITS / 8) as usize];
-                d.read_exact(&mut bytes).map_err(DecodeError::from_err)?;
+                d.read_exact(&mut bytes)?;
                 Ok(<$num_type>::from_be_bytes(bytes))
             }
         }
@@ -546,10 +546,7 @@ macro_rules! impl_encode_decode_num_as_bigsize {
                 d: &mut D,
                 _modules: &ModuleDecoderRegistry,
             ) -> Result<Self, crate::encoding::DecodeError> {
-                let varint = anyhow::Context::context(
-                    BigSize::consensus_decode_partial(d, &Default::default()),
-                    concat!("VarInt inside ", stringify!($num_type)),
-                )?;
+                let varint = BigSize::consensus_decode_partial(d, &Default::default())?;
                 <$num_type>::try_from(varint.0).map_err(crate::encoding::DecodeError::from_err)
             }
         }
@@ -764,8 +761,7 @@ impl Decodable for bool {
         _modules: &ModuleDecoderRegistry,
     ) -> Result<Self, DecodeError> {
         let mut bool_as_u8 = [0u8];
-        d.read_exact(&mut bool_as_u8)
-            .map_err(DecodeError::from_err)?;
+        d.read_exact(&mut bool_as_u8)?;
         match bool_as_u8[0] {
             0 => Ok(false),
             1 => Ok(true),
@@ -1437,5 +1433,29 @@ mod tests {
             .with_context(|| format!("Decoding item {}", 3))
             .expect_err("still Err");
         assert_eq!(err.fmt_compact().to_string(), "Decoding item 3: bad");
+    }
+
+    #[test]
+    fn truncated_input_is_an_io_error() {
+        let err = u8::consensus_decode_whole(&[], &ModuleDecoderRegistry::default())
+            .expect_err("empty input is not a u8");
+        assert!(matches!(err, DecodeError::Io(_)), "{err:?}");
+    }
+
+    #[test]
+    fn truncated_integer_is_an_io_error() {
+        let err = u32::consensus_decode_whole(&[], &ModuleDecoderRegistry::default())
+            .expect_err("zero bytes are not a u32");
+        assert!(matches!(err, DecodeError::Io(_)), "{err:?}");
+    }
+
+    #[test]
+    fn truncated_transaction_id_is_an_io_error() {
+        let err = crate::TransactionId::consensus_decode_whole(
+            &[0u8; 31],
+            &ModuleDecoderRegistry::default(),
+        )
+        .expect_err("31 bytes are not a transaction id");
+        assert!(matches!(err, DecodeError::Io(_)), "{err:?}");
     }
 }

--- a/fedimint-core/src/encoding/mod.rs
+++ b/fedimint-core/src/encoding/mod.rs
@@ -19,11 +19,10 @@ mod threshold_crypto;
 
 use std::borrow::Cow;
 use std::cmp;
-use std::fmt::{Debug, Formatter};
+use std::fmt::{Debug, Display};
 use std::io::{self, Error, Read, Write};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use anyhow::Context;
 use bitcoin::hashes::sha256;
 pub use fedimint_derive::{Decodable, Encodable};
 use hex::{FromHex, ToHex};
@@ -362,7 +361,7 @@ pub fn with_decoding_context<T>(
     result: Result<T, DecodeError>,
     context: &'static str,
 ) -> Result<T, DecodeError> {
-    result.map_err(|error| DecodeError::new_custom(anyhow::Error::new(error).context(context)))
+    DecodeContext::context(result, context)
 }
 
 impl Encodable for SafeUrl {
@@ -382,18 +381,132 @@ impl Decodable for SafeUrl {
     }
 }
 
+/// Failure to consensus-decode a value.
+///
+/// `Display` prints only the outermost layer: the context of the decoding step
+/// that failed, or the leaf cause when there is no context. The full chain is
+/// reachable through [`std::error::Error::source`] and printed flat by
+/// [`FmtCompact::fmt_compact`](crate::util::FmtCompact).
 #[derive(Debug, Error)]
-pub struct DecodeError(pub(crate) anyhow::Error);
+#[non_exhaustive]
+pub enum DecodeError {
+    /// The reader failed or ran out of input.
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    /// The input names an enum variant the type does not have.
+    #[error("Invalid enum variant {variant} while decoding {type_name}")]
+    InvalidVariant {
+        /// The variant index found in the input.
+        variant: u64,
+        /// The name of the type being decoded.
+        type_name: &'static str,
+    },
+    /// A decoding step failed; `context` names the step and `source` says why.
+    #[error("{context}")]
+    Context {
+        /// The decoding step that failed.
+        context: String,
+        /// Why it failed.
+        #[source]
+        source: Box<Self>,
+    },
+    /// The input decoded but is not a valid value of the type; the source
+    /// says why.
+    #[error(transparent)]
+    Invalid(Box<dyn std::error::Error + Send + Sync>),
+    /// The input is malformed in a way only a message describes.
+    #[error("{message}")]
+    Custom {
+        /// What is wrong with the input.
+        message: String,
+    },
+}
 
 impl DecodeError {
+    /// A decode failure described by a message.
+    pub fn custom(message: impl Into<String>) -> Self {
+        Self::Custom {
+            message: message.into(),
+        }
+    }
+
+    /// A decode failure described by a static message.
+    // TODO: think about better name
+    #[allow(clippy::should_implement_trait)]
+    pub fn from_str(s: &'static str) -> Self {
+        Self::custom(s)
+    }
+
+    /// A decode failure caused by a typed error, shown as that error.
+    pub fn from_err<E>(e: E) -> Self
+    where
+        E: std::error::Error + Send + Sync + 'static,
+    {
+        Self::Invalid(Box::new(e))
+    }
+
+    /// Wraps this error in the context of the decoding step that failed.
+    pub fn context(self, context: impl Display) -> Self {
+        Self::Context {
+            context: context.to_string(),
+            source: Box::new(self),
+        }
+    }
+
+    /// Transitional constructor for decode bodies still built on `anyhow`; the
+    /// chain is flattened into the message. Removed once no caller is left.
+    // Takes the error by value because callers pass it to `Result::map_err`.
+    #[allow(clippy::needless_pass_by_value)]
     pub fn new_custom(e: anyhow::Error) -> Self {
-        Self(e)
+        Self::custom(format!("{e:#}"))
     }
 }
 
+/// Transitional: lets `?` convert an `anyhow::Error` in decode bodies that
+/// have not moved to [`DecodeContext`] yet. Removed once no caller is left.
 impl From<anyhow::Error> for DecodeError {
     fn from(e: anyhow::Error) -> Self {
-        Self(e)
+        Self::new_custom(e)
+    }
+}
+
+/// Adds the context of a decoding step to a failed result.
+///
+/// Implemented for every `Result` whose error converts into [`DecodeError`],
+/// so it applies to results of `Decodable` calls and to `std::io::Result`.
+/// Its method names match `anyhow::Context`'s; where both traits are in scope,
+/// call it as `DecodeContext::context(result, ..)` to avoid the clash.
+pub trait DecodeContext<T> {
+    /// Wraps the error in `context`.
+    fn context<C>(self, context: C) -> Result<T, DecodeError>
+    where
+        C: Display;
+
+    /// Wraps the error in the context produced by `context`, which only runs
+    /// on failure.
+    fn with_context<C, F>(self, context: F) -> Result<T, DecodeError>
+    where
+        C: Display,
+        F: FnOnce() -> C;
+}
+
+impl<T, E> DecodeContext<T> for Result<T, E>
+where
+    E: Into<DecodeError>,
+{
+    fn context<C>(self, context: C) -> Result<T, DecodeError>
+    where
+        C: Display,
+    {
+        self.map_err(|error| error.into().context(context))
+    }
+
+    fn with_context<C, F>(self, context: F) -> Result<T, DecodeError>
+    where
+        C: Display,
+        F: FnOnce() -> C,
+    {
+        self.map_err(|error| error.into().context(context()))
     }
 }
 
@@ -433,8 +546,10 @@ macro_rules! impl_encode_decode_num_as_bigsize {
                 d: &mut D,
                 _modules: &ModuleDecoderRegistry,
             ) -> Result<Self, crate::encoding::DecodeError> {
-                let varint = BigSize::consensus_decode_partial(d, &Default::default())
-                    .context(concat!("VarInt inside ", stringify!($num_type)))?;
+                let varint = anyhow::Context::context(
+                    BigSize::consensus_decode_partial(d, &Default::default()),
+                    concat!("VarInt inside ", stringify!($num_type)),
+                )?;
                 <$num_type>::try_from(varint.0).map_err(crate::encoding::DecodeError::from_err)
             }
         }
@@ -659,35 +774,6 @@ impl Decodable for bool {
     }
 }
 
-impl DecodeError {
-    // TODO: think about better name
-    #[allow(clippy::should_implement_trait)]
-    pub fn from_str(s: &'static str) -> Self {
-        #[derive(Debug)]
-        struct StrError(&'static str);
-
-        impl std::fmt::Display for StrError {
-            fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-                std::fmt::Display::fmt(&self.0, f)
-            }
-        }
-
-        impl std::error::Error for StrError {}
-
-        Self(anyhow::Error::from(StrError(s)))
-    }
-
-    pub fn from_err<E: std::error::Error + Send + Sync + 'static>(e: E) -> Self {
-        Self(anyhow::Error::from(e))
-    }
-}
-
-impl std::fmt::Display for DecodeError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.write_fmt(format_args!("{:#}", self.0))
-    }
-}
-
 impl Encodable for Cow<'static, str> {
     fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
         self.as_ref().consensus_encode(writer)
@@ -886,6 +972,7 @@ mod tests {
     use super::*;
     use crate::encoding::{Decodable, Encodable};
     use crate::module::registry::ModuleRegistry;
+    use crate::util::FmtCompact as _;
 
     pub(crate) fn test_roundtrip<T>(value: &T)
     where
@@ -1290,5 +1377,65 @@ mod tests {
         // bitcoin structures are not lexicographically sortable so we cannot
         // test them here. in future we may crate a wrapper type that is
         // lexicographically sortable to use when needed
+    }
+
+    #[test]
+    fn decode_error_display_is_the_outer_layer_and_the_chain_is_reachable() {
+        let io = std::io::Error::new(std::io::ErrorKind::UnexpectedEof, "short read");
+        let err = Err::<(), _>(io)
+            .context("Decoding field a")
+            .context("Decoding Foo")
+            .expect_err("built from an error");
+
+        assert_eq!(err.to_string(), "Decoding Foo");
+        assert_eq!(
+            err.fmt_compact().to_string(),
+            "Decoding Foo: Decoding field a: short read"
+        );
+
+        let DecodeError::Context { source: inner, .. } = &err else {
+            panic!("outer layer is the last context added: {err:?}");
+        };
+        let DecodeError::Context { source: leaf, .. } = &**inner else {
+            panic!("inner layer is the first context added: {inner:?}");
+        };
+        assert!(matches!(**leaf, DecodeError::Io(_)), "{leaf:?}");
+    }
+
+    #[test]
+    fn from_err_shows_the_typed_error_as_is() {
+        let parse_error = "x".parse::<u8>().expect_err("not a number");
+        let message = parse_error.to_string();
+
+        let err = DecodeError::from_err(parse_error);
+
+        assert!(matches!(err, DecodeError::Invalid(_)), "{err:?}");
+        assert_eq!(err.to_string(), message);
+        assert_eq!(err.fmt_compact().to_string(), message);
+    }
+
+    #[test]
+    fn custom_and_from_str_carry_only_a_message() {
+        let err = DecodeError::custom(format!("Unknown network magic: {:x}", 0xd9b4_bef9_u32));
+        assert!(matches!(err, DecodeError::Custom { .. }), "{err:?}");
+        assert_eq!(err.to_string(), "Unknown network magic: d9b4bef9");
+        assert!(std::error::Error::source(&err).is_none());
+
+        let err = DecodeError::from_str("Out of range, expected 0 or 1");
+        assert_eq!(err.to_string(), "Out of range, expected 0 or 1");
+    }
+
+    #[test]
+    fn with_context_only_formats_on_error() {
+        let ok: Result<u8, DecodeError> = Ok(1);
+        let formatted = ok
+            .with_context(|| panic!("must not be called on Ok"))
+            .expect("still Ok");
+        assert_eq!(formatted, 1);
+
+        let err = Err::<u8, _>(DecodeError::from_str("bad"))
+            .with_context(|| format!("Decoding item {}", 3))
+            .expect_err("still Err");
+        assert_eq!(err.fmt_compact().to_string(), "Decoding item 3: bad");
     }
 }

--- a/fedimint-core/src/invite_code.rs
+++ b/fedimint-core/src/invite_code.rs
@@ -13,7 +13,7 @@ use crate::base32::{FEDIMINT_PREFIX, PrefixedDecodeError};
 use crate::config::FederationId;
 use crate::encoding::{Decodable, DecodeError, Encodable};
 use crate::module::registry::{ModuleDecoderRegistry, ModuleRegistry};
-use crate::util::SafeUrl;
+use crate::util::{FmtCompact as _, SafeUrl};
 use crate::{NumPeersExt, PeerId};
 
 /// Information required for client to join Federation
@@ -256,12 +256,24 @@ pub enum InviteCodeParseError {
     )]
     InvalidHrp { hrp: bech32::Hrp },
     /// The payload is not a valid consensus encoding of an invite code.
-    #[error("Invalid invite code payload: {0}")]
-    Decode(#[from] DecodeError),
+    #[error("Invalid invite code payload: {}", .0.fmt_compact())]
+    Decode(DecodeError),
     /// The string carries the [`FEDIMINT_PREFIX`] but its base 32 payload does
     /// not decode into an invite code.
-    #[error("Invalid prefixed base32 invite code: {0}")]
-    Base32(#[from] PrefixedDecodeError),
+    #[error("Invalid prefixed base32 invite code: {}", .0.fmt_compact())]
+    Base32(PrefixedDecodeError),
+}
+
+impl From<DecodeError> for InviteCodeParseError {
+    fn from(source: DecodeError) -> Self {
+        Self::Decode(source)
+    }
+}
+
+impl From<PrefixedDecodeError> for InviteCodeParseError {
+    fn from(source: PrefixedDecodeError) -> Self {
+        Self::Base32(source)
+    }
 }
 
 /// Parses the invite code from a bech32 string
@@ -299,7 +311,7 @@ mod tests {
     use fedimint_core::PeerId;
     use fedimint_core::base32::FEDIMINT_PREFIX;
 
-    use super::InviteCodeParseError;
+    use super::{BECH32_HRP, InviteCodeParseError};
     use crate::config::FederationId;
     use crate::invite_code::InviteCode;
 
@@ -343,6 +355,77 @@ mod tests {
     }
 
     #[test]
+    fn from_str_reports_the_whole_decode_chain_for_a_truncated_payload() {
+        use crate::encoding::Encodable;
+        use crate::util::FmtCompact as _;
+
+        // Dropping the last byte of a valid invite code cuts off mid-federation-id, so
+        // the reader runs out of input partway through the consensus decode instead of
+        // failing on the very first byte.
+        let invite_code_str = "fed11qgqpu8rhwden5te0vejkg6tdd9h8gepwd4cxcumxv4jzuen0duhsqqfqh6nl7sgk72caxfx8khtfnn8y436q3nhyrkev3qp8ugdhdllnh86qmp42pm";
+        let invite = InviteCode::from_str(invite_code_str).expect("valid invite code");
+        let bytes = invite.consensus_encode_to_vec();
+        let encoded = bech32::encode::<bech32::Bech32m>(BECH32_HRP, &bytes[..bytes.len() - 1])
+            .expect("encodes");
+
+        let err = InviteCode::from_str(&encoded).expect_err("payload is truncated");
+        let text = err.to_string();
+        let InviteCodeParseError::Decode(inner) = err else {
+            panic!("a truncated payload is a decode error: {err:?}");
+        };
+
+        assert_eq!(
+            text,
+            format!("Invalid invite code payload: {}", inner.fmt_compact())
+        );
+        assert_ne!(
+            inner.fmt_compact().to_string(),
+            inner.to_string(),
+            "the decode error has more than one layer, and the message shows all of them"
+        );
+    }
+
+    #[test]
+    fn from_str_reports_the_whole_decode_chain_for_a_truncated_prefixed_payload() {
+        use crate::base32::PrefixedDecodeError;
+        use crate::encoding::Encodable;
+        use crate::util::FmtCompact as _;
+
+        // Same truncation as the bech32 case above, but the payload carries the
+        // FEDIMINT_PREFIX and is base32-encoded instead of bech32-encoded.
+        let invite_code_str = "fed11qgqpu8rhwden5te0vejkg6tdd9h8gepwd4cxcumxv4jzuen0duhsqqfqh6nl7sgk72caxfx8khtfnn8y436q3nhyrkev3qp8ugdhdllnh86qmp42pm";
+        let invite = InviteCode::from_str(invite_code_str).expect("valid invite code");
+        let bytes = invite.consensus_encode_to_vec();
+        let encoded =
+            crate::base32::encode_prefixed_bytes(FEDIMINT_PREFIX, &bytes[..bytes.len() - 1]);
+
+        let err = InviteCode::from_str(&encoded).expect_err("payload is truncated");
+        let text = err.to_string();
+        let err_fmt_compact = err.fmt_compact().to_string();
+        let InviteCodeParseError::Base32(PrefixedDecodeError::ConsensusDecode(inner)) = err else {
+            panic!("a truncated payload is a decode error: {err:?}");
+        };
+
+        assert_eq!(
+            text,
+            format!(
+                "Invalid prefixed base32 invite code: \
+                 Invalid consensus encoding in base32 payload: {}",
+                inner.fmt_compact()
+            )
+        );
+        assert_eq!(
+            err_fmt_compact, text,
+            "no source, so nothing is printed twice"
+        );
+        assert_ne!(
+            inner.fmt_compact().to_string(),
+            inner.to_string(),
+            "the decode error has more than one layer, and the message shows all of them"
+        );
+    }
+
+    #[test]
     fn from_str_rejects_non_bech32() {
         assert!(matches!(
             InviteCode::from_str("definitely not bech32"),
@@ -352,9 +435,11 @@ mod tests {
 
     #[test]
     fn from_str_reports_corrupt_prefixed_base32() {
-        assert!(matches!(
-            InviteCode::from_str(&format!("{FEDIMINT_PREFIX}not!base32")),
-            Err(InviteCodeParseError::Base32(_))
-        ));
+        use crate::util::FmtCompact as _;
+
+        let err = InviteCode::from_str(&format!("{FEDIMINT_PREFIX}not!base32"))
+            .expect_err("not!base32 is not valid base32");
+        assert!(matches!(err, InviteCodeParseError::Base32(_)), "{err:?}");
+        assert_eq!(err.fmt_compact().to_string(), err.to_string());
     }
 }

--- a/fedimint-core/src/lib.rs
+++ b/fedimint-core/src/lib.rs
@@ -575,7 +575,7 @@ impl Decodable for TransactionId {
         _modules: &ModuleDecoderRegistry,
     ) -> Result<Self, DecodeError> {
         let mut bytes = [0u8; 32];
-        d.read_exact(&mut bytes).map_err(DecodeError::from_err)?;
+        d.read_exact(&mut bytes)?;
         Ok(Self::from_byte_array(bytes))
     }
 }

--- a/fedimint-core/src/lib.rs
+++ b/fedimint-core/src/lib.rs
@@ -47,8 +47,6 @@ use std::ops::{self, Range};
 use std::str::FromStr;
 
 pub use amount::*;
-/// Mostly re-exported for [`Decodable`] macros.
-pub use anyhow;
 use bitcoin::address::NetworkUnchecked;
 pub use bitcoin::hashes::Hash as BitcoinHash;
 use bitcoin::{Address, Network};

--- a/fedimint-core/src/macros.rs
+++ b/fedimint-core/src/macros.rs
@@ -347,11 +347,11 @@ macro_rules! module_plugin_dyn_newtype_encode_decode {
                     }
                     None => match decoders.decoding_mode() {
                         $crate::module::registry::DecodingMode::Reject => {
-                            return Err(fedimint_core::encoding::DecodeError::new_custom(
-                                anyhow::anyhow!(
-                                    "Module decoder not available for module instance: {module_instance_id} when decoding {}", std::any::type_name::<Self>()
-                                ),
-                            ));
+                            return Err(fedimint_core::encoding::DecodeError::custom(format!(
+                                "Module decoder not available for module instance: \
+                                 {module_instance_id} when decoding {}",
+                                std::any::type_name::<Self>()
+                            )));
                         }
                         $crate::module::registry::DecodingMode::Fallback => $name::from_typed(
                             module_instance_id,

--- a/fedimint-core/src/macros.rs
+++ b/fedimint-core/src/macros.rs
@@ -347,10 +347,10 @@ macro_rules! module_plugin_dyn_newtype_encode_decode {
                     }
                     None => match decoders.decoding_mode() {
                         $crate::module::registry::DecodingMode::Reject => {
-                            return Err(fedimint_core::encoding::DecodeError::custom(format!(
+                            return Err($crate::encoding::DecodeError::custom(::std::format!(
                                 "Module decoder not available for module instance: \
                                  {module_instance_id} when decoding {}",
-                                std::any::type_name::<Self>()
+                                ::std::any::type_name::<Self>()
                             )));
                         }
                         $crate::module::registry::DecodingMode::Fallback => $name::from_typed(

--- a/fedimint-core/src/net/guardian_metadata.rs
+++ b/fedimint-core/src/net/guardian_metadata.rs
@@ -1,6 +1,6 @@
 use bitcoin::hashes::{Hash, sha256};
 use bitcoin::secp256k1::Message;
-use fedimint_core::encoding::{Decodable, DecodeError, Encodable};
+use fedimint_core::encoding::{Decodable, DecodeContext as _, DecodeError, Encodable};
 use serde::{Deserialize, Serialize};
 
 use crate::util::SafeUrl;
@@ -107,7 +107,8 @@ impl Decodable for SignedGuardianMetadata {
     ) -> Result<Self, DecodeError> {
         let bytes = Vec::<u8>::consensus_decode_partial_from_finite_reader(reader, modules)?;
         let value: GuardianMetadata = serde_json::from_slice(&bytes)
-            .map_err(|e| DecodeError::new_custom(anyhow::anyhow!("Invalid JSON: {e}")))?;
+            .map_err(DecodeError::from_err)
+            .context("Invalid JSON")?;
         let signature = secp256k1::schnorr::Signature::consensus_decode_partial_from_finite_reader(
             reader, modules,
         )?;

--- a/fedimint-core/src/txoproof.rs
+++ b/fedimint-core/src/txoproof.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::encoding::{Decodable, DecodeError, Encodable};
 use crate::module::registry::ModuleDecoderRegistry;
+use crate::util::FmtCompact as _;
 
 #[derive(Clone, Debug)]
 pub struct TxOutProof {
@@ -97,13 +98,13 @@ impl<'de> Deserialize<'de> for TxOutProof {
             let bytes = Vec::from_hex(hex_str.as_ref()).map_err(D::Error::custom)?;
             Ok(
                 Self::consensus_decode_partial(&mut Cursor::new(bytes), &empty_module_registry)
-                    .map_err(D::Error::custom)?,
+                    .map_err(|e| D::Error::custom(e.fmt_compact()))?,
             )
         } else {
             let bytes: &[u8] = Deserialize::deserialize(deserializer)?;
             Ok(
                 Self::consensus_decode_partial(&mut Cursor::new(bytes), &empty_module_registry)
-                    .map_err(D::Error::custom)?,
+                    .map_err(|e| D::Error::custom(e.fmt_compact()))?,
             )
         }
     }

--- a/fedimint-derive/src/lib.rs
+++ b/fedimint-derive/src/lib.rs
@@ -281,7 +281,9 @@ fn derive_struct_decode(ident: &Ident, fields: &Fields) -> TokenStream2 {
 fn derive_enum_decode(ident: &Ident, variants: &Punctuated<Variant, Comma>) -> TokenStream2 {
     if variants.is_empty() {
         return quote! {
-            Err(::fedimint_core::encoding::DecodeError::new_custom(anyhow::anyhow!("Enum without variants can't be instantiated")))
+            Err(::fedimint_core::encoding::DecodeError::custom(
+                "Enum without variants can't be instantiated",
+            ))
         };
     }
 
@@ -299,29 +301,38 @@ fn derive_enum_decode(ident: &Ident, variants: &Punctuated<Variant, Comma>) -> T
             quote! {
                 #variant_idx => {
                     // FIXME: feels like there's a way more elegant way to do this with limited readers
-                    let bytes: Vec<u8> = ::fedimint_core::anyhow::Context::context(
+                    let bytes: Vec<u8> = ::fedimint_core::encoding::DecodeContext::context(
                         ::fedimint_core::encoding::Decodable::consensus_decode_partial_from_finite_reader(d, modules),
                         concat!(
                             "Decoding bytes of ",
-                            stringify!(#ident)
-                        ))?;
+                            stringify!(#ident),
+                        ),
+                    )?;
                     let mut cursor = std::io::Cursor::new(&bytes);
 
-                    let decoded = anyhow::Context::context(
-                        (|| -> anyhow::Result<_> {
-                          Ok(#decode_block)
-                        })(), concat!("Decoding variant ", stringify!(#variant_ident), " (idx: ", #variant_idx, ")"))?;
+                    let decoded = ::fedimint_core::encoding::DecodeContext::context(
+                        (|| -> ::std::result::Result<_, ::fedimint_core::encoding::DecodeError> {
+                            Ok(#decode_block)
+                        })(),
+                        concat!(
+                            "Decoding variant ",
+                            stringify!(#variant_ident),
+                            " (idx: ",
+                            #variant_idx,
+                            ")",
+                        ),
+                    )?;
 
                     let read_bytes = cursor.position();
                     let total_bytes = bytes.len() as u64;
                     if read_bytes != total_bytes {
-                        return Err(::fedimint_core::encoding::DecodeError::new_custom(anyhow::anyhow!(
+                        return Err(::fedimint_core::encoding::DecodeError::custom(format!(
                             "Partial read: got {total_bytes} bytes but only read {read_bytes} when decoding {}",
                             concat!(
                                 stringify!(#ident),
                                 "::",
-                                stringify!(#variant)
-                            )
+                                stringify!(#variant),
+                            ),
                         )));
                     }
 
@@ -333,12 +344,13 @@ fn derive_enum_decode(ident: &Ident, variants: &Punctuated<Variant, Comma>) -> T
     let default_match_arm = if variants.iter().any(is_default_variant_enforce_valid) {
         quote! {
             variant => {
-                let bytes: Vec<u8> = ::fedimint_core::anyhow::Context::context(
+                let bytes: Vec<u8> = ::fedimint_core::encoding::DecodeContext::context(
                     ::fedimint_core::encoding::Decodable::consensus_decode_partial_from_finite_reader(d, modules),
                     concat!(
                         "Decoding default variant of ",
-                        stringify!(#ident)
-                    ))?;
+                        stringify!(#ident),
+                    ),
+                )?;
 
                 #ident::Default {
                     variant,
@@ -349,18 +361,22 @@ fn derive_enum_decode(ident: &Ident, variants: &Punctuated<Variant, Comma>) -> T
     } else {
         quote! {
             variant => {
-                return Err(::fedimint_core::encoding::DecodeError::new_custom(anyhow::anyhow!("Invalid enum variant {} while decoding {}", variant, stringify!(#ident))));
+                return Err(::fedimint_core::encoding::DecodeError::InvalidVariant {
+                    variant,
+                    type_name: stringify!(#ident),
+                });
             }
         }
     };
 
     quote! {
-        let variant = ::fedimint_core::anyhow::Context::context(
+        let variant = ::fedimint_core::encoding::DecodeContext::context(
             <u64 as ::fedimint_core::encoding::Decodable>::consensus_decode_partial_from_finite_reader(d, modules),
             concat!(
-                "Decoding default variant of ",
-                stringify!(#ident)
-            ))?;
+                "Decoding variant index of ",
+                stringify!(#ident),
+            ),
+        )?;
 
         let decoded = match variant {
             #(#non_default_match_arms)*
@@ -405,14 +421,15 @@ fn derive_tuple_decode_block(
     quote! {
         {
             #(
-                let #field_names = ::fedimint_core::anyhow::Context::context(
+                let #field_names = ::fedimint_core::encoding::DecodeContext::context(
                     ::fedimint_core::encoding::Decodable::consensus_decode_partial_from_finite_reader(#reader, modules),
                     concat!(
                         "Decoding tuple block ",
                         stringify!(#ident),
                         " field ",
                         stringify!(#field_names),
-                    ))?;
+                    ),
+                )?;
             )*
             #constructor(#(#field_names,)*)
         }
@@ -432,7 +449,7 @@ fn derive_named_decode_block(
     quote! {
         {
             #(
-                let #variant_fields = ::fedimint_core::anyhow::Context::context(
+                let #variant_fields = ::fedimint_core::encoding::DecodeContext::context(
                     ::fedimint_core::encoding::Decodable::consensus_decode_partial_from_finite_reader(#reader, modules),
                     concat!(
                         "Decoding named block field: ",
@@ -440,7 +457,8 @@ fn derive_named_decode_block(
                         "{ ... ",
                         stringify!(#variant_fields),
                         " ... }",
-                    ))?;
+                    ),
+                )?;
             )*
             #constructor{
                 #(#variant_fields,)*

--- a/fedimint-derive/src/lib.rs
+++ b/fedimint-derive/src/lib.rs
@@ -308,7 +308,7 @@ fn derive_enum_decode(ident: &Ident, variants: &Punctuated<Variant, Comma>) -> T
                             stringify!(#ident),
                         ),
                     )?;
-                    let mut cursor = std::io::Cursor::new(&bytes);
+                    let mut cursor = ::std::io::Cursor::new(&bytes);
 
                     let decoded = ::fedimint_core::encoding::DecodeContext::context(
                         (|| -> ::std::result::Result<_, ::fedimint_core::encoding::DecodeError> {
@@ -326,7 +326,7 @@ fn derive_enum_decode(ident: &Ident, variants: &Punctuated<Variant, Comma>) -> T
                     let read_bytes = cursor.position();
                     let total_bytes = bytes.len() as u64;
                     if read_bytes != total_bytes {
-                        return Err(::fedimint_core::encoding::DecodeError::custom(format!(
+                        return Err(::fedimint_core::encoding::DecodeError::custom(::std::format!(
                             "Partial read: got {total_bytes} bytes but only read {read_bytes} when decoding {}",
                             concat!(
                                 stringify!(#ident),

--- a/fedimint-derive/src/lib.rs
+++ b/fedimint-derive/src/lib.rs
@@ -251,7 +251,6 @@ pub fn derive_decodable(input: TokenStream) -> TokenStream {
         #[allow(deprecated)]
         impl ::fedimint_core::encoding::Decodable for #ident {
             fn consensus_decode_partial_from_finite_reader<D: std::io::Read>(d: &mut D, modules: &::fedimint_core::module::registry::ModuleDecoderRegistry) -> std::result::Result<Self, ::fedimint_core::encoding::DecodeError> {
-                use ::fedimint_core:: anyhow::Context;
                 #decode_inner
             }
         }
@@ -300,8 +299,9 @@ fn derive_enum_decode(ident: &Ident, variants: &Punctuated<Variant, Comma>) -> T
             quote! {
                 #variant_idx => {
                     // FIXME: feels like there's a way more elegant way to do this with limited readers
-                    let bytes: Vec<u8> = ::fedimint_core::encoding::Decodable::consensus_decode_partial_from_finite_reader(d, modules)
-                        .context(concat!(
+                    let bytes: Vec<u8> = ::fedimint_core::anyhow::Context::context(
+                        ::fedimint_core::encoding::Decodable::consensus_decode_partial_from_finite_reader(d, modules),
+                        concat!(
                             "Decoding bytes of ",
                             stringify!(#ident)
                         ))?;
@@ -333,8 +333,9 @@ fn derive_enum_decode(ident: &Ident, variants: &Punctuated<Variant, Comma>) -> T
     let default_match_arm = if variants.iter().any(is_default_variant_enforce_valid) {
         quote! {
             variant => {
-                let bytes: Vec<u8> = ::fedimint_core::encoding::Decodable::consensus_decode_partial_from_finite_reader(d, modules)
-                    .context(concat!(
+                let bytes: Vec<u8> = ::fedimint_core::anyhow::Context::context(
+                    ::fedimint_core::encoding::Decodable::consensus_decode_partial_from_finite_reader(d, modules),
+                    concat!(
                         "Decoding default variant of ",
                         stringify!(#ident)
                     ))?;
@@ -354,8 +355,9 @@ fn derive_enum_decode(ident: &Ident, variants: &Punctuated<Variant, Comma>) -> T
     };
 
     quote! {
-        let variant = <u64 as ::fedimint_core::encoding::Decodable>::consensus_decode_partial_from_finite_reader(d, modules)
-            .context(concat!(
+        let variant = ::fedimint_core::anyhow::Context::context(
+            <u64 as ::fedimint_core::encoding::Decodable>::consensus_decode_partial_from_finite_reader(d, modules),
+            concat!(
                 "Decoding default variant of ",
                 stringify!(#ident)
             ))?;
@@ -403,8 +405,9 @@ fn derive_tuple_decode_block(
     quote! {
         {
             #(
-                let #field_names = ::fedimint_core::encoding::Decodable::consensus_decode_partial_from_finite_reader(#reader, modules)
-                    .context(concat!(
+                let #field_names = ::fedimint_core::anyhow::Context::context(
+                    ::fedimint_core::encoding::Decodable::consensus_decode_partial_from_finite_reader(#reader, modules),
+                    concat!(
                         "Decoding tuple block ",
                         stringify!(#ident),
                         " field ",
@@ -429,8 +432,9 @@ fn derive_named_decode_block(
     quote! {
         {
             #(
-                let #variant_fields = ::fedimint_core::encoding::Decodable::consensus_decode_partial_from_finite_reader(#reader, modules)
-                    .context(concat!(
+                let #variant_fields = ::fedimint_core::anyhow::Context::context(
+                    ::fedimint_core::encoding::Decodable::consensus_decode_partial_from_finite_reader(#reader, modules),
+                    concat!(
                         "Decoding named block field: ",
                         stringify!(#ident),
                         "{ ... ",

--- a/fedimint-fountain/Cargo.toml
+++ b/fedimint-fountain/Cargo.toml
@@ -13,7 +13,6 @@ name = "fedimint_fountain"
 path = "./src/lib.rs"
 
 [dependencies]
-anyhow = { workspace = true }
 bitcoin_hashes = { workspace = true }
 fedimint-core = { workspace = true }
 rand = { workspace = true }

--- a/fedimint-server-tests/Cargo.toml
+++ b/fedimint-server-tests/Cargo.toml
@@ -16,6 +16,7 @@ name = "fedimint_server_migration"
 path = "tests/migration.rs"
 
 [dev-dependencies]
+anyhow = { workspace = true }
 bitcoin = { workspace = true }
 fedimint-api-client = { workspace = true }
 fedimint-core = { workspace = true }

--- a/fedimint-server-tests/tests/migration.rs
+++ b/fedimint-server-tests/tests/migration.rs
@@ -18,7 +18,7 @@ use fedimint_core::secp256k1::rand::rngs::OsRng;
 use fedimint_core::secp256k1::rand::thread_rng;
 use fedimint_core::session_outcome::{AcceptedItem, SessionOutcome, SignedSessionOutcome};
 use fedimint_core::transaction::{Transaction, TransactionSignature};
-use fedimint_core::{Amount, BitcoinHash, PeerId, TransactionId, anyhow};
+use fedimint_core::{Amount, BitcoinHash, PeerId, TransactionId};
 use fedimint_dummy_common::{DummyCommonInit, DummyInput, DummyOutput};
 use fedimint_dummy_server::Dummy;
 use fedimint_logging::{LOG_DB, TracingSetup};

--- a/gateway/fedimint-gateway-common/Cargo.toml
+++ b/gateway/fedimint-gateway-common/Cargo.toml
@@ -16,7 +16,6 @@ name = "fedimint_gateway_common"
 path = "src/lib.rs"
 
 [dependencies]
-anyhow = { workspace = true }
 bitcoin = { workspace = true }
 clap = { workspace = true }
 fedimint-api-client = { workspace = true }

--- a/modules/fedimint-dummy-common/Cargo.toml
+++ b/modules/fedimint-dummy-common/Cargo.toml
@@ -16,7 +16,6 @@ name = "fedimint_dummy_common"
 path = "src/lib.rs"
 
 [dependencies]
-anyhow = { workspace = true }
 fedimint-core = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }

--- a/modules/fedimint-empty-common/Cargo.toml
+++ b/modules/fedimint-empty-common/Cargo.toml
@@ -16,7 +16,6 @@ name = "fedimint_empty_common"
 path = "src/lib.rs"
 
 [dependencies]
-anyhow = { workspace = true }
 fedimint-core = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }

--- a/modules/fedimint-ln-common/src/lib.rs
+++ b/modules/fedimint-ln-common/src/lib.rs
@@ -49,7 +49,7 @@ use anyhow::Context as AnyhowContext;
 use bitcoin::hashes::{Hash, sha256};
 use config::LightningClientConfig;
 use fedimint_core::core::{Decoder, ModuleInstanceId, ModuleKind};
-use fedimint_core::encoding::{Decodable, DecodeError, Encodable};
+use fedimint_core::encoding::{Decodable, DecodeContext, DecodeError, Encodable};
 use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_core::module::{CommonModuleInit, ModuleCommon, ModuleConsensusVersion};
 use fedimint_core::secp256k1::Message;
@@ -343,11 +343,10 @@ impl Decodable for LightningGatewayRegistration {
         modules: &ModuleDecoderRegistry,
     ) -> Result<Self, DecodeError> {
         let json_repr = String::consensus_decode_partial(r, modules)?;
-        serde_json::from_str(&json_repr).map_err(|e| {
-            DecodeError::new_custom(
-                anyhow::Error::new(e).context("Failed to deserialize LightningGatewayRegistration"),
-            )
-        })
+        DecodeContext::context(
+            serde_json::from_str(&json_repr).map_err(DecodeError::from_err),
+            "Failed to deserialize LightningGatewayRegistration",
+        )
     }
 }
 

--- a/modules/fedimint-meta-common/src/lib.rs
+++ b/modules/fedimint-meta-common/src/lib.rs
@@ -138,7 +138,7 @@ impl Decodable for MetaValue {
         let bytes = Vec::consensus_decode_partial(r, modules)?;
 
         if Self::MAX_LEN_BYTES < bytes.len() {
-            return Err(DecodeError::new_custom(anyhow::format_err!("Too long")));
+            return Err(DecodeError::from_str("Too long"));
         }
 
         Ok(Self(bytes))

--- a/modules/fedimint-unknown-common/Cargo.toml
+++ b/modules/fedimint-unknown-common/Cargo.toml
@@ -16,7 +16,6 @@ name = "fedimint_unknown_common"
 path = "src/lib.rs"
 
 [dependencies]
-anyhow = { workspace = true }
 fedimint-core = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }

--- a/modules/fedimint-wallet-common/src/txoproof.rs
+++ b/modules/fedimint-wallet-common/src/txoproof.rs
@@ -208,7 +208,7 @@ impl Decodable for PegInProof {
             tweak_contract_key: PublicKey::consensus_decode_partial(d, modules)?,
         };
 
-        validate_peg_in_proof(&slf).map_err(DecodeError::new_custom)?;
+        validate_peg_in_proof(&slf).map_err(|error| DecodeError::Invalid(error.into()))?;
         Ok(slf)
     }
 }


### PR DESCRIPTION
## Summary

Second PR of the #8821 series (client-facing crates first, one commit per logical change; #9082 was the first). `fedimint_core::encoding::DecodeError` was a newtype over `anyhow::Error`, so every `Decodable` impl and the `Decodable` derive built it out of `anyhow`. It is now an enum with a `source()` chain, decode bodies and the derive use its own constructors and a `DecodeContext` trait, and the last `anyhow` leaves `fedimint-core`'s public API (`pub use anyhow`, `DecodeError::new_custom`, `From<anyhow::Error> for DecodeError`).

## Details

- `DecodeError` variants: `Io(std::io::Error)` (transparent; a truncated read, including through `BigSize`), `InvalidVariant { variant, type_name }`, `Context { context, source: Box<DecodeError> }`, `Invalid(Box<dyn Error + Send + Sync>)` (transparent; a typed cause, built by `from_err`), `Custom { message }`. `from_str` and `from_err` keep their signatures; `custom(impl Into<String>)` and `context(self, impl Display)` are new. `#[non_exhaustive]`.
- `DecodeContext` gives `.context(..)` / `.with_context(..)` to any `Result<T, E: Into<DecodeError>>`, so decode bodies that used `anyhow::Context` change only their import; the derive expands to it fully qualified. `with_decoding_context` keeps its signature.
- Display convention: `Display` is the failing step, the chain is reached through `Error::source` and printed flat by `fmt_compact` — the same as every other error in the workspace. Consumers printing a `DecodeError` with `{}` see the outer layer only; every in-tree consumer either goes through `anyhow` `{:#}` or `fmt_compact`. The two consumer-facing parse errors that interpolate a `DecodeError` (`InviteCodeParseError::Decode`, `PrefixedDecodeError::ConsensusDecode`) interpolate the flat chain, so CLI text is unchanged; they stop exposing the field as `source()` so the chain is not printed twice.
- The derive no longer references `anyhow` at all, which is why four crates could drop their `anyhow` dependency; it reports an unknown discriminant as `InvalidVariant` instead of a formatted message.
- `DecodingError` (database) gains `Decode(#[from] DecodeError)` instead of boxing the inner anyhow as `Other`.
- No wire or DB format changes; `DecodeError` is never encoded and never crosses the uniffi boundary.

## Breaking changes

- `DecodeError` is an enum; external `Decodable` impls that called `DecodeError::new_custom(anyhow)` or relied on `From<anyhow::Error>` switch to `custom` / `from_str` / `from_err` / `DecodeContext`. `fedimint_core::anyhow` is gone.
- `Display` of a `DecodeError` no longer includes the cause chain (use `fmt_compact()` or walk `source()`).
- `InviteCodeParseError::Decode` and `PrefixedDecodeError::ConsensusDecode` no longer implement `source()` for the decode error (the message carries the chain).
- `DecodingError` has a new `Decode` variant (the enum is `#[non_exhaustive]`).

## Known and left alone

- `From<anyhow::Error> for UniffiError` stays: its 26 users convert results of client APIs that the `fedimint-client` and module PRs will type; it goes with the last of those.
- `fedimint-wallet-common`'s `validate_peg_in_proof` keeps its `anyhow` result until the wallet module PR; the decode error boxes it as the cause.
- The numeric decoders lost the `"VarInt inside <type>"` context layer (the derive names the field around every read; keeping the layer would hide the `Io` root).

## Reviewing

Commit by commit; every commit passes `cargo check --workspace --all-targets` on its own. Behavioural changes to look at: `Display` of `DecodeError` (outer layer only), the two interpolating parse errors, `BigSize`'s short-read mapping, the derive's `InvalidVariant`. Everything else is a mechanical constructor swap.

## Testing

- [x] `cargo check --workspace --all-targets`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo check -p fedimint-core --features uniffi`, `cargo doc --no-deps` (core, client, client-module), the `check-wasm` package set, pre-commit hook
- [x] `cargo test -p fedimint-core` (lib + doc), client crates' unit tests, module common crates' unit tests, `fedimint-server-tests` migration test
- [x] every commit passes `cargo check --workspace --all-targets` in isolation

Part of #8821.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016oQCqru2uCsmwaLxBoN9Wv
