### PR TITLE
refactor(ui): centralize session cookie verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4974,6 +4974,7 @@ dependencies = [
  "fedimint-core",
  "maud",
  "serde",
+ "subtle",
  "tokio",
 ]
 

--- a/fedimint-ui-common/Cargo.toml
+++ b/fedimint-ui-common/Cargo.toml
@@ -18,6 +18,7 @@ axum-extra = { workspace = true, features = ["cookie"] }
 fedimint-core = { workspace = true }
 maud = { workspace = true }
 serde = { workspace = true }
+subtle = { workspace = true }
 tokio = { workspace = true, features = ["net", "time"] }
 
 [lints]

--- a/fedimint-ui-common/src/auth.rs
+++ b/fedimint-ui-common/src/auth.rs
@@ -114,12 +114,10 @@ where
             .await
             .map_err(|_| Redirect::to(LOGIN_ROUTE))?;
 
-        // Check if the auth cookie exists and has the correct value
-        match jar.get(&state.auth_cookie_name) {
-            Some(cookie) if cookie.value() == state.auth_cookie_value => {
-                Ok(UserAuth::authenticated())
-            }
-            _ => Err(Redirect::to(LOGIN_ROUTE)),
+        if state.has_valid_auth_cookie(&jar) {
+            Ok(UserAuth::authenticated())
+        } else {
+            Err(Redirect::to(LOGIN_ROUTE))
         }
     }
 }

--- a/fedimint-ui-common/src/lib.rs
+++ b/fedimint-ui-common/src/lib.rs
@@ -13,6 +13,7 @@ use fedimint_core::module::ApiAuth;
 use fedimint_core::secp256k1::rand::{Rng, thread_rng};
 use maud::{DOCTYPE, Markup, PreEscaped, html};
 use serde::Deserialize;
+use subtle::ConstantTimeEq as _;
 use tokio::net::TcpStream;
 use tokio::time::timeout;
 
@@ -40,6 +41,17 @@ impl<T> UiState<T> {
             auth_cookie_value: thread_rng().r#gen::<[u8; 32]>().encode_hex(),
             requires_auth,
         }
+    }
+
+    pub(crate) fn has_valid_auth_cookie(&self, jar: &CookieJar) -> bool {
+        jar.get(&self.auth_cookie_name).is_some_and(|cookie| {
+            bool::from(
+                cookie
+                    .value()
+                    .as_bytes()
+                    .ct_eq(self.auth_cookie_value.as_bytes()),
+            )
+        })
     }
 }
 
@@ -257,14 +269,9 @@ pub async fn connectivity_check_handler<Api: Send + Sync + 'static>(
     State(state): State<UiState<Api>>,
     jar: CookieJar,
 ) -> Html<String> {
-    // Check auth manually — return empty fragment if not authenticated.
-    // In passwordless mode (`!requires_auth`), this widget is always shown.
-    let authenticated = !state.requires_auth
-        || jar
-            .get(&state.auth_cookie_name)
-            .is_some_and(|c| c.value() == state.auth_cookie_value);
-
-    if !authenticated {
+    // Return an empty fragment instead of redirecting so htmx leaves the widget
+    // empty when the UI is not authenticated.
+    if state.requires_auth && !state.has_valid_auth_cookie(&jar) {
         return Html(String::new());
     }
 
@@ -289,4 +296,31 @@ pub async fn connectivity_check_handler<Api: Send + Sync + 'static>(
     };
 
     Html(markup.into_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use axum_extra::extract::CookieJar;
+    use axum_extra::extract::cookie::Cookie;
+
+    use super::UiState;
+
+    #[test]
+    fn authentication_requires_matching_cookie() {
+        let state = UiState {
+            api: (),
+            auth_cookie_name: "session".to_owned(),
+            auth_cookie_value: "expected-value".to_owned(),
+            requires_auth: true,
+        };
+
+        let valid = CookieJar::new().add(Cookie::new("session", "expected-value"));
+        let wrong_value = CookieJar::new().add(Cookie::new("session", "wrong-value"));
+        let wrong_name = CookieJar::new().add(Cookie::new("other", "expected-value"));
+
+        assert!(state.has_valid_auth_cookie(&valid));
+        assert!(!state.has_valid_auth_cookie(&wrong_value));
+        assert!(!state.has_valid_auth_cookie(&wrong_name));
+        assert!(!state.has_valid_auth_cookie(&CookieJar::new()));
+    }
 }


### PR DESCRIPTION
*Posted by Tau*

### Summary

Guardian and gateway UIs now use one session-cookie verifier for protected UI requests and the connectivity widget. Previously, those paths duplicated their cookie string checks. The shared verifier keeps their acceptance rules aligned while preserving login redirects, the empty connectivity fragment, and passwordless UI behavior.

### Details

The request extractor continues to redirect unauthenticated protected routes to the login page, while the connectivity handler continues to return an empty fragment so htmx does not replace the widget with that page. Both paths now delegate cookie verification to `UiState`, preventing separate checks from drifting as the UI authentication flow evolves. The cookie name, cookie format, login flow, and public UI interfaces remain unchanged.

### Reviewing

Check that both UI paths call the shared verifier and retain their distinct unauthenticated responses: a login redirect for protected routes and an empty fragment for the connectivity widget.

### Testing

The focused `fedimint-ui-common` unit test covers matching, wrong-value, wrong-name, and missing cookies.