### PR TITLE
chore(connectivity): replace anyhow with typed errors in the public API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3150,7 +3150,6 @@ dependencies = [
 name = "fedimint-bitcoind"
 version = "0.13.0-alpha"
 dependencies = [
- "anyhow",
  "async-trait",
  "bitcoin",
  "bitcoincore-rpc",
@@ -3158,6 +3157,7 @@ dependencies = [
  "fedimint-core",
  "fedimint-logging",
  "fedimint-metrics",
+ "thiserror 2.0.18",
  "tracing",
 ]
 

--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -392,7 +392,7 @@ impl Federation {
                 SafeUrl::parse(&peer_env_vars.FM_API_URL)?,
                 // TODO: will need it somewhere
                 // &process_mgr.globals.FM_FORCE_API_SECRETS.get_active(),
-            )?;
+            );
             api_endpoints.insert(peer_id, peer_env_vars.FM_API_URL.clone());
             admin_clients.insert(peer_id, admin_client);
             peer_to_env_vars_map.insert(peer_id.to_usize(), peer_env_vars);

--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -364,7 +364,7 @@ impl Federation {
         let mut admin_clients: BTreeMap<PeerId, DynGlobalApi> = BTreeMap::new();
         let mut api_endpoints: BTreeMap<PeerId, _> = BTreeMap::new();
 
-        let connectors = ConnectorRegistry::build_from_testing_env()?.bind().await?;
+        let connectors = ConnectorRegistry::build_from_testing_env().bind().await;
         for peer_id in num_peers.peer_ids() {
             let peer_env_vars = vars::Fedimintd::init(
                 &process_mgr.globals,

--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -1486,7 +1486,7 @@ pub async fn guardian_metadata_tests(dev_fed: DevFed) -> Result<()> {
         .parse()
         .expect("FM_API_URL must be a valid SafeUrl");
     let connectors = ConnectorRegistry::build_from_testing_env().bind().await;
-    let admin_api = DynGlobalApi::new_admin(connectors, peer_id, peer0_real_url, None)?;
+    let admin_api = DynGlobalApi::new_admin(connectors, peer_id, peer0_real_url, None);
     let invite: InviteCode = admin_api
         .request_single_peer(
             INVITE_CODE_ENDPOINT.to_string(),

--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -1485,7 +1485,7 @@ pub async fn guardian_metadata_tests(dev_fed: DevFed) -> Result<()> {
         .FM_API_URL
         .parse()
         .expect("FM_API_URL must be a valid SafeUrl");
-    let connectors = ConnectorRegistry::build_from_testing_env()?.bind().await?;
+    let connectors = ConnectorRegistry::build_from_testing_env().bind().await;
     let admin_api = DynGlobalApi::new_admin(connectors, peer_id, peer0_real_url, None)?;
     let invite: InviteCode = admin_api
         .request_single_peer(

--- a/fedimint-api-client/src/api/error.rs
+++ b/fedimint-api-client/src/api/error.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 use fedimint_connectors::error::ServerError;
 use fedimint_core::PeerId;
+use fedimint_core::core::ModuleInstanceId;
 use fedimint_core::encoding::DecodeError;
 use fedimint_core::fmt_utils::AbbreviateJson;
 use fedimint_core::util::FmtCompact as _;
@@ -157,13 +158,21 @@ impl FederationError {
 }
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum OutputOutcomeError {
-    #[error("Response deserialization error: {0}")]
-    ResponseDeserialization(anyhow::Error),
-    #[error("Federation error: {0}")]
+    /// The outcome bytes the federation returned could not be decoded.
+    #[error("Failed to decode the output outcome")]
+    ResponseDeserialization(#[from] DecodeError),
+    /// The outcome decoded into a different type than the caller asked for.
+    #[error("Output outcome of module instance {module_instance_id} is not a {expected_type}")]
+    WrongOutcomeType {
+        module_instance_id: ModuleInstanceId,
+        expected_type: &'static str,
+    },
+    /// The request to the federation failed.
+    #[error("Federation error")]
     Federation(#[from] FederationError),
-    #[error("Core error: {0}")]
-    Core(#[from] anyhow::Error),
+    /// The transaction that would have produced the outcome was rejected.
     #[error("Transaction rejected: {0}")]
     Rejected(String),
     #[error("Invalid output index {out_idx}, larger than {outputs_num} in the transaction")]
@@ -179,7 +188,7 @@ impl OutputOutcomeError {
                 e.report_if_unusual("OutputOutcome");
                 return;
             }
-            OutputOutcomeError::Core(_)
+            OutputOutcomeError::WrongOutcomeType { .. }
             | OutputOutcomeError::InvalidVout { .. }
             | OutputOutcomeError::ResponseDeserialization(_) => true,
             OutputOutcomeError::Rejected(_) | OutputOutcomeError::Timeout(_) => false,

--- a/fedimint-api-client/src/api/error.rs
+++ b/fedimint-api-client/src/api/error.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 use fedimint_connectors::error::ServerError;
 use fedimint_core::PeerId;
+use fedimint_core::config::FederationId;
 use fedimint_core::core::ModuleInstanceId;
 use fedimint_core::encoding::DecodeError;
 use fedimint_core::fmt_utils::AbbreviateJson;
@@ -175,8 +176,10 @@ pub enum OutputOutcomeError {
     /// The transaction that would have produced the outcome was rejected.
     #[error("Transaction rejected: {0}")]
     Rejected(String),
+    /// The transaction has no output at the index the caller asked about.
     #[error("Invalid output index {out_idx}, larger than {outputs_num} in the transaction")]
     InvalidVout { out_idx: u64, outputs_num: usize },
+    /// The outcome did not become available within the time the caller allowed.
     #[error("Timeout reached after waiting {}s", .0.as_secs())]
     Timeout(Duration),
 }
@@ -208,4 +211,21 @@ impl OutputOutcomeError {
             OutputOutcomeError::Rejected(_) | OutputOutcomeError::InvalidVout { .. }
         )
     }
+}
+
+/// A failure to download a federation's client config.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum ClientConfigDownloadError {
+    /// The federation could not be asked for its config.
+    #[error("Failed to request the client config")]
+    Federation(#[from] FederationError),
+
+    /// The config the federation returned belongs to a different federation
+    /// than the invite code names.
+    #[error("Obtained client config has federation id {found}, expected {expected}")]
+    FederationIdMismatch {
+        expected: FederationId,
+        found: FederationId,
+    },
 }

--- a/fedimint-api-client/src/api/error.rs
+++ b/fedimint-api-client/src/api/error.rs
@@ -5,13 +5,31 @@ use std::time::Duration;
 use fedimint_connectors::error::ServerError;
 use fedimint_core::PeerId;
 use fedimint_core::fmt_utils::AbbreviateJson;
-use fedimint_core::util::FmtCompactAnyhow as _;
+use fedimint_core::util::FmtCompact as _;
 #[cfg(feature = "uniffi")]
 use fedimint_core::util::ffi::UniffiError;
 use fedimint_logging::LOG_CLIENT_NET_API;
 use serde::Serialize;
 use thiserror::Error;
 use tracing::{trace, warn};
+
+/// A federation-wide failure that is not simply peers returning errors.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum FederationGeneralError {
+    /// The call is an admin call, but this api handle does not know which peer
+    /// it speaks for.
+    #[error("Admin peer id not set")]
+    AdminPeerIdNotSet,
+
+    /// Not enough peers agreed for the request to produce an answer.
+    #[error("{message}")]
+    ThresholdFailed { message: String },
+
+    /// A peer answered, but with something the caller cannot use.
+    #[error("{message}")]
+    UnexpectedResponse { message: String },
+}
 
 /// An API request error when calling an entire federation
 ///
@@ -24,7 +42,7 @@ pub struct FederationError {
     ///
     /// The `general` error should be Some, when the error is not simply peers
     /// responding with enough errors, but something more global.
-    pub general: Option<anyhow::Error>,
+    pub general: Option<FederationGeneralError>,
     pub peer_errors: BTreeMap<PeerId, ServerError>,
 }
 
@@ -44,7 +62,7 @@ impl Display for FederationError {
                 "params => {:?}, ",
                 AbbreviateJson(&self.params)
             ))?;
-            f.write_fmt(format_args!("general => {general}, "))?;
+            f.write_fmt(format_args!("general => {}, ", general.fmt_compact()))?;
             if !self.peer_errors.is_empty() {
                 f.write_str(", ")?;
             }
@@ -64,12 +82,12 @@ impl FederationError {
     pub fn general(
         method: impl Into<String>,
         params: impl Serialize,
-        e: impl Into<anyhow::Error>,
+        e: FederationGeneralError,
     ) -> FederationError {
         FederationError {
             method: method.into(),
             params: serde_json::to_value(params).unwrap_or_default(),
-            general: Some(e.into()),
+            general: Some(e),
             peer_errors: BTreeMap::default(),
         }
     }
@@ -105,15 +123,15 @@ impl FederationError {
     pub fn report_if_unusual(&self, context: &str) {
         if let Some(error) = self.general.as_ref() {
             // Any general federation errors are unusual
-            warn!(target: LOG_CLIENT_NET_API, err = %error.fmt_compact_anyhow(), %context, "General FederationError");
+            warn!(target: LOG_CLIENT_NET_API, err = %error.fmt_compact(), %context, "General FederationError");
         }
         for (peer_id, e) in &self.peer_errors {
             e.report_if_unusual(*peer_id, context);
         }
     }
 
-    /// Get the general error if any.
-    pub fn get_general_error(&self) -> Option<&anyhow::Error> {
+    /// The general error, if any.
+    pub fn get_general_error(&self) -> Option<&FederationGeneralError> {
         self.general.as_ref()
     }
 

--- a/fedimint-api-client/src/api/error.rs
+++ b/fedimint-api-client/src/api/error.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 use fedimint_connectors::error::ServerError;
 use fedimint_core::PeerId;
+use fedimint_core::encoding::DecodeError;
 use fedimint_core::fmt_utils::AbbreviateJson;
 use fedimint_core::util::FmtCompact as _;
 #[cfg(feature = "uniffi")]
@@ -29,6 +30,14 @@ pub enum FederationGeneralError {
     /// A peer answered, but with something the caller cannot use.
     #[error("{message}")]
     UnexpectedResponse { message: String },
+
+    /// A peer's response was well-formed json but did not decode.
+    #[error("Failed to decode a peer's response")]
+    Decode(#[from] DecodeError),
+
+    /// The signed session outcome did not verify against the broadcast keys.
+    #[error("Invalid signature")]
+    InvalidSignature,
 }
 
 /// An API request error when calling an entire federation

--- a/fedimint-api-client/src/api/error.rs
+++ b/fedimint-api-client/src/api/error.rs
@@ -197,10 +197,14 @@ impl OutputOutcomeError {
             OutputOutcomeError::Rejected(_) | OutputOutcomeError::Timeout(_) => false,
         };
 
-        trace!(target: LOG_CLIENT_NET_API, error = %self, "OutputOutcomeError");
+        trace!(target: LOG_CLIENT_NET_API, error = %self.fmt_compact(), "OutputOutcomeError");
 
         if important {
-            warn!(target: LOG_CLIENT_NET_API, error = %self, "Uncommon OutputOutcomeError");
+            warn!(
+                target: LOG_CLIENT_NET_API,
+                error = %self.fmt_compact(),
+                "Uncommon OutputOutcomeError"
+            );
         }
     }
 

--- a/fedimint-api-client/src/api/global_api/with_cache.rs
+++ b/fedimint-api-client/src/api/global_api/with_cache.rs
@@ -3,7 +3,6 @@ use std::fmt::Debug;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 
-use anyhow::{anyhow, format_err};
 use bitcoin::secp256k1;
 use fedimint_connectors::{DynGuaridianConnection, PeerStatus, ServerResult};
 use fedimint_core::admin_client::{GuardianConfigBackup, SetLocalParamsRequest, SetupStatus};
@@ -49,7 +48,7 @@ use tracing::{debug, trace};
 
 use super::super::{DynModuleApi, IGlobalFederationApi, IRawFederationApi, StatusResponse};
 use crate::api::{
-    FederationApiExt, FederationError, FederationResult,
+    FederationApiExt, FederationError, FederationGeneralError, FederationResult,
     VERSION_THAT_INTRODUCED_GET_SESSION_STATUS_V2,
 };
 use crate::query::FilterMapThreshold;
@@ -124,19 +123,26 @@ where
         &self,
         block_index: u64,
         decoders: &ModuleDecoderRegistry,
-    ) -> anyhow::Result<SessionOutcome> {
+    ) -> FederationResult<SessionOutcome> {
         if block_index.is_multiple_of(100) {
             debug!(target: LOG_CLIENT_NET_API, block_index, "Awaiting block's outcome from Federation");
         } else {
             trace!(target: LOG_CLIENT_NET_API, block_index, "Awaiting block's outcome from Federation");
         }
-        self.request_current_consensus::<SerdeModuleEncoding<SessionOutcome>>(
-            AWAIT_SESSION_OUTCOME_ENDPOINT.to_string(),
-            ApiRequestErased::new(block_index),
-        )
-        .await?
-        .try_into_inner(decoders)
-        .map_err(|e| anyhow!(e.to_string()))
+        let response = self
+            .request_current_consensus::<SerdeModuleEncoding<SessionOutcome>>(
+                AWAIT_SESSION_OUTCOME_ENDPOINT.to_string(),
+                ApiRequestErased::new(block_index),
+            )
+            .await?;
+
+        response.try_into_inner(decoders).map_err(|e| {
+            FederationError::general(
+                AWAIT_SESSION_OUTCOME_ENDPOINT.to_string(),
+                ApiRequestErased::new(block_index),
+                FederationGeneralError::Decode(e),
+            )
+        })
     }
 
     pub(crate) fn select_peers_for_status(&self) -> impl Iterator<Item = PeerId> + '_ {
@@ -150,7 +156,7 @@ where
         block_index: u64,
         broadcast_public_keys: &BTreeMap<PeerId, secp256k1::PublicKey>,
         decoders: &ModuleDecoderRegistry,
-    ) -> anyhow::Result<SessionStatus> {
+    ) -> FederationResult<SessionStatus> {
         if block_index.is_multiple_of(100) {
             debug!(target: LOG_CLIENT_NET_API, block_index, "Get session status raw v2");
         } else {
@@ -160,16 +166,24 @@ where
         let mut last_error = None;
         // fetch serially
         for peer_id in self.select_peers_for_status() {
-            match self
+            let decoded = self
                 .request_single_peer_federation::<SerdeModuleEncodingBase64<SessionStatusV2>>(
                     SESSION_STATUS_V2_ENDPOINT.to_string(),
                     params.clone(),
                     peer_id,
                 )
                 .await
-                .map_err(anyhow::Error::from)
-                .and_then(|s| Ok(s.try_into_inner(decoders)?))
-            {
+                .and_then(|s| {
+                    s.try_into_inner(decoders).map_err(|e| {
+                        FederationError::general(
+                            SESSION_STATUS_V2_ENDPOINT.to_string(),
+                            params.clone(),
+                            FederationGeneralError::Decode(e),
+                        )
+                    })
+                });
+
+            match decoded {
                 Ok(SessionStatusV2::Complete(signed_session_outcome)) => {
                     if signed_session_outcome.verify(broadcast_public_keys, block_index) {
                         // early return
@@ -177,7 +191,11 @@ where
                             signed_session_outcome.session_outcome,
                         ));
                     }
-                    last_error = Some(format_err!("Invalid signature"));
+                    last_error = Some(FederationError::general(
+                        SESSION_STATUS_V2_ENDPOINT.to_string(),
+                        params.clone(),
+                        FederationGeneralError::InvalidSignature,
+                    ));
                 }
                 Ok(SessionStatusV2::Initial | SessionStatusV2::Pending(..)) => {
                     // no signature: use fallback method
@@ -197,19 +215,28 @@ where
         &self,
         block_index: u64,
         decoders: &ModuleDecoderRegistry,
-    ) -> anyhow::Result<SessionStatus> {
+    ) -> FederationResult<SessionStatus> {
         if block_index.is_multiple_of(100) {
             debug!(target: LOG_CLIENT_NET_API, block_index, "Get session status raw v1");
         } else {
             trace!(target: LOG_CLIENT_NET_API, block_index, "Get session status raw v1");
         }
-        self.request_current_consensus::<SerdeModuleEncoding<SessionStatus>>(
-            SESSION_STATUS_ENDPOINT.to_string(),
-            ApiRequestErased::new(block_index),
-        )
-        .await?
-        .try_into_inner(&decoders.clone().with_fallback())
-        .map_err(|e| anyhow!(e))
+        let response = self
+            .request_current_consensus::<SerdeModuleEncoding<SessionStatus>>(
+                SESSION_STATUS_ENDPOINT.to_string(),
+                ApiRequestErased::new(block_index),
+            )
+            .await?;
+
+        response
+            .try_into_inner(&decoders.clone().with_fallback())
+            .map_err(|e| {
+                FederationError::general(
+                    SESSION_STATUS_ENDPOINT.to_string(),
+                    ApiRequestErased::new(block_index),
+                    FederationGeneralError::Decode(e),
+                )
+            })
     }
 }
 
@@ -262,7 +289,7 @@ where
         &self,
         session_idx: u64,
         decoders: &ModuleDecoderRegistry,
-    ) -> anyhow::Result<SessionOutcome> {
+    ) -> FederationResult<SessionOutcome> {
         let mut lru_lock = self.await_session_lru.lock().await;
 
         let entry_arc = lru_lock
@@ -284,11 +311,11 @@ where
         decoders: &ModuleDecoderRegistry,
         core_api_version: ApiVersion,
         broadcast_public_keys: Option<&BTreeMap<PeerId, secp256k1::PublicKey>>,
-    ) -> anyhow::Result<SessionStatus> {
+    ) -> FederationResult<SessionStatus> {
         enum NoCacheErr {
             Initial,
             Pending(Vec<AcceptedItem>),
-            Err(anyhow::Error),
+            Err(FederationError),
         }
 
         let mut lru_lock = self.get_session_status_lru.lock().await;

--- a/fedimint-api-client/src/api/mod.rs
+++ b/fedimint-api-client/src/api/mod.rs
@@ -10,7 +10,9 @@ use std::sync::Arc;
 
 use anyhow::anyhow;
 use bitcoin::secp256k1;
-pub use error::{FederationError, FederationGeneralError, OutputOutcomeError};
+pub use error::{
+    ClientConfigDownloadError, FederationError, FederationGeneralError, OutputOutcomeError,
+};
 pub use fedimint_connectors::ServerResult;
 pub use fedimint_connectors::error::ServerError;
 use fedimint_connectors::{

--- a/fedimint-api-client/src/api/mod.rs
+++ b/fedimint-api-client/src/api/mod.rs
@@ -447,28 +447,26 @@ impl DynGlobalApi {
         connectors: ConnectorRegistry,
         peers: BTreeMap<PeerId, SafeUrl>,
         api_secret: Option<&str>,
-    ) -> anyhow::Result<Self> {
-        Ok(GlobalFederationApiWithCache::new(FederationApi::new(
-            connectors, peers, None, api_secret,
-        ))
-        .into())
+    ) -> Self {
+        GlobalFederationApiWithCache::new(FederationApi::new(connectors, peers, None, api_secret))
+            .into()
     }
     pub fn new_admin(
         connectors: ConnectorRegistry,
         peer: PeerId,
         url: SafeUrl,
         api_secret: Option<&str>,
-    ) -> anyhow::Result<DynGlobalApi> {
-        Ok(GlobalFederationApiWithCache::new(FederationApi::new(
+    ) -> DynGlobalApi {
+        GlobalFederationApiWithCache::new(FederationApi::new(
             connectors,
             [(peer, url)].into(),
             Some(peer),
             api_secret,
         ))
-        .into())
+        .into()
     }
 
-    pub fn new_admin_setup(connectors: ConnectorRegistry, url: SafeUrl) -> anyhow::Result<Self> {
+    pub fn new_admin_setup(connectors: ConnectorRegistry, url: SafeUrl) -> Self {
         // PeerIds are used only for informational purposes, but just in case, make a
         // big number so it stands out
         Self::new_admin(

--- a/fedimint-api-client/src/api/mod.rs
+++ b/fedimint-api-client/src/api/mod.rs
@@ -8,7 +8,7 @@ use std::pin::Pin;
 use std::result;
 use std::sync::Arc;
 
-use anyhow::{Context, anyhow};
+use anyhow::anyhow;
 use bitcoin::secp256k1;
 pub use error::{FederationError, OutputOutcomeError};
 pub use fedimint_connectors::ServerResult;
@@ -148,7 +148,7 @@ pub trait FederationApiExt: IRawFederationApi {
             .await
             .and_then(|v| {
                 serde_json::from_value(v)
-                    .map_err(|e| ServerError::ResponseDeserialization(e.into()))
+                    .map_err(|e| ServerError::ResponseDeserialization(Box::new(e)))
             })
     }
 
@@ -165,7 +165,7 @@ pub trait FederationApiExt: IRawFederationApi {
             .await
             .and_then(|v| {
                 serde_json::from_value(v)
-                    .map_err(|e| ServerError::ResponseDeserialization(e.into()))
+                    .map_err(|e| ServerError::ResponseDeserialization(Box::new(e)))
             })
             .map_err(|e| error::FederationError::new_one_peer(peer_id, method, params, e))
     }
@@ -703,9 +703,7 @@ impl FederationApi {
             .ok_or_else(|| ServerError::InvalidPeerId { peer_id: peer })?;
         let conn = self
             .get_or_create_connection(url, self.api_secret.as_deref())
-            .await
-            .context("Failed to connect to peer")
-            .map_err(ServerError::Connection)?;
+            .await?;
 
         let method_str = method.to_string();
         let peer_str = peer.to_string();

--- a/fedimint-api-client/src/api/mod.rs
+++ b/fedimint-api-client/src/api/mod.rs
@@ -491,7 +491,7 @@ pub trait IGlobalFederationApi: IRawFederationApi {
         &self,
         block_index: u64,
         decoders: &ModuleDecoderRegistry,
-    ) -> anyhow::Result<SessionOutcome>;
+    ) -> FederationResult<SessionOutcome>;
 
     async fn get_session_status(
         &self,
@@ -499,7 +499,7 @@ pub trait IGlobalFederationApi: IRawFederationApi {
         decoders: &ModuleDecoderRegistry,
         core_api_version: ApiVersion,
         broadcast_public_keys: Option<&BTreeMap<PeerId, secp256k1::PublicKey>>,
-    ) -> anyhow::Result<SessionStatus>;
+    ) -> FederationResult<SessionStatus>;
 
     async fn session_count(&self) -> FederationResult<u64>;
 

--- a/fedimint-api-client/src/api/mod.rs
+++ b/fedimint-api-client/src/api/mod.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 use anyhow::anyhow;
 use bitcoin::secp256k1;
-pub use error::{FederationError, OutputOutcomeError};
+pub use error::{FederationError, FederationGeneralError, OutputOutcomeError};
 pub use fedimint_connectors::ServerResult;
 pub use fedimint_connectors::error::ServerError;
 use fedimint_connectors::{
@@ -391,7 +391,7 @@ pub trait FederationApiExt: IRawFederationApi {
             return Err(FederationError::general(
                 method,
                 params,
-                anyhow::format_err!("Admin peer_id not set"),
+                FederationGeneralError::AdminPeerIdNotSet,
             ));
         };
 
@@ -411,7 +411,7 @@ pub trait FederationApiExt: IRawFederationApi {
             return Err(FederationError::general(
                 method,
                 params,
-                anyhow::format_err!("Admin peer_id not set"),
+                FederationGeneralError::AdminPeerIdNotSet,
             ));
         };
 

--- a/fedimint-api-client/src/api/mod.rs
+++ b/fedimint-api-client/src/api/mod.rs
@@ -616,18 +616,18 @@ pub fn deserialize_outcome<R>(
 where
     R: OutputOutcome + MaybeSend,
 {
-    let dyn_outcome = outcome
-        .try_into_inner_known_module_kind(module_decoder)
-        .map_err(|e| OutputOutcomeError::ResponseDeserialization(e.into()))?;
+    let dyn_outcome = outcome.try_into_inner_known_module_kind(module_decoder)?;
 
-    let source_instance = dyn_outcome.module_instance_id();
+    let module_instance_id = dyn_outcome.module_instance_id();
 
-    dyn_outcome.as_any().downcast_ref().cloned().ok_or_else(|| {
-        let target_type = std::any::type_name::<R>();
-        OutputOutcomeError::ResponseDeserialization(anyhow!(
-            "Could not downcast output outcome with instance id {source_instance} to {target_type}"
-        ))
-    })
+    dyn_outcome
+        .as_any()
+        .downcast_ref()
+        .cloned()
+        .ok_or(OutputOutcomeError::WrongOutcomeType {
+            module_instance_id,
+            expected_type: std::any::type_name::<R>(),
+        })
 }
 
 /// Federation API client

--- a/fedimint-api-client/src/api/tests.rs
+++ b/fedimint-api-client/src/api/tests.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::error::Error as _;
 use std::str::FromStr as _;
 
 use fedimint_core::config::FederationId;
@@ -6,7 +7,7 @@ use fedimint_core::invite_code::InviteCode;
 use fedimint_core::util::SafeUrl;
 use fedimint_core::{NumPeersExt as _, PeerId};
 
-use crate::api::{FederationError, FederationGeneralError};
+use crate::api::{ClientConfigDownloadError, FederationError, FederationGeneralError};
 
 #[test]
 fn converts_invite_code() {
@@ -59,4 +60,37 @@ fn a_general_federation_error_keeps_its_condition() {
         "{err:?}"
     );
     assert!(err.to_string().contains("Admin peer id not set"), "{err}");
+}
+
+#[test]
+fn a_federation_id_mismatch_names_both_ids() {
+    let expected = FederationId::dummy();
+    let found =
+        FederationId::from_str("0000000000000000000000000000000000000000000000000000000000000001")
+            .expect("parses");
+    let err = ClientConfigDownloadError::FederationIdMismatch { expected, found };
+
+    assert!(
+        matches!(err, ClientConfigDownloadError::FederationIdMismatch { .. }),
+        "{err:?}"
+    );
+    let msg = err.to_string();
+    assert!(msg.contains(&expected.to_string()), "{msg}");
+    assert!(msg.contains(&found.to_string()), "{msg}");
+}
+
+#[test]
+fn a_download_error_keeps_the_federation_cause() {
+    let cause =
+        FederationError::general("some_method", (), FederationGeneralError::AdminPeerIdNotSet);
+    let cause_msg = cause.to_string();
+    let err = ClientConfigDownloadError::from(cause);
+
+    assert!(
+        matches!(err, ClientConfigDownloadError::Federation(_)),
+        "{err:?}"
+    );
+    // The variant's own message must not repeat what its source already says.
+    assert!(!err.to_string().contains("Admin peer id not set"), "{err}");
+    assert_eq!(err.source().expect("has a source").to_string(), cause_msg);
 }

--- a/fedimint-api-client/src/api/tests.rs
+++ b/fedimint-api-client/src/api/tests.rs
@@ -6,6 +6,8 @@ use fedimint_core::invite_code::InviteCode;
 use fedimint_core::util::SafeUrl;
 use fedimint_core::{NumPeersExt as _, PeerId};
 
+use crate::api::{FederationError, FederationGeneralError};
+
 #[test]
 fn converts_invite_code() {
     let connect = InviteCode::new(
@@ -43,4 +45,18 @@ fn creates_essential_guardians_invite_code() {
     let expected_map: BTreeMap<PeerId, SafeUrl> =
         peer_to_url_map.into_iter().take(max_size).collect();
     assert_eq!(expected_map, code.peers());
+}
+
+#[test]
+fn a_general_federation_error_keeps_its_condition() {
+    let err =
+        FederationError::general("some_method", (), FederationGeneralError::AdminPeerIdNotSet);
+    assert!(
+        matches!(
+            err.get_general_error(),
+            Some(FederationGeneralError::AdminPeerIdNotSet)
+        ),
+        "{err:?}"
+    );
+    assert!(err.to_string().contains("Admin peer id not set"), "{err}");
 }

--- a/fedimint-api-client/src/lib.rs
+++ b/fedimint-api-client/src/lib.rs
@@ -71,9 +71,9 @@ pub async fn try_download_client_config(
     // TODO: use new download approach based on guardian PKs
     let query_strategy = FilterMap::new(move |cfg: ClientConfig| {
         if federation_id != cfg.global.calculate_federation_id() {
-            return Err(ServerError::ConditionFailed(anyhow::anyhow!(
-                "FederationId in invite code does not match client config"
-            )));
+            return Err(ServerError::ConditionFailed(
+                "FederationId in invite code does not match client config".to_string(),
+            ));
         }
 
         Ok(cfg.global.api_endpoints)

--- a/fedimint-api-client/src/lib.rs
+++ b/fedimint-api-client/src/lib.rs
@@ -41,7 +41,7 @@ pub async fn download_from_invite_code(
         endpoints.clone(),
         invite.peers(),
         invite.api_secret().as_deref(),
-    )?;
+    );
     let api_secret = invite.api_secret();
 
     fedimint_core::util::retry(
@@ -95,7 +95,7 @@ pub async fn try_download_client_config(
 
     debug!(target: LOG_CLIENT_NET, "Verifying client config with all peers");
 
-    let api_full = DynGlobalApi::new(endpoints.clone(), api_endpoints, api_secret.as_deref())?;
+    let api_full = DynGlobalApi::new(endpoints.clone(), api_endpoints, api_secret.as_deref());
     let client_config = api_full
         .request_current_consensus::<ClientConfig>(
             CLIENT_CONFIG_ENDPOINT.to_owned(),

--- a/fedimint-api-client/src/lib.rs
+++ b/fedimint-api-client/src/lib.rs
@@ -5,7 +5,6 @@
 #![allow(clippy::must_use_candidate)]
 #![allow(clippy::return_self_not_must_use)]
 
-use anyhow::{Context as _, bail};
 use api::{DynGlobalApi, FederationApiExt as _};
 use fedimint_connectors::ConnectorRegistry;
 use fedimint_connectors::error::ServerError;
@@ -18,6 +17,8 @@ use fedimint_logging::LOG_CLIENT_NET;
 use query::FilterMap;
 use tracing::debug;
 
+use crate::api::ClientConfigDownloadError;
+
 pub mod api;
 pub mod metrics;
 /// Client query system
@@ -28,7 +29,7 @@ pub mod query;
 pub async fn download_from_invite_code(
     endpoints: &ConnectorRegistry,
     invite: &InviteCode,
-) -> anyhow::Result<(ClientConfig, DynGlobalApi)> {
+) -> Result<(ClientConfig, DynGlobalApi), ClientConfigDownloadError> {
     debug!(
         target: LOG_CLIENT_NET,
         %invite,
@@ -57,7 +58,6 @@ pub async fn download_from_invite_code(
         },
     )
     .await
-    .context("Failed to download client config")
 }
 
 /// Tries to download the [`ClientConfig`] only once.
@@ -66,7 +66,7 @@ pub async fn try_download_client_config(
     api_from_invite: &DynGlobalApi,
     federation_id: FederationId,
     api_secret: Option<String>,
-) -> anyhow::Result<(ClientConfig, DynGlobalApi)> {
+) -> Result<(ClientConfig, DynGlobalApi), ClientConfigDownloadError> {
     debug!(target: LOG_CLIENT_NET, "Downloading client config from peer");
     // TODO: use new download approach based on guardian PKs
     let query_strategy = FilterMap::new(move |cfg: ClientConfig| {
@@ -103,8 +103,12 @@ pub async fn try_download_client_config(
         )
         .await?;
 
-    if client_config.calculate_federation_id() != federation_id {
-        bail!("Obtained client config has different federation id");
+    let found = client_config.calculate_federation_id();
+    if found != federation_id {
+        return Err(ClientConfigDownloadError::FederationIdMismatch {
+            expected: federation_id,
+            found,
+        });
     }
 
     Ok((client_config, api_full))

--- a/fedimint-api-client/src/query.rs
+++ b/fedimint-api-client/src/query.rs
@@ -147,7 +147,7 @@ impl<R: Eq + Clone> QueryStrategy<R> for ThresholdConsensus<R> {
 
 #[cfg(test)]
 fn dead_peer() -> ServerError {
-    ServerError::Connection(anyhow::anyhow!("peer is unreachable"))
+    ServerError::Connection("peer is unreachable".into())
 }
 
 #[test]

--- a/fedimint-bitcoind/Cargo.toml
+++ b/fedimint-bitcoind/Cargo.toml
@@ -20,7 +20,6 @@ name = "fedimint_bitcoind"
 path = "src/lib.rs"
 
 [dependencies]
-anyhow = { workspace = true }
 async-trait = { workspace = true }
 bitcoin = { workspace = true }
 bitcoincore-rpc = { workspace = true, optional = true }
@@ -28,6 +27,7 @@ esplora-client = { workspace = true }
 fedimint-core = { workspace = true }
 fedimint-logging = { workspace = true }
 fedimint-metrics = { workspace = true }
+thiserror = { workspace = true }
 tracing = { workspace = true }
 
 [lints]

--- a/fedimint-bitcoind/src/bitcoincore.rs
+++ b/fedimint-bitcoind/src/bitcoincore.rs
@@ -11,7 +11,7 @@ use fedimint_core::{apply, async_trait_maybe_send};
 use fedimint_logging::LOG_BITCOIND_CORE;
 use tracing::{debug, warn};
 
-use crate::{BlockchainInfo, IBitcoindRpc, format_err};
+use crate::{BitcoinRpcError, BlockchainInfo, IBitcoindRpc};
 
 #[derive(Debug)]
 pub struct BitcoindClient {
@@ -26,7 +26,7 @@ impl BitcoindClient {
         password: String,
         wallet_name: &str,
         network: bitcoin::Network,
-    ) -> anyhow::Result<Self> {
+    ) -> Result<Self, BitcoinRpcError> {
         let auth = Auth::UserPass(username, password);
         let url_str = if let Some(port) = url.port() {
             format!(
@@ -43,18 +43,27 @@ impl BitcoindClient {
         };
 
         let default_url_str = format!("{url_str}/wallet/");
-        let default_client = ::bitcoincore_rpc::Client::new(&default_url_str, auth.clone())?;
+        let default_client = ::bitcoincore_rpc::Client::new(&default_url_str, auth.clone())
+            .map_err(|source| BitcoinRpcError::InvalidUrl {
+                url: default_url_str.clone(),
+                source: Box::new(source),
+            })?;
         Self::create_watch_only_wallet(&default_client, wallet_name)?;
 
         let wallet_url_str = format!("{url_str}/wallet/{wallet_name}");
-        let client = ::bitcoincore_rpc::Client::new(&wallet_url_str, auth)?;
+        let client = ::bitcoincore_rpc::Client::new(&wallet_url_str, auth).map_err(|source| {
+            BitcoinRpcError::InvalidUrl {
+                url: wallet_url_str.clone(),
+                source: Box::new(source),
+            }
+        })?;
         Ok(Self { client, network })
     }
 
     fn create_watch_only_wallet(
         client: &::bitcoincore_rpc::Client,
         wallet_name: &str,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), BitcoinRpcError> {
         let create_wallet = block_in_place(|| {
             client.create_wallet(wallet_name, Some(true), Some(true), None, None)
         });
@@ -65,33 +74,43 @@ impl BitcoindClient {
                 // Wallet already exists → treat as success
                 Ok(())
             }
-            Err(e) => Err(e.into()),
+            Err(e) => Err(BitcoinRpcError::Backend(Box::new(e))),
         }
     }
 }
 
 #[apply(async_trait_maybe_send!)]
 impl IBitcoindRpc for BitcoindClient {
-    async fn get_tx_block_height(&self, txid: &Txid) -> anyhow::Result<Option<u64>> {
+    async fn get_tx_block_height(&self, txid: &Txid) -> Result<Option<u64>, BitcoinRpcError> {
         let info = block_in_place(|| self.client.get_transaction(txid, Some(true)))
             .map_err(|err| warn!(target: LOG_BITCOIND_CORE, err = %err.fmt_compact(), "Unable to get transaction"));
         let height = match info.ok().and_then(|info| info.info.blockhash) {
             None => None,
-            Some(hash) => Some(block_in_place(|| self.client.get_block_header_info(&hash))?.height),
+            Some(hash) => Some(
+                block_in_place(|| self.client.get_block_header_info(&hash))
+                    .map_err(|err| BitcoinRpcError::Backend(Box::new(err)))?
+                    .height,
+            ),
         };
         Ok(height.map(|h| h as u64))
     }
 
-    async fn watch_script_history(&self, script: &ScriptBuf) -> anyhow::Result<()> {
-        let address = Address::from_script(script, self.network)?.to_string();
+    async fn watch_script_history(&self, script: &ScriptBuf) -> Result<(), BitcoinRpcError> {
+        let address = Address::from_script(script, self.network)
+            .map_err(|err| BitcoinRpcError::NonStandardScript(Box::new(err)))?
+            .to_string();
         debug!(target: LOG_BITCOIND_CORE, %address, "Watching script history");
 
         // First get the checksum for the descriptor
         let descriptor = format!("addr({address})");
-        let descriptor_info = block_in_place(|| self.client.get_descriptor_info(&descriptor))?;
-        let checksum = descriptor_info
-            .checksum
-            .ok_or(anyhow::anyhow!("No checksum"))?;
+        let descriptor_info = block_in_place(|| self.client.get_descriptor_info(&descriptor))
+            .map_err(|err| BitcoinRpcError::Backend(Box::new(err)))?;
+        let checksum =
+            descriptor_info
+                .checksum
+                .ok_or_else(|| BitcoinRpcError::InvalidResponse {
+                    message: "Descriptor info carries no checksum".to_string(),
+                })?;
 
         // Import the descriptor
         let import_results = block_in_place(|| {
@@ -104,51 +123,61 @@ impl IBitcoindRpc for BitcoindClient {
                 internal: None,
                 label: Some(address.clone()),
             })
-        })?;
+        })
+        .map_err(|err| BitcoinRpcError::Backend(Box::new(err)))?;
 
         // Verify that the import was successful
         if import_results.iter().all(|r| r.success) {
             Ok(())
         } else {
-            Err(anyhow::anyhow!(
-                "Importing descriptor failed: {:?}",
-                import_results
-                    .into_iter()
-                    .filter(|r| !r.success)
-                    .collect::<Vec<_>>()
-            ))
+            Err(BitcoinRpcError::InvalidResponse {
+                message: format!(
+                    "Importing descriptor failed: {:?}",
+                    import_results
+                        .into_iter()
+                        .filter(|r| !r.success)
+                        .collect::<Vec<_>>()
+                ),
+            })
         }
     }
 
     async fn get_script_history(
         &self,
         script: &ScriptBuf,
-    ) -> anyhow::Result<Vec<bitcoin::Transaction>> {
-        let address = Address::from_script(script, self.network)?.to_string();
+    ) -> Result<Vec<bitcoin::Transaction>, BitcoinRpcError> {
+        let address = Address::from_script(script, self.network)
+            .map_err(|err| BitcoinRpcError::NonStandardScript(Box::new(err)))?
+            .to_string();
         let mut results = vec![];
         let list = block_in_place(|| {
             self.client
                 .list_transactions(Some(&address), None, None, Some(true))
-        })?;
+        })
+        .map_err(|err| BitcoinRpcError::Backend(Box::new(err)))?;
         for tx in list {
-            let tx = block_in_place(|| self.client.get_transaction(&tx.info.txid, Some(true)))?;
-            let raw_tx = tx.transaction()?;
+            let tx = block_in_place(|| self.client.get_transaction(&tx.info.txid, Some(true)))
+                .map_err(|err| BitcoinRpcError::Backend(Box::new(err)))?;
+            let raw_tx = tx
+                .transaction()
+                .map_err(|err| BitcoinRpcError::Backend(Box::new(err)))?;
             results.push(raw_tx);
         }
         Ok(results)
     }
 
-    async fn get_txout_proof(&self, txid: Txid) -> anyhow::Result<TxOutProof> {
+    async fn get_txout_proof(&self, txid: Txid) -> Result<TxOutProof, BitcoinRpcError> {
         TxOutProof::consensus_decode_whole(
-            &block_in_place(|| self.client.get_tx_out_proof(&[txid], None))?,
+            &block_in_place(|| self.client.get_tx_out_proof(&[txid], None))
+                .map_err(|err| BitcoinRpcError::Backend(Box::new(err)))?,
             &ModuleDecoderRegistry::default(),
         )
-        .map_err(|error| format_err!("Could not decode tx: {error}"))
+        .map_err(BitcoinRpcError::from)
     }
 
-    async fn get_info(&self) -> anyhow::Result<BlockchainInfo> {
+    async fn get_info(&self) -> Result<BlockchainInfo, BitcoinRpcError> {
         let info = block_in_place(|| self.client.get_blockchain_info())
-            .map_err(|err| anyhow::anyhow!("Unable to get blockchain info {err}"))?;
+            .map_err(|err| BitcoinRpcError::Backend(Box::new(err)))?;
         Ok(BlockchainInfo {
             block_height: info.blocks,
             synced: !info.initial_block_download,

--- a/fedimint-bitcoind/src/bitcoincore.rs
+++ b/fedimint-bitcoind/src/bitcoincore.rs
@@ -172,7 +172,7 @@ impl IBitcoindRpc for BitcoindClient {
                 .map_err(|err| BitcoinRpcError::Backend(Box::new(err)))?,
             &ModuleDecoderRegistry::default(),
         )
-        .map_err(BitcoinRpcError::from)
+        .map_err(BitcoinRpcError::Decode)
     }
 
     async fn get_info(&self) -> Result<BlockchainInfo, BitcoinRpcError> {

--- a/fedimint-bitcoind/src/error.rs
+++ b/fedimint-bitcoind/src/error.rs
@@ -14,7 +14,9 @@ pub enum BitcoinRpcError {
     /// built.
     #[error("Invalid Bitcoin rpc url {url}")]
     InvalidUrl {
-        /// The url that was rejected.
+        /// The url that was rejected, with any credentials redacted, or the
+        /// name of the environment variable it came from when it could
+        /// not be parsed at all.
         url: String,
         /// Why it was rejected.
         #[source]
@@ -52,5 +54,5 @@ pub enum BitcoinRpcError {
 
     /// A response could not be decoded.
     #[error("Failed to decode a Bitcoin rpc response")]
-    Decode(#[from] DecodeError),
+    Decode(#[source] DecodeError),
 }

--- a/fedimint-bitcoind/src/error.rs
+++ b/fedimint-bitcoind/src/error.rs
@@ -1,0 +1,56 @@
+use bitcoin::Txid;
+use fedimint_core::encoding::DecodeError;
+use thiserror::Error;
+
+/// A failure talking to the Bitcoin data source.
+///
+/// `Display` prints only the outermost layer; the backend's own error is
+/// reachable through [`std::error::Error::source`] and printed flat by
+/// [`FmtCompact::fmt_compact`](fedimint_core::util::FmtCompact).
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum BitcoinRpcError {
+    /// The backend url could not be parsed, or a client for it could not be
+    /// built.
+    #[error("Invalid Bitcoin rpc url {url}")]
+    InvalidUrl {
+        /// The url that was rejected.
+        url: String,
+        /// Why it was rejected.
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    /// The backend refused the call or could not be reached.
+    #[error("The Bitcoin rpc backend failed")]
+    Backend(#[source] Box<dyn std::error::Error + Send + Sync>),
+
+    /// The script is not one the backend can watch as an address.
+    #[error("Script is not a standard address")]
+    NonStandardScript(#[source] Box<dyn std::error::Error + Send + Sync>),
+
+    /// The backend answered, but the answer cannot be used.
+    #[error("Invalid Bitcoin rpc response: {message}")]
+    InvalidResponse {
+        /// What is wrong with the response.
+        message: String,
+    },
+
+    /// No merkle proof is available for the transaction.
+    #[error("No merkle proof found for transaction {txid}")]
+    ProofNotFound {
+        /// The transaction the proof was requested for.
+        txid: Txid,
+    },
+
+    /// The script has more history than can be processed in one go.
+    #[error("Script history exceeds the maximum of {max} transactions")]
+    ScriptHistoryTooLong {
+        /// The maximum number of transactions that can be processed.
+        max: usize,
+    },
+
+    /// A response could not be decoded.
+    #[error("Failed to decode a Bitcoin rpc response")]
+    Decode(#[from] DecodeError),
+}

--- a/fedimint-bitcoind/src/lib.rs
+++ b/fedimint-bitcoind/src/lib.rs
@@ -40,8 +40,9 @@ pub struct BlockchainInfo {
 
 pub fn create_esplora_rpc(url: &SafeUrl) -> Result<DynBitcoindRpc, BitcoinRpcError> {
     let url = match env::var(FM_FORCE_BITCOIN_RPC_URL_ENV).ok() {
+        // The raw value may carry credentials, so the error names the variable instead.
         Some(s) => SafeUrl::parse(&s).map_err(|source| BitcoinRpcError::InvalidUrl {
-            url: s,
+            url: format!("${FM_FORCE_BITCOIN_RPC_URL_ENV}"),
             source: Box::new(source),
         })?,
         None => url.clone(),

--- a/fedimint-bitcoind/src/lib.rs
+++ b/fedimint-bitcoind/src/lib.rs
@@ -6,24 +6,25 @@
 #![allow(clippy::module_name_repetitions)]
 #![allow(clippy::similar_names)]
 
+pub mod error;
 pub mod metrics;
 
 use std::env;
 use std::fmt::Debug;
 use std::sync::Arc;
 
-use anyhow::{Result, format_err};
 use bitcoin::{ScriptBuf, Transaction, Txid};
 use esplora_client::{AsyncClient, Builder};
 use fedimint_core::envs::FM_FORCE_BITCOIN_RPC_URL_ENV;
 use fedimint_core::time::now;
 use fedimint_core::txoproof::TxOutProof;
-use fedimint_core::util::{FmtCompactResultAnyhow as _, SafeUrl};
+use fedimint_core::util::{FmtCompactResult as _, SafeUrl};
 use fedimint_core::{apply, async_trait_maybe_send};
 use fedimint_logging::LOG_BITCOIND;
 use fedimint_metrics::HistogramExt as _;
 use tracing::trace;
 
+pub use crate::error::BitcoinRpcError;
 use crate::metrics::{BITCOIND_RPC_DURATION_SECONDS, BITCOIND_RPC_REQUESTS_TOTAL};
 
 const ESPLORA_CLIENT_TIMEOUT_SECONDS: u64 = 60;
@@ -37,12 +38,14 @@ pub struct BlockchainInfo {
     pub synced: bool,
 }
 
-pub fn create_esplora_rpc(url: &SafeUrl) -> Result<DynBitcoindRpc> {
-    let url = env::var(FM_FORCE_BITCOIN_RPC_URL_ENV)
-        .ok()
-        .map(|s| SafeUrl::parse(&s))
-        .transpose()?
-        .unwrap_or_else(|| url.clone());
+pub fn create_esplora_rpc(url: &SafeUrl) -> Result<DynBitcoindRpc, BitcoinRpcError> {
+    let url = match env::var(FM_FORCE_BITCOIN_RPC_URL_ENV).ok() {
+        Some(s) => SafeUrl::parse(&s).map_err(|source| BitcoinRpcError::InvalidUrl {
+            url: s,
+            source: Box::new(source),
+        })?,
+        None => url.clone(),
+    };
 
     Ok(EsploraClient::new(&url)?.into_dyn())
 }
@@ -55,20 +58,23 @@ pub type DynBitcoindRpc = Arc<dyn IBitcoindRpc + Send + Sync>;
 #[apply(async_trait_maybe_send!)]
 pub trait IBitcoindRpc: Debug + Send + Sync + 'static {
     /// If a transaction is included in a block, returns the block height.
-    async fn get_tx_block_height(&self, txid: &Txid) -> Result<Option<u64>>;
+    async fn get_tx_block_height(&self, txid: &Txid) -> Result<Option<u64>, BitcoinRpcError>;
 
     /// Watches for a script and returns any transaction associated with it
-    async fn watch_script_history(&self, script: &ScriptBuf) -> Result<()>;
+    async fn watch_script_history(&self, script: &ScriptBuf) -> Result<(), BitcoinRpcError>;
 
     /// Get script transaction history
-    async fn get_script_history(&self, script: &ScriptBuf) -> Result<Vec<Transaction>>;
+    async fn get_script_history(
+        &self,
+        script: &ScriptBuf,
+    ) -> Result<Vec<Transaction>, BitcoinRpcError>;
 
     /// Returns a proof that a tx is included in the bitcoin blockchain
-    async fn get_txout_proof(&self, txid: Txid) -> Result<TxOutProof>;
+    async fn get_txout_proof(&self, txid: Txid) -> Result<TxOutProof, BitcoinRpcError>;
 
     /// Returns `BlockchainInfo` which contains a subset of info about the chain
     /// data source.
-    async fn get_info(&self) -> Result<BlockchainInfo>;
+    async fn get_info(&self) -> Result<BlockchainInfo, BitcoinRpcError>;
 
     fn into_dyn(self) -> DynBitcoindRpc
     where
@@ -106,7 +112,7 @@ impl BitcoindTracked {
         Self { inner, name }
     }
 
-    fn record_call<T>(&self, method: &str, result: &Result<T>) {
+    fn record_call<T>(&self, method: &str, result: &Result<T, BitcoinRpcError>) {
         let result_label = if result.is_ok() { "success" } else { "error" };
         BITCOIND_RPC_REQUESTS_TOTAL
             .with_label_values(&[method, self.name, result_label])
@@ -139,7 +145,7 @@ macro_rules! tracked_call {
             method = $method,
             name = $self.name,
             duration_ms,
-            error = %result.fmt_compact_result_anyhow(),
+            error = %result.fmt_compact_result(),
             "completed bitcoind rpc"
         );
         result
@@ -148,7 +154,7 @@ macro_rules! tracked_call {
 
 #[apply(async_trait_maybe_send!)]
 impl IBitcoindRpc for BitcoindTracked {
-    async fn get_tx_block_height(&self, txid: &Txid) -> Result<Option<u64>> {
+    async fn get_tx_block_height(&self, txid: &Txid) -> Result<Option<u64>, BitcoinRpcError> {
         tracked_call!(
             self,
             "get_tx_block_height",
@@ -156,7 +162,7 @@ impl IBitcoindRpc for BitcoindTracked {
         )
     }
 
-    async fn watch_script_history(&self, script: &ScriptBuf) -> Result<()> {
+    async fn watch_script_history(&self, script: &ScriptBuf) -> Result<(), BitcoinRpcError> {
         tracked_call!(
             self,
             "watch_script_history",
@@ -164,7 +170,10 @@ impl IBitcoindRpc for BitcoindTracked {
         )
     }
 
-    async fn get_script_history(&self, script: &ScriptBuf) -> Result<Vec<Transaction>> {
+    async fn get_script_history(
+        &self,
+        script: &ScriptBuf,
+    ) -> Result<Vec<Transaction>, BitcoinRpcError> {
         tracked_call!(
             self,
             "get_script_history",
@@ -172,7 +181,7 @@ impl IBitcoindRpc for BitcoindTracked {
         )
     }
 
-    async fn get_txout_proof(&self, txid: Txid) -> Result<TxOutProof> {
+    async fn get_txout_proof(&self, txid: Txid) -> Result<TxOutProof, BitcoinRpcError> {
         tracked_call!(
             self,
             "get_txout_proof",
@@ -180,7 +189,7 @@ impl IBitcoindRpc for BitcoindTracked {
         )
     }
 
-    async fn get_info(&self) -> Result<BlockchainInfo> {
+    async fn get_info(&self) -> Result<BlockchainInfo, BitcoinRpcError> {
         tracked_call!(self, "get_info", self.inner.get_info().await)
     }
 }
@@ -191,10 +200,14 @@ pub struct EsploraClient {
 }
 
 impl EsploraClient {
-    pub fn new(url: &SafeUrl) -> anyhow::Result<Self> {
+    pub fn new(url: &SafeUrl) -> Result<Self, BitcoinRpcError> {
         let client = Builder::new(url.as_str().trim_end_matches('/'))
             .timeout(ESPLORA_CLIENT_TIMEOUT_SECONDS)
-            .build_async()?;
+            .build_async()
+            .map_err(|source| BitcoinRpcError::InvalidUrl {
+                url: url.to_string(),
+                source: Box::new(source),
+            })?;
 
         Ok(Self { client })
     }
@@ -202,16 +215,17 @@ impl EsploraClient {
 
 #[apply(async_trait_maybe_send!)]
 impl IBitcoindRpc for EsploraClient {
-    async fn get_tx_block_height(&self, txid: &Txid) -> anyhow::Result<Option<u64>> {
+    async fn get_tx_block_height(&self, txid: &Txid) -> Result<Option<u64>, BitcoinRpcError> {
         Ok(self
             .client
             .get_tx_status(txid)
-            .await?
+            .await
+            .map_err(|err| BitcoinRpcError::Backend(Box::new(err)))?
             .block_height
             .map(u64::from))
     }
 
-    async fn watch_script_history(&self, _: &ScriptBuf) -> anyhow::Result<()> {
+    async fn watch_script_history(&self, _: &ScriptBuf) -> Result<(), BitcoinRpcError> {
         // no watching needed, has all the history already
         Ok(())
     }
@@ -219,14 +233,18 @@ impl IBitcoindRpc for EsploraClient {
     async fn get_script_history(
         &self,
         script: &ScriptBuf,
-    ) -> anyhow::Result<Vec<bitcoin::Transaction>> {
+    ) -> Result<Vec<bitcoin::Transaction>, BitcoinRpcError> {
         const MAX_TX_HISTORY: usize = 1000;
 
         let mut transactions = Vec::new();
         let mut last_seen: Option<Txid> = None;
 
         loop {
-            let page = self.client.scripthash_txs(script, last_seen).await?;
+            let page = self
+                .client
+                .scripthash_txs(script, last_seen)
+                .await
+                .map_err(|err| BitcoinRpcError::Backend(Box::new(err)))?;
 
             if page.is_empty() {
                 break;
@@ -237,9 +255,9 @@ impl IBitcoindRpc for EsploraClient {
             }
 
             if transactions.len() >= MAX_TX_HISTORY {
-                return Err(format_err!(
-                    "Script history exceeds maximum limit of {MAX_TX_HISTORY}"
-                ));
+                return Err(BitcoinRpcError::ScriptHistoryTooLong {
+                    max: MAX_TX_HISTORY,
+                });
             }
 
             last_seen = Some(page.last().expect("page not empty").txid);
@@ -248,12 +266,13 @@ impl IBitcoindRpc for EsploraClient {
         Ok(transactions)
     }
 
-    async fn get_txout_proof(&self, txid: Txid) -> anyhow::Result<TxOutProof> {
+    async fn get_txout_proof(&self, txid: Txid) -> Result<TxOutProof, BitcoinRpcError> {
         let proof = self
             .client
             .get_merkle_block(&txid)
-            .await?
-            .ok_or(format_err!("No merkle proof found"))?;
+            .await
+            .map_err(|err| BitcoinRpcError::Backend(Box::new(err)))?
+            .ok_or(BitcoinRpcError::ProofNotFound { txid })?;
 
         Ok(TxOutProof {
             block_header: proof.header,
@@ -261,8 +280,12 @@ impl IBitcoindRpc for EsploraClient {
         })
     }
 
-    async fn get_info(&self) -> anyhow::Result<BlockchainInfo> {
-        let height = self.client.get_height().await?;
+    async fn get_info(&self) -> Result<BlockchainInfo, BitcoinRpcError> {
+        let height = self
+            .client
+            .get_height()
+            .await
+            .map_err(|err| BitcoinRpcError::Backend(Box::new(err)))?;
         Ok(BlockchainInfo {
             block_height: u64::from(height),
             synced: true,

--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -365,11 +365,11 @@ impl Opts {
     }
 
     async fn make_endpoints(&self) -> Result<ConnectorRegistry, anyhow::Error> {
-        ConnectorRegistry::build_from_client_defaults()
+        Ok(ConnectorRegistry::build_from_client_defaults()
             .iroh_pkarr_dht(self.iroh_enable_dht())
             .ws_force_tor(self.use_tor())
             .bind()
-            .await
+            .await)
     }
 
     fn auth(&self) -> CliResult<ApiAuth> {

--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -349,7 +349,7 @@ impl Opts {
             });
         };
 
-        DynGlobalApi::new_admin(
+        Ok(DynGlobalApi::new_admin(
             self.make_endpoints().await.map_err(|e| CliError {
                 error: e.to_string(),
             })?,
@@ -360,8 +360,7 @@ impl Opts {
                 .context("Our peer URL not found in config")
                 .map_err_cli()?,
             api_secret,
-        )
-        .map_err_cli()
+        ))
     }
 
     async fn make_endpoints(&self) -> Result<ConnectorRegistry, anyhow::Error> {
@@ -1239,8 +1238,7 @@ impl FedimintCli {
                         .get_value(&ApiSecretKey)
                         .await
                         .as_deref(),
-                )
-                .map_err_cli()?;
+                );
 
                 // Use the `auth` endpoint to verify credentials
                 admin_api.auth(auth.clone()).await.map_err(|e| CliError {
@@ -1914,7 +1912,7 @@ impl FedimintCli {
         args: SetupAdminArgs,
     ) -> anyhow::Result<Value> {
         let client =
-            DynGlobalApi::new_admin_setup(cli.make_endpoints().await?, args.endpoint.clone())?;
+            DynGlobalApi::new_admin_setup(cli.make_endpoints().await?, args.endpoint.clone());
 
         match &args.subcommand {
             SetupAdminCmd::Status => {

--- a/fedimint-client-module/src/module/init/recovery.rs
+++ b/fedimint-client-module/src/module/init/recovery.rs
@@ -15,7 +15,7 @@ use fedimint_core::module::{ApiVersion, ModuleCommon};
 use fedimint_core::session_outcome::{AcceptedItem, SessionStatus};
 use fedimint_core::task::{MaybeSend, MaybeSync, ShuttingDownError, TaskGroup};
 use fedimint_core::transaction::Transaction;
-use fedimint_core::util::FmtCompactAnyhow as _;
+use fedimint_core::util::FmtCompact as _;
 use fedimint_core::{Amount, OutPoint, PeerId, apply, async_trait_maybe_send};
 use fedimint_logging::LOG_CLIENT_RECOVERY;
 use futures::{Stream, StreamExt as _};
@@ -309,7 +309,7 @@ where
                                     Err(err) => {
                                         const MAX_SLEEP: Duration = Duration::from_mins(2);
 
-                                        warn!(target: LOG_CLIENT_RECOVERY, err = %err.fmt_compact_anyhow(), session_idx, "Error trying to fetch signed block");
+                                        warn!(target: LOG_CLIENT_RECOVERY, err = %err.fmt_compact(), session_idx, "Error trying to fetch signed block");
                                         // We don't want PARALLELISM_LEVEL tasks hammering Federation
                                         // with requests, so max sleep is significant
                                         if retry_sleep <= MAX_SLEEP {

--- a/fedimint-client-wasm/src/lib.rs
+++ b/fedimint-client-wasm/src/lib.rs
@@ -59,8 +59,7 @@ impl RpcHandler {
         let database = Database::new(cursed_db, Default::default());
         let connectors = fedimint_connectors::ConnectorRegistry::build_from_client_defaults()
             .bind()
-            .await
-            .map_err(|err| JsError::new(&format!("Failed to bind client connectors: {err:#}")))?;
+            .await;
 
         let state = Arc::new(RpcGlobalState::new(connectors, database));
 

--- a/fedimint-client/src/api_announcements.rs
+++ b/fedimint-client/src/api_announcements.rs
@@ -14,7 +14,7 @@ use fedimint_core::net::guardian_metadata::SignedGuardianMetadata;
 use fedimint_core::runtime::{self, sleep};
 use fedimint_core::secp256k1::SECP256K1;
 use fedimint_core::util::backoff_util::custom_backoff;
-use fedimint_core::util::{FmtCompactAnyhow as _, SafeUrl};
+use fedimint_core::util::{FmtCompact as _, FmtCompactAnyhow as _, SafeUrl};
 use fedimint_core::{NumPeersExt as _, PeerId, impl_db_lookup, impl_db_record};
 use fedimint_logging::LOG_CLIENT;
 use futures::stream::{FuturesUnordered, StreamExt as _};
@@ -296,7 +296,7 @@ pub async fn get_api_urls(
                             warn!(
                                 target: LOG_CLIENT,
                                 %peer_id,
-                                err = %err.fmt_compact_anyhow(),
+                                err = %err.fmt_compact(),
                                 "Ignoring peer with invalid advertised iroh-next endpoint",
                             );
                             return None;

--- a/fedimint-client/src/client/builder.rs
+++ b/fedimint-client/src/client/builder.rs
@@ -1564,7 +1564,7 @@ impl ClientPreview {
                 .map(|(peer_id, peer_url)| (*peer_id, peer_url.url.clone()))
                 .collect(),
             self.api_secret.as_deref(),
-        )?;
+        );
 
         Client::download_backup_from_federation_static(
             &api,

--- a/fedimint-client/src/client/tests.rs
+++ b/fedimint-client/src/client/tests.rs
@@ -172,7 +172,7 @@ async fn client_for_recovery_test(
         modules: ClientModuleRegistry::default(),
         module_inits: ModuleInitRegistry::new(),
         executor,
-        api: DynGlobalApi::new(connectors, BTreeMap::new(), None).expect("Global API must build"),
+        api: DynGlobalApi::new(connectors, BTreeMap::new(), None),
         root_secret: DerivableSecret::new_root(&[0; 32], &[0; 32]),
         operation_log: OperationLog::new(db),
         secp_ctx: Secp256k1::new(),

--- a/fedimint-client/src/client/tests.rs
+++ b/fedimint-client/src/client/tests.rs
@@ -145,8 +145,7 @@ async fn client_for_recovery_test(
     let federation_id = config.calculate_federation_id();
     let connectors = ConnectorRegistry::build_from_testing_defaults()
         .bind()
-        .await
-        .expect("Connector registry must build");
+        .await;
     let db = Database::new(MemDatabase::new(), ModuleRegistry::default());
     let task_group = TaskGroup::new();
     let (log_ordering_wakeup_tx, _log_ordering_wakeup_rx) = watch::channel(());

--- a/fedimint-connectors/src/error.rs
+++ b/fedimint-connectors/src/error.rs
@@ -68,62 +68,67 @@ pub enum ServerError {
     /// The response payload was returned successfully but failed to be
     /// deserialized
     #[error("Response deserialization error: {0}")]
-    ResponseDeserialization(anyhow::Error),
+    ResponseDeserialization(Box<dyn std::error::Error + Send + Sync>),
 
     /// The request was addressed to an invalid `peer_id`
     #[error("Invalid peer id: {peer_id}")]
     InvalidPeerId { peer_id: PeerId },
 
     /// The request was addressed to an invalid `url`
+    ///
+    /// The cause is boxed to keep `ServerError` cheap to move.
     #[error("Invalid peer url: {url}")]
-    InvalidPeerUrl { url: SafeUrl, source: anyhow::Error },
+    InvalidPeerUrl {
+        url: SafeUrl,
+        source: Box<ConnectorError>,
+    },
 
     /// The endpoint specification for the peer is invalid (e.g. wrong url)
-    #[error("Invalid endpoint")]
-    InvalidEndpoint(anyhow::Error),
+    #[error("Invalid endpoint: {0}")]
+    InvalidEndpoint(Box<dyn std::error::Error + Send + Sync>),
 
     /// Could not connect
     #[error("Connection failed: {0}")]
-    Connection(anyhow::Error),
+    Connection(Box<dyn std::error::Error + Send + Sync>),
 
     /// Underlying transport failed, in some typical way
     #[error("Transport error: {0}")]
-    Transport(anyhow::Error),
+    Transport(Box<dyn std::error::Error + Send + Sync>),
 
     /// The rpc id (e.g. jsonrpc method name) was not recognized by the peer
     ///
     /// This one is important and sometimes used to detect backward
     /// compatibility capabilities, so transports should properly support
     /// it.
-    #[error("Invalid rpc id")]
-    InvalidRpcId(anyhow::Error),
+    #[error("Invalid rpc id: {0}")]
+    InvalidRpcId(String),
 
     /// Something about the request we've sent was wrong, should not typically
     /// happen
-    #[error("Invalid request")]
-    InvalidRequest(anyhow::Error),
+    #[error("Invalid request: {0}")]
+    InvalidRequest(String),
 
     /// Something about the response was wrong, should not typically happen
     #[error("Invalid response: {0}")]
-    InvalidResponse(anyhow::Error),
+    InvalidResponse(String),
 
     /// Server returned an internal error, suggesting something is wrong with it
     #[error("Unspecified server error: {0}")]
-    ServerError(anyhow::Error),
+    ServerError(String),
 
     /// Some condition on the response this not match
     ///
     /// Typically expected, and often used in `FilterMap` query strategy to
     /// reject responses that don't match some criteria.
     #[error("Unspecified condition error: {0}")]
-    ConditionFailed(anyhow::Error),
+    ConditionFailed(String),
 
     /// An internal client error
     ///
     /// Things that shouldn't happen (better than panicking), logical errors,
     /// malfunctions caused by internal issues.
     #[error("Unspecified internal client error: {0}")]
-    InternalClientError(anyhow::Error),
+    InternalClientError(String),
 }
 
 impl ServerError {

--- a/fedimint-connectors/src/error.rs
+++ b/fedimint-connectors/src/error.rs
@@ -4,6 +4,63 @@ use fedimint_logging::LOG_CLIENT_NET_API;
 use thiserror::Error;
 use tracing::{trace, warn};
 
+/// A failure to build a connector, or to reach a gateway through one.
+///
+/// Peer (guardian) requests report [`ServerError`] instead; this type covers
+/// the connector layer underneath it.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum ConnectorError {
+    /// No connector is registered for the url's scheme.
+    #[error("Unsupported scheme {scheme}; missing endpoint handler")]
+    UnsupportedScheme { scheme: String },
+
+    /// The connector for this scheme was switched off when the registry was
+    /// built.
+    #[error("The {scheme} connector is not enabled")]
+    NotEnabled { scheme: &'static str },
+
+    /// Tor routing was requested from a build that has no Tor support.
+    #[error("Tor was requested, but support for it is not compiled in")]
+    TorNotCompiledIn,
+
+    /// This transport can reach guardians but not gateways.
+    #[error("This transport cannot connect to a gateway")]
+    GatewayUnsupported,
+
+    /// The url carries no host to address.
+    #[error("Missing host in url {url}")]
+    MissingHost { url: SafeUrl },
+
+    /// The url's host is not a valid Iroh node id.
+    #[error("Invalid Iroh node id {host}")]
+    InvalidNodeId {
+        host: String,
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    /// The url could not be parsed.
+    #[error("Invalid url {url}")]
+    InvalidUrl {
+        url: String,
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    /// The Iroh api url path selects a wire version this build does not know.
+    #[error("Unsupported Iroh api url path {path}")]
+    UnsupportedUrlPath { path: String },
+
+    /// The transport refused the connection or failed to start.
+    #[error("Transport failure")]
+    Transport(#[source] Box<dyn std::error::Error + Send + Sync>),
+
+    /// The Tor client could not be bootstrapped.
+    #[error("Failed to bootstrap the Tor client")]
+    Tor(#[source] Box<dyn std::error::Error + Send + Sync>),
+}
+
 /// An API request error when calling a single federation peer
 #[derive(Debug, Error)]
 #[non_exhaustive]

--- a/fedimint-connectors/src/http.rs
+++ b/fedimint-connectors/src/http.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
-use anyhow::anyhow;
-use fedimint_core::util::SafeUrl;
+use fedimint_core::util::{FmtCompact as _, SafeUrl};
 use fedimint_core::{apply, async_trait_maybe_send};
 use reqwest::{Method, StatusCode};
 use serde_json::Value;
@@ -24,9 +23,9 @@ impl crate::Connector for HttpConnector {
         _url: &SafeUrl,
         _api_secret: Option<&str>,
     ) -> ServerResult<DynGuaridianConnection> {
-        Err(ServerError::InternalClientError(anyhow!(
-            "Unsupported transport mechanism"
-        )))
+        Err(ServerError::InternalClientError(
+            "Unsupported transport mechanism".to_string(),
+        ))
     }
 
     async fn connect_gateway(&self, url: &SafeUrl) -> Result<DynGatewayConnection, ConnectorError> {
@@ -90,14 +89,14 @@ impl IGatewayConnection for HttpConnection {
         let response = builder
             .send()
             .await
-            .map_err(|e| ServerError::ServerError(e.into()))?;
+            .map_err(|e| ServerError::ServerError(e.fmt_compact().to_string()))?;
 
         match response.status() {
             StatusCode::OK => Ok(response
                 .json::<Value>()
                 .await
-                .map_err(|e| ServerError::InvalidResponse(e.into()))?),
-            status => Err(ServerError::InvalidRequest(anyhow::anyhow!(
+                .map_err(|e| ServerError::InvalidResponse(e.fmt_compact().to_string()))?),
+            status => Err(ServerError::InvalidRequest(format!(
                 "HTTP request returned unexpected status: {status}"
             ))),
         }

--- a/fedimint-connectors/src/http.rs
+++ b/fedimint-connectors/src/http.rs
@@ -6,7 +6,7 @@ use fedimint_core::{apply, async_trait_maybe_send};
 use reqwest::{Method, StatusCode};
 use serde_json::Value;
 
-use crate::error::ServerError;
+use crate::error::{ConnectorError, ServerError};
 use crate::{
     Connectivity, DynGatewayConnection, DynGuaridianConnection, IConnection, IGatewayConnection,
     ServerResult,
@@ -29,7 +29,7 @@ impl crate::Connector for HttpConnector {
         )))
     }
 
-    async fn connect_gateway(&self, url: &SafeUrl) -> anyhow::Result<DynGatewayConnection> {
+    async fn connect_gateway(&self, url: &SafeUrl) -> Result<DynGatewayConnection, ConnectorError> {
         let http_connection = HttpConnection {
             client: self.client.clone(),
             base_url: url.clone(),

--- a/fedimint-connectors/src/iroh.rs
+++ b/fedimint-connectors/src/iroh.rs
@@ -309,18 +309,18 @@ impl crate::Connector for IrohConnector {
             // There seem to be no way to pass secret over current Iroh calling
             // convention. Connecting anyway would silently drop the credential and
             // talk to an API that never authenticates us, so refuse instead.
-            return Err(ServerError::Connection(anyhow::format_err!(
-                "Iroh api secrets currently not supported"
-            )));
+            return Err(ServerError::Connection(
+                "Iroh api secrets currently not supported".into(),
+            ));
         }
         let node_id =
             Self::node_id_from_url(url).map_err(|source| ServerError::InvalidPeerUrl {
-                source: source.into(),
+                source: Box::new(source),
                 url: url.to_owned(),
             })?;
         let next_only = crate::is_iroh_next_endpoint_url(url).map_err(|source| {
             ServerError::InvalidPeerUrl {
-                source: source.into(),
+                source: Box::new(source),
                 url: url.to_owned(),
             }
         })?;
@@ -390,7 +390,7 @@ impl crate::Connector for IrohConnector {
         }
 
         Err(prev_err.unwrap_or_else(|| {
-            ServerError::ServerError(anyhow::anyhow!("Both iroh connection attempts failed"))
+            ServerError::ServerError("Both iroh connection attempts failed".to_string())
         }))
     }
 
@@ -453,7 +453,7 @@ impl crate::Connector for IrohConnector {
     ) -> ServerResult<Option<IrohPeerInfo>> {
         let node_id =
             Self::node_id_from_url(url).map_err(|source| ServerError::InvalidPeerUrl {
-                source: source.into(),
+                source: Box::new(source),
                 url: url.to_owned(),
             })?;
         let connection_override = self.connection_overrides.get(&node_id).cloned();
@@ -464,7 +464,7 @@ impl crate::Connector for IrohConnector {
         let mut conn_type_watcher = self
             .stable
             .conn_type(node_id)
-            .map_err(ServerError::Connection)?;
+            .map_err(|err| ServerError::Connection(err.into()))?;
         let mut conn_type = conn_type_watcher
             .get()
             .unwrap_or(iroh::endpoint::ConnectionType::None);
@@ -639,7 +639,7 @@ impl IrohConnector {
                 conn
             }
             None => self.stable.connect(node_id, FEDIMINT_API_ALPN).await,
-        }.map_err(ServerError::Connection)?;
+        }.map_err(|err| ServerError::Connection(err.into()))?;
 
         Ok(conn)
     }
@@ -680,8 +680,7 @@ impl IrohConnector {
                 FEDIMINT_API_ALPN
             ).await,
         }
-        .map_err(Into::into)
-        .map_err(ServerError::Connection)?;
+        .map_err(|err| ServerError::Connection(err.into()))?;
 
         // Retain the connection so `connectivity` can read its paths back;
         // iroh 1.0 offers no endpoint-level lookup to recover it from.
@@ -805,17 +804,17 @@ impl IGuardianConnection for Connection {
                     iroh::endpoint::VarInt::from_u32(IROH_REQUEST_TIMEOUT_ERROR_CODE),
                     IROH_REQUEST_TIMEOUT_ERROR_REASON,
                 );
-                return Err(ServerError::Transport(anyhow::anyhow!(
-                    "iroh request {method_str} timed out after {timeout:?}"
-                )));
+                return Err(ServerError::Transport(
+                    format!("iroh request {method_str} timed out after {timeout:?}").into(),
+                ));
             }
         };
 
         // TODO: We should not be serializing Results on the wire
         let response = serde_json::from_slice::<Result<Value, ApiError>>(&response)
-            .map_err(|e| ServerError::InvalidResponse(e.into()))?;
+            .map_err(|e| ServerError::InvalidResponse(e.fmt_compact().to_string()))?;
 
-        response.map_err(|e| ServerError::InvalidResponse(anyhow::anyhow!("Api Error: {:?}", e)))
+        response.map_err(|e| ServerError::InvalidResponse(format!("Api Error: {e:?}")))
     }
 }
 
@@ -872,17 +871,17 @@ impl IGuardianConnection for iroh_next::endpoint::Connection {
                     iroh_next::endpoint::VarInt::from_u32(IROH_REQUEST_TIMEOUT_ERROR_CODE),
                     IROH_REQUEST_TIMEOUT_ERROR_REASON,
                 );
-                return Err(ServerError::Transport(anyhow::anyhow!(
-                    "iroh request {method_str} timed out after {timeout:?}"
-                )));
+                return Err(ServerError::Transport(
+                    format!("iroh request {method_str} timed out after {timeout:?}").into(),
+                ));
             }
         };
 
         // TODO: We should not be serializing Results on the wire
         let response = serde_json::from_slice::<Result<Value, ApiError>>(&response)
-            .map_err(|e| ServerError::InvalidResponse(e.into()))?;
+            .map_err(|e| ServerError::InvalidResponse(e.fmt_compact().to_string()))?;
 
-        response.map_err(|e| ServerError::InvalidResponse(anyhow::anyhow!("Api Error: {:?}", e)))
+        response.map_err(|e| ServerError::InvalidResponse(format!("Api Error: {e:?}")))
     }
 }
 
@@ -920,14 +919,13 @@ impl IGatewayConnection for Connection {
             .map_err(|e| ServerError::Transport(e.into()))?;
 
         let response = serde_json::from_slice::<IrohGatewayResponse>(&response)
-            .map_err(|e| ServerError::InvalidResponse(e.into()))?;
-        match StatusCode::from_u16(response.status).map_err(|e| {
-            ServerError::InvalidResponse(anyhow::anyhow!("Invalid status code: {}", e))
-        })? {
+            .map_err(|e| ServerError::InvalidResponse(e.fmt_compact().to_string()))?;
+        match StatusCode::from_u16(response.status)
+            .map_err(|e| ServerError::InvalidResponse(format!("Invalid status code: {e}")))?
+        {
             StatusCode::OK => Ok(response.body),
-            status => Err(ServerError::ServerError(anyhow::anyhow!(
-                "Server returned status code: {}",
-                status
+            status => Err(ServerError::ServerError(format!(
+                "Server returned status code: {status}"
             ))),
         }
     }

--- a/fedimint-connectors/src/iroh.rs
+++ b/fedimint-connectors/src/iroh.rs
@@ -6,7 +6,6 @@ use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use anyhow::{Context, bail};
 use async_trait::async_trait;
 use fedimint_core::config::ALEPH_BFT_UNIT_BYTE_LIMIT;
 use fedimint_core::envs::{
@@ -89,6 +88,7 @@ use tokio::sync::watch;
 use tracing::{debug, trace, warn};
 
 use super::{DynGuaridianConnection, IGuardianConnection, ServerError, ServerResult};
+use crate::error::ConnectorError;
 use crate::{Connectivity, DynGatewayConnection, IConnection, IGatewayConnection, IrohPeerInfo};
 
 #[derive(Clone)]
@@ -130,7 +130,7 @@ impl fmt::Debug for IrohConnector {
 }
 
 impl IrohConnector {
-    pub async fn new(
+    pub(crate) async fn new(
         iroh_dns: Option<SafeUrl>,
         iroh_enable_dht: bool,
         path_change: Arc<watch::Sender<u64>>,
@@ -156,7 +156,7 @@ impl IrohConnector {
     }
 
     #[allow(clippy::too_many_lines)]
-    pub async fn new_no_overrides(
+    pub(crate) async fn new_no_overrides(
         iroh_dns: Option<SafeUrl>,
         iroh_enable_dht: bool,
         path_change: Arc<watch::Sender<u64>>,
@@ -276,23 +276,25 @@ impl IrohConnector {
         })
     }
 
-    pub fn with_connection_override(mut self, node: NodeId, addr: NodeAddr) -> Self {
+    pub(crate) fn with_connection_override(mut self, node: NodeId, addr: NodeAddr) -> Self {
         self.connection_overrides.insert(node, addr);
         self
     }
 
-    pub fn node_id_from_url(url: &SafeUrl) -> anyhow::Result<NodeId> {
+    pub(crate) fn node_id_from_url(url: &SafeUrl) -> Result<NodeId, ConnectorError> {
         if url.scheme() != "iroh" {
-            bail!(
-                "Unsupported scheme: {}, passed to iroh endpoint handler",
-                url.scheme()
-            );
+            return Err(ConnectorError::UnsupportedScheme {
+                scheme: url.scheme().to_owned(),
+            });
         }
-        let host = url.host_str().context("Missing host string in Iroh URL")?;
+        let host = url.host_str().ok_or_else(|| ConnectorError::MissingHost {
+            url: url.to_owned(),
+        })?;
 
-        let node_id = PublicKey::from_str(host).context("Failed to parse node id")?;
-
-        Ok(node_id)
+        PublicKey::from_str(host).map_err(|source| ConnectorError::InvalidNodeId {
+            host: host.to_owned(),
+            source: Box::new(source),
+        })
     }
 }
 
@@ -313,12 +315,12 @@ impl crate::Connector for IrohConnector {
         }
         let node_id =
             Self::node_id_from_url(url).map_err(|source| ServerError::InvalidPeerUrl {
-                source,
+                source: source.into(),
                 url: url.to_owned(),
             })?;
         let next_only = crate::is_iroh_next_endpoint_url(url).map_err(|source| {
             ServerError::InvalidPeerUrl {
-                source,
+                source: source.into(),
                 url: url.to_owned(),
             }
         })?;
@@ -392,13 +394,14 @@ impl crate::Connector for IrohConnector {
         }))
     }
 
-    async fn connect_gateway(&self, url: &SafeUrl) -> anyhow::Result<DynGatewayConnection> {
+    async fn connect_gateway(&self, url: &SafeUrl) -> Result<DynGatewayConnection, ConnectorError> {
         let node_id = Self::node_id_from_url(url)?;
         if let Some(node_addr) = self.connection_overrides.get(&node_id).cloned() {
             let conn = self
                 .stable
                 .connect(node_addr.clone(), FEDIMINT_GATEWAY_ALPN)
-                .await?;
+                .await
+                .map_err(|err| ConnectorError::Transport(err.into()))?;
 
             #[cfg(not(target_family = "wasm"))]
             Self::spawn_connection_monitoring_stable(
@@ -409,7 +412,11 @@ impl crate::Connector for IrohConnector {
 
             Ok(IGatewayConnection::into_dyn(conn))
         } else {
-            let conn = self.stable.connect(node_id, FEDIMINT_GATEWAY_ALPN).await?;
+            let conn = self
+                .stable
+                .connect(node_id, FEDIMINT_GATEWAY_ALPN)
+                .await
+                .map_err(|err| ConnectorError::Transport(err.into()))?;
             Ok(IGatewayConnection::into_dyn(conn))
         }
     }
@@ -446,7 +453,7 @@ impl crate::Connector for IrohConnector {
     ) -> ServerResult<Option<IrohPeerInfo>> {
         let node_id =
             Self::node_id_from_url(url).map_err(|source| ServerError::InvalidPeerUrl {
-                source,
+                source: source.into(),
                 url: url.to_owned(),
             })?;
         let connection_override = self.connection_overrides.get(&node_id).cloned();
@@ -937,8 +944,10 @@ mod tests {
     use fedimint_core::util::SafeUrl;
 
     use super::{
-        IROH_REQUEST_TIMEOUT_DEFAULT, IROH_REQUEST_TIMEOUT_LONG_POLL, request_timeout_for_method,
+        IROH_REQUEST_TIMEOUT_DEFAULT, IROH_REQUEST_TIMEOUT_LONG_POLL, IrohConnector,
+        request_timeout_for_method,
     };
+    use crate::error::ConnectorError;
     use crate::{iroh_next_endpoint_url, is_iroh_next_endpoint_url, preserve_iroh_next_marker};
 
     const TEST_ENDPOINT_ID: &str =
@@ -967,9 +976,36 @@ mod tests {
     }
 
     #[test]
-    fn unknown_iroh_api_version_path_is_rejected() {
-        let url = SafeUrl::parse(&format!("iroh://{TEST_ENDPOINT_ID}/v2")).expect("valid Iroh URL");
-        assert!(is_iroh_next_endpoint_url(&url).is_err());
+    fn unsupported_iroh_url_path_is_typed() {
+        let url = SafeUrl::parse("iroh://someendpoint/v2").expect("valid url");
+        assert!(
+            matches!(
+                is_iroh_next_endpoint_url(&url),
+                Err(ConnectorError::UnsupportedUrlPath { .. })
+            ),
+            "{:?}",
+            is_iroh_next_endpoint_url(&url)
+        );
+    }
+
+    #[test]
+    fn garbage_endpoint_id_is_an_invalid_node_id() {
+        let err = iroh_next_endpoint_url("not-an-endpoint-id")
+            .expect_err("garbage is not an endpoint id");
+        assert!(
+            matches!(err, ConnectorError::InvalidNodeId { .. }),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn a_non_iroh_url_has_an_unsupported_scheme() {
+        let url = SafeUrl::parse("ws://example.com").expect("valid url");
+        let err = IrohConnector::node_id_from_url(&url).expect_err("ws is not iroh");
+        assert!(
+            matches!(err, ConnectorError::UnsupportedScheme { .. }),
+            "{err:?}"
+        );
     }
 
     /// Every `await_*` endpoint currently exposed by fedimint modules

--- a/fedimint-connectors/src/lib.rs
+++ b/fedimint-connectors/src/lib.rs
@@ -14,14 +14,14 @@ use std::str::FromStr as _;
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::{Context as _, anyhow, bail};
+use anyhow::anyhow;
 use async_trait::async_trait;
 use fedimint_core::envs::{
     FM_WS_API_CONNECT_OVERRIDES_ENV, is_running_in_test_env, parse_kv_list_from_env,
 };
 use fedimint_core::module::{ApiMethod, ApiRequestErased};
 use fedimint_core::util::backoff_util::{FibonacciBackoff, custom_backoff};
-use fedimint_core::util::{FmtCompact, FmtCompactAnyhow, SafeUrl};
+use fedimint_core::util::{FmtCompact, SafeUrl};
 use fedimint_core::{apply, async_trait_maybe_send};
 use fedimint_logging::{LOG_CLIENT_NET_API, LOG_NET};
 use fedimint_metrics::HistogramExt as _;
@@ -30,7 +30,7 @@ use serde_json::Value;
 use tokio::sync::{OnceCell, SetOnce, broadcast, watch};
 use tracing::trace;
 
-use crate::error::ServerError;
+use crate::error::{ConnectorError, ServerError};
 use crate::metrics::{CONNECTION_ATTEMPTS_TOTAL, CONNECTION_DURATION_SECONDS};
 use crate::ws::WebsocketConnector;
 
@@ -41,18 +41,27 @@ const IROH_NEXT_PATH: &str = "/v1";
 /// The `/v1` path is an internal transport-selection marker. It prevents the
 /// connector from attempting Iroh 0.35 against an Iroh 1.0-only identity,
 /// avoiding both an inappropriate connection attempt and its overhead.
-pub fn iroh_next_endpoint_url(endpoint: &str) -> anyhow::Result<SafeUrl> {
-    let endpoint_id =
-        iroh_next::EndpointId::from_str(endpoint).context("Invalid Iroh 1.0 endpoint ID")?;
-    SafeUrl::parse(&format!("iroh://{endpoint_id}{IROH_NEXT_PATH}"))
-        .context("Invalid Iroh 1.0 endpoint URL")
+pub fn iroh_next_endpoint_url(endpoint: &str) -> Result<SafeUrl, ConnectorError> {
+    let endpoint_id = iroh_next::EndpointId::from_str(endpoint).map_err(|source| {
+        ConnectorError::InvalidNodeId {
+            host: endpoint.to_owned(),
+            source: Box::new(source),
+        }
+    })?;
+    let url = format!("iroh://{endpoint_id}{IROH_NEXT_PATH}");
+    SafeUrl::parse(&url).map_err(|source| ConnectorError::InvalidUrl {
+        url,
+        source: Box::new(source),
+    })
 }
 
-fn is_iroh_next_endpoint_url(url: &SafeUrl) -> anyhow::Result<bool> {
+fn is_iroh_next_endpoint_url(url: &SafeUrl) -> Result<bool, ConnectorError> {
     match url.path() {
         "" | "/" => Ok(false),
         IROH_NEXT_PATH => Ok(true),
-        path => bail!("Unsupported Iroh API URL path: {path}"),
+        path => Err(ConnectorError::UnsupportedUrlPath {
+            path: path.to_owned(),
+        }),
     }
 }
 
@@ -75,7 +84,9 @@ pub type ServerResult<T> = Result<T, ServerError>;
 
 /// Type for connector initialization functions
 type ConnectorInitFn = Arc<
-    dyn Fn() -> Pin<Box<dyn Future<Output = anyhow::Result<DynConnector>> + Send>> + Send + Sync,
+    dyn Fn() -> Pin<Box<dyn Future<Output = Result<DynConnector, ConnectorError>> + Send>>
+        + Send
+        + Sync,
 >;
 
 /// Builder for [`ConnectorRegistry`]
@@ -127,7 +138,7 @@ impl ConnectorRegistryBuilder {
         let ws_connector_init = Arc::new(move || {
             let builder = builder_ws.clone();
             Box::pin(async move { builder.build_ws_connector().await })
-                as Pin<Box<dyn Future<Output = anyhow::Result<DynConnector>> + Send>>
+                as Pin<Box<dyn Future<Output = Result<DynConnector, ConnectorError>> + Send>>
         });
         connectors_lazy.insert("ws".into(), (ws_connector_init.clone(), OnceCell::new()));
         connectors_lazy.insert("wss".into(), (ws_connector_init.clone(), OnceCell::new()));
@@ -142,7 +153,9 @@ impl ConnectorRegistryBuilder {
                     let builder = builder_iroh.clone();
                     let path_change = path_change_iroh.clone();
                     Box::pin(async move { builder.build_iroh_connector(path_change).await })
-                        as Pin<Box<dyn Future<Output = anyhow::Result<DynConnector>> + Send>>
+                        as Pin<
+                            Box<dyn Future<Output = Result<DynConnector, ConnectorError>> + Send>,
+                        >
                 }),
                 OnceCell::new(),
             ),
@@ -152,7 +165,7 @@ impl ConnectorRegistryBuilder {
         let http_connector_init = Arc::new(move || {
             let builder = builder_http.clone();
             Box::pin(async move { builder.build_http_connector() })
-                as Pin<Box<dyn Future<Output = anyhow::Result<DynConnector>> + Send>>
+                as Pin<Box<dyn Future<Output = Result<DynConnector, ConnectorError>> + Send>>
         });
 
         connectors_lazy.insert(
@@ -179,19 +192,21 @@ impl ConnectorRegistryBuilder {
     pub async fn build_iroh_connector(
         &self,
         path_change: Arc<watch::Sender<u64>>,
-    ) -> anyhow::Result<DynConnector> {
+    ) -> Result<DynConnector, ConnectorError> {
         if !self.iroh_enable {
-            bail!("Iroh connector not enabled");
+            return Err(ConnectorError::NotEnabled { scheme: "iroh" });
         }
-        Ok(Arc::new(
+        let connector =
             iroh::IrohConnector::new(self.iroh_dns.clone(), self.iroh_pkarr_dht, path_change)
-                .await?,
-        ) as DynConnector)
+                .await
+                .map_err(|err| ConnectorError::Transport(err.into()))?;
+
+        Ok(Arc::new(connector) as DynConnector)
     }
 
-    pub async fn build_ws_connector(&self) -> anyhow::Result<DynConnector> {
+    pub async fn build_ws_connector(&self) -> Result<DynConnector, ConnectorError> {
         if !self.ws_enable {
-            bail!("Websocket connector not enabled");
+            return Err(ConnectorError::NotEnabled { scheme: "ws" });
         }
 
         match self.ws_force_tor {
@@ -204,13 +219,13 @@ impl ConnectorRegistryBuilder {
 
             false => Ok(Arc::new(WebsocketConnector::new()) as DynConnector),
             #[allow(unreachable_patterns)]
-            _ => bail!("Tor requested, but not support not compiled in"),
+            _ => Err(ConnectorError::TorNotCompiledIn),
         }
     }
 
-    pub fn build_http_connector(&self) -> anyhow::Result<DynConnector> {
+    pub fn build_http_connector(&self) -> Result<DynConnector, ConnectorError> {
         if !self.http_enable {
-            bail!("Http connector not enabled");
+            return Err(ConnectorError::NotEnabled { scheme: "http" });
         }
 
         Ok(Arc::new(crate::http::HttpConnector::default()) as DynConnector)
@@ -467,7 +482,7 @@ impl ConnectorRegistry {
             .map_err(|e| {
                 ServerError::Transport(anyhow!(
                     "Connector failed to initialize: {}",
-                    e.fmt_compact_anyhow()
+                    e.fmt_compact()
                 ))
             })?
             .connect_guardian(url, api_secret)
@@ -501,7 +516,10 @@ impl ConnectorRegistry {
     ///
     /// This is the main function consumed by the downstream use for making
     /// connection.
-    pub async fn connect_gateway(&self, url: &SafeUrl) -> anyhow::Result<DynGatewayConnection> {
+    pub async fn connect_gateway(
+        &self,
+        url: &SafeUrl,
+    ) -> Result<DynGatewayConnection, ConnectorError> {
         trace!(
             target: LOG_NET,
             %url,
@@ -526,10 +544,7 @@ impl ConnectorRegistry {
         let scheme = url.scheme().to_string();
 
         let Some(connector_lazy) = self.inner.connectors_lazy.get(&scheme) else {
-            return Err(anyhow!(
-                "Unsupported scheme: {}; missing endpoint handler",
-                url.scheme()
-            ));
+            return Err(ConnectorError::UnsupportedScheme { scheme });
         };
 
         // Clone the init function to use in the async block
@@ -542,13 +557,7 @@ impl ConnectorRegistry {
         let result = connector_lazy
             .1
             .get_or_try_init(|| async move { init_fn().await })
-            .await
-            .map_err(|e| {
-                ServerError::Transport(anyhow!(
-                    "Connector failed to initialize: {}",
-                    e.fmt_compact_anyhow()
-                ))
-            })?
+            .await?
             .connect_gateway(url)
             .await;
 
@@ -606,7 +615,7 @@ impl ConnectorRegistry {
             .map_err(|e| {
                 ServerError::Transport(anyhow!(
                     "Connector failed to initialize: {}",
-                    e.fmt_compact_anyhow()
+                    e.fmt_compact()
                 ))
             })?
             .iroh_peer_info(url, path_timeout)
@@ -635,7 +644,7 @@ pub trait Connector: Send + Sync + 'static + Debug {
         api_secret: Option<&str>,
     ) -> ServerResult<DynGuaridianConnection>;
 
-    async fn connect_gateway(&self, url: &SafeUrl) -> anyhow::Result<DynGatewayConnection>;
+    async fn connect_gateway(&self, url: &SafeUrl) -> Result<DynGatewayConnection, ConnectorError>;
 
     /// Report how a connection to `url` is currently reaching its peer.
     fn connectivity(&self, url: &SafeUrl) -> Connectivity;

--- a/fedimint-connectors/src/lib.rs
+++ b/fedimint-connectors/src/lib.rs
@@ -867,7 +867,7 @@ impl<T: IConnection + ?Sized> ConnectionPool<T> {
                 let _ = leader_tx.send(
                     res.as_ref()
                         .map(|o| o.clone())
-                        .map_err(|err| err.to_string()),
+                        .map_err(|err| err.fmt_compact().to_string()),
                 );
 
                 let conn = res?;

--- a/fedimint-connectors/src/lib.rs
+++ b/fedimint-connectors/src/lib.rs
@@ -121,7 +121,7 @@ pub struct ConnectorRegistryBuilder {
 
 impl ConnectorRegistryBuilder {
     #[allow(clippy::unused_async)] // Leave room for async in the future
-    pub async fn bind(self) -> anyhow::Result<ConnectorRegistry> {
+    pub async fn bind(self) -> ConnectorRegistry {
         let iroh_next = self.iroh_next && self.iroh_enable;
 
         // Create initialization functions for each connector type
@@ -177,7 +177,7 @@ impl ConnectorRegistryBuilder {
             (http_connector_init.clone(), OnceCell::new()),
         );
 
-        Ok(ConnectorRegistry {
+        ConnectorRegistry {
             inner: ConnectorRegistryInner {
                 connectors_lazy,
                 connection_overrides: self.connection_overrides,
@@ -186,7 +186,7 @@ impl ConnectorRegistryBuilder {
                 iroh_next,
             }
             .into(),
-        })
+        }
     }
 
     pub async fn build_iroh_connector(
@@ -269,7 +269,7 @@ impl ConnectorRegistryBuilder {
     }
 
     /// Apply overrides from env variables
-    pub fn with_env_var_overrides(mut self) -> anyhow::Result<Self> {
+    pub fn with_env_var_overrides(mut self) -> Self {
         // TODO: read rest of the env
         for (k, v) in parse_kv_list_from_env::<_, SafeUrl>(FM_WS_API_CONNECT_OVERRIDES_ENV) {
             self = self.with_connection_override(k, v);
@@ -281,7 +281,7 @@ impl ConnectorRegistryBuilder {
             self.iroh_next = false;
         }
 
-        Ok(Self { ..self })
+        self
     }
 
     pub fn with_connection_override(
@@ -400,23 +400,20 @@ impl ConnectorRegistry {
 
     /// Like [`Self::build_from_client_defaults`] build will apply
     /// environment-provided overrides.
-    pub fn build_from_client_env() -> anyhow::Result<ConnectorRegistryBuilder> {
-        let builder = Self::build_from_client_defaults().with_env_var_overrides()?;
-        Ok(builder)
+    pub fn build_from_client_env() -> ConnectorRegistryBuilder {
+        Self::build_from_client_defaults().with_env_var_overrides()
     }
 
     /// Like [`Self::build_from_server_defaults`] build will apply
     /// environment-provided overrides.
-    pub fn build_from_server_env() -> anyhow::Result<ConnectorRegistryBuilder> {
-        let builder = Self::build_from_server_defaults().with_env_var_overrides()?;
-        Ok(builder)
+    pub fn build_from_server_env() -> ConnectorRegistryBuilder {
+        Self::build_from_server_defaults().with_env_var_overrides()
     }
 
     /// Like [`Self::build_from_testing_defaults`] build will apply
     /// environment-provided overrides.
-    pub fn build_from_testing_env() -> anyhow::Result<ConnectorRegistryBuilder> {
-        let builder = Self::build_from_testing_defaults().with_env_var_overrides()?;
-        Ok(builder)
+    pub fn build_from_testing_env() -> ConnectorRegistryBuilder {
+        Self::build_from_testing_defaults().with_env_var_overrides()
     }
 
     /// Wait until some connections have been made

--- a/fedimint-connectors/src/lib.rs
+++ b/fedimint-connectors/src/lib.rs
@@ -479,6 +479,8 @@ impl ConnectorRegistry {
             .get_or_try_init(|| async move { init_fn().await })
             .await
             .map_err(|e| {
+                // `Transport` is printed, not walked, by its consumers, so the whole chain
+                // goes into the text on purpose.
                 ServerError::Transport(
                     format!("Connector failed to initialize: {}", e.fmt_compact()).into(),
                 )
@@ -611,6 +613,8 @@ impl ConnectorRegistry {
             .get_or_try_init(|| async move { init_fn().await })
             .await
             .map_err(|e| {
+                // `Transport` is printed, not walked, by its consumers, so the whole chain
+                // goes into the text on purpose.
                 ServerError::Transport(
                     format!("Connector failed to initialize: {}", e.fmt_compact()).into(),
                 )

--- a/fedimint-connectors/src/lib.rs
+++ b/fedimint-connectors/src/lib.rs
@@ -14,7 +14,6 @@ use std::str::FromStr as _;
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::anyhow;
 use async_trait::async_trait;
 use fedimint_core::envs::{
     FM_WS_API_CONNECT_OVERRIDES_ENV, is_running_in_test_env, parse_kv_list_from_env,
@@ -459,10 +458,13 @@ impl ConnectorRegistry {
         let scheme = url.scheme().to_string();
 
         let Some(connector_lazy) = self.inner.connectors_lazy.get(&scheme) else {
-            return Err(ServerError::InvalidEndpoint(anyhow!(
-                "Unsupported scheme: {}; missing endpoint handler",
-                url.scheme()
-            )));
+            return Err(ServerError::InvalidEndpoint(
+                format!(
+                    "Unsupported scheme: {}; missing endpoint handler",
+                    url.scheme()
+                )
+                .into(),
+            ));
         };
 
         // Clone the init function to use in the async block
@@ -477,10 +479,9 @@ impl ConnectorRegistry {
             .get_or_try_init(|| async move { init_fn().await })
             .await
             .map_err(|e| {
-                ServerError::Transport(anyhow!(
-                    "Connector failed to initialize: {}",
-                    e.fmt_compact()
-                ))
+                ServerError::Transport(
+                    format!("Connector failed to initialize: {}", e.fmt_compact()).into(),
+                )
             })?
             .connect_guardian(url, api_secret)
             .await;
@@ -610,10 +611,9 @@ impl ConnectorRegistry {
             .get_or_try_init(|| async move { init_fn().await })
             .await
             .map_err(|e| {
-                ServerError::Transport(anyhow!(
-                    "Connector failed to initialize: {}",
-                    e.fmt_compact()
-                ))
+                ServerError::Transport(
+                    format!("Connector failed to initialize: {}", e.fmt_compact()).into(),
+                )
             })?
             .iroh_peer_info(url, path_timeout)
             .await
@@ -840,7 +840,7 @@ impl<T: IConnection + ?Sized> ConnectionPool<T> {
                 match res {
                     Ok(o) => return Ok(o),
                     Err(err) => {
-                        return Err(ServerError::Connection(anyhow::format_err!("{}", err)));
+                        return Err(ServerError::Connection(err.into()));
                     }
                 }
             }

--- a/fedimint-connectors/src/tor.rs
+++ b/fedimint-connectors/src/tor.rs
@@ -2,11 +2,10 @@
 use std::fmt;
 use std::sync::Arc;
 
-use anyhow::anyhow;
 use arti_client::{TorAddr, TorClient, TorClientConfig};
 use async_trait::async_trait;
 use base64::Engine as _;
-use fedimint_core::util::SafeUrl;
+use fedimint_core::util::{FmtCompact as _, SafeUrl};
 use jsonrpsee_ws_client::{HeaderMap, HeaderValue, WsClientBuilder};
 use tokio_rustls::TlsConnector;
 use tokio_rustls::rustls::{ClientConfig as TlsClientConfig, RootCertStore};
@@ -53,12 +52,14 @@ impl Connector for TorConnector {
     ) -> super::ServerResult<DynGuaridianConnection> {
         let addr = (
             url.host_str()
-                .ok_or_else(|| ServerError::InvalidEndpoint(anyhow!("Expected host str")))?,
+                .ok_or_else(|| ServerError::InvalidEndpoint("Expected host str".into()))?,
             url.port_or_known_default()
-                .ok_or_else(|| ServerError::InvalidEndpoint(anyhow!("Expected port number")))?,
+                .ok_or_else(|| ServerError::InvalidEndpoint("Expected port number".into()))?,
         );
         let tor_addr = TorAddr::from(addr).map_err(|e| {
-            ServerError::InvalidEndpoint(anyhow!("Invalid endpoint addr: {addr:?}: {e:#}"))
+            ServerError::InvalidEndpoint(
+                format!("Invalid endpoint addr: {addr:?}: {}", e.fmt_compact()).into(),
+            )
         })?;
 
         let tor_addr_clone = tor_addr.clone();
@@ -104,9 +105,9 @@ impl Connector for TorConnector {
             "wss" => true,
             "ws" => false,
             unexpected_scheme => {
-                return Err(ServerError::InvalidEndpoint(anyhow!(
-                    "Unsupported scheme: {unexpected_scheme}"
-                )));
+                return Err(ServerError::InvalidEndpoint(
+                    format!("Unsupported scheme: {unexpected_scheme}").into(),
+                ));
             }
         };
 
@@ -157,7 +158,7 @@ impl Connector for TorConnector {
                 let host = url
                     .host_str()
                     .map(ToOwned::to_owned)
-                    .ok_or_else(|| ServerError::InvalidEndpoint(anyhow!("Invalid host str")))?;
+                    .ok_or_else(|| ServerError::InvalidEndpoint("Invalid host str".into()))?;
 
                 // FIXME: (@leonardo) Is this leaking any data ? Should investigate it further
                 // if it's really needed.

--- a/fedimint-connectors/src/tor.rs
+++ b/fedimint-connectors/src/tor.rs
@@ -13,6 +13,7 @@ use tokio_rustls::rustls::{ClientConfig as TlsClientConfig, RootCertStore};
 use tracing::debug;
 
 use super::{Connector, DynGuaridianConnection};
+use crate::error::ConnectorError;
 use crate::{Connectivity, DynGatewayConnection, IGuardianConnection as _, ServerError};
 
 #[derive(Clone)]
@@ -27,15 +28,13 @@ impl fmt::Debug for TorConnector {
 }
 
 impl TorConnector {
-    pub async fn bootstrap() -> anyhow::Result<Self> {
+    pub async fn bootstrap() -> Result<Self, ConnectorError> {
         use tracing::debug;
-
-        use crate::ServerError;
 
         let tor_config = TorClientConfig::default();
         let tor_client = TorClient::create_bootstrapped(tor_config)
             .await
-            .map_err(|err| ServerError::InternalClientError(err.into()))?
+            .map_err(|err| ConnectorError::Tor(Box::new(err)))?
             .isolated_client();
 
         debug!("Successfully created and bootstrapped the `TorClient`, for given `TorConfig`.");
@@ -180,8 +179,11 @@ impl Connector for TorConnector {
         }
     }
 
-    async fn connect_gateway(&self, _url: &SafeUrl) -> anyhow::Result<DynGatewayConnection> {
-        Err(anyhow!("Unsupported transport method"))
+    async fn connect_gateway(
+        &self,
+        _url: &SafeUrl,
+    ) -> Result<DynGatewayConnection, ConnectorError> {
+        Err(ConnectorError::GatewayUnsupported)
     }
 
     fn connectivity(&self, _url: &SafeUrl) -> Connectivity {

--- a/fedimint-connectors/src/ws.rs
+++ b/fedimint-connectors/src/ws.rs
@@ -22,6 +22,7 @@ use tracing::trace;
 pub type JsonRpcResult<T> = Result<T, JsonRpcClientError>;
 
 use super::Connector;
+use crate::error::ConnectorError;
 use crate::{
     Connectivity, DynGatewayConnection, DynGuaridianConnection, IConnection, IGuardianConnection,
     ServerError, ServerResult,
@@ -129,8 +130,11 @@ impl Connector for WebsocketConnector {
         Ok(client.into_dyn())
     }
 
-    async fn connect_gateway(&self, _url: &SafeUrl) -> anyhow::Result<DynGatewayConnection> {
-        Err(anyhow!("Unsupported transport method"))
+    async fn connect_gateway(
+        &self,
+        _url: &SafeUrl,
+    ) -> Result<DynGatewayConnection, ConnectorError> {
+        Err(ConnectorError::GatewayUnsupported)
     }
 
     fn connectivity(&self, _url: &SafeUrl) -> Connectivity {

--- a/fedimint-connectors/src/ws.rs
+++ b/fedimint-connectors/src/ws.rs
@@ -1,12 +1,10 @@
 use std::sync::Arc;
 
-#[allow(unused)]
-use anyhow::anyhow;
 use async_trait::async_trait;
 use fedimint_core::module::{ApiMethod, ApiRequestErased};
 #[cfg(not(target_family = "wasm"))]
 use fedimint_core::rustls::install_crypto_provider;
-use fedimint_core::util::SafeUrl;
+use fedimint_core::util::{FmtCompact as _, SafeUrl};
 use fedimint_core::{apply, async_trait_maybe_send};
 use fedimint_logging::LOG_NET_WS;
 use jsonrpsee_core::client::ClientT;
@@ -91,14 +89,13 @@ impl WebsocketConnector {
                 // `user:pass@...`
                 let mut url = url.clone();
                 url.set_username("fedimint")
-                    .map_err(|_| ServerError::InvalidEndpoint(anyhow!("invalid username")))?;
+                    .map_err(|_| ServerError::InvalidEndpoint("Invalid username".into()))?;
                 url.set_password(Some(&api_secret))
-                    .map_err(|_| ServerError::InvalidEndpoint(anyhow!("invalid secret")))?;
+                    .map_err(|_| ServerError::InvalidEndpoint("Invalid secret".into()))?;
 
-                let client = client
-                    .build(url.as_str())
-                    .await
-                    .map_err(|err| ServerError::InternalClientError(err.into()))?;
+                let client = client.build(url.as_str()).await.map_err(|err| {
+                    ServerError::InternalClientError(err.fmt_compact().to_string())
+                })?;
 
                 return Ok(Arc::new(client));
             }
@@ -107,7 +104,7 @@ impl WebsocketConnector {
         let client = client
             .build(url.as_str())
             .await
-            .map_err(|err| ServerError::InternalClientError(err.into()))?;
+            .map_err(|err| ServerError::InternalClientError(err.fmt_compact().to_string()))?;
 
         Ok(Arc::new(client))
     }
@@ -197,37 +194,39 @@ impl IGuardianConnection for Arc<WsClient> {
 fn jsonrpc_error_to_peer_error(jsonrpc_error: JsonRpcClientError) -> ServerError {
     match jsonrpc_error {
         JsonRpcClientError::Call(error_object) => {
-            let error = anyhow!(error_object.message().to_owned());
+            let message = error_object.message().to_owned();
             match ErrorCode::from(error_object.code()) {
                 ErrorCode::ParseError | ErrorCode::OversizedRequest | ErrorCode::InvalidRequest => {
-                    ServerError::InvalidRequest(error)
+                    ServerError::InvalidRequest(message)
                 }
-                ErrorCode::MethodNotFound => ServerError::InvalidRpcId(error),
-                ErrorCode::InvalidParams => ServerError::InvalidRequest(error),
+                ErrorCode::MethodNotFound => ServerError::InvalidRpcId(message),
+                ErrorCode::InvalidParams => ServerError::InvalidRequest(message),
                 ErrorCode::InternalError | ErrorCode::ServerIsBusy | ErrorCode::ServerError(_) => {
-                    ServerError::ServerError(error)
+                    ServerError::ServerError(message)
                 }
             }
         }
-        JsonRpcClientError::Transport(error) => ServerError::Transport(anyhow!(error)),
-        JsonRpcClientError::RestartNeeded(arc) => ServerError::Transport(anyhow!(arc)),
-        JsonRpcClientError::ParseError(error) => ServerError::InvalidResponse(anyhow!(error)),
+        JsonRpcClientError::Transport(error) => ServerError::Transport(error),
+        JsonRpcClientError::RestartNeeded(arc) => ServerError::Transport(arc.to_string().into()),
+        JsonRpcClientError::ParseError(error) => {
+            ServerError::InvalidResponse(error.fmt_compact().to_string())
+        }
         JsonRpcClientError::InvalidSubscriptionId => {
-            ServerError::Transport(anyhow!("Invalid subscription id"))
+            ServerError::Transport("Invalid subscription id".into())
         }
         JsonRpcClientError::InvalidRequestId(invalid_request_id) => {
-            ServerError::InvalidRequest(anyhow!(invalid_request_id))
+            ServerError::InvalidRequest(invalid_request_id.fmt_compact().to_string())
         }
-        JsonRpcClientError::RequestTimeout => ServerError::Transport(anyhow!("Request timeout")),
-        JsonRpcClientError::Custom(e) => ServerError::Transport(anyhow!(e)),
+        JsonRpcClientError::RequestTimeout => ServerError::Transport("Request timeout".into()),
+        JsonRpcClientError::Custom(e) => ServerError::Transport(e.into()),
         JsonRpcClientError::HttpNotImplemented => {
-            ServerError::ServerError(anyhow!("Http not implemented"))
+            ServerError::ServerError("Http not implemented".to_string())
         }
         JsonRpcClientError::EmptyBatchRequest(empty_batch_request) => {
-            ServerError::InvalidRequest(anyhow!(empty_batch_request))
+            ServerError::InvalidRequest(empty_batch_request.fmt_compact().to_string())
         }
         JsonRpcClientError::RegisterMethod(register_method_error) => {
-            ServerError::InvalidResponse(anyhow!(register_method_error))
+            ServerError::InvalidResponse(register_method_error.fmt_compact().to_string())
         }
     }
 }

--- a/fedimint-connectors/src/ws.rs
+++ b/fedimint-connectors/src/ws.rs
@@ -207,7 +207,9 @@ fn jsonrpc_error_to_peer_error(jsonrpc_error: JsonRpcClientError) -> ServerError
             }
         }
         JsonRpcClientError::Transport(error) => ServerError::Transport(error),
-        JsonRpcClientError::RestartNeeded(arc) => ServerError::Transport(arc.to_string().into()),
+        JsonRpcClientError::RestartNeeded(arc) => {
+            ServerError::Transport(arc.fmt_compact().to_string().into())
+        }
         JsonRpcClientError::ParseError(error) => {
             ServerError::InvalidResponse(error.fmt_compact().to_string())
         }

--- a/fedimint-connectors/src/ws.rs
+++ b/fedimint-connectors/src/ws.rs
@@ -93,9 +93,10 @@ impl WebsocketConnector {
                 url.set_password(Some(&api_secret))
                     .map_err(|_| ServerError::InvalidEndpoint("Invalid secret".into()))?;
 
-                let client = client.build(url.as_str()).await.map_err(|err| {
-                    ServerError::InternalClientError(err.fmt_compact().to_string())
-                })?;
+                let client = client
+                    .build(url.as_str())
+                    .await
+                    .map_err(jsonrpc_error_to_peer_error)?;
 
                 return Ok(Arc::new(client));
             }
@@ -104,7 +105,7 @@ impl WebsocketConnector {
         let client = client
             .build(url.as_str())
             .await
-            .map_err(|err| ServerError::InternalClientError(err.fmt_compact().to_string()))?;
+            .map_err(jsonrpc_error_to_peer_error)?;
 
         Ok(Arc::new(client))
     }

--- a/fedimint-load-test-tool/src/common.rs
+++ b/fedimint-load-test-tool/src/common.rs
@@ -163,7 +163,7 @@ pub async fn build_client(
     let client_secret = Client::load_or_generate_client_secret(&db).await?;
     let root_secret =
         RootSecret::StandardDoubleDerive(PlainRootSecretStrategy::to_root_secret(&client_secret));
-    let connectors = ConnectorRegistry::build_from_client_env()?.bind().await?;
+    let connectors = ConnectorRegistry::build_from_client_env().bind().await;
 
     let client = if Client::is_initialized(&db).await {
         client_builder.open(connectors, db, root_secret).await

--- a/fedimint-load-test-tool/src/main.rs
+++ b/fedimint-load-test-tool/src/main.rs
@@ -310,7 +310,7 @@ async fn main() -> anyhow::Result<()> {
             timeout_secs,
             limit_endpoints,
         } => {
-            let connectors = ConnectorRegistry::build_from_client_env()?.bind().await?;
+            let connectors = ConnectorRegistry::build_from_client_env().bind().await;
             let invite_code = InviteCode::from_str(&invite_code).context("invalid invite code")?;
             test_connect_raw_client(
                 &connectors,
@@ -324,7 +324,7 @@ async fn main() -> anyhow::Result<()> {
             .await?
         }
         Command::TestDownload { invite_code } => {
-            let connectors = ConnectorRegistry::build_from_client_env()?.bind().await?;
+            let connectors = ConnectorRegistry::build_from_client_env().bind().await;
             let invite_code = InviteCode::from_str(&invite_code).context("invalid invite code")?;
             test_download_config(&connectors, &invite_code, opts.users, &event_sender.clone())
         }

--- a/fedimint-recurringd/src/main.rs
+++ b/fedimint-recurringd/src/main.rs
@@ -84,10 +84,10 @@ async fn main() -> anyhow::Result<()> {
 
     let db = RocksDb::build(cli_opts.data_dir).open().await?;
     let recurring_invoice_server = RecurringInvoiceServer::new(
-        ConnectorRegistry::build_from_server_env()?
+        ConnectorRegistry::build_from_server_env()
             .http(true)
             .bind()
-            .await?,
+            .await,
         db,
         cli_opts.api_address.clone(),
     )

--- a/fedimint-recurringdv2/src/main.rs
+++ b/fedimint-recurringdv2/src/main.rs
@@ -65,9 +65,9 @@ async fn main() -> anyhow::Result<()> {
     let cli_opts = CliOpts::parse();
 
     let connector_registry = ConnectorRegistry::build_from_client_defaults()
-        .with_env_var_overrides()?
+        .with_env_var_overrides()
         .bind()
-        .await?;
+        .await;
 
     if cli_opts.api_address.scheme() != "https" {
         warn!(

--- a/fedimint-server/src/consensus/engine.rs
+++ b/fedimint-server/src/consensus/engine.rs
@@ -1162,7 +1162,7 @@ impl ConsensusEngine {
         let filter_map = move |response: SerdeModuleEncoding<SignedSessionOutcome>| {
             let signed_session_outcome = response
                 .try_into_inner(&decoders)
-                .map_err(|x| ServerError::ResponseDeserialization(x.into()))?;
+                .map_err(|x| ServerError::ResponseDeserialization(Box::new(x)))?;
             let header = signed_session_outcome.session_outcome.header(index);
             if signed_session_outcome.signatures.len() == threshold
                 && signed_session_outcome
@@ -1172,7 +1172,9 @@ impl ConsensusEngine {
             {
                 Ok(signed_session_outcome)
             } else {
-                Err(ServerError::InvalidResponse(anyhow!("Invalid signatures")))
+                Err(ServerError::InvalidResponse(
+                    "Invalid signatures".to_string(),
+                ))
             }
         };
 

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -273,7 +273,7 @@ pub async fn run(
             .map(|(&peer_id, url)| (peer_id, url.url.clone()))
             .collect(),
         None,
-    )?;
+    );
 
     let bitcoin_rpc_connection = ServerBitcoinRpcMonitor::new(
         dyn_server_bitcoin_rpc,
@@ -480,7 +480,7 @@ pub async fn run(
             connectors,
             api_urls,
             force_api_secrets.get_active().as_deref(),
-        )?,
+        ),
         cfg: cfg.clone(),
         connections,
         ord_latency_sender,

--- a/fedimint-server/src/lib.rs
+++ b/fedimint-server/src/lib.rs
@@ -293,9 +293,7 @@ pub async fn run_with_iroh_p2p_relays_and_next_api(
 
     info!(target: LOG_CONSENSUS, "Starting consensus...");
 
-    let connectors = ConnectorRegistry::build_from_server_defaults()
-        .bind()
-        .await?;
+    let connectors = ConnectorRegistry::build_from_server_defaults().bind().await;
 
     Box::pin(consensus::run(
         connectors,

--- a/fedimint-server/src/net/api/announcement.rs
+++ b/fedimint-server/src/net/api/announcement.rs
@@ -61,7 +61,7 @@ pub async fn start_api_announcement_service(
         ConnectorRegistry::build_from_server_env().bind().await,
         get_api_urls(&db, &cfg.consensus).await,
         api_secret.as_deref(),
-    )?;
+    );
 
     let our_peer_id = cfg.local.identity;
     tg.spawn_cancellable("submit-api-url-announcement", async move {

--- a/fedimint-server/src/net/api/announcement.rs
+++ b/fedimint-server/src/net/api/announcement.rs
@@ -58,7 +58,7 @@ pub async fn start_api_announcement_service(
     // FIXME: (@leonardo) how should we handle the connector here ?
     let api_client = DynGlobalApi::new(
         // TODO: get from somewhere/unify?
-        ConnectorRegistry::build_from_server_env()?.bind().await?,
+        ConnectorRegistry::build_from_server_env().bind().await,
         get_api_urls(&db, &cfg.consensus).await,
         api_secret.as_deref(),
     )?;

--- a/fedimint-server/src/net/api/guardian_metadata.rs
+++ b/fedimint-server/src/net/api/guardian_metadata.rs
@@ -72,11 +72,11 @@ pub async fn prepare_guardian_metadata_service(
     cfg: &ServerConfig,
     api_secret: Option<String>,
 ) -> anyhow::Result<DynGlobalApi> {
-    DynGlobalApi::new(
+    Ok(DynGlobalApi::new(
         ConnectorRegistry::build_from_server_env().bind().await,
         super::announcement::get_api_urls(db, &cfg.consensus).await,
         api_secret.as_deref(),
-    )
+    ))
 }
 
 /// Store and publish this guardian's current metadata.

--- a/fedimint-server/src/net/api/guardian_metadata.rs
+++ b/fedimint-server/src/net/api/guardian_metadata.rs
@@ -73,7 +73,7 @@ pub async fn prepare_guardian_metadata_service(
     api_secret: Option<String>,
 ) -> anyhow::Result<DynGlobalApi> {
     DynGlobalApi::new(
-        ConnectorRegistry::build_from_server_env()?.bind().await?,
+        ConnectorRegistry::build_from_server_env().bind().await,
         super::announcement::get_api_urls(db, &cfg.consensus).await,
         api_secret.as_deref(),
     )

--- a/fedimint-testing/src/btc/mock.rs
+++ b/fedimint-testing/src/btc/mock.rs
@@ -3,7 +3,7 @@ use std::iter::repeat_n;
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::{Context, Result, format_err};
+use anyhow::{Context, Result};
 use async_trait::async_trait;
 use bitcoin::absolute::LockTime;
 use bitcoin::block::{Header as BlockHeader, Version};
@@ -14,7 +14,7 @@ use bitcoin::merkle_tree::PartialMerkleTree;
 use bitcoin::{
     Address, Block, BlockHash, CompactTarget, Network, OutPoint, ScriptBuf, Transaction, TxOut,
 };
-use fedimint_bitcoind::{BlockchainInfo, IBitcoindRpc};
+use fedimint_bitcoind::{BitcoinRpcError, BlockchainInfo, IBitcoindRpc};
 use fedimint_core::envs::BitcoinRpcConfig;
 use fedimint_core::task::sleep_in_test;
 use fedimint_core::txoproof::TxOutProof;
@@ -295,7 +295,10 @@ impl BitcoinTest for FakeBitcoinTest {
 
 #[async_trait]
 impl IBitcoindRpc for FakeBitcoinTest {
-    async fn get_tx_block_height(&self, txid: &bitcoin::Txid) -> Result<Option<u64>> {
+    async fn get_tx_block_height(
+        &self,
+        txid: &bitcoin::Txid,
+    ) -> Result<Option<u64>, BitcoinRpcError> {
         for (height, block) in self.inner.read().unwrap().blocks.iter().enumerate() {
             if block.txdata.iter().any(|tx| &tx.compute_txid() == txid) {
                 return Ok(Some(height as u64));
@@ -304,25 +307,27 @@ impl IBitcoindRpc for FakeBitcoinTest {
         Ok(None)
     }
 
-    async fn watch_script_history(&self, _: &bitcoin::ScriptBuf) -> Result<()> {
+    async fn watch_script_history(&self, _: &bitcoin::ScriptBuf) -> Result<(), BitcoinRpcError> {
         Ok(())
     }
 
     async fn get_script_history(
         &self,
         script: &bitcoin::ScriptBuf,
-    ) -> Result<Vec<bitcoin::Transaction>> {
+    ) -> Result<Vec<bitcoin::Transaction>, BitcoinRpcError> {
         let inner = self.inner.read().unwrap();
         Ok(inner.scripts.get(script).cloned().unwrap_or_default())
     }
 
-    async fn get_txout_proof(&self, txid: bitcoin::Txid) -> Result<TxOutProof> {
+    async fn get_txout_proof(&self, txid: bitcoin::Txid) -> Result<TxOutProof, BitcoinRpcError> {
         let inner = self.inner.read().unwrap();
         let proof = inner.proofs.get(&txid);
-        Ok(proof.ok_or(format_err!("No proof stored"))?.clone())
+        Ok(proof
+            .ok_or(BitcoinRpcError::ProofNotFound { txid })?
+            .clone())
     }
 
-    async fn get_info(&self) -> Result<BlockchainInfo> {
+    async fn get_info(&self) -> Result<BlockchainInfo, BitcoinRpcError> {
         let inner = self.inner.read().unwrap();
         let count = inner.blocks.len() as u64;
         let synced = inner.pending.is_empty();

--- a/fedimint-testing/src/federation.rs
+++ b/fedimint-testing/src/federation.rs
@@ -85,12 +85,12 @@ impl FederationTest {
     pub async fn new_admin_api(&self, peer_id: PeerId) -> anyhow::Result<DynGlobalApi> {
         let config = self.configs.get(&peer_id).expect("peer to have config");
 
-        DynGlobalApi::new_admin(
+        Ok(DynGlobalApi::new_admin(
             ConnectorRegistry::build_from_testing_env().bind().await,
             peer_id,
             config.consensus.api_endpoints()[&peer_id].url.clone(),
             None,
-        )
+        ))
     }
 
     /// Create a new admin client connected to this fed
@@ -419,8 +419,7 @@ impl FederationTestBuilder {
                 peer_id,
                 config.consensus.api_endpoints()[&peer_id].url.clone(),
                 None,
-            )
-            .unwrap();
+            );
 
             while let Err(e) = api
                 .request_admin_no_auth::<u64>(SESSION_COUNT_ENDPOINT, ApiRequestErased::default())

--- a/fedimint-testing/src/federation.rs
+++ b/fedimint-testing/src/federation.rs
@@ -86,7 +86,7 @@ impl FederationTest {
         let config = self.configs.get(&peer_id).expect("peer to have config");
 
         DynGlobalApi::new_admin(
-            ConnectorRegistry::build_from_testing_env()?.bind().await?,
+            ConnectorRegistry::build_from_testing_env().bind().await,
             peer_id,
             config.consensus.api_endpoints()[&peer_id].url.clone(),
             None,
@@ -376,11 +376,7 @@ impl FederationTestBuilder {
 
             task_group.spawn("fedimintd", move |_| async move {
                 Box::pin(consensus::run(
-                    ConnectorRegistry::build_from_testing_env()
-                        .unwrap()
-                        .bind()
-                        .await
-                        .unwrap(),
+                    ConnectorRegistry::build_from_testing_env().bind().await,
                     Some(ApiAuth::new("pass".to_string())),
                     Some(ApiAuth::new("pass".to_string())),
                     connections,
@@ -417,11 +413,7 @@ impl FederationTestBuilder {
                 continue;
             }
 
-            let connectors = ConnectorRegistry::build_from_testing_env()
-                .unwrap()
-                .bind()
-                .await
-                .unwrap();
+            let connectors = ConnectorRegistry::build_from_testing_env().bind().await;
             let api = DynGlobalApi::new_admin(
                 connectors,
                 peer_id,
@@ -449,11 +441,7 @@ impl FederationTestBuilder {
             _task: task_group,
             num_peers: self.num_peers,
             num_offline: self.num_offline,
-            connectors: ConnectorRegistry::build_from_testing_env()
-                .expect("Failed to initialize endpoints for testing (env)")
-                .bind()
-                .await
-                .expect("Failed to initialize endpoints for testing"),
+            connectors: ConnectorRegistry::build_from_testing_env().bind().await,
         }
     }
 }

--- a/fedimint-wasm-tests/src/lib.rs
+++ b/fedimint-wasm-tests/src/lib.rs
@@ -44,7 +44,7 @@ async fn client(invite_code: &InviteCode) -> Result<fedimint_client::ClientHandl
     let client_secret = load_or_generate_mnemonic(&db).await?;
     let connectors = ConnectorRegistry::build_from_testing_defaults()
         .bind()
-        .await?;
+        .await;
     builder.stopped();
     let client = builder
         .preview(connectors, invite_code)

--- a/gateway/fedimint-gateway-client/src/general_commands.rs
+++ b/gateway/fedimint-gateway-client/src/general_commands.rs
@@ -166,7 +166,7 @@ impl GeneralCommands {
                     .expect("Before unix epoch")
                     .as_millis()
                     .try_into()
-                    .map_err(|e| ServerError::InternalClientError(anyhow::anyhow!("{e}")))?;
+                    .map_err(|e| ServerError::InternalClientError(format!("{e}")))?;
                 let one_day_ago = now
                     .checked_sub(Duration::from_hours(24))
                     .expect("Before unix epoch");
@@ -175,7 +175,7 @@ impl GeneralCommands {
                     .expect("Before unix epoch")
                     .as_millis()
                     .try_into()
-                    .map_err(|e| ServerError::InternalClientError(anyhow::anyhow!("{e}")))?;
+                    .map_err(|e| ServerError::InternalClientError(format!("{e}")))?;
                 let end_millis = end.unwrap_or(now_millis);
                 let start_millis = start.unwrap_or(one_day_ago_millis);
                 let payment_summary = payment_summary(

--- a/gateway/fedimint-gateway-client/src/lib.rs
+++ b/gateway/fedimint-gateway-client/src/lib.rs
@@ -69,9 +69,9 @@ fn validate_federation_status(
     federation_id: FederationId,
 ) -> ServerResult<FederationStatusResponse> {
     if status.federation_id() != federation_id {
-        return Err(ServerError::InvalidResponse(anyhow::anyhow!(
-            "Gateway federation status response names a different federation"
-        )));
+        return Err(ServerError::InvalidResponse(
+            "Gateway federation status response names a different federation".to_string(),
+        ));
     }
     Ok(status)
 }

--- a/gateway/fedimint-gateway-client/src/lightning_commands.rs
+++ b/gateway/fedimint-gateway-client/src/lightning_commands.rs
@@ -262,11 +262,11 @@ impl LightningCommands {
                 let start_secs = start_time
                     .timestamp()
                     .try_into()
-                    .map_err(|e| ServerError::InternalClientError(anyhow::anyhow!("{e}")))?;
+                    .map_err(|e| ServerError::InternalClientError(format!("{e}")))?;
                 let end_secs = end_time
                     .timestamp()
                     .try_into()
-                    .map_err(|e| ServerError::InternalClientError(anyhow::anyhow!("{e}")))?;
+                    .map_err(|e| ServerError::InternalClientError(format!("{e}")))?;
                 let response = list_transactions(
                     client,
                     base_url,

--- a/gateway/fedimint-gateway-client/src/main.rs
+++ b/gateway/fedimint-gateway-client/src/main.rs
@@ -271,10 +271,8 @@ async fn run() -> CliOutputResult {
     let cli = Cli::parse();
     let connector_registry = ConnectorRegistry::build_from_client_defaults()
         .with_env_var_overrides()
-        .map_err(ServerError::InternalClientError)?
         .bind()
-        .await
-        .map_err(ServerError::InternalClientError)?;
+        .await;
     let client = GatewayApi::new(cli.rpcpassword, connector_registry);
 
     let output = match cli.command {

--- a/gateway/fedimint-gateway-client/src/tests.rs
+++ b/gateway/fedimint-gateway-client/src/tests.rs
@@ -75,8 +75,7 @@ async fn http_client_sends_exact_public_scoped_request() {
     });
     let connectors = ConnectorRegistry::build_from_testing_defaults()
         .bind()
-        .await
-        .expect("test connectors build");
+        .await;
     let client = GatewayApi::new(None, connectors);
     let base_url = SafeUrl::parse(&format!("http://{address}/")).expect("valid test URL");
 

--- a/gateway/fedimint-gateway-server/src/client.rs
+++ b/gateway/fedimint-gateway-server/src/client.rs
@@ -37,7 +37,7 @@ impl GatewayClientBuilder {
         db_backend: DatabaseBackend,
     ) -> anyhow::Result<Self> {
         Ok(Self {
-            connectors: ConnectorRegistry::build_from_client_env()?.bind().await?,
+            connectors: ConnectorRegistry::build_from_client_env().bind().await,
             work_dir,
             registry,
             db_backend,

--- a/modules/fedimint-gwv2-client/src/receive_sm.rs
+++ b/modules/fedimint-gwv2-client/src/receive_sm.rs
@@ -1,7 +1,6 @@
 use core::fmt;
 use std::collections::BTreeMap;
 
-use anyhow::anyhow;
 use fedimint_api_client::api::{FederationApiExt, ServerError};
 use fedimint_api_client::query::FilterMapThreshold;
 use fedimint_client_module::DynGlobalClientContext;
@@ -157,13 +156,13 @@ impl ReceiveStateMachine {
                     if !contract.verify_decryption_share(
                         tpe_pks
                             .get(&peer_id)
-                            .ok_or(ServerError::InternalClientError(anyhow!(
+                            .ok_or(ServerError::InternalClientError(format!(
                                 "Missing TPE PK for peer {peer_id}?!"
                             )))?,
                         &share,
                     ) {
                         return Err(fedimint_api_client::api::ServerError::InvalidResponse(
-                            anyhow!("Invalid decryption share"),
+                            "Invalid decryption share".to_string(),
                         ));
                     }
 

--- a/modules/fedimint-ln-client/src/api.rs
+++ b/modules/fedimint-ln-client/src/api.rs
@@ -2,7 +2,6 @@ use std::collections::{BTreeMap, HashMap};
 use std::convert::identity;
 use std::time::Duration;
 
-use anyhow::anyhow;
 use bitcoin::hashes::sha256::{self, Hash as Sha256Hash};
 use fedimint_api_client::api::{
     FederationApiExt, FederationResult, IModuleFederationApi, ServerError,
@@ -256,7 +255,7 @@ where
                 ),
             )
             .await
-            .map_err(|e| ServerError::Transport(anyhow!("Request timed out: {e}")))
+            .map_err(|e| ServerError::Transport(format!("Request timed out: {e}").into()))
             .and_then(identity)
             {
                 responses.insert(*peer, response);
@@ -280,7 +279,7 @@ where
                 ),
             )
             .await
-            .map_err(|e| ServerError::Transport(anyhow!("Request timed out: {e}")))
+            .map_err(|e| ServerError::Transport(format!("Request timed out: {e}").into()))
             .and_then(identity)
             {
                 if response {

--- a/modules/fedimint-ln-client/src/receive.rs
+++ b/modules/fedimint-ln-client/src/receive.rs
@@ -351,7 +351,9 @@ pub async fn get_incoming_contract(
                 Err(fedimint_api_client::api::FederationError::general(
                     ACCOUNT_ENDPOINT,
                     contract_id,
-                    anyhow::anyhow!("Contract {contract_id} is not an incoming contract"),
+                    fedimint_api_client::api::FederationGeneralError::UnexpectedResponse {
+                        message: format!("Contract {contract_id} is not an incoming contract"),
+                    },
                 ))
             }
         }

--- a/modules/fedimint-ln-common/src/client.rs
+++ b/modules/fedimint-ln-common/src/client.rs
@@ -32,7 +32,7 @@ impl GatewayApi {
                 let conn = connectors
                     .connect_gateway(&url)
                     .await
-                    .map_err(ServerError::Connection)?;
+                    .map_err(|err| ServerError::Connection(err.into()))?;
                 Ok(conn)
             })
             .await

--- a/modules/fedimint-ln-common/src/client.rs
+++ b/modules/fedimint-ln-common/src/client.rs
@@ -5,7 +5,7 @@ use fedimint_connectors::error::ServerError;
 use fedimint_connectors::{
     ConnectionPool, ConnectorRegistry, DynGatewayConnection, IGatewayConnection, ServerResult,
 };
-use fedimint_core::util::SafeUrl;
+use fedimint_core::util::{FmtCompact as _, SafeUrl};
 use reqwest::Method;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -31,7 +31,8 @@ impl GatewayApi {
                 let conn = connectors
                     .connect_gateway(&url)
                     .await
-                    .map_err(|err| ServerError::Connection(Box::new(err)))?;
+                    // `Connection` neither prints nor exposes a source, so flatten the chain.
+                    .map_err(|err| ServerError::Connection(err.fmt_compact().to_string().into()))?;
                 Ok(conn)
             })
             .await

--- a/modules/fedimint-ln-common/src/client.rs
+++ b/modules/fedimint-ln-common/src/client.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeSet;
 use std::fmt::Debug;
 
-use anyhow::Context;
 use fedimint_connectors::error::ServerError;
 use fedimint_connectors::{
     ConnectionPool, ConnectorRegistry, DynGatewayConnection, IGatewayConnection, ServerResult,
@@ -32,7 +31,7 @@ impl GatewayApi {
                 let conn = connectors
                     .connect_gateway(&url)
                     .await
-                    .map_err(|err| ServerError::Connection(err.into()))?;
+                    .map_err(|err| ServerError::Connection(Box::new(err)))?;
                 Ok(conn)
             })
             .await
@@ -45,18 +44,13 @@ impl GatewayApi {
         route: &str,
         payload: Option<P>,
     ) -> ServerResult<T> {
-        let conn = self
-            .get_or_create_connection(base_url)
-            .await
-            .context("Failed to connect to gateway")
-            .map_err(ServerError::Connection)?;
+        let conn = self.get_or_create_connection(base_url).await?;
         let payload = payload.map(|p| serde_json::to_value(p).expect("Could not serialize"));
         let res = conn
             .request(self.password.clone(), method, route, payload)
             .await?;
-        let response = serde_json::from_value::<T>(res).map_err(|e| {
-            ServerError::InvalidResponse(anyhow::anyhow!("Received invalid response: {e}"))
-        })?;
+        let response = serde_json::from_value::<T>(res)
+            .map_err(|e| ServerError::InvalidResponse(format!("Received invalid response: {e}")))?;
         Ok(response)
     }
 

--- a/modules/fedimint-lnv2-tests/tests/mock.rs
+++ b/modules/fedimint-lnv2-tests/tests/mock.rs
@@ -1,6 +1,5 @@
 use std::time::Duration;
 
-use anyhow::anyhow;
 use bitcoin::hashes::{Hash, sha256};
 use bitcoin::secp256k1::{SECP256K1, SecretKey};
 use fedimint_api_client::api::ServerError;
@@ -140,9 +139,9 @@ impl GatewayConnection for MockGatewayConnection {
         match invoice {
             LightningInvoice::Bolt11(invoice) => {
                 if *invoice.payment_secret() == PaymentSecret(GATEWAY_CRASH_PAYMENT_SECRET) {
-                    return Err(ServerError::InvalidRequest(anyhow!(
-                        "Gateway crash payment secret"
-                    )));
+                    return Err(ServerError::InvalidRequest(
+                        "Gateway crash payment secret".to_string(),
+                    ));
                 }
 
                 if *invoice.payment_secret() == PaymentSecret(UNPAYABLE_PAYMENT_SECRET) {

--- a/modules/fedimint-mint-client/src/output.rs
+++ b/modules/fedimint-mint-client/src/output.rs
@@ -344,7 +344,9 @@ impl MintOutputStatesCreated {
                             &module_decoder,
                             &tbs_pks,
                         )
-                        .map_err(ServerError::InvalidResponse)
+                        .map_err(|err| {
+                            ServerError::InvalidResponse(err.fmt_compact_anyhow().to_string())
+                        })
                     },
                     global_context.api().all_peers().to_num_peers(),
                 ),
@@ -586,7 +588,7 @@ impl MintOutputStatesCreatedMulti {
                     move |peer, outcomes: Vec<Option<SerdeOutputOutcome>>| {
                         // Verify the response has the expected length
                         if outcomes.len() != common.out_point_range.count() {
-                            return Err(ServerError::InvalidResponse(anyhow::anyhow!(
+                            return Err(ServerError::InvalidResponse(format!(
                                 "Peer {peer} returned {} outcomes but expected {}",
                                 outcomes.len(),
                                 common.out_point_range.count()
@@ -623,7 +625,9 @@ impl MintOutputStatesCreatedMulti {
                                             out_point = %OutPoint { txid: common.txid(), out_idx},
                                             "Invalid signature share from peer"
                                         );
-                                        return Err(ServerError::InvalidResponse(err));
+                                        return Err(ServerError::InvalidResponse(
+                                            err.fmt_compact_anyhow().to_string(),
+                                        ));
                                     }
                                 }
                             } else {
@@ -693,7 +697,9 @@ impl MintOutputStatesCreatedMulti {
                                 &module_decoder,
                                 &tbs_pks,
                             )
-                            .map_err(ServerError::InvalidResponse)
+                            .map_err(|err| {
+                                ServerError::InvalidResponse(err.fmt_compact_anyhow().to_string())
+                            })
                         },
                         api.all_peers().to_num_peers(),
                     ),
@@ -729,7 +735,11 @@ impl MintOutputStatesCreatedMulti {
                                             &module_decoder,
                                             &tbs_pks,
                                         )
-                                        .map_err(ServerError::InvalidResponse)
+                                        .map_err(|err| {
+                                            ServerError::InvalidResponse(
+                                                err.fmt_compact_anyhow().to_string(),
+                                            )
+                                        })
                                     },
                                     api.all_peers().to_num_peers(),
                                 ),

--- a/modules/fedimint-mintv2-client/src/api.rs
+++ b/modules/fedimint-mintv2-client/src/api.rs
@@ -5,6 +5,7 @@ use bitcoin_hashes::sha256;
 use fedimint_api_client::api::{DynModuleApi, FederationApiExt, ServerError};
 use fedimint_api_client::query::FilterMapThreshold;
 use fedimint_core::module::ApiRequestErased;
+use fedimint_core::util::FmtCompactAnyhow as _;
 use fedimint_core::{NumPeersExt, OutPointRange, PeerId, apply, async_trait_maybe_send};
 use fedimint_mintv2_common::endpoint_constants::{
     RECOVERY_COUNT_ENDPOINT, RECOVERY_SLICE_ENDPOINT, RECOVERY_SLICE_HASH_ENDPOINT,
@@ -57,7 +58,9 @@ impl MintV2ModuleApi for DynModuleApi {
             FilterMapThreshold::new(
                 move |peer, signature_shares| {
                     verify_blind_shares(peer, signature_shares, &issuance_requests, &tbs_pks)
-                        .map_err(ServerError::InvalidResponse)
+                        .map_err(|err| {
+                            ServerError::InvalidResponse(err.fmt_compact_anyhow().to_string())
+                        })
                 },
                 self.all_peers().to_num_peers(),
             ),
@@ -82,7 +85,9 @@ impl MintV2ModuleApi for DynModuleApi {
             FilterMapThreshold::new(
                 move |peer, signature_shares| {
                     verify_blind_shares(peer, signature_shares, &issuance_requests, &tbs_pks)
-                        .map_err(ServerError::InvalidResponse)
+                        .map_err(|err| {
+                            ServerError::InvalidResponse(err.fmt_compact_anyhow().to_string())
+                        })
                 },
                 self.all_peers().to_num_peers(),
             ),

--- a/modules/fedimint-wallet-client/src/api.rs
+++ b/modules/fedimint-wallet-client/src/api.rs
@@ -1,7 +1,8 @@
 use anyhow::anyhow;
 use bitcoin::{Address, Amount};
 use fedimint_api_client::api::{
-    FederationApiExt, FederationError, FederationResult, IModuleFederationApi, ServerResult,
+    FederationApiExt, FederationError, FederationGeneralError, FederationResult,
+    IModuleFederationApi, ServerResult,
 };
 use fedimint_api_client::query::{FilterMapThreshold, ThresholdAgreement};
 use fedimint_core::envs::BitcoinRpcConfig;
@@ -117,7 +118,9 @@ where
             return Err(FederationError::general(
                 BLOCK_COUNT_LOCAL_ENDPOINT.to_string(),
                 ApiRequestErased::default(),
-                anyhow!("No valid block counts received"),
+                FederationGeneralError::ThresholdFailed {
+                    message: "No valid block counts received".to_string(),
+                },
             ));
         }
 
@@ -165,12 +168,14 @@ where
         Err(FederationError::general(
             PEG_OUT_FEES_ENDPOINT.to_string(),
             params,
-            anyhow!(
-                "Guardians disagree on peg-out fees ({detail}). The quote is consensus \
-                 state, so a guardian returning a different value has diverged - most \
-                 often because its Bitcoin backend is lagging. The same rate validates \
-                 the peg-out, so it cannot be accepted until the federation agrees."
-            ),
+            FederationGeneralError::ThresholdFailed {
+                message: format!(
+                    "Guardians disagree on peg-out fees ({detail}). The quote is consensus \
+                     state, so a guardian returning a different value has diverged - most \
+                     often because its Bitcoin backend is lagging. The same rate validates \
+                     the peg-out, so it cannot be accepted until the federation agrees."
+                ),
+            },
         ))
     }
 

--- a/modules/fedimint-wallet-client/src/deposit.rs
+++ b/modules/fedimint-wallet-client/src/deposit.rs
@@ -15,6 +15,7 @@ use fedimint_core::module::{Amounts, ModuleConsensusVersion};
 use fedimint_core::secp256k1::Keypair;
 use fedimint_core::task::sleep;
 use fedimint_core::txoproof::TxOutProof;
+use fedimint_core::util::FmtCompact as _;
 use fedimint_core::{OutPoint, TransactionId};
 use fedimint_logging::LOG_CLIENT_MODULE_WALLET;
 use fedimint_wallet_common::WalletInput;
@@ -115,7 +116,10 @@ async fn await_created_btc_transaction_submitted(
     loop {
         match context.rpc.watch_script_history(&script).await {
             Ok(()) => break,
-            Err(e) => warn!("Error while awaiting btc tx submitting: {e}"),
+            Err(e) => warn!(
+                "Error while awaiting btc tx submitting: {}",
+                e.fmt_compact()
+            ),
         }
         sleep(TRANSACTION_STATUS_FETCH_INTERVAL).await;
     }
@@ -226,7 +230,7 @@ async fn await_btc_transaction_confirmed(
             Ok(Some(confirmation_height)) => Some(confirmation_height + 1),
             Ok(None) => None,
             Err(e) => {
-                warn!("Failed to fetch confirmation height: {e:?}");
+                warn!("Failed to fetch confirmation height: {}", e.fmt_compact());
                 sleep(TRANSACTION_STATUS_FETCH_INTERVAL).await;
                 continue;
             }
@@ -255,7 +259,7 @@ async fn await_btc_transaction_confirmed(
         {
             Ok(txout_proof) => txout_proof,
             Err(e) => {
-                warn!("Failed to fetch transaction proof: {e:?}");
+                warn!("Failed to fetch transaction proof: {}", e.fmt_compact());
                 sleep(TRANSACTION_STATUS_FETCH_INTERVAL).await;
                 continue;
             }

--- a/modules/fedimint-wallet-client/src/withdraw.rs
+++ b/modules/fedimint-wallet-client/src/withdraw.rs
@@ -9,6 +9,7 @@ use fedimint_core::encoding::{Decodable, Encodable};
 #[allow(deprecated)]
 use fedimint_core::endpoint_constants::AWAIT_OUTPUT_OUTCOME_ENDPOINT;
 use fedimint_core::module::ApiRequestErased;
+use fedimint_core::util::FmtCompact as _;
 use fedimint_wallet_common::WalletOutputOutcome;
 use futures::future::pending;
 use tracing::warn;
@@ -84,7 +85,7 @@ async fn await_withdraw_processed(
         .await;
 
     match deserialize_outcome::<WalletOutputOutcome>(&outcome, &context.wallet_decoder)
-        .map_err(|e| e.to_string())
+        .map_err(|e| e.fmt_compact().to_string())
         .and_then(|outcome| {
             outcome
                 .ensure_v0_ref()

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -761,7 +761,7 @@ async fn peg_ins_that_are_unconfirmed_are_rejected() -> anyhow::Result<()> {
             )]
             .into(),
             None,
-        )?
+        )
         .with_module(module_instance_id),
         ServerBitcoinRpcMonitor::new(
             bitcoin_rpc_connection.clone(),
@@ -911,7 +911,7 @@ async fn peg_in_claiming_an_already_tracked_utxo_is_rejected() -> anyhow::Result
             )]
             .into(),
             None,
-        )?
+        )
         .with_module(module_instance_id),
         ServerBitcoinRpcMonitor::new(
             fixtures.server_bitcoin_rpc(),
@@ -1054,7 +1054,7 @@ async fn peg_out_change_is_recorded_as_claimed() -> anyhow::Result<()> {
             )]
             .into(),
             None,
-        )?
+        )
         .with_module(module_instance_id),
         ServerBitcoinRpcMonitor::new(
             fixtures.server_bitcoin_rpc(),
@@ -1815,7 +1815,7 @@ async fn unknown_consensus_item_variant_is_rejected_without_panicking() -> anyho
             )]
             .into(),
             None,
-        )?
+        )
         .with_module(module_instance_id),
         ServerBitcoinRpcMonitor::new(
             fixtures.server_bitcoin_rpc(),
@@ -1881,7 +1881,7 @@ async fn submission_rejects_a_fee_rate_that_cannot_produce_a_real_fee() -> anyho
             )]
             .into(),
             None,
-        )?
+        )
         .with_module(module_instance_id),
         ServerBitcoinRpcMonitor::new(
             fixtures.server_bitcoin_rpc(),

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -754,7 +754,7 @@ async fn peg_ins_that_are_unconfirmed_are_rejected() -> anyhow::Result<()> {
         PeerId::from(0),
         // FIXME: use proper mock
         DynGlobalApi::new(
-            ConnectorRegistry::build_from_testing_env()?.bind().await?,
+            ConnectorRegistry::build_from_testing_env().bind().await,
             [(
                 PeerId::from(0),
                 SafeUrl::from_str("ws://dummy.xyz").unwrap(),
@@ -904,7 +904,7 @@ async fn peg_in_claiming_an_already_tracked_utxo_is_rejected() -> anyhow::Result
         &task_group,
         PeerId::from(0),
         DynGlobalApi::new(
-            ConnectorRegistry::build_from_testing_env()?.bind().await?,
+            ConnectorRegistry::build_from_testing_env().bind().await,
             [(
                 PeerId::from(0),
                 SafeUrl::from_str("ws://dummy.xyz").unwrap(),
@@ -1047,7 +1047,7 @@ async fn peg_out_change_is_recorded_as_claimed() -> anyhow::Result<()> {
         &task_group,
         PeerId::from(0),
         DynGlobalApi::new(
-            ConnectorRegistry::build_from_testing_env()?.bind().await?,
+            ConnectorRegistry::build_from_testing_env().bind().await,
             [(
                 PeerId::from(0),
                 SafeUrl::from_str("ws://dummy.xyz").unwrap(),
@@ -1808,7 +1808,7 @@ async fn unknown_consensus_item_variant_is_rejected_without_panicking() -> anyho
         &task_group,
         PeerId::from(0),
         DynGlobalApi::new(
-            ConnectorRegistry::build_from_testing_env()?.bind().await?,
+            ConnectorRegistry::build_from_testing_env().bind().await,
             [(
                 PeerId::from(0),
                 SafeUrl::from_str("ws://dummy.xyz").unwrap(),
@@ -1874,7 +1874,7 @@ async fn submission_rejects_a_fee_rate_that_cannot_produce_a_real_fee() -> anyho
         &task_group,
         PeerId::from(0),
         DynGlobalApi::new(
-            ConnectorRegistry::build_from_testing_env()?.bind().await?,
+            ConnectorRegistry::build_from_testing_env().bind().await,
             [(
                 PeerId::from(0),
                 SafeUrl::from_str("ws://dummy.xyz").unwrap(),

--- a/modules/fedimint-walletv2-client/src/api.rs
+++ b/modules/fedimint-walletv2-client/src/api.rs
@@ -1,8 +1,8 @@
 use std::collections::BTreeMap;
 
-use anyhow::anyhow;
 use fedimint_api_client::api::{
-    FederationApiExt, FederationError, FederationResult, IModuleFederationApi,
+    FederationApiExt, FederationError, FederationGeneralError, FederationResult,
+    IModuleFederationApi,
 };
 use fedimint_api_client::query::ThresholdAgreement;
 use fedimint_core::module::ApiRequestErased;
@@ -103,14 +103,16 @@ where
         Err(FederationError::general(
             SEND_FEE_ENDPOINT.to_string(),
             ApiRequestErased::new(()),
-            anyhow!(
-                "Guardians disagree on the onchain send fee ({}). The fee is \
-                 consensus state, so a guardian returning a different value has \
-                 diverged - because its Bitcoin backend is lagging, or because its \
-                 view of the pending transaction stack differs. The same fee \
-                 validates the send, so it cannot be accepted until they agree.",
-                describe_fee_quotes(&quotes)
-            ),
+            FederationGeneralError::ThresholdFailed {
+                message: format!(
+                    "Guardians disagree on the onchain send fee ({}). The fee is \
+                     consensus state, so a guardian returning a different value has \
+                     diverged - because its Bitcoin backend is lagging, or because its \
+                     view of the pending transaction stack differs. The same fee \
+                     validates the send, so it cannot be accepted until they agree.",
+                    describe_fee_quotes(&quotes)
+                ),
+            },
         ))
     }
 
@@ -135,14 +137,16 @@ where
         Err(FederationError::general(
             RECEIVE_FEE_ENDPOINT.to_string(),
             ApiRequestErased::new(()),
-            anyhow!(
-                "Guardians disagree on the onchain receive fee ({}). The fee is \
-                 consensus state, so a guardian returning a different value has \
-                 diverged - because its Bitcoin backend is lagging, or because its \
-                 view of the pending transaction stack differs. The same fee \
-                 validates the claim, so it cannot be accepted until they agree.",
-                describe_fee_quotes(&quotes)
-            ),
+            FederationGeneralError::ThresholdFailed {
+                message: format!(
+                    "Guardians disagree on the onchain receive fee ({}). The fee is \
+                     consensus state, so a guardian returning a different value has \
+                     diverged - because its Bitcoin backend is lagging, or because its \
+                     view of the pending transaction stack differs. The same fee \
+                     validates the claim, so it cannot be accepted until they agree.",
+                    describe_fee_quotes(&quotes)
+                ),
+            },
         ))
     }
 


### PR DESCRIPTION
## Summary

Third PR of the #8821 series (after #9082 and #9103). This one removes `anyhow` from the public API of `fedimint-connectors`, `fedimint-api-client` and `fedimint-bitcoind`, the crates that talk to guardians, gateways and the Bitcoin backend.

## What changed

- `ConnectorError` (new, `fedimint-connectors`): what a `Connector` can fail with when building a connection or reaching a gateway, so callers can match on the scheme, url or node-id problem instead of parsing text.
- `FederationGeneralError` (new, `fedimint-api-client`): the typed replacement for the free-form `anyhow::Error` that `FederationError::general` used to carry.
- `ClientConfigDownloadError` (new, `fedimint-api-client`): the typed result of `download_from_invite_code` and `try_download_client_config`.
- `BitcoinRpcError` (new, `fedimint-bitcoind`): the typed result of every `IBitcoindRpc` method and its three constructors.
- `ServerError` (retyped, `fedimint-connectors`): its eleven `anyhow::Error` payloads are now concrete types (boxed std errors, a boxed `ConnectorError`, or plain `String`), so a caller that matches a variant no longer has to parse the message to learn more.
- `OutputOutcomeError` (retyped, `fedimint-api-client`): `Core` is gone (nothing ever produced it), `ResponseDeserialization` now holds a `DecodeError` directly, and a new `WrongOutcomeType` variant covers the case where the outcome decoded but into the wrong type.
- `ConnectorRegistryBuilder::{bind, with_env_var_overrides}`, `ConnectorRegistry::build_from_{client,server,testing}_env` and `DynGlobalApi::{new, new_admin, new_admin_setup}` all dropped `Result`: none of these eight functions could actually fail.

## Breaking changes

- Anyone implementing `fedimint_connectors::Connector` must change `connect_gateway`'s return type to `Result<DynGatewayConnection, ConnectorError>`.
- Anyone implementing `fedimint_bitcoind::IBitcoindRpc` must change all five methods (`get_tx_block_height`, `watch_script_history`, `get_script_history`, `get_txout_proof`, `get_info`) to `Result<_, BitcoinRpcError>`.
- `ServerError`'s payloads changed type: `ResponseDeserialization`, `InvalidEndpoint`, `Connection` and `Transport` now hold `Box<dyn Error + Send + Sync>`; `InvalidPeerUrl`'s `source` holds a `Box<ConnectorError>`; `InvalidRpcId`, `InvalidRequest`, `InvalidResponse`, `ServerError`, `ConditionFailed` and `InternalClientError` hold a `String`. Code that used a variant as a function pointer (for example `.map_err(ServerError::InvalidResponse)`) needs a closure instead. Variant names and arity are unchanged, so existing `match` arms still compile.
- `OutputOutcomeError::Core` is gone; `ResponseDeserialization` now holds a `DecodeError` instead of `anyhow::Error`; a new `WrongOutcomeType` variant was added.
- `FederationError::general`'s third parameter and the `general` field are now `FederationGeneralError` instead of `anyhow::Error`; `get_general_error` returns `Option<&FederationGeneralError>`.
- Eight functions lost their `Result` and now return their success type directly, so call sites drop a trailing `?`: `ConnectorRegistryBuilder::bind`, `ConnectorRegistryBuilder::with_env_var_overrides`, `ConnectorRegistry::build_from_client_env`, `ConnectorRegistry::build_from_server_env`, `ConnectorRegistry::build_from_testing_env`, `DynGlobalApi::new`, `DynGlobalApi::new_admin`, `DynGlobalApi::new_admin_setup`.
- `IGlobalFederationApi::{await_block, get_session_status}` now return `FederationResult<T>` (that is, `Result<T, FederationError>`) instead of `anyhow::Result<T>`.

## Not changed

No wire, DB or RPC/JSON *shape* changed anywhere in this PR: every retyped error only affects how a failure is represented in Rust, not what a peer, gateway or client sees on the wire. No type touched by this PR derives `Serialize`, `Encodable` or `uniffi::Error` (confirmed by grepping the diff for new derives on `Serialize`, `Deserialize`, `Encodable`, `Decodable` or `uniffi`; the grep is empty). `fedimint-server-bitcoin-rpc` and the `IServerBitcoinRpc` trait it implements are untouched: that is server-side code and out of scope for this client-facing series. `fedimint-api-client`'s private retry closures in `request_with_strategy_retry` (`api/mod.rs`) still use `anyhow`; they are not reachable from any public signature, since `util::retry`'s error type is a generic parameter there.

## Reviewing

Best read commit by commit; each commit checks on its own. Two behavioural things worth a close look:

1. `fedimint-cli`'s `CliError.error` and the gateway CLI's `error`/`cause` strings now carry the real underlying failure where they previously carried a generic wrapper message. This is a side effect of the next point: once a connection failure is no longer squashed into an opaque `anyhow` chain, its own message is what callers see.
2. `FederationApi::request_raw` and `GatewayApi::request` used to wrap an already-typed `ServerError` inside another `ServerError::Connection` (with a "Failed to connect to peer" / "Failed to connect to gateway" prefix). That double-wrap is now removed, so the original, more specific `ServerError` variant reaches the caller directly. One observable consequence: the gateway CLI's `errorCode` field, which is derived from the `ServerError` variant, can now be something other than `ConnectionFailed` for a connection failure whose real cause was not a transport problem (its JSON shape is unchanged, only the value can differ).

Two smaller, self-contained changes:

- `ServerError::InvalidPeerUrl`'s `cause` text (surfaced by the gateway CLI) is now the `Display` of the actual `ConnectorError` that produced it, instead of an untyped `anyhow` message.
- `FederationError`'s `Display` prints its `general` cause as the whole chain (`fmt_compact`) rather than the outermost layer only; `FederationGeneralError::{ThresholdFailed, UnexpectedResponse}` render their message verbatim so the strings `fedimint-cli` shows are byte-identical to before.
- `BitcoinRpcError::InvalidUrl` names the `FM_FORCE_BITCOIN_RPC_URL` environment variable it came from instead of echoing the value that failed to parse, since a value that could not be parsed cannot be redacted through `SafeUrl` and may carry credentials.

## Testing

```
cargo check --workspace --all-targets
cargo clippy --workspace --all-targets -- -D warnings
cargo check -p fedimint-connectors --features tor
cargo check -p fedimint-bitcoind --features bitcoincore
cargo check -p fedimint-api-client --features uniffi
cargo clippy -p fedimint-connectors --features tor --all-targets -- -D warnings
cargo doc --no-deps -p fedimint-connectors -p fedimint-api-client -p fedimint-bitcoind
cargo test -p fedimint-connectors -p fedimint-api-client -p fedimint-bitcoind -p fedimint-wallet-client -p fedimint-client --lib
```

Plus the `check-wasm` package set (`fedimint-client`, `fedimint-client-wasm`, `fedimint-wasm-tests`, `fedimint-mintv2-client`, `fedimint-walletv2-client` at `wasm32-unknown-unknown`), the pre-commit hook, and `git diff --check` against `origin/master` for whitespace. All green.

Part of #8821.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtKSNoo4GVaPc5TRp48kwY
