### PR TITLE
fix(recurringdv2): make LNURL responses spec compliant

### DIFF
--- a/fedimint-lnurl/Cargo.toml
+++ b/fedimint-lnurl/Cargo.toml
@@ -16,7 +16,5 @@ bech32 = { workspace = true }
 lightning-invoice = { workspace = true, features = ["serde"] }
 reqwest = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 serde_with = { workspace = true }
-
-[dev-dependencies]
-serde_json.workspace = true

--- a/fedimint-lnurl/src/lib.rs
+++ b/fedimint-lnurl/src/lib.rs
@@ -89,9 +89,37 @@ pub struct InvoiceResponse {
 #[serde_as]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct VerifyResponse {
+    /// Always "OK" for successful responses per LUD-21. Defaulted when
+    /// parsing since not all services send it.
+    #[serde(default = "ok_status")]
+    pub status: String,
     pub settled: bool,
     #[serde_as(as = "Option<Hex>")]
     pub preimage: Option<[u8; 32]>,
+}
+
+fn ok_status() -> String {
+    "OK".to_string()
+}
+
+impl VerifyResponse {
+    /// A LUD-21 response for a payment that has been settled
+    pub fn settled(preimage: [u8; 32]) -> Self {
+        Self {
+            status: ok_status(),
+            settled: true,
+            preimage: Some(preimage),
+        }
+    }
+
+    /// A LUD-21 response for a payment that is still pending
+    pub fn pending() -> Self {
+        Self {
+            status: ok_status(),
+            settled: false,
+            preimage: None,
+        }
+    }
 }
 
 /// Fetch and parse an LNURL-pay response
@@ -228,6 +256,24 @@ fn parse_error_response() {
     let response: LnurlResponse<PayResponse> = serde_json::from_str(json).unwrap();
 
     assert_eq!(response.into_result().unwrap_err(), "Invalid request");
+}
+
+#[test]
+fn serialize_verify_response_lud_21() {
+    let json = serde_json::to_value(LnurlResponse::Ok(VerifyResponse::pending())).unwrap();
+
+    // LUD-21 responses carry an explicit "OK" status alongside the payment
+    // state
+    assert_eq!(json["status"], "OK");
+    assert_eq!(json["settled"], false);
+    assert_eq!(json["preimage"], serde_json::Value::Null);
+
+    let json =
+        serde_json::to_value(LnurlResponse::Ok(VerifyResponse::settled([0x42; 32]))).unwrap();
+
+    assert_eq!(json["status"], "OK");
+    assert_eq!(json["settled"], true);
+    assert_eq!(json["preimage"], "42".repeat(32));
 }
 
 #[test]

--- a/fedimint-lnurl/src/lib.rs
+++ b/fedimint-lnurl/src/lib.rs
@@ -77,6 +77,10 @@ pub struct PayResponse {
 pub struct InvoiceResponse {
     /// The BOLT11 invoice
     pub pr: Bolt11Invoice,
+    /// Vestigial routing hints, always empty in practice, but required by
+    /// LUD-06. Defaulted when parsing since not all services send it.
+    #[serde(default)]
+    pub routes: Vec<serde_json::Value>,
     /// LUD-21 verify URL
     pub verify: Option<String>,
 }
@@ -182,6 +186,39 @@ fn parse_pay_response_lud_06() {
     assert_eq!(pay.callback, "https://example.com/lnurl/pay/callback");
     assert_eq!(pay.min_sendable, 1000);
     assert_eq!(pay.max_sendable, 100000000);
+}
+
+#[test]
+fn serialize_invoice_response_lud_06() {
+    let invoice = "lnbc20m1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqhp58yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqsfpp3qjmp7lwpagxun9pygexvgpjdc4jdj85fr9yq20q82gphp2nflc7jtzrcazrra7wwgzxqc8u7754cdlpfrmccae92qgzqvzq2ps8pqqqqqqpqqqqq9qqqvpeuqafqxu92d8lr6fvg0r5gv0heeeqgcrqlnm6jhphu9y00rrhy4grqszsvpcgpy9qqqqqqgqqqqq7qqzq9qrsgqdfjcdk6w3ak5pca9hwfwfh63zrrz06wwfya0ydlzpgzxkn5xagsqz7x9j4jwe7yj7vaf2k9lqsdk45kts2fd0fkr28am0u4w95tt2nsq76cqw0";
+
+    let response = InvoiceResponse {
+        pr: invoice.parse().unwrap(),
+        routes: vec![],
+        verify: Some("https://example.com/verify/abc".to_string()),
+    };
+
+    let json = serde_json::to_value(LnurlResponse::Ok(response)).unwrap();
+
+    assert_eq!(json["pr"], invoice);
+    // LUD-06 requires the routes field to be present as an empty array
+    assert_eq!(json["routes"], serde_json::json!([]));
+    assert_eq!(json["verify"], "https://example.com/verify/abc");
+}
+
+#[test]
+fn parse_invoice_response_without_routes() {
+    let json = r#"{
+        "pr": "lnbc20m1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqhp58yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqsfpp3qjmp7lwpagxun9pygexvgpjdc4jdj85fr9yq20q82gphp2nflc7jtzrcazrra7wwgzxqc8u7754cdlpfrmccae92qgzqvzq2ps8pqqqqqqpqqqqq9qqqvpeuqafqxu92d8lr6fvg0r5gv0heeeqgcrqlnm6jhphu9y00rrhy4grqszsvpcgpy9qqqqqqgqqqqq7qqzq9qrsgqdfjcdk6w3ak5pca9hwfwfh63zrrz06wwfya0ydlzpgzxkn5xagsqz7x9j4jwe7yj7vaf2k9lqsdk45kts2fd0fkr28am0u4w95tt2nsq76cqw0",
+        "verify": null
+    }"#;
+
+    let response: LnurlResponse<InvoiceResponse> = serde_json::from_str(json).unwrap();
+
+    let invoice = response.into_result().unwrap();
+
+    assert!(invoice.routes.is_empty());
+    assert!(invoice.verify.is_none());
 }
 
 #[test]

--- a/fedimint-recurringdv2/src/main.rs
+++ b/fedimint-recurringdv2/src/main.rs
@@ -177,6 +177,7 @@ async fn invoice(
 
     Json(LnurlResponse::Ok(InvoiceResponse {
         pr: invoice.clone(),
+        routes: vec![],
         verify: Some(
             gateway
                 .join_path(&format!("verify/{}", invoice.payment_hash()))

--- a/fedimint-recurringdv2/src/main.rs
+++ b/fedimint-recurringdv2/src/main.rs
@@ -25,7 +25,7 @@ use fedimint_lnv2_common::{
     Bolt11InvoiceDescription, GatewayApi, MINIMUM_INCOMING_CONTRACT_AMOUNT, tweak,
 };
 use fedimint_logging::TracingSetup;
-use lightning_invoice::Bolt11Invoice;
+use lightning_invoice::{Bolt11Invoice, Bolt11InvoiceDescriptionRef};
 use serde::{Deserialize, Serialize};
 use tokio::net::TcpListener;
 use tower_http::cors;
@@ -35,6 +35,11 @@ use tracing::{info, warn};
 
 const MAX_SENDABLE_MSAT: u64 = 100_000_000_000;
 const MIN_SENDABLE_MSAT: u64 = 100_000;
+
+/// LNURL-pay metadata served in the initial `payRequest` response. Per LUD-06
+/// the invoice returned by the callback has to commit to this exact string via
+/// its description hash, so it must not change between the two requests.
+const LNURL_METADATA: &str = "[[\"text/plain\", \"Pay to Recurringd\"]]";
 
 #[derive(Debug, Parser)]
 struct CliOpts {
@@ -126,7 +131,7 @@ async fn pay(
         max_sendable: MAX_SENDABLE_MSAT,
         min_sendable: MIN_SENDABLE_MSAT,
         tag: pay_request_tag(),
-        metadata: "[[\"text/plain\", \"Pay to Recurringd\"]]".to_string(),
+        metadata: LNURL_METADATA.to_string(),
     }))
 }
 
@@ -241,13 +246,15 @@ async fn create_contract_and_fetch_invoice(
         ephemeral_pk,
     );
 
+    let metadata_hash = sha256::Hash::hash(LNURL_METADATA.as_bytes());
+
     let invoice = gateway_conn
         .bolt11_invoice(
             gateway.clone(),
             federation_id,
             contract.clone(),
             Amount::from_msats(amount),
-            Bolt11InvoiceDescription::Direct("LNURL Payment".to_string()),
+            Bolt11InvoiceDescription::Hash(metadata_hash),
             expiry_secs,
         )
         .await?;
@@ -260,6 +267,14 @@ async fn create_contract_and_fetch_invoice(
     ensure!(
         invoice.amount_milli_satoshis() == Some(amount),
         "Invalid invoice amount"
+    );
+
+    ensure!(
+        matches!(
+            invoice.description(),
+            Bolt11InvoiceDescriptionRef::Hash(hash) if hash.0 == metadata_hash
+        ),
+        "Invoice does not commit to the LNURL metadata via its description hash"
     );
 
     Ok((gateway, invoice))

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -3579,10 +3579,7 @@ impl Gateway {
         let operation_id = OperationId::from_encodable(&registered_contract.contract);
 
         if !(wait || client.operation_exists(operation_id).await) {
-            return Ok(VerifyResponse {
-                settled: false,
-                preimage: None,
-            });
+            return Ok(VerifyResponse::pending());
         }
 
         let module = client
@@ -3591,10 +3588,7 @@ impl Gateway {
 
         let Ok(state) = timeout(VERIFY_WAIT_TIMEOUT, module.await_receive(operation_id)).await
         else {
-            return Ok(VerifyResponse {
-                settled: false,
-                preimage: None,
-            });
+            return Ok(VerifyResponse::pending());
         };
 
         let preimage = match state {
@@ -3604,10 +3598,7 @@ impl Gateway {
             FinalReceiveState::Rejected => Err("Payment has been rejected".to_string()),
         }?;
 
-        Ok(VerifyResponse {
-            settled: true,
-            preimage: Some(preimage),
-        })
+        Ok(VerifyResponse::settled(preimage))
     }
 
     /// Retrieves the persisted `CreateInvoicePayload` from the database

--- a/modules/fedimint-lnv2-tests/bin/tests.rs
+++ b/modules/fedimint-lnv2-tests/bin/tests.rs
@@ -977,6 +977,8 @@ struct LnUrlPayResponse {
 #[derive(Deserialize, Clone)]
 struct LnUrlPayInvoiceResponse {
     pr: Bolt11Invoice,
+    // LUD-06 requires this field, so parsing fails if the service omits it
+    routes: Vec<serde_json::Value>,
     verify: String,
 }
 
@@ -995,6 +997,11 @@ async fn fetch_invoice(lnurl: String, amount_msat: u64) -> anyhow::Result<(Bolt1
     ensure!(
         invoice_response.pr.amount_milli_satoshis() == Some(amount_msat),
         "Invoice amount is not set"
+    );
+
+    ensure!(
+        invoice_response.routes.is_empty(),
+        "LUD-06 requires routes to be an empty array"
     );
 
     let metadata_hash = sha256::Hash::hash(response.metadata.as_bytes());

--- a/modules/fedimint-lnv2-tests/bin/tests.rs
+++ b/modules/fedimint-lnv2-tests/bin/tests.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use anyhow::ensure;
-use bitcoin::hashes::sha256;
+use bitcoin::hashes::{Hash, sha256};
 use clap::{Parser, Subcommand};
 use devimint::devfed::DevJitFed;
 use devimint::envs::FM_CLIENT_DIR_ENV;
@@ -17,7 +17,7 @@ use fedimint_core::task::{self};
 use fedimint_core::util::{backoff_util, retry, write_overwrite_async};
 use fedimint_lnurl::{LnurlResponse, VerifyResponse, parse_lnurl};
 use fedimint_lnv2_client::FinalSendOperationState;
-use lightning_invoice::Bolt11Invoice;
+use lightning_invoice::{Bolt11Invoice, Bolt11InvoiceDescriptionRef};
 use serde::Deserialize;
 use tokio::try_join;
 use tracing::info;
@@ -971,6 +971,7 @@ async fn verify_payment_wait(verify_url: String) -> anyhow::Result<VerifyRespons
 #[derive(Deserialize, Clone)]
 struct LnUrlPayResponse {
     callback: String,
+    metadata: String,
 }
 
 #[derive(Deserialize, Clone)]
@@ -986,17 +987,27 @@ async fn fetch_invoice(lnurl: String, amount_msat: u64) -> anyhow::Result<(Bolt1
 
     let callback_url = format!("{}?amount={}", response.callback, amount_msat);
 
-    let response = reqwest::get(callback_url)
+    let invoice_response = reqwest::get(callback_url)
         .await?
         .json::<LnUrlPayInvoiceResponse>()
         .await?;
 
     ensure!(
-        response.pr.amount_milli_satoshis() == Some(amount_msat),
+        invoice_response.pr.amount_milli_satoshis() == Some(amount_msat),
         "Invoice amount is not set"
     );
 
-    Ok((response.pr, response.verify))
+    let metadata_hash = sha256::Hash::hash(response.metadata.as_bytes());
+
+    ensure!(
+        matches!(
+            invoice_response.pr.description(),
+            Bolt11InvoiceDescriptionRef::Hash(hash) if hash.0 == metadata_hash
+        ),
+        "Invoice does not commit to the LNURL metadata via its description hash (LUD-06)"
+    );
+
+    Ok((invoice_response.pr, invoice_response.verify))
 }
 
 async fn test_iroh_payment(


### PR DESCRIPTION
## Summary

A downstream integration reported that invoices returned by `recurringdv2` are missing the LNURL description hash. Auditing the whole flow against the raw LUD-06/LUD-21 texts turned up three compliance gaps, fixed here one commit each.

## Details

1. **Invoice description hash (the reported issue).** The invoice was created with a plain `Direct("LNURL Payment")` description. LUD-06 expects the invoice to commit to the `payRequest` metadata via its description hash (`h` tag = SHA-256 of the exact metadata string), and many wallets refuse to pay without it. The metadata string is now a shared constant, the invoice is requested with `Bolt11InvoiceDescription::Hash(sha256(metadata))`, and recurringdv2 verifies the gateway honored the hash before handing the invoice to the payer — mirroring the existing payment-hash and amount checks against the semi-trusted gateway.
2. **`routes` field.** LUD-06 defines the callback response as `{pr, routes: []}`; the field is vestigial but mandatory. Added to `InvoiceResponse`, `#[serde(default)]` so parsing responses from services that omit it keeps working. This required promoting `serde_json` from dev-dependency to dependency in `fedimint-lnurl`.
3. **`status` field in LUD-21 verify responses.** The gateway's `/verify/{payment_hash}` endpoint (which the `verify` URL handed out by recurringdv2 points at) returned only `{settled, preimage}`, while LUD-21 responses carry `"status": "OK"` — clients that switch on `status` couldn't distinguish success from error. Added the field with `settled()`/`pending()` constructors keeping the `"OK"` literal in one place.

Everything else checked out against the spec: metadata format, min/max sendable, error shape, amount validation, callback URL construction.

**Known remaining deviation (out of scope):** LUD-21 examples also include `pr` (the invoice) in the verify response, but the gateway only persists the incoming contract, not the invoice, so returning it needs a `RegisteredIncomingContract` DB migration with an optional field for in-flight records. Left for a follow-up; verify callers already hold the invoice from the callback step.

## Reviewing

- The metadata constant must stay byte-identical between the `/pay` response and the hashed value; that's why it was hoisted into `LNURL_METADATA` rather than staying inline.
- The new JSON fields are additive and defaulted on deserialization, so older services/clients interoperate both ways.
- The description-hash `ensure!` after invoice creation is hardening, not required for compliance — without it a misbehaving gateway would silently reintroduce the exact downstream complaint.

## Testing

- New unit tests in `fedimint-lnurl` assert the serialized response shapes (`routes: []` present, `status: "OK"` present, parsing without either still works).
- The lnv2 integration test now derives the expected hash from the served metadata and asserts the invoice commits to it, and fails to parse a callback response without `routes`. (Back-compat CI never swaps the recurringdv2 binary, so these assertions are safe there.)
- `just final-lint` (pre-commit hook, workspace clippy `-D warnings`, cargo-sort) passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)