### PR TITLE
refactor(gateway): centralize preimage authorization checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4032,6 +4032,7 @@ dependencies = [
  "serde",
  "serde-big-array",
  "serde_json",
+ "subtle",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -107,10 +107,10 @@ use fedimint_lightning::{
     PayInvoiceResponse, PaymentAction, RouteHtlcStream, ldk,
 };
 use fedimint_ln_client::pay::PaymentData;
-use fedimint_ln_common::LightningCommonInit;
 use fedimint_ln_common::config::LightningClientConfig;
 use fedimint_ln_common::contracts::outgoing::OutgoingContractAccount;
 use fedimint_ln_common::contracts::{IdentifiableContract, Preimage};
+use fedimint_ln_common::{LightningCommonInit, PreimageAuth};
 use fedimint_lnurl::VerifyResponse;
 use fedimint_lnv2_common::Bolt11InvoiceDescription;
 use fedimint_lnv2_common::contracts::{IncomingContract, PaymentImage};
@@ -3832,7 +3832,7 @@ impl IGatewayClientV1 for Gateway {
     ) -> std::result::Result<(), OutgoingPaymentError> {
         let mut dbtx = self.gateway_db.begin_transaction().await;
         if let Some(secret_hash) = dbtx.load_preimage_authentication(payment_hash).await {
-            if secret_hash != preimage_auth {
+            if !PreimageAuth::new(secret_hash).verifies(preimage_auth) {
                 return Err(OutgoingPaymentError {
                     error_type: OutgoingPaymentErrorType::InvalidInvoicePreimage,
                     contract_id: contract.contract.contract_id(),

--- a/modules/fedimint-gw-client/src/lib.rs
+++ b/modules/fedimint-gw-client/src/lib.rs
@@ -62,7 +62,8 @@ use fedimint_ln_common::{
     GatewayRegistrationAuth, KIND, LNV1_INCOMING_HTLC_ADVERTISED_EXPIRY_DELTA,
     LNV1_INCOMING_HTLC_EXPIRY_SAFETY_MARGIN, LightningCommonInit, LightningGateway,
     LightningGatewayAnnouncement, LightningModuleTypes, LightningOutput, LightningOutputV0,
-    RemoveGatewayRequest, create_gateway_registration_message, create_gateway_remove_message,
+    PreimageAuth, RemoveGatewayRequest, create_gateway_registration_message,
+    create_gateway_remove_message,
 };
 use fedimint_lnv2_common::GatewayApi;
 use futures::StreamExt;
@@ -904,7 +905,8 @@ impl GatewayClientModule {
                             if !matches!(
                                 entry.try_meta::<GatewayMeta>(),
                                 Ok(GatewayMeta::Pay { preimage_auth })
-                                    if preimage_auth == payload.preimage_auth
+                                    if PreimageAuth::new(preimage_auth)
+                                        .verifies(payload.preimage_auth)
                             ) {
                                 anyhow::bail!(
                                     "Not authorized to receive the preimage for contract {}",

--- a/modules/fedimint-ln-common/Cargo.toml
+++ b/modules/fedimint-ln-common/Cargo.toml
@@ -36,6 +36,7 @@ reqwest = { workspace = true }
 serde = { workspace = true }
 serde-big-array = { workspace = true }
 serde_json = { workspace = true }
+subtle = { workspace = true }
 thiserror = { workspace = true }
 threshold_crypto = { workspace = true }
 tokio = { workspace = true }

--- a/modules/fedimint-ln-common/src/lib.rs
+++ b/modules/fedimint-ln-common/src/lib.rs
@@ -22,6 +22,7 @@ pub mod config;
 pub mod contracts;
 pub mod federation_endpoint_constants;
 pub mod gateway_endpoint_constants;
+mod preimage_auth;
 
 /// Exclusive remaining-CLTV safety margin for funding LNv1 incoming contracts.
 ///
@@ -59,6 +60,7 @@ use fedimint_core::{
     extensible_associated_module_type, plugin_types_trait_impl_common, secp256k1,
 };
 use lightning_invoice::{Bolt11Invoice, RoutingFees};
+pub use preimage_auth::PreimageAuth;
 pub use reqwest::Method;
 use secp256k1::schnorr::Signature;
 use serde::{Deserialize, Serialize};

--- a/modules/fedimint-ln-common/src/preimage_auth.rs
+++ b/modules/fedimint-ln-common/src/preimage_auth.rs
@@ -1,0 +1,42 @@
+use bitcoin::hashes::{Hash as _, sha256};
+use subtle::ConstantTimeEq as _;
+
+/// Authorization value a client presents before receiving an LNv1 preimage.
+#[derive(Clone, Copy)]
+pub struct PreimageAuth(sha256::Hash);
+
+impl PreimageAuth {
+    /// Creates an authorization verifier for a stored LNv1 preimage
+    /// authorization value.
+    pub const fn new(expected: sha256::Hash) -> Self {
+        Self(expected)
+    }
+
+    /// Returns whether the supplied value authorizes access to the LNv1
+    /// preimage.
+    pub fn verifies(self, supplied: sha256::Hash) -> bool {
+        bool::from(self.0.as_byte_array().ct_eq(supplied.as_byte_array()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bitcoin::hashes::Hash as _;
+
+    use super::PreimageAuth;
+
+    #[test]
+    fn accepts_matching_preimage_auth() {
+        let preimage_auth = bitcoin::hashes::sha256::Hash::hash(b"preimage auth");
+
+        assert!(PreimageAuth::new(preimage_auth).verifies(preimage_auth));
+    }
+
+    #[test]
+    fn rejects_non_matching_preimage_auth() {
+        let expected = bitcoin::hashes::sha256::Hash::hash(b"expected preimage auth");
+        let supplied = bitcoin::hashes::sha256::Hash::hash(b"supplied preimage auth");
+
+        assert!(!PreimageAuth::new(expected).verifies(supplied));
+    }
+}


### PR DESCRIPTION
*Posted by Tau*

### Summary

LNv1 gateway payment operations compared preimage authorization values separately when checking a persisted authorization and when joining an existing operation. This change adds one shared `PreimageAuth` verifier and routes both paths through it, keeping the authorization rule consistent. Existing SHA-256 fields, persistence values, and wire encodings remain unchanged.

### Details

The gateway server reads an authorization value from its database before continuing a payment, while the gateway client reads one from operation metadata before allowing a duplicate request to join. Before, each path carried its own equality check. Now both construct the shared verifier from the expected value and use its typed method for the supplied value. This keeps the two gateway flows aligned without changing their stored or transmitted values.

### Testing

- `cargo test -p fedimint-ln-common preimage_auth --lib`
- `cargo test -p fedimint-gateway-server --test gatewayd-tests test_gateway_client_pay_invoice_is_idempotent_per_contract -- --nocapture`
- Focused clippy for `fedimint-ln-common`, `fedimint-gw-client`, and gateway-server library targets
- `just final-lint`
