### PR TITLE
refactor(recurringd): centralize federation authentication

### DIFF
--- a/fedimint-core/src/module/mod.rs
+++ b/fedimint-core/src/module/mod.rs
@@ -362,7 +362,7 @@ pub struct IrohGatewayResponse {
 pub const FEDIMINT_API_ALPN: &[u8] = b"FEDIMINT_API_ALPN";
 pub const FEDIMINT_GATEWAY_ALPN: &[u8] = b"FEDIMINT_GATEWAY_ALPN";
 
-/// Authentication secret used to verify guardian admin API requests.
+/// Authentication secret used to verify privileged API requests.
 ///
 /// The inner value is private to prevent timing leaks via direct comparison.
 /// Use [`Self::verify`] for authentication checks.

--- a/fedimint-recurringd-tests/src/bin/fedimint-recurringd-tests.rs
+++ b/fedimint-recurringd-tests/src/bin/fedimint-recurringd-tests.rs
@@ -31,16 +31,22 @@ async fn main() -> anyhow::Result<()> {
                     .json(&serde_json::json!({ "invite": dummy_invite }))
                     .send()
                     .await?;
-                assert!(response_no_auth.status().is_client_error());
+                assert_eq!(
+                    response_no_auth.status(),
+                    reqwest::StatusCode::UNAUTHORIZED
+                );
 
                 let response_with_wrong_auth = client
                     .put(&url)
-                    .header("Authorization", "Bearer wrong-token")
+                    .header("Authorization", "Bearer recurringd-test-token-wrong")
                     .header("Content-Type", "application/json")
                     .json(&serde_json::json!({ "invite": dummy_invite }))
                     .send()
                     .await?;
-                assert!(response_with_wrong_auth.status().is_client_error());
+                assert_eq!(
+                    response_with_wrong_auth.status(),
+                    reqwest::StatusCode::UNAUTHORIZED
+                );
             }
 
             // Give the LND Gateway a balance, it's the only GW serving LNv1 and recurringd

--- a/fedimint-recurringd/src/main.rs
+++ b/fedimint-recurringd/src/main.rs
@@ -3,7 +3,8 @@ use std::path::PathBuf;
 
 use axum::Json;
 use axum::body::Body;
-use axum::extract::{Path, Query, State};
+use axum::extract::{FromRequestParts, Path, Query, State};
+use axum::http::request::Parts;
 use axum::http::{Response, StatusCode};
 use axum::response::IntoResponse;
 use axum::routing::{get, put};
@@ -14,6 +15,7 @@ use fedimint_core::Amount;
 use fedimint_core::config::FederationId;
 use fedimint_core::core::OperationId;
 use fedimint_core::invite_code::InviteCode;
+use fedimint_core::module::ApiAuth;
 use fedimint_core::util::SafeUrl;
 use fedimint_ln_client::recurring::api::{
     RecurringPaymentRegistrationRequest, RecurringPaymentRegistrationResponse,
@@ -47,15 +49,30 @@ struct CliOpts {
     bind_address: SocketAddr,
     #[clap(long, env = "FM_RECURRING_API_ADDRESS")]
     api_address: SafeUrl,
-    #[clap(long, env = "FM_RECURRING_API_BEARER_TOKEN")]
+    #[clap(
+        long,
+        env = "FM_RECURRING_API_BEARER_TOKEN",
+        value_parser = parse_non_empty_bearer_token
+    )]
     bearer_token: String,
     #[clap(long, env = "FM_RECURRING_DATA_DIR")]
     data_dir: PathBuf,
 }
 
+fn parse_non_empty_bearer_token(token: &str) -> Result<String, &'static str> {
+    if token.is_empty() {
+        Err("bearer token must not be empty")
+    } else {
+        Ok(token.to_owned())
+    }
+}
+
+#[cfg(test)]
+mod main_tests;
+
 #[derive(Clone)]
 struct AppState {
-    auth_token: String,
+    auth_token: ApiAuth,
     recurring_invoice_server: RecurringInvoiceServer,
 }
 
@@ -103,7 +120,7 @@ async fn main() -> anyhow::Result<()> {
     let app = axum::Router::new()
         .nest("/lnv1", api_v1)
         .with_state(AppState {
-            auth_token: cli_opts.bearer_token,
+            auth_token: ApiAuth::new(cli_opts.bearer_token),
             recurring_invoice_server,
         });
 
@@ -119,15 +136,33 @@ struct AddFederationRequest {
     invite: InviteCode,
 }
 
+/// Extractor that verifies the bearer token required to register federations.
+struct FederationAuth;
+
+impl FromRequestParts<AppState> for FederationAuth {
+    type Rejection = StatusCode;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        app_state: &AppState,
+    ) -> Result<Self, Self::Rejection> {
+        let AuthBearer(token) = AuthBearer::from_request_parts(parts, app_state)
+            .await
+            .map_err(|_| StatusCode::UNAUTHORIZED)?;
+
+        if app_state.auth_token.verify(&token) {
+            Ok(Self)
+        } else {
+            Err(StatusCode::UNAUTHORIZED)
+        }
+    }
+}
+
 async fn add_federation(
     State(app_state): State<AppState>,
-    AuthBearer(token): AuthBearer,
+    _auth: FederationAuth,
     request: Json<AddFederationRequest>,
 ) -> Result<Json<FederationId>, ApiError> {
-    if token != app_state.auth_token {
-        return Err(ApiError(anyhow::anyhow!("Invalid auth token")));
-    }
-
     let federation_id = app_state
         .recurring_invoice_server
         .register_federation(&request.invite)

--- a/fedimint-recurringd/src/main_tests.rs
+++ b/fedimint-recurringd/src/main_tests.rs
@@ -1,0 +1,22 @@
+use clap::Parser as _;
+
+use super::CliOpts;
+
+#[test]
+fn rejects_empty_bearer_token() {
+    let error = CliOpts::try_parse_from([
+        "fedimint-recurringd",
+        "--api-address",
+        "https://example.com",
+        "--bearer-token",
+        "",
+        "--data-dir",
+        "data",
+    ])
+    .expect_err("empty bearer token must be rejected");
+
+    assert!(
+        error.to_string().contains("bearer token must not be empty"),
+        "unexpected error: {error}"
+    );
+}


### PR DESCRIPTION
*Posted by Tau*

### Summary

This refactor moves recurringd federation registration authentication into a reusable route extractor and rejects empty bearer-token configuration before startup. Previously, the registration handler parsed and checked bearer headers locally while an empty configured token was accepted. The new flow keeps registration logic focused on federation registration and makes invalid configuration fail early.

### Details

`FederationAuth` parses and verifies bearer headers before the `PUT /lnv1/federations` handler runs. Missing, malformed, and unaccepted values receive the same `401 Unauthorized` response. The shared Clap value parser also rejects empty bearer tokens supplied through either `--bearer-token` or `FM_RECURRING_API_BEARER_TOKEN`; other recurringd route policies remain unchanged.

### Reviewing

Check that `FederationAuth` runs before JSON body extraction and maps missing, malformed, and unaccepted bearer values to `401 Unauthorized`. Confirm that the shared Clap value parser validates bearer tokens supplied by both command-line and environment configuration.

### Testing

The new unit test covers empty bearer-token CLI input. Existing recurringd integration coverage checks the missing and wrong bearer-header responses.