### PR TITLE
chore(client): replace anyhow with typed errors in the public API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3625,6 +3625,7 @@ dependencies = [
  "serde",
  "serde_json",
  "test-log",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "uniffi",

--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -858,7 +858,6 @@ impl FedimintCli {
     async fn make_client_builder(&self, cli: &Opts) -> CliResult<(ClientBuilder, Database)> {
         let mut client_builder = Client::builder()
             .await
-            .map_err_cli()?
             .with_iroh_enable_dht(cli.iroh_enable_dht());
         client_builder.with_module_inits(self.module_inits.clone());
 

--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -1826,7 +1826,7 @@ impl FedimintCli {
                             Box::pin(async move {
                                 info!(target: LOG_CLIENT, "{event:?}");
 
-                                Ok(())
+                                Ok::<(), std::convert::Infallible>(())
                             })
                         },
                     )

--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -1508,10 +1508,7 @@ impl FedimintCli {
 
             Command::Dev(DevCmd::WaitComplete) => {
                 let client = self.client_open(&cli).await?;
-                client
-                    .wait_for_all_active_state_machines()
-                    .await
-                    .map_err_cli_msg("failed to wait for all active state machines")?;
+                client.wait_for_all_active_state_machines().await;
                 Ok(CliOutput::Raw(serde_json::Value::Null))
             }
             Command::Dev(DevCmd::Wait { seconds }) => {

--- a/fedimint-client-module/Cargo.toml
+++ b/fedimint-client-module/Cargo.toml
@@ -18,7 +18,7 @@ rustc-args = ["--cfg", "tokio_unstable"]
 
 [features]
 tor = ["fedimint-api-client/tor"]
-uniffi = ["dep:uniffi"]
+uniffi = ["dep:uniffi", "fedimint-core/uniffi"]
 
 [lib]
 name = "fedimint_client_module"

--- a/fedimint-client-module/src/api_version_discovery.rs
+++ b/fedimint-client-module/src/api_version_discovery.rs
@@ -1,11 +1,12 @@
 use std::collections::BTreeMap;
 
-use anyhow::format_err;
 use fedimint_api_client::api::ApiVersionSet;
 use fedimint_core::PeerId;
 use fedimint_core::module::{
     ApiVersion, SupportedApiVersionsSummary, SupportedCoreApiVersions, SupportedModuleApiVersions,
 };
+
+use crate::error::ApiVersionDiscoveryError;
 
 pub fn discover_common_core_api_version(
     client_versions: &SupportedCoreApiVersions,
@@ -218,7 +219,7 @@ fn discover_common_module_api_version(
 pub fn discover_common_api_versions_set(
     client_versions: &SupportedApiVersionsSummary,
     peer_versions: &BTreeMap<PeerId, SupportedApiVersionsSummary>,
-) -> anyhow::Result<ApiVersionSet> {
+) -> Result<ApiVersionSet, ApiVersionDiscoveryError> {
     Ok(ApiVersionSet {
         core: discover_common_core_api_version(
             &client_versions.core,
@@ -229,7 +230,7 @@ pub fn discover_common_api_versions_set(
                 })
                 .collect(),
         )
-        .ok_or_else(|| format_err!("Could not find a common core API version"))?,
+        .ok_or(ApiVersionDiscoveryError)?,
         modules: client_versions
             .modules
             .iter()

--- a/fedimint-client-module/src/error.rs
+++ b/fedimint-client-module/src/error.rs
@@ -5,7 +5,7 @@
 //! sides; they live here rather than in `fedimint-client`, which the modules do
 //! not depend on.
 
-use fedimint_core::core::{ModuleKind, OperationId};
+use fedimint_core::core::{ModuleInstanceId, ModuleKind, OperationId};
 use fedimint_core::db::DatabaseError;
 use fedimint_core::module::AmountUnit;
 use thiserror::Error;
@@ -95,4 +95,47 @@ pub enum TransactionSubmitError {
     /// The transaction's state machines could not be registered.
     #[error("Failed to add the transaction's state machines")]
     StateMachines(#[from] AddStateMachinesError),
+}
+
+/// A failure to find a module able to serve a request.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum ModuleLookupError {
+    /// The client was not built with a module of this kind, or the federation
+    /// does not offer one.
+    #[error("No module of kind {kind} found")]
+    NoModuleOfKind {
+        /// The kind that was asked for.
+        kind: ModuleKind,
+    },
+
+    /// The client has no module with this instance id.
+    #[error("Unknown module instance {instance_id}")]
+    UnknownInstance {
+        /// The instance id that was asked for.
+        instance_id: ModuleInstanceId,
+    },
+
+    /// The module instance exists, but is not of the requested type.
+    #[error("Module instance {instance_id} is not of type {expected}")]
+    WrongModuleType {
+        /// The instance that was asked for.
+        instance_id: ModuleInstanceId,
+        /// The Rust type the caller asked the instance to be.
+        expected: &'static str,
+    },
+
+    /// No primary module can hold funds of this unit.
+    #[error("No primary module for unit {unit:?}")]
+    NoPrimaryModule {
+        /// The unit that has no primary module.
+        unit: AmountUnit,
+    },
+}
+
+#[cfg(feature = "uniffi")]
+impl From<ModuleLookupError> for fedimint_core::util::ffi::UniffiError {
+    fn from(e: ModuleLookupError) -> Self {
+        Self::General(e.to_string())
+    }
 }

--- a/fedimint-client-module/src/error.rs
+++ b/fedimint-client-module/src/error.rs
@@ -10,7 +10,30 @@ use fedimint_core::db::DatabaseError;
 use fedimint_core::module::AmountUnit;
 use thiserror::Error;
 
-use crate::AddStateMachinesError;
+/// A failure to add state machines to the client's executor.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum AddStateMachinesError {
+    /// One of the states is already in the database.
+    #[error("State already exists in database")]
+    StateAlreadyExists,
+
+    /// A state belongs to a module instance the executor does not know.
+    #[error("Unknown module instance {module_instance_id}")]
+    UnknownModule {
+        /// The instance the state claims to belong to.
+        module_instance_id: ModuleInstanceId,
+    },
+
+    /// A state that can no longer transition was handed to the executor,
+    /// which would never make progress on it.
+    #[error("State is already terminal, adding it to the executor does not make sense")]
+    StateAlreadyTerminal,
+
+    /// The database write failed.
+    #[error("Database error")]
+    Database(#[from] DatabaseError),
+}
 
 /// An operation with the same id already exists in the operation log.
 #[derive(Debug, Error)]

--- a/fedimint-client-module/src/error.rs
+++ b/fedimint-client-module/src/error.rs
@@ -1,0 +1,48 @@
+//! Error types shared between the client and its modules.
+//!
+//! The client implements the traits in [`crate::module`] and [`crate`] for its
+//! modules, so the failures those traits report have to be nameable from both
+//! sides; they live here rather than in `fedimint-client`, which the modules do
+//! not depend on.
+
+use fedimint_core::core::{ModuleKind, OperationId};
+use thiserror::Error;
+
+/// An operation with the same id already exists in the operation log.
+#[derive(Debug, Error)]
+#[error("An operation with id {} already exists", .operation_id.fmt_short())]
+pub struct OperationAlreadyExistsError {
+    /// The id that is already taken.
+    pub operation_id: OperationId,
+}
+
+/// No operation with the requested id exists in the operation log.
+#[derive(Debug, Error)]
+#[error("No operation with id {}", .operation_id.fmt_short())]
+pub struct OperationNotFoundError {
+    /// The id that was looked up.
+    pub operation_id: OperationId,
+}
+
+/// A failure to look up one of a module's own operations.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum OperationLookupError {
+    /// The operation log has no entry with this id.
+    #[error("The operation does not exist")]
+    NotFound(#[from] OperationNotFoundError),
+
+    /// The operation exists, but was started by a different module.
+    #[error(
+        "Operation {} was started by module {found}, not {expected}",
+        .operation_id.fmt_short()
+    )]
+    WrongModuleKind {
+        /// The operation that was looked up.
+        operation_id: OperationId,
+        /// The kind of the module doing the lookup.
+        expected: ModuleKind,
+        /// The kind of the module that started the operation.
+        found: String,
+    },
+}

--- a/fedimint-client-module/src/error.rs
+++ b/fedimint-client-module/src/error.rs
@@ -162,3 +162,12 @@ impl From<ModuleLookupError> for fedimint_core::util::ffi::UniffiError {
         Self::General(e.to_string())
     }
 }
+
+/// The client and the federation's peers share no core API version.
+///
+/// Module version mismatches are not an error: a module whose versions do not
+/// line up is left out of the negotiated set and stays unusable until one side
+/// is upgraded.
+#[derive(Debug, Error)]
+#[error("Could not find a common core API version")]
+pub struct ApiVersionDiscoveryError;

--- a/fedimint-client-module/src/error.rs
+++ b/fedimint-client-module/src/error.rs
@@ -174,6 +174,13 @@ impl From<ModuleLookupError> for fedimint_core::util::ffi::UniffiError {
 pub struct ApiVersionDiscoveryError;
 
 /// A failure to fetch the federation's meta fields.
+///
+/// The built-in sources produce the specific variants. A [`MetaSource`]
+/// implemented elsewhere reports anything they do not describe through
+/// [`Custom`].
+///
+/// [`MetaSource`]: crate::meta::MetaSource
+/// [`Custom`]: MetaFetchError::Custom
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum MetaFetchError {
@@ -181,8 +188,8 @@ pub enum MetaFetchError {
     #[error("Failed to read the meta override URL from the client config")]
     Config(#[from] ModuleConfigError),
 
-    /// The meta override source could not be reached, or did not answer with
-    /// the expected body.
+    /// The meta override source could not be reached, or its body could not
+    /// be read.
     #[error("The meta override source could not be fetched")]
     Http(#[from] reqwest::Error),
 
@@ -203,4 +210,9 @@ pub enum MetaFetchError {
         /// The federation that was looked up.
         federation_id: FederationId,
     },
+
+    /// A meta source implemented outside this crate failed in a way the other
+    /// variants do not describe.
+    #[error("The meta source failed")]
+    Custom(#[source] Box<dyn std::error::Error + Send + Sync>),
 }

--- a/fedimint-client-module/src/error.rs
+++ b/fedimint-client-module/src/error.rs
@@ -99,7 +99,7 @@ pub enum TransactionSubmitError {
 
     /// No primary module can hold funds of this unit, so the transaction
     /// cannot be balanced.
-    #[error("No primary module for unit {unit:?}")]
+    #[error("No primary module for unit {unit}")]
     NoPrimaryModule {
         /// The unit that could not be balanced.
         unit: AmountUnit,
@@ -150,7 +150,7 @@ pub enum ModuleLookupError {
     },
 
     /// No primary module can hold funds of this unit.
-    #[error("No primary module for unit {unit:?}")]
+    #[error("No primary module for unit {unit}")]
     NoPrimaryModule {
         /// The unit that has no primary module.
         unit: AmountUnit,
@@ -177,8 +177,8 @@ pub struct ApiVersionDiscoveryError;
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum MetaFetchError {
-    /// The meta override url could not be read from the client config.
-    #[error("Failed to read the meta override url from the client config")]
+    /// The meta override URL could not be read from the client config.
+    #[error("Failed to read the meta override URL from the client config")]
     Config(#[from] ModuleConfigError),
 
     /// The meta override source could not be reached, or did not answer with

--- a/fedimint-client-module/src/error.rs
+++ b/fedimint-client-module/src/error.rs
@@ -5,6 +5,7 @@
 //! sides; they live here rather than in `fedimint-client`, which the modules do
 //! not depend on.
 
+use fedimint_core::config::{FederationId, ModuleConfigError};
 use fedimint_core::core::{ModuleInstanceId, ModuleKind, OperationId};
 use fedimint_core::db::DatabaseError;
 use fedimint_core::module::AmountUnit;
@@ -171,3 +172,35 @@ impl From<ModuleLookupError> for fedimint_core::util::ffi::UniffiError {
 #[derive(Debug, Error)]
 #[error("Could not find a common core API version")]
 pub struct ApiVersionDiscoveryError;
+
+/// A failure to fetch the federation's meta fields.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum MetaFetchError {
+    /// The meta override url could not be read from the client config.
+    #[error("Failed to read the meta override url from the client config")]
+    Config(#[from] ModuleConfigError),
+
+    /// The meta override source could not be reached, or did not answer with
+    /// the expected body.
+    #[error("The meta override source could not be fetched")]
+    Http(#[from] reqwest::Error),
+
+    /// The meta override source answered with a non-success status.
+    #[error("The meta override source answered with status {status}")]
+    Status {
+        /// The status the source answered with.
+        status: reqwest::StatusCode,
+    },
+
+    /// The meta override source's body is not the expected JSON.
+    #[error("The meta override source returned invalid JSON")]
+    Json(#[from] serde_json::Error),
+
+    /// The meta override source has no entry for this federation.
+    #[error("The meta override source has no entry for federation {federation_id}")]
+    NoEntry {
+        /// The federation that was looked up.
+        federation_id: FederationId,
+    },
+}

--- a/fedimint-client-module/src/error.rs
+++ b/fedimint-client-module/src/error.rs
@@ -6,7 +6,11 @@
 //! not depend on.
 
 use fedimint_core::core::{ModuleKind, OperationId};
+use fedimint_core::db::DatabaseError;
+use fedimint_core::module::AmountUnit;
 use thiserror::Error;
+
+use crate::AddStateMachinesError;
 
 /// An operation with the same id already exists in the operation log.
 #[derive(Debug, Error)]
@@ -45,4 +49,50 @@ pub enum OperationLookupError {
         /// The kind of the module that started the operation.
         found: String,
     },
+}
+
+/// A failure to build, submit or complete a client transaction.
+///
+/// Covers the whole path a transaction takes on the client: balancing it with
+/// the primary module, recording its operation, registering its state machines,
+/// and waiting for the primary module's outputs to finalize. Submission to the
+/// federation itself is driven by a state machine and is not reported here.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum TransactionSubmitError {
+    /// The operation the transaction would be recorded under already exists.
+    #[error("The operation already exists")]
+    OperationAlreadyExists(#[from] OperationAlreadyExistsError),
+
+    /// The finalized transaction is larger than the federation accepts.
+    #[error("The transaction is {size} bytes, over the limit of {max}")]
+    TransactionTooLarge {
+        /// The size of the encoded transaction.
+        size: usize,
+        /// The largest transaction the federation accepts.
+        max: usize,
+    },
+
+    /// No primary module can hold funds of this unit, so the transaction
+    /// cannot be balanced.
+    #[error("No primary module for unit {unit:?}")]
+    NoPrimaryModule {
+        /// The unit that could not be balanced.
+        unit: AmountUnit,
+    },
+
+    /// The primary module failed to balance the transaction or to complete
+    /// its outputs.
+    // The boxed cause narrows to `ClientModuleError` once the module->client
+    // trait boundary is typed (#8821 part E).
+    #[error("The primary module failed")]
+    PrimaryModule(#[source] Box<dyn std::error::Error + Send + Sync>),
+
+    /// Writing the transaction to the database failed.
+    #[error("Database error")]
+    Database(#[from] DatabaseError),
+
+    /// The transaction's state machines could not be registered.
+    #[error("Failed to add the transaction's state machines")]
+    StateMachines(#[from] AddStateMachinesError),
 }

--- a/fedimint-client-module/src/lib.rs
+++ b/fedimint-client-module/src/lib.rs
@@ -41,7 +41,10 @@ use transaction::{
     ClientInputBundle, ClientInputSM, ClientOutput, ClientOutputSM, TxSubmissionStatesSM,
 };
 
-pub use crate::error::{OperationAlreadyExistsError, OperationLookupError, OperationNotFoundError};
+pub use crate::error::{
+    OperationAlreadyExistsError, OperationLookupError, OperationNotFoundError,
+    TransactionSubmitError,
+};
 pub use crate::module::{ClientModule, StateGenerator};
 use crate::sm::executor::ContextGen;
 use crate::sm::{ClientSMDatabaseTransaction, DynState, IState, State};
@@ -244,7 +247,7 @@ pub trait IGlobalClientContext: Debug + MaybeSend + MaybeSync + 'static {
         &self,
         dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
         inputs: InstancelessDynClientInputBundle,
-    ) -> anyhow::Result<OutPointRange>;
+    ) -> Result<OutPointRange, TransactionSubmitError>;
 
     /// This function is mostly meant for internal use, you are probably looking
     /// for [`DynGlobalClientContext::fund_output`].
@@ -254,7 +257,7 @@ pub trait IGlobalClientContext: Debug + MaybeSend + MaybeSync + 'static {
         &self,
         dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
         outputs: InstancelessDynClientOutputBundle,
-    ) -> anyhow::Result<OutPointRange>;
+    ) -> Result<OutPointRange, TransactionSubmitError>;
 
     /// Adds a state machine to the executor.
     async fn add_state_machine_dyn(
@@ -314,7 +317,7 @@ impl IGlobalClientContext for () {
         &self,
         _dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
         _input: InstancelessDynClientInputBundle,
-    ) -> anyhow::Result<OutPointRange> {
+    ) -> Result<OutPointRange, TransactionSubmitError> {
         unimplemented!("fake implementation, only for tests");
     }
 
@@ -322,7 +325,7 @@ impl IGlobalClientContext for () {
         &self,
         _dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
         _outputs: InstancelessDynClientOutputBundle,
-    ) -> anyhow::Result<OutPointRange> {
+    ) -> Result<OutPointRange, TransactionSubmitError> {
         unimplemented!("fake implementation, only for tests");
     }
 
@@ -396,7 +399,7 @@ impl DynGlobalClientContext {
         &self,
         dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
         inputs: ClientInputBundle<I, S>,
-    ) -> anyhow::Result<OutPointRange>
+    ) -> Result<OutPointRange, TransactionSubmitError>
     where
         I: IInput + MaybeSend + MaybeSync + 'static,
         S: IState + MaybeSend + MaybeSync + 'static,
@@ -417,7 +420,7 @@ impl DynGlobalClientContext {
         &self,
         dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
         outputs: ClientOutputBundle<O, S>,
-    ) -> anyhow::Result<OutPointRange>
+    ) -> Result<OutPointRange, TransactionSubmitError>
     where
         O: IOutput + MaybeSend + MaybeSync + 'static,
         S: IState + MaybeSend + MaybeSync + 'static,

--- a/fedimint-client-module/src/lib.rs
+++ b/fedimint-client-module/src/lib.rs
@@ -41,7 +41,7 @@ use transaction::{
 };
 
 pub use crate::error::{
-    AddStateMachinesError, ApiVersionDiscoveryError, ModuleLookupError,
+    AddStateMachinesError, ApiVersionDiscoveryError, MetaFetchError, ModuleLookupError,
     OperationAlreadyExistsError, OperationLookupError, OperationNotFoundError,
     TransactionSubmitError,
 };

--- a/fedimint-client-module/src/lib.rs
+++ b/fedimint-client-module/src/lib.rs
@@ -41,8 +41,9 @@ use transaction::{
 };
 
 pub use crate::error::{
-    AddStateMachinesError, ModuleLookupError, OperationAlreadyExistsError, OperationLookupError,
-    OperationNotFoundError, TransactionSubmitError,
+    AddStateMachinesError, ApiVersionDiscoveryError, ModuleLookupError,
+    OperationAlreadyExistsError, OperationLookupError, OperationNotFoundError,
+    TransactionSubmitError,
 };
 pub use crate::module::{ClientModule, StateGenerator};
 use crate::sm::executor::ContextGen;

--- a/fedimint-client-module/src/lib.rs
+++ b/fedimint-client-module/src/lib.rs
@@ -35,15 +35,14 @@ use fedimint_logging::LOG_CLIENT;
 use futures::StreamExt;
 use module::OutPointRange;
 use serde::{Deserialize, Serialize};
-use thiserror::Error;
 use tracing::debug;
 use transaction::{
     ClientInputBundle, ClientInputSM, ClientOutput, ClientOutputSM, TxSubmissionStatesSM,
 };
 
 pub use crate::error::{
-    ModuleLookupError, OperationAlreadyExistsError, OperationLookupError, OperationNotFoundError,
-    TransactionSubmitError,
+    AddStateMachinesError, ModuleLookupError, OperationAlreadyExistsError, OperationLookupError,
+    OperationNotFoundError, TransactionSubmitError,
 };
 pub use crate::module::{ClientModule, StateGenerator};
 use crate::sm::executor::ContextGen;
@@ -210,14 +209,6 @@ pub type InstancelessDynClientOutputBundle = ClientOutputBundle<
     Box<maybe_add_send_sync!(dyn IOutput + 'static)>,
     Box<maybe_add_send_sync!(dyn IState + 'static)>,
 >;
-
-#[derive(Debug, Error)]
-pub enum AddStateMachinesError {
-    #[error("State already exists in database")]
-    StateAlreadyExists,
-    #[error("Got {0}")]
-    Other(#[from] anyhow::Error),
-}
 
 pub type AddStateMachinesResult = Result<(), AddStateMachinesError>;
 

--- a/fedimint-client-module/src/lib.rs
+++ b/fedimint-client-module/src/lib.rs
@@ -41,6 +41,7 @@ use transaction::{
     ClientInputBundle, ClientInputSM, ClientOutput, ClientOutputSM, TxSubmissionStatesSM,
 };
 
+pub use crate::error::{OperationAlreadyExistsError, OperationLookupError, OperationNotFoundError};
 pub use crate::module::{ClientModule, StateGenerator};
 use crate::sm::executor::ContextGen;
 use crate::sm::{ClientSMDatabaseTransaction, DynState, IState, State};
@@ -49,6 +50,9 @@ use crate::transaction::{ClientInput, ClientOutputBundle, TxSubmissionStates};
 pub mod api;
 
 pub mod db;
+
+/// Error types shared between the client and its modules
+pub mod error;
 
 pub mod backup;
 /// Environment variables

--- a/fedimint-client-module/src/lib.rs
+++ b/fedimint-client-module/src/lib.rs
@@ -42,7 +42,7 @@ use transaction::{
 };
 
 pub use crate::error::{
-    OperationAlreadyExistsError, OperationLookupError, OperationNotFoundError,
+    ModuleLookupError, OperationAlreadyExistsError, OperationLookupError, OperationNotFoundError,
     TransactionSubmitError,
 };
 pub use crate::module::{ClientModule, StateGenerator};

--- a/fedimint-client-module/src/meta.rs
+++ b/fedimint-client-module/src/meta.rs
@@ -172,9 +172,9 @@ pub async fn fetch_meta_overrides(
         });
     }
 
-    let mut federation_map = response
-        .json::<BTreeMap<String, BTreeMap<String, serde_json::Value>>>()
-        .await?;
+    let body = response.bytes().await?;
+    let mut federation_map =
+        serde_json::from_slice::<BTreeMap<String, BTreeMap<String, serde_json::Value>>>(&body)?;
 
     let federation_id = client_config.calculate_federation_id();
     let meta_fields = federation_map

--- a/fedimint-client-module/src/meta.rs
+++ b/fedimint-client-module/src/meta.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeMap;
 use std::time::{Duration, SystemTime};
 
-use anyhow::{Context as _, bail};
 use fedimint_api_client::api::DynGlobalApi;
 use fedimint_core::config::ClientConfig;
 use fedimint_core::encoding::{Decodable, DecodeError, Encodable};
@@ -13,6 +12,8 @@ use fedimint_logging::LOG_CLIENT;
 use serde::{Deserialize, Serialize, de};
 use tracing::debug;
 
+use crate::error::MetaFetchError;
+
 #[apply(async_trait_maybe_send!)]
 pub trait MetaSource: MaybeSend + MaybeSync + 'static {
     /// Wait for next change in this source.
@@ -23,7 +24,7 @@ pub trait MetaSource: MaybeSend + MaybeSync + 'static {
         api: &DynGlobalApi,
         fetch_kind: FetchKind,
         last_revision: Option<u64>,
-    ) -> anyhow::Result<MetaValues>;
+    ) -> Result<MetaValues, MetaFetchError>;
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -67,7 +68,7 @@ impl MetaSource for LegacyMetaSource {
         _api: &DynGlobalApi,
         fetch_kind: FetchKind,
         last_revision: Option<u64>,
-    ) -> anyhow::Result<MetaValues> {
+    ) -> Result<MetaValues, MetaFetchError> {
         let config_iter = client_config.global.meta.iter().map(|(key, value)| {
             (
                 MetaFieldKey(key.clone()),
@@ -157,34 +158,28 @@ pub async fn fetch_meta_overrides(
     reqwest: &reqwest::Client,
     client_config: &ClientConfig,
     field_name: &str,
-) -> anyhow::Result<BTreeMap<MetaFieldKey, MetaFieldValue>> {
+) -> Result<BTreeMap<MetaFieldKey, MetaFieldValue>, MetaFetchError> {
     let Some(url) = client_config.meta::<String>(field_name)? else {
         return Ok(BTreeMap::new());
     };
-    let response = reqwest
-        .get(&url)
-        .send()
-        .await
-        .context("Meta override source could not be fetched")?;
+    let response = reqwest.get(&url).send().await?;
 
     debug!("Meta override source returned status: {response:?}");
 
     if response.status() != reqwest::StatusCode::OK {
-        bail!(
-            "Meta override request returned non-OK status code: {}",
-            response.status()
-        );
+        return Err(MetaFetchError::Status {
+            status: response.status(),
+        });
     }
 
     let mut federation_map = response
         .json::<BTreeMap<String, BTreeMap<String, serde_json::Value>>>()
-        .await
-        .context("Meta override could not be parsed as JSON")?;
+        .await?;
 
-    let federation_id = client_config.calculate_federation_id().to_string();
+    let federation_id = client_config.calculate_federation_id();
     let meta_fields = federation_map
-        .remove(&federation_id)
-        .with_context(|| anyhow::format_err!("No entry for federation {federation_id} in {url}"))?
+        .remove(&federation_id.to_string())
+        .ok_or(MetaFetchError::NoEntry { federation_id })?
         .into_iter()
         .map(|(key, value)| (MetaFieldKey(key), MetaFieldValue(value)))
         .collect::<BTreeMap<_, _>>();

--- a/fedimint-client-module/src/module/mod.rs
+++ b/fedimint-client-module/src/module/mod.rs
@@ -35,7 +35,7 @@ use tracing::warn;
 
 use self::init::ClientModuleInit;
 use crate::error::{
-    OperationAlreadyExistsError, OperationLookupError, OperationNotFoundError,
+    ModuleLookupError, OperationAlreadyExistsError, OperationLookupError, OperationNotFoundError,
     TransactionSubmitError,
 };
 use crate::module::recovery::{DynModuleBackup, ModuleBackup};
@@ -101,7 +101,7 @@ pub trait ClientContextIface: MaybeSend + MaybeSync {
 
     /// The client's balance for `unit`, held by the primary module. See
     /// `Client::get_balance_for_unit`.
-    async fn get_balance_for_unit(&self, unit: AmountUnit) -> anyhow::Result<Amount>;
+    async fn get_balance_for_unit(&self, unit: AmountUnit) -> Result<Amount, ModuleLookupError>;
 
     async fn transaction_updates(&self, operation_id: OperationId) -> TransactionUpdates;
 
@@ -445,7 +445,7 @@ where
 
     /// The client's Bitcoin balance, held by the primary module. See
     /// `Client::get_balance_for_btc`.
-    pub async fn get_balance_for_btc(&self) -> anyhow::Result<Amount> {
+    pub async fn get_balance_for_btc(&self) -> Result<Amount, ModuleLookupError> {
         self.client
             .get()
             .get_balance_for_unit(AmountUnit::BITCOIN)

--- a/fedimint-client-module/src/module/mod.rs
+++ b/fedimint-client-module/src/module/mod.rs
@@ -34,6 +34,7 @@ use serde::de::DeserializeOwned;
 use tracing::warn;
 
 use self::init::ClientModuleInit;
+use crate::error::{OperationLookupError, OperationNotFoundError};
 use crate::module::recovery::{DynModuleBackup, ModuleBackup};
 use crate::oplog::{IOperationLog, OperationLogEntry, UpdateStreamOrOutcome};
 use crate::sm::executor::{ActiveStateKey, IExecutor, InactiveStateKey};
@@ -468,17 +469,21 @@ where
     pub async fn get_operation(
         &self,
         operation_id: OperationId,
-    ) -> anyhow::Result<oplog::OperationLogEntry> {
+    ) -> Result<oplog::OperationLogEntry, OperationLookupError> {
         let operation = self
             .client
             .get()
             .operation_log()
             .get_operation(operation_id)
             .await
-            .ok_or(anyhow::anyhow!("Operation not found"))?;
+            .ok_or(OperationNotFoundError { operation_id })?;
 
         if operation.operation_module_kind() != M::kind().as_str() {
-            bail!("Operation is not a lightning operation");
+            return Err(OperationLookupError::WrongModuleKind {
+                operation_id,
+                expected: M::kind(),
+                found: operation.operation_module_kind().to_owned(),
+            });
         }
 
         Ok(operation)

--- a/fedimint-client-module/src/module/mod.rs
+++ b/fedimint-client-module/src/module/mod.rs
@@ -126,7 +126,7 @@ pub trait ClientContextIface: MaybeSend + MaybeSync {
 
     async fn invite_code(&self, peer: PeerId) -> Option<InviteCode>;
 
-    fn get_internal_payment_markers(&self) -> anyhow::Result<(PublicKey, u64)>;
+    fn get_internal_payment_markers(&self) -> Result<(PublicKey, u64), bitcoin::secp256k1::Error>;
 
     #[allow(clippy::too_many_arguments)]
     async fn log_event_json(
@@ -629,7 +629,9 @@ where
             .expect("The guardian we requested an invite code for exists")
     }
 
-    pub fn get_internal_payment_markers(&self) -> anyhow::Result<(PublicKey, u64)> {
+    pub fn get_internal_payment_markers(
+        &self,
+    ) -> Result<(PublicKey, u64), bitcoin::secp256k1::Error> {
         self.client.get().get_internal_payment_markers()
     }
 

--- a/fedimint-client-module/src/module/mod.rs
+++ b/fedimint-client-module/src/module/mod.rs
@@ -6,7 +6,7 @@ use std::pin::Pin;
 use std::sync::{Arc, Weak};
 use std::{ffi, marker, ops};
 
-use anyhow::{anyhow, bail};
+use anyhow::bail;
 use bitcoin::secp256k1::PublicKey;
 use fedimint_api_client::api::{DynGlobalApi, DynModuleApi};
 use fedimint_core::config::ClientConfig;
@@ -34,7 +34,10 @@ use serde::de::DeserializeOwned;
 use tracing::warn;
 
 use self::init::ClientModuleInit;
-use crate::error::{OperationLookupError, OperationNotFoundError};
+use crate::error::{
+    OperationAlreadyExistsError, OperationLookupError, OperationNotFoundError,
+    TransactionSubmitError,
+};
 use crate::module::recovery::{DynModuleBackup, ModuleBackup};
 use crate::oplog::{IOperationLog, OperationLogEntry, UpdateStreamOrOutcome};
 use crate::sm::executor::{ActiveStateKey, IExecutor, InactiveStateKey};
@@ -68,7 +71,7 @@ pub trait ClientContextIface: MaybeSend + MaybeSync {
         operation_type: &str,
         operation_meta_gen: Box<maybe_add_send_sync!(dyn Fn(OutPointRange) -> serde_json::Value)>,
         tx_builder: TransactionBuilder,
-    ) -> anyhow::Result<OutPointRange>;
+    ) -> Result<OutPointRange, TransactionSubmitError>;
 
     async fn finalize_and_submit_transaction_dbtx(
         &self,
@@ -77,7 +80,7 @@ pub trait ClientContextIface: MaybeSend + MaybeSync {
         operation_type: &str,
         operation_meta_gen: Box<maybe_add_send_sync!(dyn Fn(OutPointRange) -> serde_json::Value)>,
         tx_builder: TransactionBuilder,
-    ) -> anyhow::Result<OutPointRange>;
+    ) -> Result<OutPointRange, TransactionSubmitError>;
 
     // TODO: unify
     async fn finalize_and_submit_transaction_inner(
@@ -85,7 +88,7 @@ pub trait ClientContextIface: MaybeSend + MaybeSync {
         dbtx: &mut DatabaseTransaction<'_>,
         operation_id: OperationId,
         tx_builder: TransactionBuilder,
-    ) -> anyhow::Result<OutPointRange>;
+    ) -> Result<OutPointRange, TransactionSubmitError>;
 
     /// Computes the fee finalizing and submitting a transaction with the
     /// explicit items described by `request` would incur, without submitting
@@ -94,7 +97,7 @@ pub trait ClientContextIface: MaybeSend + MaybeSync {
         &self,
         operation_id: OperationId,
         request: FeeQuoteRequest,
-    ) -> anyhow::Result<FeeQuote>;
+    ) -> Result<FeeQuote, TransactionSubmitError>;
 
     /// The client's balance for `unit`, held by the primary module. See
     /// `Client::get_balance_for_unit`.
@@ -107,7 +110,7 @@ pub trait ClientContextIface: MaybeSend + MaybeSync {
         operation_id: OperationId,
         // TODO: make `impl Iterator<Item = ...>`
         outputs: Vec<OutPoint>,
-    ) -> anyhow::Result<()>;
+    ) -> Result<(), TransactionSubmitError>;
 
     fn operation_log(&self) -> &dyn IOperationLog;
 
@@ -380,7 +383,7 @@ where
         operation_type: &str,
         operation_meta_gen: F,
         tx_builder: TransactionBuilder,
-    ) -> anyhow::Result<OutPointRange>
+    ) -> Result<OutPointRange, TransactionSubmitError>
     where
         F: Fn(OutPointRange) -> Meta + Clone + MaybeSend + MaybeSync + 'static,
         Meta: serde::Serialize + MaybeSend,
@@ -405,7 +408,7 @@ where
         operation_type: &str,
         operation_meta_gen: F,
         tx_builder: TransactionBuilder,
-    ) -> anyhow::Result<OutPointRange>
+    ) -> Result<OutPointRange, TransactionSubmitError>
     where
         F: Fn(OutPointRange) -> Meta + MaybeSend + MaybeSync + 'static,
         Meta: serde::Serialize + MaybeSend,
@@ -436,7 +439,7 @@ where
         &self,
         operation_id: OperationId,
         request: FeeQuoteRequest,
-    ) -> anyhow::Result<FeeQuote> {
+    ) -> Result<FeeQuote, TransactionSubmitError> {
         self.client.get().fee_quote(operation_id, request).await
     }
 
@@ -458,7 +461,7 @@ where
         operation_id: OperationId,
         // TODO: make `impl Iterator<Item = ...>`
         outputs: Vec<OutPoint>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), TransactionSubmitError> {
         self.client
             .get()
             .await_primary_module_outputs(operation_id, outputs)
@@ -638,7 +641,7 @@ where
         op_type: &str,
         operation_meta: impl serde::Serialize + Debug,
         sms: Vec<DynState>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), TransactionSubmitError> {
         let db = self.module_db();
         let mut dbtx = db.begin_transaction().await;
         {
@@ -654,12 +657,7 @@ where
             .await?;
         }
 
-        dbtx.commit_tx_result().await.map_err(|_| {
-            anyhow!(
-                "Operation with id {} already exists",
-                operation_id.fmt_short()
-            )
-        })?;
+        dbtx.commit_tx_result().await?;
 
         Ok(())
     }
@@ -671,7 +669,7 @@ where
         op_type: &str,
         operation_meta: impl serde::Serialize + Debug,
         sms: Vec<DynState>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), OperationAlreadyExistsError> {
         self.manual_operation_start_inner(
             &mut dbtx.global_dbtx(self.global_dbtx_access_token),
             operation_id,
@@ -691,7 +689,7 @@ where
         op_type: &str,
         operation_meta: impl serde::Serialize + Debug,
         sms: Vec<DynState>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), OperationAlreadyExistsError> {
         dbtx.ensure_global()
             .expect("Must deal with global dbtx here");
 
@@ -703,10 +701,7 @@ where
             .await
             .is_some()
         {
-            bail!(
-                "Operation with id {} already exists",
-                operation_id.fmt_short()
-            );
+            return Err(OperationAlreadyExistsError { operation_id });
         }
 
         self.client
@@ -807,7 +802,7 @@ where
         dbtx: &mut DatabaseTransaction<'_>,
         inputs: ClientInputBundle<I, S>,
         operation_id: OperationId,
-    ) -> anyhow::Result<OutPointRange>
+    ) -> Result<OutPointRange, TransactionSubmitError>
     where
         I: IInput + MaybeSend + MaybeSync + 'static,
         S: sm::IState + MaybeSend + MaybeSync + 'static,
@@ -821,7 +816,7 @@ where
         dbtx: &mut DatabaseTransaction<'_>,
         inputs: InstancelessDynClientInputBundle,
         operation_id: OperationId,
-    ) -> anyhow::Result<OutPointRange> {
+    ) -> Result<OutPointRange, TransactionSubmitError> {
         let tx_builder =
             TransactionBuilder::new().with_inputs(inputs.into_dyn(self.module_instance_id));
 

--- a/fedimint-client-module/src/transaction/builder.rs
+++ b/fedimint-client-module/src/transaction/builder.rs
@@ -517,7 +517,7 @@ impl FeeQuote {
 ///
 /// The LNv2 and LNv1 send-all flows share this solver; they differ only in
 /// `gross_up` (the gateway fee model) and which `fee_quote` they pass.
-pub async fn max_affordable_send_amount<GrossUp, Quote, Fut>(
+pub async fn max_affordable_send_amount<GrossUp, Quote, Fut, E>(
     balance: Amount,
     min_amount: Amount,
     max_amount: Amount,
@@ -527,7 +527,7 @@ pub async fn max_affordable_send_amount<GrossUp, Quote, Fut>(
 where
     GrossUp: Fn(Amount) -> Amount,
     Quote: Fn(Amount) -> Fut,
-    Fut: Future<Output = anyhow::Result<FeeQuote>>,
+    Fut: Future<Output = Result<FeeQuote, E>>,
 {
     // Nothing above the balance can ever be funded, so cap the upper bound.
     let hi_bound = max_amount.msats.min(balance.msats);
@@ -621,7 +621,7 @@ where
 /// balance. A quote error (the balance cannot fund a value this large) counts
 /// as unaffordable, making this safe as the monotone predicate for
 /// [`max_affordable_send_amount`].
-async fn send_amount_affordable<GrossUp, Quote, Fut>(
+async fn send_amount_affordable<GrossUp, Quote, Fut, E>(
     amount: Amount,
     balance: Amount,
     gross_up: &GrossUp,
@@ -630,7 +630,7 @@ async fn send_amount_affordable<GrossUp, Quote, Fut>(
 where
     GrossUp: Fn(Amount) -> Amount,
     Quote: Fn(Amount) -> Fut,
-    Fut: Future<Output = anyhow::Result<FeeQuote>>,
+    Fut: Future<Output = Result<FeeQuote, E>>,
 {
     let funded_amount = gross_up(amount);
 

--- a/fedimint-client-module/src/transaction/builder/tests.rs
+++ b/fedimint-client-module/src/transaction/builder/tests.rs
@@ -331,6 +331,7 @@ async fn max_affordable_treats_quote_error_as_ceiling() {
         |invoice| invoice,
         move |contract: Amount| async move {
             if contract.msats > cap {
+                // The quote error is never inspected, so any type will do.
                 Err("insufficient funds")
             } else {
                 Ok(federation_fee(Amount::ZERO))

--- a/fedimint-client-module/src/transaction/builder/tests.rs
+++ b/fedimint-client-module/src/transaction/builder/tests.rs
@@ -1,4 +1,5 @@
 use core::fmt;
+use std::convert::Infallible;
 use std::fmt::Write as _;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
@@ -203,7 +204,7 @@ async fn max_affordable_no_fees_spends_whole_balance() {
         Amount::from_msats(1),
         balance,
         |invoice| invoice, // no gateway fee
-        |_contract| async { Ok(federation_fee(Amount::ZERO)) },
+        |_contract| async { Ok::<_, Infallible>(federation_fee(Amount::ZERO)) },
     )
     .await;
 
@@ -221,7 +222,7 @@ async fn max_affordable_leaves_room_for_gateway_fee() {
         Amount::from_msats(1),
         balance,
         gross_up,
-        |_contract| async { Ok(federation_fee(Amount::ZERO)) },
+        |_contract| async { Ok::<_, Infallible>(federation_fee(Amount::ZERO)) },
     )
     .await
     .expect("balance covers a payment")
@@ -243,7 +244,7 @@ async fn max_affordable_leaves_room_for_module_fee() {
         Amount::from_msats(1),
         balance,
         |invoice| invoice, // no gateway fee, so contract == invoice
-        move |contract| async move { Ok(federation_fee(module_fee(contract))) },
+        move |contract| async move { Ok::<_, Infallible>(federation_fee(module_fee(contract))) },
     )
     .await
     .expect("balance covers a payment")
@@ -273,7 +274,7 @@ async fn max_affordable_handles_stepwise_fee() {
         Amount::from_msats(1),
         balance,
         |invoice| invoice,
-        move |contract| async move { Ok(federation_fee(module_fee(contract))) },
+        move |contract| async move { Ok::<_, Infallible>(federation_fee(module_fee(contract))) },
     )
     .await;
 
@@ -291,7 +292,7 @@ async fn max_affordable_respects_max_bound() {
         Amount::from_msats(1),
         Amount::from_msats(100), // cap well below the balance
         |invoice| invoice,
-        |_contract| async { Ok(federation_fee(Amount::ZERO)) },
+        |_contract| async { Ok::<_, Infallible>(federation_fee(Amount::ZERO)) },
     )
     .await;
 
@@ -308,7 +309,7 @@ async fn max_affordable_none_when_min_unaffordable() {
         Amount::from_msats(1),
         balance,
         |invoice: Amount| Amount::from_msats(invoice.msats + 1000), // 1000 msat base fee
-        |_contract| async { Ok(federation_fee(Amount::ZERO)) },
+        |_contract| async { Ok::<_, Infallible>(federation_fee(Amount::ZERO)) },
     )
     .await;
 
@@ -330,7 +331,7 @@ async fn max_affordable_treats_quote_error_as_ceiling() {
         |invoice| invoice,
         move |contract: Amount| async move {
             if contract.msats > cap {
-                Err(anyhow::anyhow!("insufficient funds"))
+                Err("insufficient funds")
             } else {
                 Ok(federation_fee(Amount::ZERO))
             }
@@ -362,7 +363,7 @@ async fn max_affordable_seeds_search_near_the_top() {
         gross_up,
         |contract| {
             quote_calls.fetch_add(1, Ordering::Relaxed);
-            async move { Ok(federation_fee(fed_fee(contract))) }
+            async move { Ok::<_, Infallible>(federation_fee(fed_fee(contract))) }
         },
     )
     .await

--- a/fedimint-client-rpc/src/lib.rs
+++ b/fedimint-client-rpc/src/lib.rs
@@ -15,7 +15,7 @@ use fedimint_core::db::{Database, IDatabaseTransactionOpsCoreTyped};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::invite_code::InviteCode;
 use fedimint_core::task::{MaybeSend, MaybeSync};
-use fedimint_core::util::{BoxFuture, BoxStream};
+use fedimint_core::util::{BoxFuture, BoxStream, FmtCompactAnyhow as _};
 use fedimint_core::{Amount, TieredCounts, impl_db_record};
 use fedimint_derive_secret::{ChildId, DerivableSecret};
 use fedimint_ln_client::{LightningClientInit, LightningClientModule};
@@ -185,7 +185,7 @@ impl RpcGlobalState {
     }
 
     async fn client_builder() -> Result<fedimint_client::ClientBuilder, anyhow::Error> {
-        let mut builder = fedimint_client::Client::builder().await?;
+        let mut builder = fedimint_client::Client::builder().await;
         builder.with_module(MintClientInit);
         builder.with_module(LightningClientInit::default());
         builder.with_module(WalletClientInit(None));
@@ -534,7 +534,7 @@ impl RpcGlobalState {
                     Err(e) => RpcResponse {
                         request_id,
                         kind: RpcResponseKind::Error {
-                            error: e.to_string(),
+                            error: e.fmt_compact_anyhow().to_string(),
                         },
                     },
                 };

--- a/fedimint-client/src/api_announcements.rs
+++ b/fedimint-client/src/api_announcements.rs
@@ -50,23 +50,19 @@ pub(crate) async fn run_api_announcement_refresh_task(client_inner: Arc<Client>)
     // Wait for the guardian keys to be available
     let guardian_pub_keys = client_inner.get_guardian_public_keys_blocking().await;
     loop {
-        if let Err(err) = {
-            let api: &DynGlobalApi = &client_inner.api;
-            let results = fetch_api_announcements_from_at_least_num_of_peers(
-                1,
-                api,
-                &guardian_pub_keys,
-                if is_running_in_test_env() {
-                    Duration::from_millis(1)
-                } else {
-                    Duration::from_secs(30)
-                },
-            )
-            .await;
-            store_api_announcements_updates_from_peers(client_inner.db(), &results).await
-        } {
-            debug!(target: LOG_CLIENT, err = %err.fmt_compact_anyhow(), "Refreshing api announcements failed");
-        }
+        let api: &DynGlobalApi = &client_inner.api;
+        let results = fetch_api_announcements_from_at_least_num_of_peers(
+            1,
+            api,
+            &guardian_pub_keys,
+            if is_running_in_test_env() {
+                Duration::from_millis(1)
+            } else {
+                Duration::from_secs(30)
+            },
+        )
+        .await;
+        store_api_announcements_updates_from_peers(client_inner.db(), &results).await;
 
         let duration = if is_running_in_test_env() {
             Duration::from_secs(1)
@@ -81,12 +77,10 @@ pub(crate) async fn run_api_announcement_refresh_task(client_inner: Arc<Client>)
 pub(crate) async fn store_api_announcements_updates_from_peers(
     db: &Database,
     updates: &[BTreeMap<PeerId, SignedApiAnnouncement>],
-) -> Result<(), anyhow::Error> {
+) {
     for announcements in updates {
         store_api_announcement_updates(db, announcements).await;
     }
-
-    Ok(())
 }
 
 pub(crate) type PeersSignedApiAnnouncements = BTreeMap<PeerId, SignedApiAnnouncement>;

--- a/fedimint-client/src/backup.rs
+++ b/fedimint-client/src/backup.rs
@@ -23,6 +23,7 @@ use tracing::{debug, info, warn};
 
 use super::Client;
 use crate::db::LastBackupKey;
+use crate::error::ClientSecretError;
 use crate::secret::DeriveableSecretClientExt;
 
 /// Backup metadata
@@ -465,7 +466,7 @@ impl Client {
         Self::get_derived_backup_signing_key_static(&self.root_secret())
     }
 
-    pub async fn get_decoded_client_secret<T: Decodable>(&self) -> anyhow::Result<T> {
+    pub async fn get_decoded_client_secret<T: Decodable>(&self) -> Result<T, ClientSecretError> {
         crate::db::get_decoded_client_secret::<T>(self.db()).await
     }
 }

--- a/fedimint-client/src/backup.rs
+++ b/fedimint-client/src/backup.rs
@@ -3,9 +3,8 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::io;
 use std::io::{Cursor, Write};
 
-use anyhow::{Result, bail, ensure};
 use bitcoin::secp256k1::{Keypair, PublicKey, Secp256k1, SignOnly};
-use fedimint_api_client::api::DynGlobalApi;
+use fedimint_api_client::api::{DynGlobalApi, FederationError};
 use fedimint_client_module::module::recovery::DynModuleBackup;
 use fedimint_core::core::ModuleInstanceId;
 use fedimint_core::core::backup::{
@@ -15,6 +14,7 @@ use fedimint_core::db::IDatabaseTransactionOpsCoreTyped;
 use fedimint_core::encoding::{Decodable, DecodeContext as _, DecodeError, Encodable};
 use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_core::module::serde_json;
+use fedimint_core::util::FmtCompact as _;
 use fedimint_derive_secret::DerivableSecret;
 use fedimint_eventlog::{Event, EventKind, EventPersistence};
 use fedimint_logging::{LOG_CLIENT, LOG_CLIENT_BACKUP, LOG_CLIENT_RECOVERY};
@@ -23,7 +23,7 @@ use tracing::{debug, info, warn};
 
 use super::Client;
 use crate::db::LastBackupKey;
-use crate::error::ClientSecretError;
+use crate::error::{BackupError, ClientSecretError};
 use crate::secret::DeriveableSecretClientExt;
 
 /// Backup metadata
@@ -58,13 +58,15 @@ impl Metadata {
     }
 
     /// Attempt to deserialize metadata as typed json
-    pub fn to_json_deserialized<T: serde::de::DeserializeOwned>(&self) -> Result<T> {
-        Ok(serde_json::from_slice(&self.0)?)
+    pub fn to_json_deserialized<T: serde::de::DeserializeOwned>(
+        &self,
+    ) -> Result<T, serde_json::Error> {
+        serde_json::from_slice(&self.0)
     }
 
     /// Attempt to deserialize metadata as untyped json (`serde_json::Value`)
-    pub fn to_json_value(&self) -> Result<serde_json::Value> {
-        Ok(serde_json::from_slice(&self.0)?)
+    pub fn to_json_value(&self) -> Result<serde_json::Value, serde_json::Error> {
+        serde_json::from_slice(&self.0)
     }
 }
 
@@ -146,14 +148,20 @@ impl ClientBackup {
     }
 
     /// Encrypt with a key and turn into [`EncryptedClientBackup`]
-    pub fn encrypt_to(&self, key: &fedimint_aead::LessSafeKey) -> Result<EncryptedClientBackup> {
+    pub fn encrypt_to(
+        &self,
+        key: &fedimint_aead::LessSafeKey,
+    ) -> Result<EncryptedClientBackup, BackupError> {
         let mut encoded = Encodable::consensus_encode_to_vec(self);
 
         let alignment_size = Self::get_alignment_size(encoded.len());
         let padding_size = alignment_size - encoded.len();
-        encoded.write_all(&vec![0u8; padding_size])?;
+        encoded
+            .write_all(&vec![0u8; padding_size])
+            .expect("Writing to a Vec cannot fail");
 
-        let encrypted = fedimint_aead::encrypt(encoded, key)?;
+        let encrypted = fedimint_aead::encrypt(encoded, key)
+            .map_err(|err| BackupError::Encryption(err.into()))?;
         Ok(EncryptedClientBackup(encrypted))
     }
 
@@ -226,8 +234,9 @@ impl EncryptedClientBackup {
         mut self,
         key: &fedimint_aead::LessSafeKey,
         decoders: &ModuleDecoderRegistry,
-    ) -> Result<ClientBackup> {
-        let decrypted = fedimint_aead::decrypt(&mut self.0, key)?;
+    ) -> Result<ClientBackup, BackupError> {
+        let decrypted = fedimint_aead::decrypt(&mut self.0, key)
+            .map_err(|err| BackupError::Encryption(err.into()))?;
         let mut cursor = Cursor::new(decrypted);
         // We specifically want to ignore the padding in the backup here.
         let client_backup = ClientBackup::consensus_decode_partial(&mut cursor, decoders)?;
@@ -275,13 +284,16 @@ impl Client {
     #[deprecated(
         note = "Recovery is now efficient enough that backups are no longer necessary. Backups will be removed in v0.13.0 due to backups being inherently complicated and brittle."
     )]
-    pub async fn create_backup(&self, metadata: Metadata) -> anyhow::Result<ClientBackup> {
+    pub async fn create_backup(&self, metadata: Metadata) -> Result<ClientBackup, BackupError> {
         let session_count = self.api.session_count().await?;
         let mut modules = BTreeMap::new();
         for (id, kind, module) in self.modules.iter_modules() {
             debug!(target: LOG_CLIENT_BACKUP, module_id=id, module_kind=%kind, "Preparing module backup");
             if module.supports_backup() {
-                let backup = module.backup(id).await?;
+                let backup = module.backup(id).await.map_err(|err| BackupError::Module {
+                    instance_id: id,
+                    source: err.into(),
+                })?;
 
                 debug!(target: LOG_CLIENT_BACKUP, module_id=id, module_kind=%kind, "Prepared module backup");
                 modules.insert(id, backup);
@@ -313,11 +325,10 @@ impl Client {
         note = "Recovery is now efficient enough that backups are no longer necessary. Backups will be removed in v0.13.0 due to backups being inherently complicated and brittle."
     )]
     #[allow(deprecated)]
-    pub async fn backup_to_federation(&self, metadata: Metadata) -> Result<()> {
-        ensure!(
-            !self.has_pending_recoveries(),
-            "Cannot backup while there are pending recoveries"
-        );
+    pub async fn backup_to_federation(&self, metadata: Metadata) -> Result<(), BackupError> {
+        if self.has_pending_recoveries() {
+            return Err(BackupError::PendingRecoveries);
+        }
 
         let last_backup = self.load_previous_backup().await;
         let new_backup = self.create_backup(metadata).await?;
@@ -341,9 +352,12 @@ impl Client {
     #[deprecated(
         note = "Recovery is now efficient enough that backups are no longer necessary. Backups will be removed in v0.13.0 due to backups being inherently complicated and brittle."
     )]
-    pub fn validate_backup(&self, backup: &EncryptedClientBackup) -> Result<()> {
+    pub fn validate_backup(&self, backup: &EncryptedClientBackup) -> Result<(), BackupError> {
         if BACKUP_REQUEST_MAX_PAYLOAD_SIZE_BYTES < backup.len() {
-            bail!("Backup payload too large");
+            return Err(BackupError::TooLarge {
+                size: backup.len(),
+                max: BACKUP_REQUEST_MAX_PAYLOAD_SIZE_BYTES,
+            });
         }
         Ok(())
     }
@@ -353,7 +367,7 @@ impl Client {
         note = "Recovery is now efficient enough that backups are no longer necessary. Backups will be removed in v0.13.0 due to backups being inherently complicated and brittle."
     )]
     #[allow(deprecated)]
-    pub async fn upload_backup(&self, backup: &EncryptedClientBackup) -> Result<()> {
+    pub async fn upload_backup(&self, backup: &EncryptedClientBackup) -> Result<(), BackupError> {
         self.validate_backup(backup)?;
         let size = backup.len();
         info!(
@@ -375,7 +389,9 @@ impl Client {
         note = "Recovery is now efficient enough that backups are no longer necessary. Backups will be removed in v0.13.0 due to backups being inherently complicated and brittle."
     )]
     #[allow(deprecated)]
-    pub async fn download_backup_from_federation(&self) -> Result<Option<ClientBackup>> {
+    pub async fn download_backup_from_federation(
+        &self,
+    ) -> Result<Option<ClientBackup>, FederationError> {
         Self::download_backup_from_federation_static(
             &self.api,
             &self.root_secret(),
@@ -393,7 +409,7 @@ impl Client {
         api: &DynGlobalApi,
         root_secret: &DerivableSecret,
         decoders: &ModuleDecoderRegistry,
-    ) -> Result<Option<ClientBackup>> {
+    ) -> Result<Option<ClientBackup>, FederationError> {
         debug!(target: LOG_CLIENT, "Downloading backup from the federation");
         let mut responses: Vec<_> = api
             .download_backup(&Client::get_backup_id_static(root_secret))
@@ -408,7 +424,9 @@ impl Client {
                     Err(e) => {
                         warn!(
                             target: LOG_CLIENT_RECOVERY,
-                            "Invalid backup returned by {peer}: {e}"
+                            err = %e.fmt_compact(),
+                            %peer,
+                            "Invalid backup returned by peer"
                         );
                         None
                     }

--- a/fedimint-client/src/client.rs
+++ b/fedimint-client/src/client.rs
@@ -6,7 +6,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use anyhow::{Context as _, anyhow, bail, format_err};
+use anyhow::{Context as _, anyhow, bail};
 use async_stream::try_stream;
 use bitcoin::key::Secp256k1;
 use bitcoin::key::rand::thread_rng;
@@ -90,7 +90,9 @@ use crate::db::{
     PeerLastApiVersionsSummaryKey, PendingClientConfigKey, TransactionFeesKey,
     apply_migrations_core_client_dbtx, get_decoded_client_secret, verify_client_db_integrity_dbtx,
 };
-use crate::error::{OperationAlreadyExistsError, OperationNotFoundError, TransactionSubmitError};
+use crate::error::{
+    ModuleLookupError, OperationAlreadyExistsError, OperationNotFoundError, TransactionSubmitError,
+};
 use crate::meta::MetaService;
 use crate::module_init::{ClientModuleInitRegistry, DynClientModuleInit, IClientModuleInit};
 use crate::oplog::OperationLog;
@@ -1281,17 +1283,22 @@ impl Client {
     /// Returns a reference to a typed module client instance by kind
     pub fn get_first_module<M: ClientModule>(
         &'_ self,
-    ) -> anyhow::Result<ClientModuleInstance<'_, M>> {
+    ) -> Result<ClientModuleInstance<'_, M>, ModuleLookupError> {
         let module_kind = M::kind();
-        let id = self
-            .get_first_instance(&module_kind)
-            .ok_or_else(|| format_err!("No modules found of kind {module_kind}"))?;
+        let id = self.get_first_instance(&module_kind).ok_or_else(|| {
+            ModuleLookupError::NoModuleOfKind {
+                kind: module_kind.clone(),
+            }
+        })?;
         let module: &M = self
             .try_get_module(id)
-            .ok_or_else(|| format_err!("Unknown module instance {id}"))?
+            .ok_or(ModuleLookupError::UnknownInstance { instance_id: id })?
             .as_any()
             .downcast_ref::<M>()
-            .ok_or_else(|| format_err!("Module is not of type {}", std::any::type_name::<M>()))?;
+            .ok_or(ModuleLookupError::WrongModuleType {
+                instance_id: id,
+                expected: std::any::type_name::<M>(),
+            })?;
         let (db, _) = self.db().with_prefix_module_id(id);
         Ok(ClientModuleInstance {
             id,
@@ -1306,27 +1313,32 @@ impl Client {
     /// Unlike [`Self::get_first_module`], this hands out a cloned `Arc` so the
     /// caller can hold the module independently of the `Client`'s lifetime.
     #[cfg(not(target_family = "wasm"))]
-    pub fn get_first_module_arc<M: ClientModule>(&self) -> anyhow::Result<Arc<M>> {
+    pub fn get_first_module_arc<M: ClientModule>(&self) -> Result<Arc<M>, ModuleLookupError> {
         let module_kind = M::kind();
-        let id = self
-            .get_first_instance(&module_kind)
-            .ok_or_else(|| format_err!("No modules found of kind {module_kind}"))?;
+        let id = self.get_first_instance(&module_kind).ok_or_else(|| {
+            ModuleLookupError::NoModuleOfKind {
+                kind: module_kind.clone(),
+            }
+        })?;
         let dyn_module = self
             .modules
             .get(id)
-            .ok_or_else(|| format_err!("Unknown module instance {id}"))?;
+            .ok_or(ModuleLookupError::UnknownInstance { instance_id: id })?;
         dyn_module
             .as_any_arc()
             .downcast::<M>()
-            .map_err(|_| format_err!("Module is not of type {}", std::any::type_name::<M>()))
+            .map_err(|_| ModuleLookupError::WrongModuleType {
+                instance_id: id,
+                expected: std::any::type_name::<M>(),
+            })
     }
 
     pub fn get_module_client_dyn(
         &self,
         instance_id: ModuleInstanceId,
-    ) -> anyhow::Result<&maybe_add_send_sync!(dyn IClientModule)> {
+    ) -> Result<&maybe_add_send_sync!(dyn IClientModule), ModuleLookupError> {
         self.try_get_module(instance_id)
-            .ok_or(anyhow!("Unknown module instance {}", instance_id))
+            .ok_or(ModuleLookupError::UnknownInstance { instance_id })
     }
 
     pub fn db(&self) -> &Database {
@@ -1388,14 +1400,17 @@ impl Client {
     #[doc(hidden)]
     /// Like [`Self::get_balance`] but returns an error if primary module is not
     /// available
-    pub async fn get_balance_for_btc(&self) -> anyhow::Result<Amount> {
+    pub async fn get_balance_for_btc(&self) -> Result<Amount, ModuleLookupError> {
         self.get_balance_for_unit(AmountUnit::BITCOIN).await
     }
 
-    pub async fn get_balance_for_unit(&self, unit: AmountUnit) -> anyhow::Result<Amount> {
+    pub async fn get_balance_for_unit(
+        &self,
+        unit: AmountUnit,
+    ) -> Result<Amount, ModuleLookupError> {
         let (id, module) = self
             .primary_module_for_unit(unit)
-            .ok_or_else(|| anyhow!("Primary module not available"))?;
+            .ok_or(ModuleLookupError::NoPrimaryModule { unit })?;
         Ok(module
             .get_balance(id, &mut self.db().begin_transaction_nc().await, unit)
             .await)
@@ -2915,7 +2930,7 @@ impl ClientContextIface for Client {
         Client::fee_quote(self, operation_id, request).await
     }
 
-    async fn get_balance_for_unit(&self, unit: AmountUnit) -> anyhow::Result<Amount> {
+    async fn get_balance_for_unit(&self, unit: AmountUnit) -> Result<Amount, ModuleLookupError> {
         Client::get_balance_for_unit(self, unit).await
     }
 

--- a/fedimint-client/src/client.rs
+++ b/fedimint-client/src/client.rs
@@ -6,7 +6,6 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use anyhow::{Context as _, anyhow};
 use async_stream::try_stream;
 use bitcoin::key::Secp256k1;
 use bitcoin::key::rand::thread_rng;
@@ -92,7 +91,7 @@ use crate::db::{
 };
 use crate::error::{
     ClientSecretError, ModuleLookupError, OperationAlreadyExistsError, OperationNotFoundError,
-    TransactionSubmitError,
+    RecoveryError, TransactionSubmitError,
 };
 use crate::meta::MetaService;
 use crate::module_init::{ClientModuleInitRegistry, DynClientModuleInit, IClientModuleInit};
@@ -1983,19 +1982,18 @@ impl Client {
     /// Returns `Ok(())` once every module recovery completed, or an error as
     /// soon as any one of them fails terminally.
     ///
-    /// An error does not mean the recovery task is done: the failed module's
-    /// progress stays pending forever (so [`Self::has_pending_recoveries`]
-    /// keeps returning `true`) and the recovery task stays parked. The
-    /// failure is in-memory only and is not persisted, so reopening the
-    /// client retries the recovery from its last persisted, non-terminal
-    /// progress.
+    /// A [`RecoveryError::Failed`] does not mean the recovery task is done: the
+    /// failed module's progress stays pending forever (so
+    /// [`Self::has_pending_recoveries`] keeps returning `true`) and the
+    /// recovery task stays parked. The failure is in-memory only and is not
+    /// persisted, so reopening the client retries the recovery from its last
+    /// persisted, non-terminal progress.
     ///
     /// A bit of a heavy approach.
-    pub async fn wait_for_all_recoveries(&self) -> anyhow::Result<()> {
+    pub async fn wait_for_all_recoveries(&self) -> Result<(), RecoveryError> {
         Self::wait_for_recoveries(
             self.client_recovery_status_receiver.clone(),
             |_module_instance_id| true,
-            "Recovery task completed and update receiver disconnected, but some modules failed to recover",
         )
         .await
     }
@@ -2011,8 +2009,7 @@ impl Client {
     async fn wait_for_recoveries(
         mut status_receiver: watch::Receiver<BTreeMap<ModuleInstanceId, RecoveryStatus>>,
         module_filter: impl Fn(ModuleInstanceId) -> bool,
-        disconnected_context: &'static str,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), RecoveryError> {
         let failure = status_receiver
             .wait_for(|statuses| {
                 let matching = || {
@@ -2029,7 +2026,7 @@ impl Client {
                     || matching().all(RecoveryStatus::is_successfully_done)
             })
             .await
-            .context(disconnected_context)?
+            .map_err(|_closed| RecoveryError::ClientStopped)?
             // Classified from the woken-up snapshot before anything else, so a
             // failure of one module still wins over another one completing.
             .iter()
@@ -2041,9 +2038,10 @@ impl Client {
             });
 
         match failure {
-            Some((module_instance_id, error)) => Err(anyhow!(
-                "Module recovery failed: module_instance_id={module_instance_id}, error={error}"
-            )),
+            Some((module_instance_id, error)) => Err(RecoveryError::Failed {
+                module_instance_id,
+                error,
+            }),
             None => Ok(()),
         }
     }
@@ -2080,7 +2078,7 @@ impl Client {
     pub async fn wait_for_module_kind_recovery(
         &self,
         module_kind: ModuleKind,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), RecoveryError> {
         let config = self.config().await;
         Self::wait_for_recoveries(
             self.client_recovery_status_receiver.clone(),
@@ -2090,7 +2088,6 @@ impl Client {
                     .get(&module_instance_id)
                     .is_some_and(|module| module.kind == module_kind)
             },
-            "Recovery task completed and update receiver disconnected, but the desired modules are still unavailable or failed to recover",
         )
         .await
     }

--- a/fedimint-client/src/client.rs
+++ b/fedimint-client/src/client.rs
@@ -1001,10 +1001,23 @@ impl Client {
     /// does not abort an already-committed submission.
     ///
     /// ## Errors
-    /// The function will return an error if the operation with given ID already
-    /// exists, or if the database transaction keeps colliding with others and
-    /// cannot be committed within its retry budget, which should not happen
-    /// except in excessively concurrent scenarios.
+    /// Every variant of [`TransactionSubmitError`] can come back from here:
+    /// [`OperationAlreadyExists`] if an operation with this id is already
+    /// recorded; [`NoPrimaryModule`] and [`PrimaryModule`] if the transaction
+    /// cannot be balanced, because no primary module holds the unit or because
+    /// the one that does fails to fund it; [`TransactionTooLarge`] if the
+    /// finalized transaction exceeds the federation's size limit;
+    /// [`StateMachines`] if the transaction's state machines cannot be
+    /// registered; and [`Database`] if the transaction keeps colliding with
+    /// others and cannot be committed within its retry budget, which should not
+    /// happen except in excessively concurrent scenarios.
+    ///
+    /// [`OperationAlreadyExists`]: TransactionSubmitError::OperationAlreadyExists
+    /// [`NoPrimaryModule`]: TransactionSubmitError::NoPrimaryModule
+    /// [`PrimaryModule`]: TransactionSubmitError::PrimaryModule
+    /// [`TransactionTooLarge`]: TransactionSubmitError::TransactionTooLarge
+    /// [`StateMachines`]: TransactionSubmitError::StateMachines
+    /// [`Database`]: TransactionSubmitError::Database
     pub async fn finalize_and_submit_transaction<F, M>(
         &self,
         operation_id: OperationId,

--- a/fedimint-client/src/client.rs
+++ b/fedimint-client/src/client.rs
@@ -90,6 +90,7 @@ use crate::db::{
     PeerLastApiVersionsSummaryKey, PendingClientConfigKey, TransactionFeesKey,
     apply_migrations_core_client_dbtx, get_decoded_client_secret, verify_client_db_integrity_dbtx,
 };
+use crate::error::OperationNotFoundError;
 use crate::meta::MetaService;
 use crate::module_init::{ClientModuleInitRegistry, DynClientModuleInit, IClientModuleInit};
 use crate::oplog::OperationLog;
@@ -1224,9 +1225,9 @@ impl Client {
     pub async fn get_operation_fees(
         &self,
         operation_id: OperationId,
-    ) -> anyhow::Result<Option<Amounts>> {
+    ) -> Result<Option<Amounts>, OperationNotFoundError> {
         if !self.operation_exists(operation_id).await {
-            bail!("Operation does not exist");
+            return Err(OperationNotFoundError { operation_id });
         }
 
         let (active_states, inactive_states) =

--- a/fedimint-client/src/client.rs
+++ b/fedimint-client/src/client.rs
@@ -306,6 +306,8 @@ pub struct GetBalanceChangesRequest {
 impl Client {
     /// Initialize a client builder that can be configured to create a new
     /// client.
+    // Nothing here awaits; the function stays `async` so existing call sites
+    // keep their `.await`.
     pub async fn builder() -> ClientBuilder {
         ClientBuilder::new()
     }

--- a/fedimint-client/src/client.rs
+++ b/fedimint-client/src/client.rs
@@ -12,7 +12,8 @@ use bitcoin::key::rand::thread_rng;
 use bitcoin::secp256k1::{self, PublicKey};
 use fedimint_api_client::api::global_api::with_request_hook::ApiRequestHook;
 use fedimint_api_client::api::{
-    ApiVersionSet, DynGlobalApi, FederationApiExt as _, FederationResult, IGlobalFederationApi,
+    ApiVersionSet, DynGlobalApi, FederationApiExt as _, FederationError, FederationResult,
+    IGlobalFederationApi,
 };
 use fedimint_bitcoind::DynBitcoindRpc;
 use fedimint_client_module::module::recovery::RecoveryProgress;
@@ -449,7 +450,7 @@ impl Client {
     ///
     /// This can be used by downstream clients to expose metrics via their own
     /// HTTP server or print them for debugging purposes.
-    pub fn get_metrics() -> anyhow::Result<String> {
+    pub fn get_metrics() -> Result<String, fedimint_metrics::prometheus::Error> {
         fedimint_metrics::get_metrics()
     }
 
@@ -601,7 +602,7 @@ impl Client {
     /// This is cached in the database after the first successful fetch.
     /// The chain ID uniquely identifies which bitcoin network the federation
     /// operates on (mainnet, testnet, signet, regtest).
-    pub async fn chain_id(&self) -> anyhow::Result<ChainId> {
+    pub async fn chain_id(&self) -> Result<ChainId, FederationError> {
         // Check cache first
         if let Some(chain_id) = self
             .db
@@ -682,7 +683,9 @@ impl Client {
         (in_amounts, out_amounts)
     }
 
-    pub fn get_internal_payment_markers(&self) -> anyhow::Result<(PublicKey, u64)> {
+    pub fn get_internal_payment_markers(
+        &self,
+    ) -> Result<(PublicKey, u64), bitcoin::secp256k1::Error> {
         Ok((self.federation_id().to_fake_ln_pub_key(&self.secp_ctx)?, 0))
     }
 
@@ -2091,14 +2094,13 @@ impl Client {
         .await
     }
 
-    pub async fn wait_for_all_active_state_machines(&self) -> anyhow::Result<()> {
+    pub async fn wait_for_all_active_state_machines(&self) {
         loop {
             if self.executor.get_active_states().await.is_empty() {
                 break;
             }
             sleep(Duration::from_millis(100)).await;
         }
-        Ok(())
     }
 
     /// Set the client [`Metadata`]
@@ -2968,7 +2970,7 @@ impl ClientContextIface for Client {
         Client::invite_code(self, peer).await
     }
 
-    fn get_internal_payment_markers(&self) -> anyhow::Result<(PublicKey, u64)> {
+    fn get_internal_payment_markers(&self) -> Result<(PublicKey, u64), bitcoin::secp256k1::Error> {
         Client::get_internal_payment_markers(self)
     }
 

--- a/fedimint-client/src/client.rs
+++ b/fedimint-client/src/client.rs
@@ -39,7 +39,7 @@ use fedimint_core::config::{
 };
 use fedimint_core::core::{DynInput, DynOutput, ModuleInstanceId, ModuleKind, OperationId};
 use fedimint_core::db::{
-    AutocommitError, Database, DatabaseRecord, DatabaseTransaction,
+    AutocommitError, Database, DatabaseRecord, DatabaseTransaction, DbMigrationError,
     IDatabaseTransactionOpsCore as _, IDatabaseTransactionOpsCoreTyped as _, NonCommittable,
 };
 use fedimint_core::encoding::{Decodable, Encodable};
@@ -305,8 +305,8 @@ pub struct GetBalanceChangesRequest {
 impl Client {
     /// Initialize a client builder that can be configured to create a new
     /// client.
-    pub async fn builder() -> anyhow::Result<ClientBuilder> {
-        Ok(ClientBuilder::new())
+    pub async fn builder() -> ClientBuilder {
+        ClientBuilder::new()
     }
 
     pub fn api(&self) -> &(dyn IGlobalFederationApi + 'static) {
@@ -2812,7 +2812,7 @@ impl Client {
 
     pub(crate) async fn run_core_migrations(
         db_no_decoders: &Database,
-    ) -> Result<(), anyhow::Error> {
+    ) -> Result<(), DbMigrationError> {
         let mut dbtx = db_no_decoders.begin_transaction().await;
         apply_migrations_core_client_dbtx(&mut dbtx.to_ref_nc(), "fedimint-client".to_string())
             .await?;

--- a/fedimint-client/src/client.rs
+++ b/fedimint-client/src/client.rs
@@ -67,8 +67,9 @@ use fedimint_core::{
 };
 use fedimint_derive_secret::DerivableSecret;
 use fedimint_eventlog::{
-    DBTransactionEventLogExt as _, DynEventLogTrimableTracker, Event, EventKind, EventLogEntry,
-    EventLogId, EventLogTrimableId, EventLogTrimableTracker, EventPersistence, PersistedLogEntry,
+    DBTransactionEventLogExt as _, DynEventLogTrimableTracker, Event, EventHandlerError, EventKind,
+    EventLogEntry, EventLogId, EventLogTrimableId, EventLogTrimableTracker, EventPersistence,
+    PersistedLogEntry,
 };
 use fedimint_logging::{LOG_CLIENT, LOG_CLIENT_NET_API, LOG_CLIENT_RECOVERY};
 use futures::stream::FuturesUnordered;
@@ -2682,14 +2683,15 @@ impl Client {
     /// that is infrequent and important enough to be persisted
     /// forever. Most applications should prefer to use [`Self::handle_events`]
     /// which emits *all* events.
-    pub async fn handle_historical_events<F, R>(
+    pub async fn handle_historical_events<F, R, E>(
         &self,
         tracker: fedimint_eventlog::DynEventLogTracker,
         handler_fn: F,
-    ) -> anyhow::Result<()>
+    ) -> Result<(), EventHandlerError<E>>
     where
         F: Fn(&mut DatabaseTransaction<NonCommittable>, EventLogEntry) -> R,
-        R: Future<Output = anyhow::Result<()>>,
+        R: Future<Output = Result<(), E>>,
+        E: std::error::Error + 'static,
     {
         fedimint_eventlog::handle_events(
             self.db.clone(),
@@ -2718,14 +2720,15 @@ impl Client {
     /// This method returns only when client is shutting down or on internal
     /// error, so typically should be called in a background task dedicated
     /// to handling events.
-    pub async fn handle_events<F, R>(
+    pub async fn handle_events<F, R, E>(
         &self,
         tracker: fedimint_eventlog::DynEventLogTrimableTracker,
         handler_fn: F,
-    ) -> anyhow::Result<()>
+    ) -> Result<(), EventHandlerError<E>>
     where
         F: Fn(&mut DatabaseTransaction<NonCommittable>, EventLogEntry) -> R,
-        R: Future<Output = anyhow::Result<()>>,
+        R: Future<Output = Result<(), E>>,
+        E: std::error::Error + 'static,
     {
         fedimint_eventlog::handle_trimable_events(
             self.db.clone(),

--- a/fedimint-client/src/client.rs
+++ b/fedimint-client/src/client.rs
@@ -90,8 +90,8 @@ use crate::db::{
     apply_migrations_core_client_dbtx, verify_client_db_integrity_dbtx,
 };
 use crate::error::{
-    ClientSecretError, ModuleLookupError, OperationAlreadyExistsError, OperationNotFoundError,
-    RecoveryError, TransactionSubmitError,
+    ApiVersionDiscoveryError, ClientSecretError, ModuleLookupError, OperationAlreadyExistsError,
+    OperationNotFoundError, RecoveryError, TransactionSubmitError,
 };
 use crate::meta::MetaService;
 use crate::module_init::{ClientModuleInitRegistry, DynClientModuleInit, IClientModuleInit};
@@ -1620,7 +1620,7 @@ impl Client {
     pub async fn fetch_common_api_versions(
         config: &ClientConfig,
         api: &DynGlobalApi,
-    ) -> anyhow::Result<BTreeMap<PeerId, SupportedApiVersionsSummary>> {
+    ) -> BTreeMap<PeerId, SupportedApiVersionsSummary> {
         debug!(
             target: LOG_CLIENT,
             "Fetching common api versions"
@@ -1628,10 +1628,7 @@ impl Client {
 
         let num_peers = NumPeers::from(config.global.api_endpoints.len());
 
-        let peer_api_version_sets =
-            Self::fetch_peers_api_versions_from_threshold_of_peers(num_peers, api.clone()).await;
-
-        Ok(peer_api_version_sets)
+        Self::fetch_peers_api_versions_from_threshold_of_peers(num_peers, api.clone()).await
     }
 
     /// Write API version set to database cache.
@@ -1684,7 +1681,7 @@ impl Client {
                 debug!(target: LOG_CLIENT, "Calculated and stored common API version set");
             }
             Err(err) => {
-                debug!(target: LOG_CLIENT, err = %err.fmt_compact_anyhow(), "Failed to calculate common API versions from prefetched data");
+                debug!(target: LOG_CLIENT, err = %err.fmt_compact(), "Failed to calculate common API versions from prefetched data");
             }
         }
 
@@ -1732,7 +1729,9 @@ impl Client {
         }
     }
 
-    pub async fn load_and_refresh_common_api_version(&self) -> anyhow::Result<ApiVersionSet> {
+    pub async fn load_and_refresh_common_api_version(
+        &self,
+    ) -> Result<ApiVersionSet, ApiVersionDiscoveryError> {
         Self::load_and_refresh_common_api_version_static(
             &self.config().await,
             &self.module_inits,
@@ -1750,7 +1749,7 @@ impl Client {
     /// This queries all peers for their supported API versions and calculates
     /// the common API version set to use. The result is stored in the database
     /// cache for future use.
-    pub async fn refresh_api_versions(&self) -> anyhow::Result<ApiVersionSet> {
+    pub async fn refresh_api_versions(&self) -> Result<ApiVersionSet, ApiVersionDiscoveryError> {
         Self::refresh_common_api_version_static(
             &self.config().await,
             &self.module_inits,
@@ -1776,7 +1775,7 @@ impl Client {
         db: &Database,
         task_group: &TaskGroup,
         client_span: &Span,
-    ) -> anyhow::Result<ApiVersionSet> {
+    ) -> Result<ApiVersionSet, ApiVersionDiscoveryError> {
         if let Some(v) = db
             .begin_transaction_nc()
             .await
@@ -1816,7 +1815,7 @@ impl Client {
                     {
                         warn!(
                             target: LOG_CLIENT,
-                            err = %error.fmt_compact_anyhow(), "Failed to discover common api versions"
+                            err = %error.fmt_compact(), "Failed to discover common api versions"
                         );
                     }
                 },
@@ -1849,7 +1848,7 @@ impl Client {
         task_group: TaskGroup,
         client_span: &Span,
         block_until_ok: bool,
-    ) -> anyhow::Result<ApiVersionSet> {
+    ) -> Result<ApiVersionSet, ApiVersionDiscoveryError> {
         debug!(
             target: LOG_CLIENT,
             "Refreshing common api versions"
@@ -1893,7 +1892,7 @@ impl Client {
                 Err(err) if block_until_ok => {
                     warn!(
                         target: LOG_CLIENT,
-                        err = %err.fmt_compact_anyhow(),
+                        err = %err.fmt_compact(),
                         "Failed to discover API version to use. Retrying..."
                     );
                     continue;

--- a/fedimint-client/src/client.rs
+++ b/fedimint-client/src/client.rs
@@ -6,7 +6,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use anyhow::{Context as _, anyhow, bail};
+use anyhow::{Context as _, anyhow};
 use async_stream::try_stream;
 use bitcoin::key::Secp256k1;
 use bitcoin::key::rand::thread_rng;
@@ -88,10 +88,11 @@ use crate::db::{
     ChronologicalOperationLogKey, ClientConfigKey, ClientMetadataKey, ClientModuleRecovery,
     ClientModuleRecoveryState, EncodedClientSecretKey, OperationLogKey, PeerLastApiVersionsSummary,
     PeerLastApiVersionsSummaryKey, PendingClientConfigKey, TransactionFeesKey,
-    apply_migrations_core_client_dbtx, get_decoded_client_secret, verify_client_db_integrity_dbtx,
+    apply_migrations_core_client_dbtx, verify_client_db_integrity_dbtx,
 };
 use crate::error::{
-    ModuleLookupError, OperationAlreadyExistsError, OperationNotFoundError, TransactionSubmitError,
+    ClientSecretError, ModuleLookupError, OperationAlreadyExistsError, OperationNotFoundError,
+    TransactionSubmitError,
 };
 use crate::meta::MetaService;
 use crate::module_init::{ClientModuleInitRegistry, DynClientModuleInit, IClientModuleInit};
@@ -477,12 +478,12 @@ impl Client {
     pub async fn store_encodable_client_secret<T: Encodable>(
         db: &Database,
         secret: T,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), ClientSecretError> {
         let mut dbtx = db.begin_transaction().await;
 
         // Don't overwrite an existing secret
         if dbtx.get_value(&EncodedClientSecretKey).await.is_some() {
-            bail!("Encoded client secret already exists, cannot overwrite")
+            return Err(ClientSecretError::AlreadyExists);
         }
 
         let encoded_secret = T::consensus_encode_to_vec(&secret);
@@ -492,31 +493,34 @@ impl Client {
         Ok(())
     }
 
-    pub async fn load_decodable_client_secret<T: Decodable>(db: &Database) -> anyhow::Result<T> {
+    pub async fn load_decodable_client_secret<T: Decodable>(
+        db: &Database,
+    ) -> Result<T, ClientSecretError> {
         let Some(secret) = Self::load_decodable_client_secret_opt(db).await? else {
-            bail!("Encoded client secret not present in DB")
+            return Err(ClientSecretError::NotPresent);
         };
 
         Ok(secret)
     }
+
     pub async fn load_decodable_client_secret_opt<T: Decodable>(
         db: &Database,
-    ) -> anyhow::Result<Option<T>> {
+    ) -> Result<Option<T>, ClientSecretError> {
         let mut dbtx = db.begin_transaction_nc().await;
 
         let client_secret = dbtx.get_value(&EncodedClientSecretKey).await;
 
         Ok(match client_secret {
-            Some(client_secret) => Some(
-                T::consensus_decode_whole(&client_secret, &ModuleRegistry::default())
-                    .context("Decoding failed")?,
-            ),
+            Some(client_secret) => Some(T::consensus_decode_whole(
+                &client_secret,
+                &ModuleRegistry::default(),
+            )?),
             None => None,
         })
     }
 
-    pub async fn load_or_generate_client_secret(db: &Database) -> anyhow::Result<[u8; 64]> {
-        let client_secret = match Self::load_decodable_client_secret::<[u8; 64]>(db).await {
+    pub async fn load_or_generate_client_secret(db: &Database) -> [u8; 64] {
+        match Self::load_decodable_client_secret::<[u8; 64]>(db).await {
             Ok(secret) => secret,
             _ => {
                 let secret = PlainRootSecretStrategy::random(&mut thread_rng());
@@ -525,8 +529,7 @@ impl Client {
                     .expect("Storing client secret must work");
                 secret
             }
-        };
-        Ok(client_secret)
+        }
     }
 
     pub async fn is_initialized(db: &Database) -> bool {
@@ -1363,12 +1366,6 @@ impl Client {
             .iter_modules()
             .find(|(_, kind, _module)| *kind == module_kind)
             .map(|(instance_id, _, _)| instance_id)
-    }
-
-    /// Returns the data from which the client's root secret is derived (e.g.
-    /// BIP39 seed phrase struct).
-    pub async fn root_secret_encoding<T: Decodable>(&self) -> anyhow::Result<T> {
-        get_decoded_client_secret::<T>(self.db()).await
     }
 
     /// Waits for outputs from the primary module to reach its final

--- a/fedimint-client/src/client.rs
+++ b/fedimint-client/src/client.rs
@@ -90,7 +90,7 @@ use crate::db::{
     PeerLastApiVersionsSummaryKey, PendingClientConfigKey, TransactionFeesKey,
     apply_migrations_core_client_dbtx, get_decoded_client_secret, verify_client_db_integrity_dbtx,
 };
-use crate::error::OperationNotFoundError;
+use crate::error::{OperationAlreadyExistsError, OperationNotFoundError, TransactionSubmitError};
 use crate::meta::MetaService;
 use crate::module_init::{ClientModuleInitRegistry, DynClientModuleInit, IClientModuleInit};
 use crate::oplog::OperationLog;
@@ -742,7 +742,7 @@ impl Client {
         dbtx: &mut DatabaseTransaction<'_>,
         operation_id: OperationId,
         mut partial_transaction: TransactionBuilder,
-    ) -> anyhow::Result<FinalizedTransaction> {
+    ) -> Result<FinalizedTransaction, TransactionSubmitError> {
         let (in_amounts, out_amounts) = self.transaction_builder_get_balance(&partial_transaction);
 
         let mut added_inputs_bundles = vec![];
@@ -766,7 +766,7 @@ impl Client {
             }
 
             let Some((module_id, module)) = self.primary_module_for_unit(*unit) else {
-                bail!("No module to balance a partial transaction (affected unit: {unit:?}");
+                return Err(TransactionSubmitError::NoPrimaryModule { unit: *unit });
             };
 
             let (added_input_bundle, added_output_bundle) = module
@@ -778,7 +778,8 @@ impl Client {
                     input_amount,
                     output_amount,
                 )
-                .await?;
+                .await
+                .map_err(|err| TransactionSubmitError::PrimaryModule(err.into()))?;
 
             added_inputs_bundles.push(added_input_bundle);
             added_outputs_bundles.push(added_output_bundle);
@@ -867,7 +868,7 @@ impl Client {
         &self,
         operation_id: OperationId,
         request: FeeQuoteRequest,
-    ) -> anyhow::Result<FeeQuote> {
+    ) -> Result<FeeQuote, TransactionSubmitError> {
         let FeeQuoteRequest {
             input_amount,
             output_amount,
@@ -909,7 +910,7 @@ impl Client {
             }
 
             let Some((module_id, module)) = self.primary_module_for_unit(*unit) else {
-                bail!("No module to balance a partial transaction (affected unit: {unit:?}");
+                return Err(TransactionSubmitError::NoPrimaryModule { unit: *unit });
             };
 
             let (change_input, change_output) = module
@@ -921,7 +922,8 @@ impl Client {
                     balance_input_amount,
                     balance_output_amount,
                 )
-                .await?;
+                .await
+                .map_err(|err| TransactionSubmitError::PrimaryModule(err.into()))?;
 
             // Fold the change into the totals. These are a disjoint set of items
             // from the explicit ones (the primary module only sees the scalar
@@ -990,19 +992,16 @@ impl Client {
     ///
     /// ## Errors
     /// The function will return an error if the operation with given ID already
-    /// exists.
-    ///
-    /// ## Panics
-    /// The function will panic if the database transaction collides with
-    /// other and fails with others too often, this should not happen except for
-    /// excessively concurrent scenarios.
+    /// exists, or if the database transaction keeps colliding with others and
+    /// cannot be committed within its retry budget, which should not happen
+    /// except in excessively concurrent scenarios.
     pub async fn finalize_and_submit_transaction<F, M>(
         &self,
         operation_id: OperationId,
         operation_type: &str,
         operation_meta_gen: F,
         tx_builder: TransactionBuilder,
-    ) -> anyhow::Result<OutPointRange>
+    ) -> Result<OutPointRange, TransactionSubmitError>
     where
         F: Fn(OutPointRange) -> M + Clone + MaybeSend + MaybeSync,
         M: serde::Serialize + MaybeSend,
@@ -1034,12 +1033,9 @@ impl Client {
         match autocommit_res {
             Ok(txid) => Ok(txid),
             Err(AutocommitError::ClosureError { error, .. }) => Err(error),
-            Err(AutocommitError::CommitFailed {
-                attempts,
-                last_error,
-            }) => panic!(
-                "Failed to commit tx submission dbtx after {attempts} attempts: {last_error}"
-            ),
+            Err(AutocommitError::CommitFailed { last_error, .. }) => {
+                Err(TransactionSubmitError::Database(last_error))
+            }
         }
     }
 
@@ -1058,13 +1054,13 @@ impl Client {
         operation_type: &str,
         operation_meta_gen: F,
         tx_builder: TransactionBuilder,
-    ) -> anyhow::Result<OutPointRange>
+    ) -> Result<OutPointRange, TransactionSubmitError>
     where
         F: FnOnce(OutPointRange) -> M + MaybeSend,
         M: serde::Serialize + MaybeSend,
     {
         if Client::operation_exists_dbtx(dbtx, operation_id).await {
-            bail!("There already exists an operation with id {operation_id:?}")
+            return Err(OperationAlreadyExistsError { operation_id }.into());
         }
 
         let out_point_range = self
@@ -1088,7 +1084,7 @@ impl Client {
         dbtx: &mut DatabaseTransaction<'_>,
         operation_id: OperationId,
         tx_builder: TransactionBuilder,
-    ) -> anyhow::Result<OutPointRange> {
+    ) -> Result<OutPointRange, TransactionSubmitError> {
         let FinalizedTransaction {
             transaction,
             mut states,
@@ -1117,9 +1113,10 @@ impl Client {
                 "Transaction too large",
             );
             debug!(target: LOG_CLIENT_NET_API, ?transaction, "transaction details");
-            bail!(
-                "The generated transaction would be rejected by the federation for being too large."
-            );
+            return Err(TransactionSubmitError::TransactionTooLarge {
+                size: transaction.consensus_encode_to_vec().len(),
+                max: Transaction::MAX_TX_SIZE,
+            });
         }
 
         let txid = transaction.tx_hash();
@@ -1270,12 +1267,15 @@ impl Client {
         &self,
         operation_id: OperationId,
         out_point: OutPoint,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), TransactionSubmitError> {
         self.primary_module_for_unit(AmountUnit::BITCOIN)
-            .ok_or_else(|| anyhow!("No primary module available"))?
+            .ok_or(TransactionSubmitError::NoPrimaryModule {
+                unit: AmountUnit::BITCOIN,
+            })?
             .1
             .await_primary_module_output(operation_id, out_point)
             .await
+            .map_err(|err| TransactionSubmitError::PrimaryModule(err.into()))
     }
 
     /// Returns a reference to a typed module client instance by kind
@@ -1365,7 +1365,7 @@ impl Client {
         &self,
         operation_id: OperationId,
         outputs: Vec<OutPoint>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), TransactionSubmitError> {
         for out_point in outputs {
             self.await_primary_bitcoin_module_output(operation_id, out_point)
                 .await?;
@@ -2867,7 +2867,7 @@ impl ClientContextIface for Client {
         operation_type: &str,
         operation_meta_gen: Box<maybe_add_send_sync!(dyn Fn(OutPointRange) -> serde_json::Value)>,
         tx_builder: TransactionBuilder,
-    ) -> anyhow::Result<OutPointRange> {
+    ) -> Result<OutPointRange, TransactionSubmitError> {
         Client::finalize_and_submit_transaction(
             self,
             operation_id,
@@ -2886,7 +2886,7 @@ impl ClientContextIface for Client {
         operation_type: &str,
         operation_meta_gen: Box<maybe_add_send_sync!(dyn Fn(OutPointRange) -> serde_json::Value)>,
         tx_builder: TransactionBuilder,
-    ) -> anyhow::Result<OutPointRange> {
+    ) -> Result<OutPointRange, TransactionSubmitError> {
         Client::finalize_and_submit_transaction_dbtx(
             self,
             dbtx,
@@ -2903,7 +2903,7 @@ impl ClientContextIface for Client {
         dbtx: &mut DatabaseTransaction<'_>,
         operation_id: OperationId,
         tx_builder: TransactionBuilder,
-    ) -> anyhow::Result<OutPointRange> {
+    ) -> Result<OutPointRange, TransactionSubmitError> {
         Client::finalize_and_submit_transaction_inner(self, dbtx, operation_id, tx_builder).await
     }
 
@@ -2911,7 +2911,7 @@ impl ClientContextIface for Client {
         &self,
         operation_id: OperationId,
         request: FeeQuoteRequest,
-    ) -> anyhow::Result<FeeQuote> {
+    ) -> Result<FeeQuote, TransactionSubmitError> {
         Client::fee_quote(self, operation_id, request).await
     }
 
@@ -2928,7 +2928,7 @@ impl ClientContextIface for Client {
         operation_id: OperationId,
         // TODO: make `impl Iterator<Item = ...>`
         outputs: Vec<OutPoint>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), TransactionSubmitError> {
         Client::await_primary_bitcoin_module_outputs(self, operation_id, outputs).await
     }
 

--- a/fedimint-client/src/client/builder.rs
+++ b/fedimint-client/src/client/builder.rs
@@ -11,6 +11,7 @@ use fedimint_api_client::api::global_api::with_request_hook::{
 };
 use fedimint_api_client::api::{
     ApiVersionSet, ClientConfigDownloadError, DynGlobalApi, FederationApi, FederationApiExt as _,
+    FederationError,
 };
 use fedimint_api_client::download_from_invite_code;
 use fedimint_bitcoind::DynBitcoindRpc;
@@ -1555,7 +1556,7 @@ impl ClientPreview {
     pub async fn download_backup_from_federation(
         &self,
         pre_root_secret: RootSecret,
-    ) -> anyhow::Result<Option<ClientBackup>> {
+    ) -> Result<Option<ClientBackup>, FederationError> {
         let pre_root_secret = pre_root_secret.to_inner(self.config.calculate_federation_id());
         let api = DynGlobalApi::new(
             self.connectors.clone(),

--- a/fedimint-client/src/client/builder.rs
+++ b/fedimint-client/src/client/builder.rs
@@ -346,7 +346,7 @@ impl ClientBuilder {
         preview_prefetch_api_version_set: Option<
             Jit<BTreeMap<PeerId, SupportedApiVersionsSummary>>,
         >,
-        prefetch_chain_id: Option<JitTry<ChainId, anyhow::Error>>,
+        prefetch_chain_id: Option<JitTry<ChainId, FederationError>>,
     ) -> Result<ClientHandle, ClientBuildError> {
         if Client::is_initialized(&db_no_decoders).await {
             return Err(ClientBuildError::DatabaseAlreadyInitialized);
@@ -473,9 +473,8 @@ impl ClientBuilder {
             })
         });
 
-        let prefetch_chain_id = prefetch_api.map(|api| {
-            JitTry::new_try(|| async move { api.chain_id().await.map_err(anyhow::Error::from) })
-        });
+        let prefetch_chain_id =
+            prefetch_api.map(|api| JitTry::new_try(|| async move { api.chain_id().await }));
 
         ClientPreview {
             connectors,
@@ -568,7 +567,7 @@ impl ClientBuilder {
         preview_prefetch_api_version_set: Option<
             Jit<BTreeMap<PeerId, SupportedApiVersionsSummary>>,
         >,
-        prefetch_chain_id: Option<JitTry<ChainId, anyhow::Error>>,
+        prefetch_chain_id: Option<JitTry<ChainId, FederationError>>,
     ) -> Result<ClientHandle, ClientBuildError> {
         let log_event_added_transient_tx = self.log_event_added_transient_tx.clone();
         let request_hook = self.request_hook.clone();
@@ -613,7 +612,7 @@ impl ClientBuilder {
         preview_prefetch_api_version_set: Option<
             Jit<BTreeMap<PeerId, SupportedApiVersionsSummary>>,
         >,
-        prefetch_chain_id: Option<JitTry<ChainId, anyhow::Error>>,
+        prefetch_chain_id: Option<JitTry<ChainId, FederationError>>,
     ) -> Result<ClientHandle, ClientBuildError> {
         debug!(
             target: LOG_CLIENT,
@@ -1398,7 +1397,7 @@ pub struct ClientPreview {
     api_secret: Option<String>,
     prefetch_api_announcements: Option<Jit<Vec<PeersSignedApiAnnouncements>>>,
     preview_prefetch_api_version_set: Option<Jit<BTreeMap<PeerId, SupportedApiVersionsSummary>>>,
-    prefetch_chain_id: Option<JitTry<ChainId, anyhow::Error>>,
+    prefetch_chain_id: Option<JitTry<ChainId, FederationError>>,
 }
 
 impl ClientPreview {

--- a/fedimint-client/src/client/builder.rs
+++ b/fedimint-client/src/client/builder.rs
@@ -343,7 +343,7 @@ impl ClientBuilder {
         init_mode: InitMode,
         preview_prefetch_api_announcements: Option<Jit<Vec<PeersSignedApiAnnouncements>>>,
         preview_prefetch_api_version_set: Option<
-            JitTry<BTreeMap<PeerId, SupportedApiVersionsSummary>, anyhow::Error>,
+            Jit<BTreeMap<PeerId, SupportedApiVersionsSummary>>,
         >,
         prefetch_chain_id: Option<JitTry<ChainId, anyhow::Error>>,
     ) -> Result<ClientHandle, ClientBuildError> {
@@ -465,7 +465,7 @@ impl ClientBuilder {
         prefetch_api_announcements: Option<Jit<Vec<PeersSignedApiAnnouncements>>>,
     ) -> ClientPreview {
         let preview_prefetch_api_version_set = prefetch_api.as_ref().map(|api| {
-            JitTry::new_try({
+            Jit::new({
                 let config = config.clone();
                 let api = api.clone();
                 || async move { Client::fetch_common_api_versions(&config, &api).await }
@@ -565,7 +565,7 @@ impl ClientBuilder {
         stopped: bool,
         preview_prefetch_api_announcements: Option<Jit<Vec<PeersSignedApiAnnouncements>>>,
         preview_prefetch_api_version_set: Option<
-            JitTry<BTreeMap<PeerId, SupportedApiVersionsSummary>, anyhow::Error>,
+            Jit<BTreeMap<PeerId, SupportedApiVersionsSummary>>,
         >,
         prefetch_chain_id: Option<JitTry<ChainId, anyhow::Error>>,
     ) -> Result<ClientHandle, ClientBuildError> {
@@ -610,7 +610,7 @@ impl ClientBuilder {
         request_hook: ApiRequestHook,
         preview_prefetch_api_announcements: Option<Jit<Vec<PeersSignedApiAnnouncements>>>,
         preview_prefetch_api_version_set: Option<
-            JitTry<BTreeMap<PeerId, SupportedApiVersionsSummary>, anyhow::Error>,
+            Jit<BTreeMap<PeerId, SupportedApiVersionsSummary>>,
         >,
         prefetch_chain_id: Option<JitTry<ChainId, anyhow::Error>>,
     ) -> Result<ClientHandle, ClientBuildError> {
@@ -679,20 +679,13 @@ impl ClientBuilder {
         }
 
         if let Some(preview_prefetch_api_version_set) = preview_prefetch_api_version_set {
-            match preview_prefetch_api_version_set.get_try().await {
-                Ok(peer_api_versions) => {
-                    Client::store_prefetched_api_versions(
-                        &db,
-                        &config,
-                        &self.module_inits,
-                        peer_api_versions,
-                    )
-                    .await;
-                }
-                Err(err) => {
-                    debug!(target: LOG_CLIENT, err = %err.fmt_compact(), "Prefetching api version negotiation failed");
-                }
-            }
+            Client::store_prefetched_api_versions(
+                &db,
+                &config,
+                &self.module_inits,
+                preview_prefetch_api_version_set.get().await,
+            )
+            .await;
         }
 
         let common_api_versions = Client::load_and_refresh_common_api_version_static(
@@ -706,7 +699,7 @@ impl ClientBuilder {
         )
         .await
         .inspect_err(|err| {
-            warn!(target: LOG_CLIENT, err = %err.fmt_compact_anyhow(), "Failed to discover API version to use.");
+            warn!(target: LOG_CLIENT, err = %err.fmt_compact(), "Failed to discover API version to use.");
         })
         .unwrap_or(ApiVersionSet {
             core: ApiVersion::new(0, 0),
@@ -1403,8 +1396,7 @@ pub struct ClientPreview {
     connectors: ConnectorRegistry,
     api_secret: Option<String>,
     prefetch_api_announcements: Option<Jit<Vec<PeersSignedApiAnnouncements>>>,
-    preview_prefetch_api_version_set:
-        Option<JitTry<BTreeMap<PeerId, SupportedApiVersionsSummary>, anyhow::Error>>,
+    preview_prefetch_api_version_set: Option<Jit<BTreeMap<PeerId, SupportedApiVersionsSummary>>>,
     prefetch_chain_id: Option<JitTry<ChainId, anyhow::Error>>,
 }
 

--- a/fedimint-client/src/client/builder.rs
+++ b/fedimint-client/src/client/builder.rs
@@ -3,13 +3,15 @@ use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::{Context as _, bail, ensure};
+use anyhow::bail;
 use bitcoin::key::Secp256k1;
 use fedimint_api_client::api::global_api::with_cache::GlobalFederationApiWithCacheExt as _;
 use fedimint_api_client::api::global_api::with_request_hook::{
     ApiRequestHook, RawFederationApiWithRequestHookExt as _,
 };
-use fedimint_api_client::api::{ApiVersionSet, DynGlobalApi, FederationApi, FederationApiExt as _};
+use fedimint_api_client::api::{
+    ApiVersionSet, ClientConfigDownloadError, DynGlobalApi, FederationApi, FederationApiExt as _,
+};
 use fedimint_api_client::download_from_invite_code;
 use fedimint_bitcoind::DynBitcoindRpc;
 use fedimint_client_module::api::ClientRawFederationApiExt as _;
@@ -62,6 +64,7 @@ use crate::db::{
     ClientModuleRecoveryState, ClientPreRootSecretHashKey, InitMode, InitState,
     PendingClientConfigKey, apply_migrations_client_module_dbtx,
 };
+use crate::error::ClientBuildError;
 use crate::guardian_metadata::run_guardian_metadata_refresh_task;
 use crate::meta::MetaService;
 use crate::module_init::ClientModuleInitRegistry;
@@ -281,7 +284,7 @@ impl ClientBuilder {
         &self,
         db: &Database,
         client_config: &ClientConfig,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), ClientBuildError> {
         for (module_id, module_cfg) in &client_config.modules {
             let kind = module_cfg.kind.clone();
             let Some(init) = self.module_inits.get(&kind) else {
@@ -314,9 +317,12 @@ impl ClientBuilder {
         Ok(())
     }
 
-    pub async fn load_existing_config(&self, db: &Database) -> anyhow::Result<ClientConfig> {
+    pub async fn load_existing_config(
+        &self,
+        db: &Database,
+    ) -> Result<ClientConfig, ClientBuildError> {
         let Some(config) = Client::get_config_from_db(db).await else {
-            bail!("Client database not initialized")
+            return Err(ClientBuildError::DatabaseNotInitialized);
         };
 
         Ok(config)
@@ -340,9 +346,9 @@ impl ClientBuilder {
             JitTry<BTreeMap<PeerId, SupportedApiVersionsSummary>, anyhow::Error>,
         >,
         prefetch_chain_id: Option<JitTry<ChainId, anyhow::Error>>,
-    ) -> anyhow::Result<ClientHandle> {
+    ) -> Result<ClientHandle, ClientBuildError> {
         if Client::is_initialized(&db_no_decoders).await {
-            bail!("Client database already initialized")
+            return Err(ClientBuildError::DatabaseAlreadyInitialized);
         }
 
         Client::run_core_migrations(&db_no_decoders).await?;
@@ -397,7 +403,7 @@ impl ClientBuilder {
         self,
         connectors: ConnectorRegistry,
         invite_code: &InviteCode,
-    ) -> anyhow::Result<ClientPreview> {
+    ) -> Result<ClientPreview, ClientConfigDownloadError> {
         let (config, api) = download_from_invite_code(&connectors, invite_code).await?;
 
         let prefetch_api_announcements =
@@ -425,14 +431,15 @@ impl ClientBuilder {
                     })
                 });
 
-        self.preview_inner(
-            connectors,
-            config,
-            invite_code.api_secret(),
-            Some(api),
-            prefetch_api_announcements,
-        )
-        .await
+        Ok(self
+            .preview_inner(
+                connectors,
+                config,
+                invite_code.api_secret(),
+                Some(api),
+                prefetch_api_announcements,
+            )
+            .await)
     }
 
     /// Use [`Self::preview`] instead
@@ -444,7 +451,7 @@ impl ClientBuilder {
         connectors: ConnectorRegistry,
         config: ClientConfig,
         api_secret: Option<String>,
-    ) -> anyhow::Result<ClientPreview> {
+    ) -> ClientPreview {
         self.preview_inner(connectors, config, api_secret, None, None)
             .await
     }
@@ -456,7 +463,7 @@ impl ClientBuilder {
         api_secret: Option<String>,
         prefetch_api: Option<DynGlobalApi>,
         prefetch_api_announcements: Option<Jit<Vec<PeersSignedApiAnnouncements>>>,
-    ) -> anyhow::Result<ClientPreview> {
+    ) -> ClientPreview {
         let preview_prefetch_api_version_set = prefetch_api.as_ref().map(|api| {
             JitTry::new_try({
                 let config = config.clone();
@@ -469,7 +476,7 @@ impl ClientBuilder {
             JitTry::new_try(|| async move { api.chain_id().await.map_err(anyhow::Error::from) })
         });
 
-        Ok(ClientPreview {
+        ClientPreview {
             connectors,
             inner: self,
             config,
@@ -477,7 +484,7 @@ impl ClientBuilder {
             prefetch_api_announcements,
             preview_prefetch_api_version_set,
             prefetch_chain_id,
-        })
+        }
     }
 
     pub async fn open(
@@ -485,14 +492,14 @@ impl ClientBuilder {
         connectors: ConnectorRegistry,
         db_no_decoders: Database,
         pre_root_secret: RootSecret,
-    ) -> anyhow::Result<ClientHandle> {
+    ) -> Result<ClientHandle, ClientBuildError> {
         Client::run_core_migrations(&db_no_decoders).await?;
 
         // Check for pending config and migrate if present
         Self::migrate_pending_config_if_present(&db_no_decoders).await;
 
         let Some(config) = Client::get_config_from_db(&db_no_decoders).await else {
-            bail!("Client database not initialized")
+            return Err(ClientBuildError::DatabaseNotInitialized);
         };
 
         let pre_root_secret = pre_root_secret.to_inner(config.calculate_federation_id());
@@ -504,10 +511,9 @@ impl ClientBuilder {
             .await
         {
             Some(secret_hash) => {
-                ensure!(
-                    pre_root_secret.derive_pre_root_secret_hash() == secret_hash,
-                    "Secret hash does not match. Incorrect secret"
-                );
+                if pre_root_secret.derive_pre_root_secret_hash() != secret_hash {
+                    return Err(ClientBuildError::SecretMismatch);
+                }
             }
             _ => {
                 debug!(target: LOG_CLIENT, "Backfilling secret hash");
@@ -562,7 +568,7 @@ impl ClientBuilder {
             JitTry<BTreeMap<PeerId, SupportedApiVersionsSummary>, anyhow::Error>,
         >,
         prefetch_chain_id: Option<JitTry<ChainId, anyhow::Error>>,
-    ) -> anyhow::Result<ClientHandle> {
+    ) -> Result<ClientHandle, ClientBuildError> {
         let log_event_added_transient_tx = self.log_event_added_transient_tx.clone();
         let request_hook = self.request_hook.clone();
         let client = self
@@ -607,7 +613,7 @@ impl ClientBuilder {
             JitTry<BTreeMap<PeerId, SupportedApiVersionsSummary>, anyhow::Error>,
         >,
         prefetch_chain_id: Option<JitTry<ChainId, anyhow::Error>>,
-    ) -> anyhow::Result<ClientHandle> {
+    ) -> Result<ClientHandle, ClientBuildError> {
         debug!(
             target: LOG_CLIENT,
             version = %fedimint_build_code_version_env!(),
@@ -665,12 +671,11 @@ impl ClientBuilder {
         let notifier = Notifier::new();
 
         if let Some(p) = preview_prefetch_api_announcements {
-            // We want to fail if we were unable to figure out
-            // current addresses of peers in the federation, as it will potentially never
-            // fix itself, so it's better to fail the join explicitly.
+            // Wait for the prefetch so the join starts with the current
+            // addresses of the peers instead of the ones in the invite code.
             let announcements = p.get().await;
 
-            store_api_announcements_updates_from_peers(&db, announcements).await?
+            store_api_announcements_updates_from_peers(&db, announcements).await;
         }
 
         if let Some(preview_prefetch_api_version_set) = preview_prefetch_api_version_set {
@@ -882,8 +887,10 @@ impl ClientBuilder {
                     module_init
                         .prepare_recovery(db.clone(), module_instance_id, api.clone())
                         .await
-                        .with_context(|| {
-                            format!("Failed to prepare recovery of module {module_instance_id}")
+                        .map_err(|err| ClientBuildError::ModuleRecoveryPrepare {
+                            kind: kind.clone(),
+                            instance_id: module_instance_id,
+                            source: err.into(),
                         })?;
                 }
 
@@ -983,7 +990,12 @@ impl ClientBuilder {
                             user_bitcoind_rpc.clone(),
                             self.bitcoind_rpc_no_chain_id_factory.clone(),
                         )
-                        .await?;
+                        .await
+                        .map_err(|err| ClientBuildError::ModuleInit {
+                            kind: kind.clone(),
+                            instance_id: module_instance_id,
+                            source: err.into(),
+                        })?;
 
                     modules.register_module(module_instance_id, kind, module);
                 }
@@ -1463,8 +1475,7 @@ impl ClientPreview {
     ///     // .with_module(LightningClientInit)
     ///     // .with_module(MintClientInit)
     ///     // .with_module(WalletClientInit::default())
-    ///      .expect("Error building client")
-    ///      .preview(connectors, &invite_code).await?;
+    ///     .preview(connectors, &invite_code).await?;
     ///
     /// println!(
     ///     "The federation name is: {}",
@@ -1484,7 +1495,7 @@ impl ClientPreview {
         self,
         db_no_decoders: Database,
         pre_root_secret: RootSecret,
-    ) -> anyhow::Result<ClientHandle> {
+    ) -> Result<ClientHandle, ClientBuildError> {
         let pre_root_secret = pre_root_secret.to_inner(self.config.calculate_federation_id());
 
         let client = self
@@ -1521,7 +1532,7 @@ impl ClientPreview {
         db_no_decoders: Database,
         pre_root_secret: RootSecret,
         backup: Option<ClientBackup>,
-    ) -> anyhow::Result<ClientHandle> {
+    ) -> Result<ClientHandle, ClientBuildError> {
         let pre_root_secret = pre_root_secret.to_inner(self.config.calculate_federation_id());
 
         let client = self

--- a/fedimint-client/src/client/global_ctx.rs
+++ b/fedimint-client/src/client/global_ctx.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use fedimint_api_client::api::{DynGlobalApi, DynModuleApi};
+use fedimint_client_module::error::TransactionSubmitError;
 use fedimint_client_module::module::OutPointRange;
 use fedimint_client_module::sm::{ClientSMDatabaseTransaction, DynState, IState};
 use fedimint_client_module::transaction::{TransactionBuilder, TxSubmissionStatesSM};
@@ -49,7 +50,7 @@ impl IGlobalClientContext for ModuleGlobalClientContext {
         &self,
         dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
         inputs: InstancelessDynClientInputBundle,
-    ) -> anyhow::Result<OutPointRange> {
+    ) -> Result<OutPointRange, TransactionSubmitError> {
         let tx_builder =
             TransactionBuilder::new().with_inputs(inputs.into_dyn(self.module_instance_id));
 
@@ -66,7 +67,7 @@ impl IGlobalClientContext for ModuleGlobalClientContext {
         &self,
         dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
         outputs: InstancelessDynClientOutputBundle,
-    ) -> anyhow::Result<OutPointRange> {
+    ) -> Result<OutPointRange, TransactionSubmitError> {
         let tx_builder =
             TransactionBuilder::new().with_outputs(outputs.into_dyn(self.module_instance_id));
 

--- a/fedimint-client/src/client/handle.rs
+++ b/fedimint-client/src/client/handle.rs
@@ -2,7 +2,6 @@ use std::ops;
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::format_err;
 #[cfg(not(target_family = "wasm"))]
 use fedimint_core::runtime;
 use fedimint_core::util::FmtCompact as _;
@@ -13,6 +12,7 @@ use tracing::{Instrument as _, debug, error, trace, warn};
 
 use super::Client;
 use crate::ClientBuilder;
+use crate::error::ClientBuildError;
 
 /// User handle to the [`Client`] instance
 ///
@@ -107,17 +107,17 @@ impl ClientHandle {
 
     /// Restart the client
     ///
-    /// Returns false if there are other clones of [`ClientHandle`], or starting
-    /// the client again failed for some reason.
+    /// Fails if there are other clones of [`ClientHandle`], or if starting the
+    /// client again failed for some reason.
     ///
     /// Notably it will re-use the original [`fedimint_core::db::Database`]
     /// handle, and not attempt to open it again.
-    pub async fn restart(self) -> anyhow::Result<ClientHandle> {
+    pub async fn restart(self) -> Result<ClientHandle, ClientBuildError> {
         let (builder, config, api_secret, root_secret, db, endpoints) = {
             let client = self
                 .inner
                 .as_ref()
-                .ok_or_else(|| format_err!("Already stopped"))?;
+                .ok_or(ClientBuildError::AlreadyStopped)?;
             let builder = ClientBuilder::from_existing(client);
             let config = client.config().await;
             let api_secret = client.api_secret.clone();

--- a/fedimint-client/src/client/tests.rs
+++ b/fedimint-client/src/client/tests.rs
@@ -34,6 +34,7 @@ use tokio::task::yield_now;
 use super::{Client, ModuleRecoveryFuture, RecoveryStatus};
 use crate::ClientHandle;
 use crate::db::ClientModuleRecovery;
+use crate::error::RecoveryError;
 use crate::meta::MetaService;
 use crate::oplog::OperationLog;
 use crate::sm::executor::Executor;
@@ -307,6 +308,21 @@ async fn persisted_recovery_progress(db: &Database) -> Option<RecoveryProgress> 
         .map(|state| state.progress)
 }
 
+/// Asserts that `err` is the terminal failure of `module_instance_id`,
+/// carrying the message the module's recovery failed with.
+fn assert_module_recovery_failed(err: &RecoveryError, module_instance_id: ModuleInstanceId) {
+    match err {
+        RecoveryError::Failed {
+            module_instance_id: failed,
+            error,
+        } => {
+            assert_eq!(*failed, module_instance_id, "{err:?}");
+            assert!(error.contains(RECOVERY_ERROR), "{error}");
+        }
+        other => panic!("Expected a failed module recovery, got {other:?}"),
+    }
+}
+
 #[tokio::test]
 async fn forged_done_recovery_progress_does_not_mask_a_later_failure() {
     // `ClientModuleRecoverArgs::progress_tx` is public, so a module can report a
@@ -381,14 +397,9 @@ async fn forged_done_recovery_progress_does_not_mask_a_later_failure() {
     })
     .await
     .expect("Waiting on a failed module recovery must not block forever")
-    .expect_err("A failure after a forged done progress must still be reported as an error")
-    .to_string();
+    .expect_err("A failure after a forged done progress must still be reported as an error");
 
-    assert!(error.contains(RECOVERY_ERROR), "{error}");
-    assert!(
-        error.contains(&format!("module_instance_id={FAILING_MODULE_INSTANCE_ID}")),
-        "{error}"
-    );
+    assert_module_recovery_failed(&error, FAILING_MODULE_INSTANCE_ID);
 }
 
 #[tokio::test]
@@ -496,15 +507,9 @@ async fn wait_for_all_recoveries_reports_failed_module_recovery() {
     })
     .await
     .expect("Waiting on a failed module recovery must not block forever");
-    let error = result
-        .expect_err("Failed module recovery must be reported as an error")
-        .to_string();
+    let error = result.expect_err("Failed module recovery must be reported as an error");
 
-    assert!(error.contains(RECOVERY_ERROR), "{error}");
-    assert!(
-        error.contains(&format!("module_instance_id={FAILING_MODULE_INSTANCE_ID}")),
-        "{error}"
-    );
+    assert_module_recovery_failed(&error, FAILING_MODULE_INSTANCE_ID);
     // Reporting the failure doesn't finish the recovery: the failed module's
     // progress stays pending, which is what the progress-based observers keep
     // reporting.
@@ -552,13 +557,11 @@ async fn wait_for_all_recoveries_reports_a_recovery_task_that_went_away() {
     let error = timeout(WAIT_TIMEOUT, client.wait_for_all_recoveries())
         .await
         .expect("A recovery task that went away must not block the wait forever")
-        .expect_err("An unfinished recovery whose task went away must be reported as an error")
-        .to_string();
+        .expect_err("An unfinished recovery whose task went away must be reported as an error");
 
-    assert!(error.contains("disconnected"), "{error}");
     assert!(
-        !error.contains("module_instance_id="),
-        "A closed status channel must not be reported as a module failure: {error}"
+        matches!(error, RecoveryError::ClientStopped),
+        "A closed status channel must not be reported as a module failure: {error:?}"
     );
 }
 
@@ -639,14 +642,9 @@ async fn recovery_failure_wins_if_completion_is_also_observable() {
     let error = timeout(WAIT_TIMEOUT, client.wait_for_all_recoveries())
         .await
         .expect("Recovery outcome must be determinate")
-        .expect_err("A recovery failure must take precedence over a completed recovery")
-        .to_string();
+        .expect_err("A recovery failure must take precedence over a completed recovery");
 
-    assert!(error.contains(RECOVERY_ERROR), "{error}");
-    assert!(
-        error.contains(&format!("module_instance_id={FAILING_MODULE_INSTANCE_ID}")),
-        "{error}"
-    );
+    assert_module_recovery_failed(&error, FAILING_MODULE_INSTANCE_ID);
 }
 
 #[tokio::test]
@@ -739,14 +737,9 @@ async fn failed_status_is_not_overwritten_by_late_module_progress() {
     })
     .await
     .expect("A late waiter on a failed module recovery must not block forever")
-    .expect_err("A late waiter must still be told about the failed module recovery")
-    .to_string();
+    .expect_err("A late waiter must still be told about the failed module recovery");
 
-    assert!(error.contains(RECOVERY_ERROR), "{error}");
-    assert!(
-        error.contains(&format!("module_instance_id={FAILING_MODULE_INSTANCE_ID}")),
-        "{error}"
-    );
+    assert_module_recovery_failed(&error, FAILING_MODULE_INSTANCE_ID);
 }
 
 #[tokio::test]
@@ -820,14 +813,9 @@ async fn wait_for_module_kind_recovery_reports_failure_despite_other_kind_failin
     )
     .await
     .expect("Waiting on a failed module recovery must not block forever")
-    .expect_err("Failure of the requested kind must be reported despite an unrelated failure")
-    .to_string();
+    .expect_err("Failure of the requested kind must be reported despite an unrelated failure");
 
-    assert!(error.contains(RECOVERY_ERROR), "{error}");
-    assert!(
-        error.contains(&format!("module_instance_id={FAILING_MODULE_INSTANCE_ID}")),
-        "{error}"
-    );
+    assert_module_recovery_failed(&error, FAILING_MODULE_INSTANCE_ID);
 }
 
 /// The last [`ClientHandle`] may get dropped on a thread without a tokio

--- a/fedimint-client/src/client/tests.rs
+++ b/fedimint-client/src/client/tests.rs
@@ -8,6 +8,8 @@ use anyhow::anyhow;
 use bitcoin::key::Secp256k1;
 use fedimint_api_client::api::DynGlobalApi;
 use fedimint_api_client::api::global_api::with_request_hook::ApiRequestHook;
+use fedimint_client_module::OperationId;
+use fedimint_client_module::error::OperationNotFoundError;
 use fedimint_client_module::meta::LegacyMetaSource;
 use fedimint_client_module::module::recovery::RecoveryProgress;
 use fedimint_client_module::module::{ClientModuleRegistry, FinalClientIface};
@@ -843,4 +845,38 @@ async fn client_handle_drop_outside_runtime_does_not_panic() {
     std::thread::spawn(move || drop(handle))
         .join()
         .expect("Dropping a ClientHandle outside a runtime must not panic");
+}
+
+/// A client with no modules and an empty database, enough to exercise the
+/// lookups that only read the operation log.
+async fn client_for_lookup_test() -> Client {
+    let (_status_sender, status_receiver) = watch::channel(BTreeMap::new());
+    client_for_recovery_test(status_receiver, BTreeMap::new()).await
+}
+
+#[tokio::test]
+async fn operation_fees_of_a_missing_operation_are_reported_as_not_found() {
+    let client = client_for_lookup_test().await;
+    let operation_id = OperationId::new_random();
+
+    let err = client
+        .get_operation_fees(operation_id)
+        .await
+        .expect_err("An operation that was never started has no fees");
+
+    assert_eq!(err.operation_id, operation_id);
+}
+
+#[tokio::test]
+async fn visualizing_a_missing_operation_is_reported_as_not_found() {
+    let client = client_for_lookup_test().await;
+    let operation_id = OperationId::new_random();
+
+    // `OperationVisData` is not `Debug`, so `expect_err` is not available here.
+    let Err(err) = client.get_operations_vis(Some(operation_id), None).await else {
+        panic!("An operation that was never started cannot be visualized");
+    };
+    let err: OperationNotFoundError = err;
+
+    assert_eq!(err.operation_id, operation_id);
 }

--- a/fedimint-client/src/client/tests.rs
+++ b/fedimint-client/src/client/tests.rs
@@ -951,3 +951,32 @@ async fn a_balance_without_a_primary_module_is_reported_as_such() {
         "{err:?}"
     );
 }
+
+#[tokio::test]
+async fn loading_a_client_secret_that_was_never_stored_is_typed() {
+    use crate::error::ClientSecretError;
+
+    let db = Database::new(MemDatabase::new(), ModuleRegistry::default());
+
+    let err = Client::load_decodable_client_secret::<[u8; 64]>(&db)
+        .await
+        .expect_err("Nothing was ever stored");
+
+    assert!(matches!(err, ClientSecretError::NotPresent), "{err:?}");
+}
+
+#[tokio::test]
+async fn storing_a_second_client_secret_is_typed() {
+    use crate::error::ClientSecretError;
+
+    let db = Database::new(MemDatabase::new(), ModuleRegistry::default());
+
+    Client::store_encodable_client_secret(&db, [0u8; 64])
+        .await
+        .expect("The first secret must be stored");
+    let err = Client::store_encodable_client_secret(&db, [1u8; 64])
+        .await
+        .expect_err("A stored secret must not be overwritten");
+
+    assert!(matches!(err, ClientSecretError::AlreadyExists), "{err:?}");
+}

--- a/fedimint-client/src/client/tests.rs
+++ b/fedimint-client/src/client/tests.rs
@@ -912,3 +912,42 @@ async fn quoting_a_fee_without_a_primary_module_is_typed() {
         "{err:?}"
     );
 }
+
+#[tokio::test]
+async fn an_unknown_module_instance_is_reported_as_such() {
+    use fedimint_client_module::error::ModuleLookupError;
+
+    let client = client_for_lookup_test().await;
+
+    let err = client
+        .get_module_client_dyn(7)
+        .expect_err("A client without modules has no instance 7");
+
+    assert!(
+        matches!(err, ModuleLookupError::UnknownInstance { instance_id: 7 }),
+        "{err:?}"
+    );
+}
+
+#[tokio::test]
+async fn a_balance_without_a_primary_module_is_reported_as_such() {
+    use fedimint_client_module::error::ModuleLookupError;
+    use fedimint_core::module::AmountUnit;
+
+    let client = client_for_lookup_test().await;
+
+    let err = client
+        .get_balance_for_unit(AmountUnit::BITCOIN)
+        .await
+        .expect_err("A client without a primary module has no balance");
+
+    assert!(
+        matches!(
+            err,
+            ModuleLookupError::NoPrimaryModule {
+                unit: AmountUnit::BITCOIN
+            }
+        ),
+        "{err:?}"
+    );
+}

--- a/fedimint-client/src/client/tests.rs
+++ b/fedimint-client/src/client/tests.rs
@@ -880,3 +880,35 @@ async fn visualizing_a_missing_operation_is_reported_as_not_found() {
 
     assert_eq!(err.operation_id, operation_id);
 }
+
+#[tokio::test]
+async fn quoting_a_fee_without_a_primary_module_is_typed() {
+    use fedimint_client_module::error::TransactionSubmitError;
+    use fedimint_client_module::transaction::FeeQuoteRequest;
+    use fedimint_core::module::{AmountUnit, Amounts};
+
+    let client = client_for_lookup_test().await;
+
+    let err = client
+        .fee_quote(
+            OperationId::new_random(),
+            FeeQuoteRequest {
+                input_amount: Amounts::ZERO,
+                output_amount: Amounts::new_bitcoin(fedimint_core::Amount::from_sats(1)),
+                input_fee: Amounts::ZERO,
+                output_fee: Amounts::ZERO,
+            },
+        )
+        .await
+        .expect_err("A client without a primary module cannot balance a transaction");
+
+    assert!(
+        matches!(
+            err,
+            TransactionSubmitError::NoPrimaryModule {
+                unit: AmountUnit::BITCOIN
+            }
+        ),
+        "{err:?}"
+    );
+}

--- a/fedimint-client/src/db.rs
+++ b/fedimint-client/src/db.rs
@@ -1,7 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::time::SystemTime;
 
-use anyhow::{Context as _, bail};
 use bitcoin::hex::DisplayHex as _;
 use fedimint_api_client::api::ApiVersionSet;
 use fedimint_client_module::db::ClientModuleMigrationFn;
@@ -33,6 +32,7 @@ use strum_macros::EnumIter;
 use tracing::{debug, info, trace, warn};
 
 use crate::backup::{ClientBackup, Metadata};
+use crate::error::ClientSecretError;
 use crate::sm::executor::{
     ActiveStateKeyBytes, ActiveStateKeyPrefixBytes, ExecutorDbPrefixes, InactiveStateKeyBytes,
     InactiveStateKeyPrefixBytes,
@@ -1057,16 +1057,18 @@ pub async fn remove_old_and_persist_new_inactive_states(
 /// Fetches the encoded client secret from the database and decodes it.
 /// If an encoded client secret is not present in the database, or if
 /// decoding fails, an error is returned.
-pub async fn get_decoded_client_secret<T: Decodable>(db: &Database) -> anyhow::Result<T> {
+pub async fn get_decoded_client_secret<T: Decodable>(
+    db: &Database,
+) -> Result<T, ClientSecretError> {
     let mut tx = db.begin_transaction_nc().await;
     let client_secret = tx.get_value(&EncodedClientSecretKey).await;
 
     match client_secret {
-        Some(client_secret) => {
-            T::consensus_decode_whole(&client_secret, &ModuleRegistry::default())
-                .context("Decoding failed")
-        }
-        None => bail!("Encoded client secret not present in DB"),
+        Some(client_secret) => Ok(T::consensus_decode_whole(
+            &client_secret,
+            &ModuleRegistry::default(),
+        )?),
+        None => Err(ClientSecretError::NotPresent),
     }
 }
 

--- a/fedimint-client/src/error.rs
+++ b/fedimint-client/src/error.rs
@@ -4,7 +4,7 @@
 //! [`fedimint_client_module::error`] and re-exported here, so this module is
 //! the single place to look.
 
-use fedimint_api_client::api::ClientConfigDownloadError;
+use fedimint_api_client::api::{ClientConfigDownloadError, FederationError};
 pub use fedimint_client_module::error::*;
 use fedimint_core::core::{ModuleInstanceId, ModuleKind};
 use fedimint_core::db::{DatabaseError, DbMigrationError};
@@ -96,6 +96,53 @@ pub enum ClientBuildError {
 impl From<ClientConfigDownloadError> for ClientBuildError {
     fn from(source: ClientConfigDownloadError) -> Self {
         Self::ConfigDownload(Box::new(source))
+    }
+}
+
+/// A failure to create, encrypt, upload or read back a client backup.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum BackupError {
+    /// A module is still recovering, so its state is not backed up yet.
+    #[error("Cannot back up while a module recovery is still running")]
+    PendingRecoveries,
+
+    /// The federation could not be reached.
+    #[error("The federation could not be reached")]
+    Federation(#[source] Box<FederationError>),
+
+    /// A module failed to produce its part of the backup.
+    // The boxed cause narrows to `ClientModuleError` in #8821 part E.
+    #[error("Module {instance_id} failed to produce its backup")]
+    Module {
+        /// The module that failed.
+        instance_id: ModuleInstanceId,
+        /// The failure the module reported.
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    /// The encrypted backup is larger than the federation stores.
+    #[error("The backup payload is {size} bytes, over the limit of {max}")]
+    TooLarge {
+        /// The size of the encrypted backup.
+        size: usize,
+        /// The largest payload the federation stores.
+        max: usize,
+    },
+
+    /// The backup could not be encrypted or decrypted.
+    #[error("The backup could not be encrypted or decrypted")]
+    Encryption(#[source] Box<dyn std::error::Error + Send + Sync>),
+
+    /// A downloaded backup could not be decoded.
+    #[error("The backup could not be decoded")]
+    Decode(#[from] DecodeError),
+}
+
+impl From<FederationError> for BackupError {
+    fn from(source: FederationError) -> Self {
+        Self::Federation(Box::new(source))
     }
 }
 

--- a/fedimint-client/src/error.rs
+++ b/fedimint-client/src/error.rs
@@ -5,3 +5,22 @@
 //! the single place to look.
 
 pub use fedimint_client_module::error::*;
+use fedimint_core::encoding::DecodeError;
+use thiserror::Error;
+
+/// A failure to read or write the client's stored root secret.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum ClientSecretError {
+    /// The database already holds a secret, which is never overwritten.
+    #[error("An encoded client secret already exists and cannot be overwritten")]
+    AlreadyExists,
+
+    /// The database holds no secret.
+    #[error("No encoded client secret is present in the database")]
+    NotPresent,
+
+    /// The stored secret is not a valid encoding of the requested type.
+    #[error("The stored client secret could not be decoded")]
+    Decode(#[from] DecodeError),
+}

--- a/fedimint-client/src/error.rs
+++ b/fedimint-client/src/error.rs
@@ -4,7 +4,10 @@
 //! [`fedimint_client_module::error`] and re-exported here, so this module is
 //! the single place to look.
 
+use fedimint_api_client::api::ClientConfigDownloadError;
 pub use fedimint_client_module::error::*;
+use fedimint_core::core::{ModuleInstanceId, ModuleKind};
+use fedimint_core::db::{DatabaseError, DbMigrationError};
 use fedimint_core::encoding::DecodeError;
 use thiserror::Error;
 
@@ -23,4 +26,75 @@ pub enum ClientSecretError {
     /// The stored secret is not a valid encoding of the requested type.
     #[error("The stored client secret could not be decoded")]
     Decode(#[from] DecodeError),
+}
+
+/// A failure to open, join or recover a client.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum ClientBuildError {
+    /// The database was never joined to a federation.
+    #[error("The client database is not initialized")]
+    DatabaseNotInitialized,
+
+    /// The database already belongs to a federation and cannot be joined
+    /// again.
+    #[error("The client database is already initialized")]
+    DatabaseAlreadyInitialized,
+
+    /// The secret does not match the one the database was created with.
+    #[error("The secret does not match the one this database was created with")]
+    SecretMismatch,
+
+    /// The federation's client config could not be downloaded.
+    #[error("Failed to download the client config")]
+    ConfigDownload(#[source] Box<ClientConfigDownloadError>),
+
+    /// The stored client config could not be decoded with the modules this
+    /// client was built with.
+    #[error("Failed to decode the client config")]
+    ConfigDecode(#[from] DecodeError),
+
+    /// A database migration failed.
+    #[error("Failed to migrate the client database")]
+    Migration(#[from] DbMigrationError),
+
+    /// A module could not prepare its recovery.
+    // The boxed cause narrows to `ClientModuleError` in #8821 part E.
+    #[error("Module {instance_id} ({kind}) failed to prepare its recovery")]
+    ModuleRecoveryPrepare {
+        /// The kind of the module that failed.
+        kind: ModuleKind,
+        /// The instance of the module that failed.
+        instance_id: ModuleInstanceId,
+        /// The failure the module reported.
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    /// A module could not be initialized.
+    // The boxed cause narrows to `ClientModuleError` in #8821 part E.
+    #[error("Module {instance_id} ({kind}) failed to initialize")]
+    ModuleInit {
+        /// The kind of the module that failed.
+        kind: ModuleKind,
+        /// The instance of the module that failed.
+        instance_id: ModuleInstanceId,
+        /// The failure the module reported.
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    /// The database write failed.
+    #[error("Database error")]
+    Database(#[from] DatabaseError),
+
+    /// The client handle was already shut down and cannot be restarted.
+    #[error("The client is already stopped")]
+    AlreadyStopped,
+}
+
+impl From<ClientConfigDownloadError> for ClientBuildError {
+    fn from(source: ClientConfigDownloadError) -> Self {
+        Self::ConfigDownload(Box::new(source))
+    }
 }

--- a/fedimint-client/src/error.rs
+++ b/fedimint-client/src/error.rs
@@ -9,6 +9,7 @@ pub use fedimint_client_module::error::*;
 use fedimint_core::core::{ModuleInstanceId, ModuleKind};
 use fedimint_core::db::{DatabaseError, DbMigrationError};
 use fedimint_core::encoding::DecodeError;
+pub use fedimint_eventlog::EventHandlerError;
 use thiserror::Error;
 
 /// A failure to read or write the client's stored root secret.

--- a/fedimint-client/src/error.rs
+++ b/fedimint-client/src/error.rs
@@ -98,3 +98,33 @@ impl From<ClientConfigDownloadError> for ClientBuildError {
         Self::ConfigDownload(Box::new(source))
     }
 }
+
+/// A failure to wait for a module recovery to finish.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum RecoveryError {
+    /// A module's recovery gave up.
+    ///
+    /// The failure is in-memory only and is never persisted: reopening the
+    /// client retries the recovery from its last persisted progress.
+    // `error` is the module's already-stringified failure; it becomes a typed
+    // `ClientModuleError` in #8821 part E.
+    #[error("Recovery of module {module_instance_id} failed: {error}")]
+    Failed {
+        /// The module whose recovery failed.
+        module_instance_id: ModuleInstanceId,
+        /// What the module reported.
+        error: String,
+    },
+
+    /// The client shut down before the recovery reached an outcome.
+    #[error("The client shut down before the recovery finished")]
+    ClientStopped,
+}
+
+#[cfg(feature = "uniffi")]
+impl From<RecoveryError> for fedimint_core::util::ffi::UniffiError {
+    fn from(e: RecoveryError) -> Self {
+        Self::General(e.to_string())
+    }
+}

--- a/fedimint-client/src/error.rs
+++ b/fedimint-client/src/error.rs
@@ -1,0 +1,7 @@
+//! Error types of the client.
+//!
+//! The types the client's *modules* also need are defined in
+//! [`fedimint_client_module::error`] and re-exported here, so this module is
+//! the single place to look.
+
+pub use fedimint_client_module::error::*;

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -91,6 +91,8 @@ mod client;
 pub mod backup;
 /// Database keys used by the client
 pub mod db;
+/// Error types of the client
+pub mod error;
 #[cfg(feature = "uniffi")]
 pub mod ffi;
 

--- a/fedimint-client/src/meta.rs
+++ b/fedimint-client/src/meta.rs
@@ -6,7 +6,7 @@ use async_stream::stream;
 use fedimint_client_module::meta::{FetchKind, MetaSource, MetaValue, MetaValues};
 use fedimint_core::db::{Database, DatabaseTransaction, IDatabaseTransactionOpsCoreTyped};
 use fedimint_core::task::waiter::Waiter;
-use fedimint_core::util::{FmtCompact as _, FmtCompactAnyhow as _};
+use fedimint_core::util::FmtCompact as _;
 use fedimint_logging::LOG_CLIENT;
 use futures::StreamExt as _;
 use serde::de::DeserializeOwned;
@@ -200,7 +200,7 @@ impl<S: MetaSource + ?Sized> MetaService<S> {
         match meta_values {
             Ok(meta_values) => self.save_meta_values(client, &meta_values).await,
             Err(error) => {
-                warn!(target: LOG_CLIENT, err = %error.fmt_compact_anyhow(), "failed to fetch source");
+                warn!(target: LOG_CLIENT, err = %error.fmt_compact(), "failed to fetch source");
             }
         };
         self.initial_fetch_waiter.done();

--- a/fedimint-client/src/oplog.rs
+++ b/fedimint-client/src/oplog.rs
@@ -8,7 +8,9 @@ use fedimint_client_module::oplog::{
     IOperationLog, JsonStringed, OperationLogEntry, OperationOutcome, UpdateStreamOrOutcome,
 };
 use fedimint_core::core::OperationId;
-use fedimint_core::db::{Database, DatabaseTransaction, IDatabaseTransactionOpsCoreTyped as _};
+use fedimint_core::db::{
+    Database, DatabaseError, DatabaseTransaction, IDatabaseTransactionOpsCoreTyped as _,
+};
 use fedimint_core::task::{MaybeSend, MaybeSync};
 use fedimint_core::time::now;
 use fedimint_core::util::{BoxStream, FmtCompact as _};
@@ -212,7 +214,7 @@ impl OperationLog {
         db: &Database,
         operation_id: OperationId,
         outcome: &(impl Serialize + Debug),
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), DatabaseError> {
         let outcome_json =
             JsonStringed(serde_json::to_value(outcome).expect("Outcome is not serializable"));
 
@@ -300,7 +302,8 @@ impl OperationLog {
         if let Err(e) = Self::set_operation_outcome(db, operation_id, outcome).await {
             warn!(
                 target: LOG_CLIENT,
-                "Error setting operation outcome: {e}"
+                err = %e.fmt_compact(),
+                "Error setting operation outcome"
             );
         }
     }

--- a/fedimint-client/src/sm/executor.rs
+++ b/fedimint-client/src/sm/executor.rs
@@ -6,7 +6,6 @@ use std::mem;
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::anyhow;
 use fedimint_client_module::sm::executor::{
     ActiveStateKey, ContextGen, IExecutor, InactiveStateKey,
 };
@@ -186,7 +185,10 @@ impl Executor {
     ///
     /// **Attention**: do not use before background task is started!
     // TODO: remove warning once finality is an inherent state attribute
-    pub async fn add_state_machines(&self, states: Vec<DynState>) -> anyhow::Result<()> {
+    pub async fn add_state_machines(
+        &self,
+        states: Vec<DynState>,
+    ) -> Result<(), AddStateMachinesError> {
         self.inner
             .db
             .autocommit(
@@ -195,11 +197,10 @@ impl Executor {
             )
             .await
             .map_err(|e| match e {
-                AutocommitError::CommitFailed {
-                    last_error,
-                    attempts,
-                } => anyhow!("Failed to commit after {attempts} attempts: {last_error}"),
-                AutocommitError::ClosureError { error, .. } => anyhow!("{error:?}"),
+                AutocommitError::CommitFailed { last_error, .. } => {
+                    AddStateMachinesError::Database(last_error)
+                }
+                AutocommitError::ClosureError { error, .. } => error,
             })?;
 
         // TODO: notify subscribers to state changes?
@@ -226,7 +227,9 @@ impl Executor {
                 .valid_module_ids
                 .contains(&state.module_instance_id())
             {
-                return Err(AddStateMachinesError::Other(anyhow!("Unknown module")));
+                return Err(AddStateMachinesError::UnknownModule {
+                    module_instance_id: state.module_instance_id(),
+                });
             }
 
             let is_active_state = dbtx
@@ -260,9 +263,7 @@ impl Executor {
                 {
                     Some(context) => {
                         if state.is_terminal(module_context, &context) {
-                            return Err(AddStateMachinesError::Other(anyhow!(
-                                "State is already terminal, adding it to the executor doesn't make sense."
-                            )));
+                            return Err(AddStateMachinesError::StateAlreadyTerminal);
                         }
                     }
                     _ => {

--- a/fedimint-client/src/sm/executor/tests.rs
+++ b/fedimint-client/src/sm/executor/tests.rs
@@ -2,6 +2,7 @@ use std::fmt::Debug;
 use std::sync::Arc;
 use std::time::Duration;
 
+use fedimint_client_module::error::AddStateMachinesError;
 use fedimint_client_module::sm::{Context, DynContext, DynState, State, StateTransition};
 use fedimint_core::core::{Decoder, IntoDynInstance, ModuleInstanceId, ModuleKind, OperationId};
 use fedimint_core::db::Database;
@@ -171,15 +172,16 @@ async fn test_executor() {
         .await
         .unwrap();
 
+    let err = executor
+        .add_state_machines(vec![DynState::from_typed(
+            MOCK_INSTANCE_1,
+            MockStateMachine::Start,
+        )])
+        .await
+        .expect_err("Running the same state machine a second time should fail");
     assert!(
-        executor
-            .add_state_machines(vec![DynState::from_typed(
-                MOCK_INSTANCE_1,
-                MockStateMachine::Start
-            )])
-            .await
-            .is_err(),
-        "Running the same state machine a second time should fail"
+        matches!(err, AddStateMachinesError::StateAlreadyExists),
+        "{err:?}"
     );
 
     assert!(
@@ -205,6 +207,31 @@ async fn test_executor() {
             .contains_inactive_state(MOCK_INSTANCE_1, MockStateMachine::Final)
             .await,
         "State was written to DB and waits for broadcast"
+    );
+}
+
+#[tokio::test]
+async fn adding_a_state_of_an_unknown_module_is_typed() {
+    const UNREGISTERED_INSTANCE: ModuleInstanceId = 21;
+
+    let (executor, _sender, _db) = get_executor();
+
+    let err = executor
+        .add_state_machines(vec![DynState::from_typed(
+            UNREGISTERED_INSTANCE,
+            MockStateMachine::Start,
+        )])
+        .await
+        .expect_err("The executor does not know this module instance");
+
+    assert!(
+        matches!(
+            err,
+            AddStateMachinesError::UnknownModule {
+                module_instance_id: UNREGISTERED_INSTANCE
+            }
+        ),
+        "{err:?}"
     );
 }
 

--- a/fedimint-client/src/visualize.rs
+++ b/fedimint-client/src/visualize.rs
@@ -20,6 +20,7 @@ use fedimint_core::core::{ModuleInstanceId, OperationId};
 use time::OffsetDateTime;
 
 use crate::Client;
+use crate::error::OperationNotFoundError;
 
 /// Visualization data for a single operation and its state machines.
 pub struct OperationVisData {
@@ -324,13 +325,14 @@ impl Client {
         &self,
         explicit: Option<OperationId>,
         limit: Option<usize>,
-    ) -> anyhow::Result<Vec<(OperationId, Option<SystemTime>, OperationLogEntry)>> {
+    ) -> Result<Vec<(OperationId, Option<SystemTime>, OperationLogEntry)>, OperationNotFoundError>
+    {
         if let Some(id) = explicit {
             let entry = self
                 .operation_log()
                 .get_operation(id)
                 .await
-                .ok_or_else(|| anyhow::anyhow!("Operation not found"))?;
+                .ok_or(OperationNotFoundError { operation_id: id })?;
             return Ok(vec![(id, None, entry)]);
         }
         let ops = self
@@ -348,7 +350,7 @@ impl Client {
         &self,
         operation_id: Option<OperationId>,
         limit: Option<usize>,
-    ) -> anyhow::Result<Vec<OperationVisData>> {
+    ) -> Result<Vec<OperationVisData>, OperationNotFoundError> {
         let ops: Vec<(OperationId, Option<SystemTime>, OperationLogEntry)> =
             self.resolve_operations(operation_id, limit).await?;
         let kinds = self.sm_module_to_string_map().await;
@@ -401,7 +403,7 @@ impl Client {
         &self,
         operation_id: Option<OperationId>,
         limit: Option<usize>,
-    ) -> anyhow::Result<Vec<OperationTransactionsVisData>> {
+    ) -> Result<Vec<OperationTransactionsVisData>, OperationNotFoundError> {
         let ops: Vec<(OperationId, Option<SystemTime>, OperationLogEntry)> =
             self.resolve_operations(operation_id, limit).await?;
         let kinds = self.sm_module_to_string_map().await;

--- a/fedimint-core/src/module/mod.rs
+++ b/fedimint-core/src/module/mod.rs
@@ -98,6 +98,16 @@ impl AmountUnit {
     }
 }
 
+impl fmt::Display for AmountUnit {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        if self.is_bitcoin() {
+            f.write_str("bitcoin")
+        } else {
+            write!(f, "{}", self.0)
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub struct AmountWithUnit {
     amounts: Amount,

--- a/fedimint-eventlog/Cargo.toml
+++ b/fedimint-eventlog/Cargo.toml
@@ -28,6 +28,7 @@ hex = { workspace = true }
 itertools = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+thiserror = { workspace = true }
 tokio = { workspace = true, features = ["time", "macros", "rt"] }
 tracing = { workspace = true }
 uniffi = { workspace = true, optional = true }

--- a/fedimint-eventlog/src/lib.rs
+++ b/fedimint-eventlog/src/lib.rs
@@ -864,6 +864,10 @@ pub enum EventHandlerError<E> {
     Tracker(#[source] Box<dyn std::error::Error + Send + Sync>),
 }
 
+/// Feeds every entry of the event log, past and future, to `call_fn`.
+///
+/// `tracker` remembers how far the log has been read so a restart resumes where
+/// it left off; the loop stops when `call_fn` fails or the client shuts down.
 pub async fn handle_events<F, R, E>(
     db: Database,
     mut tracker: DynEventLogTracker,
@@ -910,6 +914,8 @@ where
     }
 }
 
+/// Like [`handle_events`], for the trimable part of the log: entries are handed
+/// to `call_fn` and the tracker's position drives when they can be trimmed.
 pub async fn handle_trimable_events<F, R, E>(
     db: Database,
     mut tracker: DynEventLogTrimableTracker,

--- a/fedimint-eventlog/src/lib.rs
+++ b/fedimint-eventlog/src/lib.rs
@@ -31,6 +31,7 @@ use fedimint_logging::LOG_CLIENT_EVENT_LOG;
 use futures::{Future, StreamExt};
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 use tokio::sync::{broadcast, watch};
 use tracing::{debug, trace};
 
@@ -850,19 +851,34 @@ pub trait EventLogTrimableTracker {
 }
 pub type DynEventLogTrimableTracker = Box<dyn EventLogTrimableTracker>;
 
-pub async fn handle_events<F, R>(
+/// A failure while handling entries from the event log.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum EventHandlerError<E> {
+    /// The handler rejected an event.
+    #[error("The event handler failed")]
+    Handler(#[source] E),
+
+    /// The tracker could not load or store the position in the log.
+    #[error("The event log tracker failed")]
+    Tracker(#[source] Box<dyn std::error::Error + Send + Sync>),
+}
+
+pub async fn handle_events<F, R, E>(
     db: Database,
     mut tracker: DynEventLogTracker,
     mut log_event_added: watch::Receiver<()>,
     call_fn: F,
-) -> anyhow::Result<()>
+) -> Result<(), EventHandlerError<E>>
 where
     F: Fn(&mut DatabaseTransaction<NonCommittable>, EventLogEntry) -> R,
-    R: Future<Output = anyhow::Result<()>>,
+    R: Future<Output = Result<(), E>>,
+    E: std::error::Error + 'static,
 {
     let mut next_key: EventLogId = tracker
         .load(&mut db.begin_transaction_nc().await)
-        .await?
+        .await
+        .map_err(|err| EventHandlerError::Tracker(err.into()))?
         .unwrap_or_default();
 
     trace!(target: LOG_CLIENT_EVENT_LOG, ?next_key, "Handling events");
@@ -872,11 +888,16 @@ where
 
         match dbtx.get_value(&next_key).await {
             Some(event) => {
-                (call_fn)(&mut dbtx.to_ref_nc(), event).await?;
+                (call_fn)(&mut dbtx.to_ref_nc(), event)
+                    .await
+                    .map_err(EventHandlerError::Handler)?;
 
                 next_key = next_key.next();
 
-                tracker.store(&mut dbtx.to_ref_nc(), next_key).await?;
+                tracker
+                    .store(&mut dbtx.to_ref_nc(), next_key)
+                    .await
+                    .map_err(|err| EventHandlerError::Tracker(err.into()))?;
 
                 dbtx.commit_tx().await;
             }
@@ -889,19 +910,21 @@ where
     }
 }
 
-pub async fn handle_trimable_events<F, R>(
+pub async fn handle_trimable_events<F, R, E>(
     db: Database,
     mut tracker: DynEventLogTrimableTracker,
     mut log_event_added: watch::Receiver<()>,
     call_fn: F,
-) -> anyhow::Result<()>
+) -> Result<(), EventHandlerError<E>>
 where
     F: Fn(&mut DatabaseTransaction<NonCommittable>, EventLogEntry) -> R,
-    R: Future<Output = anyhow::Result<()>>,
+    R: Future<Output = Result<(), E>>,
+    E: std::error::Error + 'static,
 {
     let mut next_key: EventLogTrimableId = tracker
         .load(&mut db.begin_transaction_nc().await)
-        .await?
+        .await
+        .map_err(|err| EventHandlerError::Tracker(err.into()))?
         .unwrap_or_default();
     trace!(target: LOG_CLIENT_EVENT_LOG, ?next_key, "Handling trimable events");
 
@@ -910,10 +933,15 @@ where
 
         match dbtx.get_value(&next_key).await {
             Some(event) => {
-                (call_fn)(&mut dbtx.to_ref_nc(), event).await?;
+                (call_fn)(&mut dbtx.to_ref_nc(), event)
+                    .await
+                    .map_err(EventHandlerError::Handler)?;
 
                 next_key = next_key.next();
-                tracker.store(&mut dbtx.to_ref_nc(), next_key).await?;
+                tracker
+                    .store(&mut dbtx.to_ref_nc(), next_key)
+                    .await
+                    .map_err(|err| EventHandlerError::Tracker(err.into()))?;
 
                 dbtx.commit_tx().await;
             }

--- a/fedimint-eventlog/src/tests.rs
+++ b/fedimint-eventlog/src/tests.rs
@@ -3,7 +3,7 @@ use std::sync::atomic::AtomicU8;
 
 use fedimint_core::db::mem_impl::MemDatabase;
 use fedimint_core::db::{
-    DatabaseTransaction, IDatabaseTransactionOpsCoreTyped as _, IRawDatabaseExt as _,
+    Database, DatabaseTransaction, IDatabaseTransactionOpsCoreTyped as _, IRawDatabaseExt as _,
     NonCommittable,
 };
 use fedimint_core::encoding::{Decodable, Encodable};
@@ -15,9 +15,9 @@ use tokio::try_join;
 use tracing::info;
 
 use super::{
-    DBTransactionEventLogExt as _, EventKind, EventLogEntry, EventLogId, EventLogTrimableId,
-    EventLogTrimableIdPrefixAll, TRIMABLE_EVENTLOG_MIN_ID_AGE, TRIMABLE_EVENTLOG_MIN_TS_AGE,
-    handle_events, run_event_log_ordering_task, trim_trimable_log,
+    DBTransactionEventLogExt as _, EventHandlerError, EventKind, EventLogEntry, EventLogId,
+    EventLogTrimableId, EventLogTrimableIdPrefixAll, TRIMABLE_EVENTLOG_MIN_ID_AGE,
+    TRIMABLE_EVENTLOG_MIN_TS_AGE, handle_events, run_event_log_ordering_task, trim_trimable_log,
 };
 use crate::EventLogNonTrimableTracker;
 
@@ -53,15 +53,56 @@ impl EventLogNonTrimableTracker for TestEventLogTracker {
     }
 }
 
+/// Which of [`FailingTracker`]'s methods should fail.
+#[derive(Debug, Clone, Copy)]
+enum FailOn {
+    Load,
+    Store,
+}
+
+/// Like [`TestEventLogTracker`], but the configured method always fails.
+///
+/// Used to verify that a failure while loading or storing the tracked
+/// position surfaces as [`EventHandlerError::Tracker`].
+struct FailingTracker {
+    fail_on: FailOn,
+}
+
+#[apply(async_trait_maybe_send!)]
+impl EventLogNonTrimableTracker for FailingTracker {
+    async fn store(
+        &mut self,
+        dbtx: &mut DatabaseTransaction<NonCommittable>,
+        pos: EventLogId,
+    ) -> anyhow::Result<()> {
+        if matches!(self.fail_on, FailOn::Store) {
+            return Err(anyhow::anyhow!("tracker failed"));
+        }
+        dbtx.insert_entry(&TestEventLogIdKey, &pos).await;
+        Ok(())
+    }
+
+    async fn load(
+        &mut self,
+        dbtx: &mut DatabaseTransaction<NonCommittable>,
+    ) -> anyhow::Result<Option<EventLogId>> {
+        if matches!(self.fail_on, FailOn::Load) {
+            return Err(anyhow::anyhow!("tracker failed"));
+        }
+        Ok(dbtx.get_value(&TestEventLogIdKey).await)
+    }
+}
+
 /// The error the test handler returns to stop handling events.
 #[derive(Debug, thiserror::Error)]
 #[error("Time to wrap up")]
 struct WrapUp;
 
-#[test_log::test(tokio::test)]
-async fn sanity_handle_events() {
+/// Spawns the event log ordering task and returns the pieces `handle_events`
+/// and the event-logging code need: the database, the receiver that wakes up
+/// once new events are ordered, and the sender used to request ordering.
+fn spawn_ordering_task(tg: &TaskGroup) -> (Database, watch::Receiver<()>, watch::Sender<()>) {
     let db = MemDatabase::new().into_database();
-    let tg = TaskGroup::new();
 
     let (log_event_added_tx, log_event_added_rx) = watch::channel(());
     let (log_ordering_wakeup_tx, log_ordering_wakeup_rx) = watch::channel(());
@@ -77,9 +118,17 @@ async fn sanity_handle_events() {
         ),
     );
 
+    (db, log_event_added_rx, log_ordering_wakeup_tx)
+}
+
+#[test_log::test(tokio::test)]
+async fn sanity_handle_events() {
+    let tg = TaskGroup::new();
+    let (db, log_event_added_rx, log_ordering_wakeup_tx) = spawn_ordering_task(&tg);
+
     let counter = Arc::new(AtomicU8::new(0));
 
-    let _ = try_join!(
+    let res = try_join!(
         handle_events(
             db.clone(),
             Box::new(TestEventLogTracker),
@@ -124,6 +173,52 @@ async fn sanity_handle_events() {
             Ok(())
         }
     );
+
+    // The handler stops the loop by returning `WrapUp` on the fifth event; make
+    // sure that error actually surfaces as `EventHandlerError::Handler` instead
+    // of being silently dropped.
+    let Err(err) = res else {
+        panic!("expected the handler's error to stop `handle_events`, got {res:?}");
+    };
+    assert!(matches!(err, EventHandlerError::Handler(WrapUp)));
+}
+
+#[test_log::test(tokio::test)]
+async fn handle_events_tracker_failure() {
+    for fail_on in [FailOn::Load, FailOn::Store] {
+        let tg = TaskGroup::new();
+        let (db, log_event_added_rx, log_ordering_wakeup_tx) = spawn_ordering_task(&tg);
+
+        // The `Store` case needs an event to reach the handler (and thus the
+        // tracker's `store`); the `Load` case fails before any event is needed.
+        if matches!(fail_on, FailOn::Store) {
+            let mut dbtx = db.begin_transaction().await;
+            dbtx.log_event_raw(
+                log_ordering_wakeup_tx.clone(),
+                EventKind::from("0"),
+                None,
+                None,
+                vec![],
+                crate::EventPersistence::Persistent,
+            )
+            .await;
+
+            dbtx.commit_tx().await;
+        }
+
+        let res = handle_events(
+            db.clone(),
+            Box::new(FailingTracker { fail_on }),
+            log_event_added_rx,
+            |_dbtx, _event| Box::pin(async { Ok::<(), WrapUp>(()) }),
+        )
+        .await;
+
+        let Err(EventHandlerError::Tracker(source)) = res else {
+            panic!("expected `EventHandlerError::Tracker` for {fail_on:?}, got {res:?}");
+        };
+        assert_eq!(source.to_string(), "tracker failed");
+    }
 }
 
 #[test_log::test(tokio::test)]

--- a/fedimint-eventlog/src/tests.rs
+++ b/fedimint-eventlog/src/tests.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 use std::sync::atomic::AtomicU8;
 
-use anyhow::bail;
 use fedimint_core::db::mem_impl::MemDatabase;
 use fedimint_core::db::{
     DatabaseTransaction, IDatabaseTransactionOpsCoreTyped as _, IRawDatabaseExt as _,
@@ -54,6 +53,11 @@ impl EventLogNonTrimableTracker for TestEventLogTracker {
     }
 }
 
+/// The error the test handler returns to stop handling events.
+#[derive(Debug, thiserror::Error)]
+#[error("Time to wrap up")]
+struct WrapUp;
+
 #[test_log::test(tokio::test)]
 async fn sanity_handle_events() {
     let db = MemDatabase::new().into_database();
@@ -94,7 +98,7 @@ async fn sanity_handle_events() {
                     );
 
                     if counter.load(std::sync::atomic::Ordering::Relaxed) == 4 {
-                        bail!("Time to wrap up");
+                        return Err(WrapUp);
                     }
                     counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                     Ok(())

--- a/fedimint-load-test-tool/src/common.rs
+++ b/fedimint-load-test-tool/src/common.rs
@@ -154,7 +154,7 @@ pub async fn build_client(
         fedimint_core::db::mem_impl::MemDatabase::new().into()
     };
     let mut client_builder = Client::builder()
-        .await?
+        .await
         .with_iroh_enable_dht(false)
         .with_iroh_enable_dht(false);
     client_builder.with_module(MintClientInit);

--- a/fedimint-load-test-tool/src/common.rs
+++ b/fedimint-load-test-tool/src/common.rs
@@ -160,7 +160,7 @@ pub async fn build_client(
     client_builder.with_module(MintClientInit);
     client_builder.with_module(LightningClientInit::default());
     client_builder.with_module(WalletClientInit::default());
-    let client_secret = Client::load_or_generate_client_secret(&db).await?;
+    let client_secret = Client::load_or_generate_client_secret(&db).await;
     let root_secret =
         RootSecret::StandardDoubleDerive(PlainRootSecretStrategy::to_root_secret(&client_secret));
     let connectors = ConnectorRegistry::build_from_client_env().bind().await;

--- a/fedimint-metrics/src/lib.rs
+++ b/fedimint-metrics/src/lib.rs
@@ -72,10 +72,14 @@ pub static AMOUNTS_BUCKETS_SATS: LazyLock<Vec<f64>> = LazyLock::new(|| {
 });
 
 /// Returns all registered metrics encoded in Prometheus text format.
-pub fn get_metrics() -> anyhow::Result<String> {
+///
+/// # Panics
+/// Never, in practice: the Prometheus text encoder only ever emits valid
+/// UTF-8.
+pub fn get_metrics() -> Result<String, prometheus::Error> {
     let metric_families = REGISTRY.gather();
     let mut buffer = Vec::new();
     let encoder = TextEncoder::new();
     encoder.encode(&metric_families, &mut buffer)?;
-    Ok(String::from_utf8(buffer)?)
+    Ok(String::from_utf8(buffer).expect("Prometheus text encoding is valid UTF-8"))
 }

--- a/fedimint-recurringd/src/lib.rs
+++ b/fedimint-recurringd/src/lib.rs
@@ -74,7 +74,7 @@ impl RecurringInvoiceServer {
         let mut gateway_cache = HashMap::<FederationId, watch::Receiver<Vec<CachedGateway>>>::new();
 
         for (federation_id, db) in load_federation_client_databases(&db).await {
-            let mut client_builder = Client::builder().await?;
+            let mut client_builder = Client::builder().await;
             client_builder.with_meta_service(recurringd_meta_service());
             client_builder.with_module(LightningClientInit::default());
             client_builder.with_module(MintClientInit);
@@ -161,9 +161,7 @@ impl RecurringInvoiceServer {
         client_db: Database,
         invite_code: &InviteCode,
     ) -> Result<ClientHandleArc, RecurringPaymentError> {
-        let mut client_builder = Client::builder()
-            .await
-            .map_err(RecurringPaymentError::JoiningFederationFailed)?;
+        let mut client_builder = Client::builder().await;
 
         client_builder.with_meta_service(recurringd_meta_service());
         client_builder.with_module(LightningClientInit::default());
@@ -171,13 +169,18 @@ impl RecurringInvoiceServer {
 
         let client = client_builder
             .preview(connectors, invite_code)
-            .await?
+            .await
+            .map_err(|err| {
+                RecurringPaymentError::JoiningFederationFailed(anyhow!("{}", err.fmt_compact()))
+            })?
             .join(
                 client_db,
                 fedimint_client::RootSecret::StandardDoubleDerive(Self::default_secret()),
             )
             .await
-            .map_err(RecurringPaymentError::JoiningFederationFailed)?;
+            .map_err(|err| {
+                RecurringPaymentError::JoiningFederationFailed(anyhow!("{}", err.fmt_compact()))
+            })?;
         Ok(Arc::new(client))
     }
 

--- a/fedimint-testing/src/federation.rs
+++ b/fedimint-testing/src/federation.rs
@@ -113,7 +113,7 @@ impl FederationTest {
         admin_creds: Option<AdminCreds>,
     ) -> ClientHandleArc {
         info!(target: LOG_TEST, "Setting new client with config");
-        let mut client_builder = Client::builder().await.expect("Failed to build client");
+        let mut client_builder = Client::builder().await;
         client_builder.with_module_inits(self.client_init.clone());
         if let Some(admin_creds) = admin_creds {
             client_builder.set_admin_creds(admin_creds);
@@ -122,7 +122,6 @@ impl FederationTest {
         client_builder
             .preview_with_existing_config(self.connectors.clone(), client_config, None)
             .await
-            .expect("Preview failed")
             .join(
                 db,
                 RootSecret::StandardDoubleDerive(PlainRootSecretStrategy::to_root_secret(
@@ -146,12 +145,11 @@ impl FederationTest {
             .unwrap();
 
         info!(target: LOG_TEST, "Joining client with existing db");
-        let mut client_builder = Client::builder().await.expect("Failed to build client");
+        let mut client_builder = Client::builder().await;
         client_builder.with_module_inits(self.client_init.clone());
         client_builder
             .preview_with_existing_config(self.connectors.clone(), client_config, None)
             .await
-            .expect("Preview failed")
             .join(db, root_secret)
             .await
             .map(Arc::new)
@@ -172,12 +170,11 @@ impl FederationTest {
             .unwrap();
 
         info!(target: LOG_TEST, "Recovering client with existing db");
-        let mut client_builder = Client::builder().await.expect("Failed to build client");
+        let mut client_builder = Client::builder().await;
         client_builder.with_module_inits(self.client_init.clone());
         client_builder
             .preview_with_existing_config(self.connectors.clone(), client_config, None)
             .await
-            .expect("Preview failed")
             .recover(db, root_secret, None)
             .await
             .map(Arc::new)
@@ -191,7 +188,7 @@ impl FederationTest {
         root_secret: RootSecret,
     ) -> ClientHandleArc {
         info!(target: LOG_TEST, "Opening client with existing db");
-        let mut client_builder = Client::builder().await.expect("Failed to build client");
+        let mut client_builder = Client::builder().await;
         client_builder.with_module_inits(self.client_init.clone());
         client_builder
             .open(self.connectors.clone(), db, root_secret)

--- a/fedimint-testing/src/federation.rs
+++ b/fedimint-testing/src/federation.rs
@@ -118,7 +118,7 @@ impl FederationTest {
         if let Some(admin_creds) = admin_creds {
             client_builder.set_admin_creds(admin_creds);
         }
-        let client_secret = Client::load_or_generate_client_secret(&db).await.unwrap();
+        let client_secret = Client::load_or_generate_client_secret(&db).await;
         client_builder
             .preview_with_existing_config(self.connectors.clone(), client_config, None)
             .await

--- a/fedimint-wasm-tests/src/lib.rs
+++ b/fedimint-wasm-tests/src/lib.rs
@@ -31,7 +31,7 @@ async fn load_or_generate_mnemonic(db: &Database) -> anyhow::Result<[u8; 64]> {
 
 async fn make_client_builder() -> Result<(fedimint_client::ClientBuilder, Database)> {
     let mem_database = MemDatabase::default();
-    let mut builder = fedimint_client::Client::builder().await?;
+    let mut builder = fedimint_client::Client::builder().await;
     builder.with_module(LightningClientInit::default());
     builder.with_module(MintClientInit);
     builder.with_module(WalletClientInit::default());

--- a/gateway/fedimint-gateway-server/src/client.rs
+++ b/gateway/fedimint-gateway-server/src/client.rs
@@ -111,7 +111,7 @@ impl GatewayClientBuilder {
         client
             .wait_for_all_recoveries()
             .await
-            .map_err(AdminGatewayError::ClientCreationError)?;
+            .map_err(|err| AdminGatewayError::ClientCreationError(err.into()))?;
         Ok(())
     }
 

--- a/gateway/fedimint-gateway-server/src/client.rs
+++ b/gateway/fedimint-gateway-server/src/client.rs
@@ -53,7 +53,7 @@ impl GatewayClientBuilder {
     async fn client_plainrootsecret(&self, db: &Database) -> AdminResult<DerivableSecret> {
         let client_secret = Client::load_decodable_client_secret::<[u8; 64]>(db)
             .await
-            .map_err(AdminGatewayError::ClientCreationError)?;
+            .map_err(|err| AdminGatewayError::ClientCreationError(err.into()))?;
         Ok(PlainRootSecretStrategy::to_root_secret(&client_secret))
     }
 

--- a/gateway/fedimint-gateway-server/src/client.rs
+++ b/gateway/fedimint-gateway-server/src/client.rs
@@ -79,10 +79,7 @@ impl GatewayClientBuilder {
             gateway: gateway.clone(),
         });
 
-        let mut client_builder = Client::builder()
-            .await
-            .map_err(AdminGatewayError::ClientCreationError)?
-            .with_iroh_enable_dht(true);
+        let mut client_builder = Client::builder().await.with_iroh_enable_dht(true);
         client_builder.with_module_inits(registry);
         Ok(client_builder)
     }
@@ -105,11 +102,12 @@ impl GatewayClientBuilder {
         );
         let client = client_builder
             .preview(self.connectors.clone(), &config.invite_code)
-            .await?
+            .await
+            .map_err(|err| AdminGatewayError::ClientCreationError(err.into()))?
             .recover(db, root_secret, None)
             .await
             .map(Arc::new)
-            .map_err(AdminGatewayError::ClientCreationError)?;
+            .map_err(|err| AdminGatewayError::ClientCreationError(err.into()))?;
         client
             .wait_for_all_recoveries()
             .await
@@ -167,12 +165,13 @@ impl GatewayClientBuilder {
         } else {
             client_builder
                 .preview(self.connectors.clone(), &invite_code)
-                .await?
+                .await
+                .map_err(|err| AdminGatewayError::ClientCreationError(err.into()))?
                 .join(db, root_secret)
                 .await
         }
         .map(Arc::new)
-        .map_err(AdminGatewayError::ClientCreationError)
+        .map_err(|err| AdminGatewayError::ClientCreationError(err.into()))
     }
 
     /// Verifies that the saved `ClientConfig` contains the expected

--- a/gateway/fedimint-gateway-server/src/federation_manager.rs
+++ b/gateway/fedimint-gateway-server/src/federation_manager.rs
@@ -8,7 +8,7 @@ use fedimint_client::ClientHandleArc;
 use fedimint_core::config::{FederationId, FederationIdPrefix, JsonClientConfig};
 use fedimint_core::db::{Committable, DatabaseTransaction, NonCommittable};
 use fedimint_core::invite_code::InviteCode;
-use fedimint_core::util::{FmtCompactAnyhow as _, Spanned};
+use fedimint_core::util::{FmtCompact as _, Spanned};
 use fedimint_core::{PeerId, TieredCounts};
 use fedimint_gateway_common::FederationInfo;
 use fedimint_gateway_server_db::GatewayDbtxNcExt as _;
@@ -122,12 +122,17 @@ impl FederationManager {
                             if !meta.waits_for_completion() {
                                 continue;
                             }
-                            let lnv2 =
-                                client.value().get_first_module::<GatewayClientModuleV2>()?;
+                            let lnv2 = client
+                                .value()
+                                .get_first_module::<GatewayClientModuleV2>()
+                                .map_err(anyhow::Error::from)?;
                             lnv2.await_completion(op_id).await;
                         }
                         "ln" => {
-                            let lnv1 = client.value().get_first_module::<GatewayClientModule>()?;
+                            let lnv1 = client
+                                .value()
+                                .get_first_module::<GatewayClientModule>()
+                                .map_err(anyhow::Error::from)?;
                             lnv1.await_completion(op_id).await;
                         }
                         _ => {}
@@ -277,7 +282,7 @@ impl FederationManager {
                 Err(err) => {
                     warn!(
                         target: LOG_GATEWAY,
-                        err = %err.fmt_compact_anyhow(),
+                        err = %err.fmt_compact(),
                         "Skipped Federation due to lack of primary module"
                     );
                     continue;
@@ -385,7 +390,10 @@ impl FederationManager {
         let client = self.client(federation_id).ok_or(FederationNotConnected {
             federation_id_prefix: federation_id.to_prefix(),
         })?;
-        let mint = client.value().get_first_module::<MintClientModule>()?;
+        let mint = client
+            .value()
+            .get_first_module::<MintClientModule>()
+            .map_err(anyhow::Error::from)?;
         let mut dbtx = mint.client_ctx.module_db().begin_transaction_nc().await;
         let counts = mint.get_note_counts_by_denomination(&mut dbtx).await;
         info!(target: LOG_GATEWAY, ?counts, "Note counts");

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -1629,7 +1629,8 @@ impl Gateway {
             .backup_to_federation(fedimint_client::backup::Metadata::from_json_serialized(
                 metadata,
             ))
-            .await?;
+            .await
+            .map_err(anyhow::Error::from)?;
         Ok(())
     }
 

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -2440,7 +2440,7 @@ impl IAdminGateway for Gateway {
             .await?;
 
         if recover {
-            client.wait_for_all_active_state_machines().await?;
+            client.wait_for_all_active_state_machines().await;
         }
 
         // Instead of using `FederationManager::federation_info`, we manually create

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -698,7 +698,7 @@ impl Gateway {
 
                 Client::store_encodable_client_secret(&gateway_db, mnemonic.to_entropy())
                     .await
-                    .map_err(AdminGatewayError::MnemonicError)?;
+                    .map_err(|err| AdminGatewayError::MnemonicError(err.into()))?;
                 GatewayState::Disconnected
             } else {
                 GatewayState::NotConfigured { mnemonic_sender }
@@ -3212,7 +3212,7 @@ impl IAdminGateway for Gateway {
 
         Client::store_encodable_client_secret(&self.gateway_db, mnemonic.to_entropy())
             .await
-            .map_err(AdminGatewayError::MnemonicError)?;
+            .map_err(|err| AdminGatewayError::MnemonicError(err.into()))?;
 
         *state_guard = GatewayState::Disconnected;
         drop(state_guard);

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -439,7 +439,7 @@ async fn withdraw_v2(
             let balance = client.get_balance_for_btc().await.map_err(|err| {
                 AdminGatewayError::Unexpected(anyhow!(
                     "Balance not available: {}",
-                    err.fmt_compact_anyhow()
+                    err.fmt_compact()
                 ))
             })?;
 
@@ -505,10 +505,7 @@ async fn calculate_max_withdrawable(
     address: &Address,
 ) -> AdminResult<WithdrawDetails> {
     let balance = client.get_balance_for_btc().await.map_err(|err| {
-        AdminGatewayError::Unexpected(anyhow!(
-            "Balance not available: {}",
-            err.fmt_compact_anyhow()
-        ))
+        AdminGatewayError::Unexpected(anyhow!("Balance not available: {}", err.fmt_compact()))
     })?;
 
     if let Ok(wallet_module) =
@@ -1561,7 +1558,7 @@ impl Gateway {
         let gateway_module = &client
             .value()
             .get_first_module::<GatewayClientModule>()
-            .map_err(LNv1Error::OutgoingPayment)
+            .map_err(|err| LNv1Error::OutgoingPayment(err.into()))
             .map_err(PublicGatewayError::LNv1)?;
         let operation_id = gateway_module
             .gateway_pay_bolt11_invoice(payload)
@@ -2453,7 +2450,7 @@ impl IAdminGateway for Gateway {
             balance_msat: client.get_balance_for_btc().await.unwrap_or_else(|err| {
                 warn!(
                     target: LOG_GATEWAY,
-                    err = %err.fmt_compact_anyhow(),
+                    err = %err.fmt_compact(),
                     %federation_id,
                     "Balance not immediately available after joining/recovering."
                 );
@@ -2963,7 +2960,10 @@ impl IAdminGateway for Gateway {
             return withdraw_v2(client.value(), &wallet_module, &address, amount).await;
         }
 
-        let wallet_module = client.value().get_first_module::<WalletClientModule>()?;
+        let wallet_module = client
+            .value()
+            .get_first_module::<WalletClientModule>()
+            .map_err(anyhow::Error::from)?;
 
         // If fees are provided (from UI preview flow), use them directly
         // Otherwise fetch fees (CLI backwards compatibility)
@@ -2993,7 +2993,7 @@ impl IAdminGateway for Gateway {
                     let balance = client.value().get_balance_for_btc().await.map_err(|err| {
                         AdminGatewayError::Unexpected(anyhow!(
                             "Balance not available: {}",
-                            err.fmt_compact_anyhow()
+                            err.fmt_compact()
                         ))
                     })?;
 
@@ -3378,7 +3378,7 @@ impl Gateway {
         let module = client
             .value()
             .get_first_module::<GatewayClientModuleV2>()
-            .map_err(|err| PublicGatewayError::LNv2(LNv2Error::OutgoingPayment(err)))?;
+            .map_err(|err| PublicGatewayError::LNv2(LNv2Error::OutgoingPayment(err.into())))?;
 
         module
             .send_payment(payload)

--- a/gateway/fedimint-gateway-server/tests/tests.rs
+++ b/gateway/fedimint-gateway-server/tests/tests.rs
@@ -10,6 +10,7 @@ use assert_matches::assert_matches;
 use bitcoin::hashes::{Hash, sha256};
 use fedimint_api_client::api::ServerError;
 use fedimint_client::ClientHandleArc;
+use fedimint_client::error::TransactionSubmitError;
 use fedimint_client::transaction::{
     ClientInput, ClientInputBundle, ClientOutput, ClientOutputBundle, TransactionBuilder,
 };
@@ -908,7 +909,15 @@ async fn test_gateway_client_intercept_htlc_no_funds() -> anyhow::Result<()> {
             .await
         {
             Ok(_) => panic!("Expected incoming offer validation to fail due to lack of funds"),
-            Err(e) => assert_eq!(e.to_string(), "Insufficient funds".to_string()),
+            Err(e) => {
+                let TransactionSubmitError::PrimaryModule(cause) = e
+                    .downcast::<TransactionSubmitError>()
+                    .expect("funding the HTLC fails at transaction submission")
+                else {
+                    panic!("Expected the primary module to reject the funding");
+                };
+                assert_eq!(cause.to_string(), "Insufficient funds");
+            }
         }
 
         Ok(())

--- a/modules/fedimint-gw-client/src/lib.rs
+++ b/modules/fedimint-gw-client/src/lib.rs
@@ -805,7 +805,7 @@ impl GatewayClientModule {
                                     },
                                     Err(e) => {
                                         warn!(?operation_id, "Got failure {e:?} while awaiting for refund outputs {out_points:?}");
-                                        break GatewayExtReceiveStates::RefundError{ error_message: e.to_string(), error }
+                                        break GatewayExtReceiveStates::RefundError{ error_message: e.fmt_compact().to_string(), error }
                                     },
                                 }
                             },

--- a/modules/fedimint-gwv2-client/src/lib.rs
+++ b/modules/fedimint-gwv2-client/src/lib.rs
@@ -612,7 +612,7 @@ impl GatewayClientModuleV2 {
             if let Err(error) = creation_result {
                 let operation_exists = self.client_ctx.operation_exists(receive_operation_id).await;
                 if operation_creation_failed_permanently(true, operation_exists) {
-                    return Err(error);
+                    return Err(error.into());
                 }
             } else {
                 let mut dbtx = self.client_ctx.module_db().begin_transaction().await;
@@ -655,7 +655,7 @@ impl GatewayClientModuleV2 {
                 .operation_exists(completion_operation_id)
                 .await;
             if operation_creation_failed_permanently(true, operation_exists) {
-                return Err(error);
+                return Err(error.into());
             }
         }
 

--- a/modules/fedimint-gwv2-client/src/receive_sm.rs
+++ b/modules/fedimint-gwv2-client/src/receive_sm.rs
@@ -10,7 +10,7 @@ use fedimint_core::core::OperationId;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::{Amounts, ApiRequestErased};
 use fedimint_core::secp256k1::Keypair;
-use fedimint_core::util::FmtCompactAnyhow;
+use fedimint_core::util::FmtCompact;
 use fedimint_core::{NumPeersExt, OutPoint, PeerId};
 use fedimint_lnv2_common::contracts::IncomingContract;
 use fedimint_lnv2_common::endpoint_constants::DECRYPTION_KEY_SHARE_ENDPOINT;
@@ -292,7 +292,7 @@ impl ReceiveStateMachine {
             Err(err) => {
                 warn!(
                     target: LOG_CLIENT_MODULE_GW,
-                    err = %err.fmt_compact_anyhow(),
+                    err = %err.fmt_compact(),
                     amount = %old_state.common.contract.commitment.amount,
                     "Not refunding incoming contract, its amount does not cover the refund fee"
                 );

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -1855,6 +1855,7 @@ impl LightningClientModule {
                 },
             )
             .await
+            .map_err(anyhow::Error::from)
     }
 
     /// Computes the federation fee a `pay` funding an outgoing contract worth
@@ -1883,6 +1884,7 @@ impl LightningClientModule {
                 },
             )
             .await
+            .map_err(anyhow::Error::from)
     }
 
     /// Computes the largest invoice amount the client can pay in full out of

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -63,7 +63,7 @@ use fedimint_core::secp256k1::{
 };
 use fedimint_core::task::{MaybeSend, MaybeSync, timeout};
 use fedimint_core::util::update_merge::UpdateMerge;
-use fedimint_core::util::{BoxStream, FmtCompactAnyhow as _, backoff_util, retry};
+use fedimint_core::util::{BoxStream, FmtCompact as _, FmtCompactAnyhow as _, backoff_util, retry};
 use fedimint_core::{
     Amount, OutPoint, apply, async_trait_maybe_send, push_db_pair_items, runtime, secp256k1,
 };
@@ -1591,7 +1591,7 @@ impl LightningClientModule {
                             IncomingSmStates::RefundSubmitted{ out_points, error } => {
                                 match client_ctx.await_primary_module_outputs(operation_id, out_points.clone()).await {
                                     Ok(()) => break InternalPayState::RefundSuccess { out_points, error },
-                                    Err(e) => break InternalPayState::RefundError{ error_message: e.to_string(), error },
+                                    Err(e) => break InternalPayState::RefundError{ error_message: e.fmt_compact().to_string(), error },
                                 }
                             },
                             IncomingSmStates::FundingFailed { error } => break InternalPayState::FundingFailed{ error },

--- a/modules/fedimint-ln-client/src/recurring/mod.rs
+++ b/modules/fedimint-ln-client/src/recurring/mod.rs
@@ -26,7 +26,7 @@ use fedimint_core::encoding::{
 use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_core::secp256k1::{Keypair, PublicKey};
 use fedimint_core::task::sleep;
-use fedimint_core::util::{BoxFuture, FmtCompact, FmtCompactAnyhow, SafeUrl};
+use fedimint_core::util::{BoxFuture, FmtCompact, SafeUrl};
 use fedimint_derive_secret::ChildId;
 use fedimint_eventlog::{Event, EventKind, EventPersistence};
 use futures::StreamExt;
@@ -348,10 +348,10 @@ impl LightningClientModule {
                 ?operation_id,
                 payment_code_key=?payment_code.root_keypair.public_key(),
                 invoice_index=%invoice_index,
-                err = %e.fmt_compact_anyhow(),
+                err = %e.fmt_compact(),
                 "Failed to create recurring receive operation"
             );
-            Err(e)
+            Err(e.into())
         } else {
             Ok(operation_id)
         }

--- a/modules/fedimint-lnv2-client/src/lib.rs
+++ b/modules/fedimint-lnv2-client/src/lib.rs
@@ -900,6 +900,7 @@ impl LightningClientModule {
                 },
             )
             .await
+            .map_err(anyhow::Error::from)
     }
 
     /// Whether an incoming contract worth `amount` is worth claiming, i.e.
@@ -946,6 +947,7 @@ impl LightningClientModule {
                 },
             )
             .await
+            .map_err(anyhow::Error::from)
     }
 
     /// Computes the largest invoice amount the client can pay in full out of

--- a/modules/fedimint-lnv2-client/src/lib.rs
+++ b/modules/fedimint-lnv2-client/src/lib.rs
@@ -42,7 +42,7 @@ use fedimint_core::module::{
 use fedimint_core::secp256k1::SECP256K1;
 use fedimint_core::task::TaskGroup;
 use fedimint_core::time::duration_since_epoch;
-use fedimint_core::util::SafeUrl;
+use fedimint_core::util::{FmtCompact as _, SafeUrl};
 use fedimint_core::{Amount, PeerId, apply, async_trait_maybe_send};
 use fedimint_derive_secret::{ChildId, DerivableSecret};
 use fedimint_lnv2_common::config::LightningClientConfig;
@@ -666,7 +666,7 @@ impl LightningClientModule {
                 transaction,
             )
             .await
-            .map_err(|e| SendPaymentError::FailedToFundPayment(e.to_string()))?;
+            .map_err(|e| SendPaymentError::FailedToFundPayment(e.fmt_compact().to_string()))?;
 
         let mut dbtx = self.client_ctx.module_db().begin_transaction().await;
 

--- a/modules/fedimint-lnv2-client/src/receive_sm.rs
+++ b/modules/fedimint-lnv2-client/src/receive_sm.rs
@@ -5,7 +5,7 @@ use fedimint_core::core::OperationId;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::Amounts;
 use fedimint_core::secp256k1::Keypair;
-use fedimint_core::util::FmtCompactAnyhow;
+use fedimint_core::util::FmtCompact;
 use fedimint_core::{Amount, OutPoint};
 use fedimint_lnv2_common::contracts::{IncomingContract, fee_from_expiration};
 use fedimint_lnv2_common::{LightningInput, LightningInputV0};
@@ -152,7 +152,7 @@ impl ReceiveStateMachine {
             Err(err) => {
                 warn!(
                     target: LOG_CLIENT_MODULE_LNV2,
-                    err = %err.fmt_compact_anyhow(),
+                    err = %err.fmt_compact(),
                     amount = %old_state.common.contract.commitment.amount,
                     "Not claiming incoming contract, its amount does not cover the claim fee"
                 );

--- a/modules/fedimint-meta-client/src/lib.rs
+++ b/modules/fedimint-meta-client/src/lib.rs
@@ -20,6 +20,7 @@ use common::{KIND, MetaConsensusValue, MetaKey, MetaValue};
 use db::DbKeyPrefix;
 use fedimint_api_client::api::{DynGlobalApi, DynModuleApi};
 use fedimint_client_module::db::ClientModuleMigrationFn;
+use fedimint_client_module::error::MetaFetchError;
 use fedimint_client_module::meta::{FetchKind, LegacyMetaSource, MetaSource, MetaValues};
 use fedimint_client_module::module::init::{ClientModuleInit, ClientModuleInitArgs};
 use fedimint_client_module::module::recovery::NoModuleBackup;
@@ -286,7 +287,7 @@ impl<S: MetaSource> MetaSource for MetaModuleMetaSourceWithFallback<S> {
         api: &DynGlobalApi,
         fetch_kind: fedimint_client_module::meta::FetchKind,
         last_revision: Option<u64>,
-    ) -> anyhow::Result<fedimint_client_module::meta::MetaValues> {
+    ) -> Result<fedimint_client_module::meta::MetaValues, MetaFetchError> {
         let backoff = match fetch_kind {
             // need to be fast the first time.
             FetchKind::Initial => backoff_util::aggressive_backoff(),
@@ -296,7 +297,7 @@ impl<S: MetaSource> MetaSource for MetaModuleMetaSourceWithFallback<S> {
         let maybe_meta_module_meta = get_meta_module_value(client_config, api, backoff)
             .await
             .map(|meta| {
-                Result::<_, anyhow::Error>::Ok(MetaValues {
+                Result::<_, MetaFetchError>::Ok(MetaValues {
                     values: serde_json::from_slice(meta.value.as_slice())?,
                     revision: meta.revision,
                 })

--- a/modules/fedimint-mint-client/src/input.rs
+++ b/modules/fedimint-mint-client/src/input.rs
@@ -6,7 +6,7 @@ use fedimint_client_module::transaction::{ClientInput, ClientInputBundle};
 use fedimint_core::core::OperationId;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::Amounts;
-use fedimint_core::util::FmtCompactAnyhow;
+use fedimint_core::util::FmtCompact;
 use fedimint_core::{Amount, TransactionId};
 use fedimint_logging::LOG_CLIENT_MODULE_MINT;
 use fedimint_mint_common::MintInput;
@@ -464,7 +464,7 @@ impl MintInputStateRefundedBundle {
                 Err(err) => {
                     warn!(
                         target: LOG_CLIENT_MODULE_MINT,
-                        err = %err.fmt_compact_anyhow(),
+                        err = %err.fmt_compact(),
                         refund_input_amounts = ?refund_input.amounts,
                         input = %refund_input.input,
                         "Failed to remint a single note"

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -1911,6 +1911,7 @@ impl MintClientModule {
                 },
             )
             .await
+            .map_err(anyhow::Error::from)
     }
 
     /// Computes the fee a `send_oob_notes(amount)` would incur given the
@@ -1972,6 +1973,7 @@ impl MintClientModule {
                 },
             )
             .await
+            .map_err(anyhow::Error::from)
     }
 
     /// Try to reissue e-cash notes received from a third party to receive them

--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -258,7 +258,7 @@ async fn send_fee_quote_matches_actual_fee() -> anyhow::Result<()> {
 
         // Settle any pending change from the previous iteration so the quote and
         // the send observe the same inventory.
-        client.wait_for_all_active_state_machines().await?;
+        client.wait_for_all_active_state_machines().await;
 
         let quote = mint.send_fee_quote(sats(1_000)).await?;
         let before = client.get_balance_for_btc().await?;
@@ -268,7 +268,7 @@ async fn send_fee_quote_matches_actual_fee() -> anyhow::Result<()> {
 
         // A send may trigger an internal reissue whose change notes are credited
         // by output state machines; wait for them before reading the balance.
-        client.wait_for_all_active_state_machines().await?;
+        client.wait_for_all_active_state_machines().await;
         let after = client.get_balance_for_btc().await?;
 
         // Value conservation: the wallet loses exactly the sent value plus the fee.

--- a/modules/fedimint-mintv2-client/src/lib.rs
+++ b/modules/fedimint-mintv2-client/src/lib.rs
@@ -1107,6 +1107,7 @@ impl MintClientModule {
                 },
             )
             .await
+            .map_err(anyhow::Error::from)
     }
 
     /// Computes the fee a `send(amount)` would incur given the client's current
@@ -1151,6 +1152,7 @@ impl MintClientModule {
                 },
             )
             .await
+            .map_err(anyhow::Error::from)
     }
 
     /// Returns whether the client's current notes can be handed out to cover

--- a/modules/fedimint-mintv2-tests/tests/tests.rs
+++ b/modules/fedimint-mintv2-tests/tests/tests.rs
@@ -283,7 +283,7 @@ async fn send_fee_quote_matches_actual_fee() -> anyhow::Result<()> {
 
         // Settle any pending change from the previous iteration so the quote and
         // the send observe the same inventory.
-        client.wait_for_all_active_state_machines().await?;
+        client.wait_for_all_active_state_machines().await;
 
         let quote = mint.send_fee_quote(Amount::from_sats(1_000)).await?;
         let before = client.get_balance_for_btc().await?;
@@ -295,7 +295,7 @@ async fn send_fee_quote_matches_actual_fee() -> anyhow::Result<()> {
 
         // A send may trigger an internal reissue whose change notes are credited
         // by output state machines; wait for them before reading the balance.
-        client.wait_for_all_active_state_machines().await?;
+        client.wait_for_all_active_state_machines().await;
         let after = client.get_balance_for_btc().await?;
 
         // Value conservation: the wallet loses exactly the sent value plus the fee.
@@ -354,7 +354,7 @@ async fn test_client_recovery(
     root_secret: RootSecret,
 ) -> anyhow::Result<()> {
     // Wait for state machines to complete
-    client.wait_for_all_active_state_machines().await?;
+    client.wait_for_all_active_state_machines().await;
 
     let expected_balance = client.get_balance_for_btc().await?;
 
@@ -387,9 +387,7 @@ async fn test_client_recovery(
 
     // The recovered notes are signed and land in the very client that ran the
     // recovery, without it having to be reopened first.
-    recovering_client
-        .wait_for_all_active_state_machines()
-        .await?;
+    recovering_client.wait_for_all_active_state_machines().await;
 
     let recovered_balance = recovering_client.get_balance_for_btc().await?;
 
@@ -404,7 +402,7 @@ async fn test_client_recovery(
         .open_client_with_db(recovering_client.db().clone(), root_secret)
         .await;
 
-    reopened_client.wait_for_all_active_state_machines().await?;
+    reopened_client.wait_for_all_active_state_machines().await;
 
     let reopened_balance = reopened_client.get_balance_for_btc().await?;
 

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -902,6 +902,7 @@ impl WalletClientModule {
                 },
             )
             .await
+            .map_err(anyhow::Error::from)
     }
 
     /// Finds the largest amount that can be withdrawn in full out of

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -1609,7 +1609,7 @@ impl WalletClientModule {
                         btc_deposited,
                         btc_out_point
                     },
-                    Err(e) => yield DepositStateV2::Failed(e.to_string())
+                    Err(e) => yield DepositStateV2::Failed(e.fmt_compact().to_string())
                 }
             }
         }}))

--- a/modules/fedimint-walletv2-client/src/lib.rs
+++ b/modules/fedimint-walletv2-client/src/lib.rs
@@ -294,6 +294,7 @@ impl WalletClientModule {
                 },
             )
             .await
+            .map_err(anyhow::Error::from)
     }
 
     /// Finds the largest value that can be sent on chain in full out of


### PR DESCRIPTION
## Summary

Fourth PR of the #8821 series (after #9082, #9103 and #9115). This one removes `anyhow` from the public API of `fedimint-client`, and from the half of `fedimint-client-module` the client implements for its modules (`ClientContextIface`, `IGlobalClientContext`, the `ClientContext<M>` wrappers, `MetaSource`, `discover_common_api_versions_set`, `max_affordable_send_amount`, `AddStateMachinesError`), so an integrator can match on "operation already exists", "no primary module", "database not initialized" or "recovery of module N failed" instead of parsing a string.

## What changed

New types, all in `fedimint_client_module::error` and re-exported through `fedimint_client::error` unless noted:

- `OperationAlreadyExistsError { operation_id }` and `OperationNotFoundError { operation_id }`: the two identity failures every integrator hits first, shared between the crates.
- `OperationLookupError`: wraps `OperationNotFoundError` and adds `WrongModuleKind` for `ClientContext::get_operation`, which used to hardcode "is not a lightning operation" no matter which module asked.
- `TransactionSubmitError`: the error of the whole path from a transaction builder to a registered state machine, covering `finalize_and_submit_transaction*`, the `ClientContextIface`/`IGlobalClientContext` equivalents, `claim_inputs*`, `fund_output*`, `fee_quote` and `await_primary_module_outputs`.
- `ModuleLookupError`: `get_first_module[_arc]`, `get_module_client_dyn`, and the "no primary module" case of the balance queries and `await_primary_bitcoin_module_output[s]`.
- `AddStateMachinesError` (re-cut): its `Other(anyhow::Error)` variant is gone, replaced with named `UnknownModule` and `StateAlreadyTerminal` variants plus a `Database(DatabaseError)` one; `Executor::add_state_machines` now returns it directly instead of flattening it through `Debug`.
- `ClientSecretError` (`fedimint_client::error`): `AlreadyExists`, `NotPresent`, `Decode` for the client-secret storage functions.
- `ClientBuildError` (`fedimint_client::error`): everything that can go wrong joining, opening or restarting a client, from an uninitialized database to a module that would not start.
- `RecoveryError` (`fedimint_client::error`): `Failed { module_instance_id, error }` and `ClientStopped`, for `wait_for_all_recoveries`/`wait_for_module_kind_recovery`.
- `ApiVersionDiscoveryError` (unit struct): the single failure mode of `discover_common_api_versions_set`.
- `MetaFetchError`: `Http`, `Json`, `Status`, `NoEntry`, `Config`, plus `Custom(Box<dyn Error>)` for `MetaSource` implementations outside this repository, for `MetaSource::fetch` and `fetch_meta_overrides`.
- `BackupError` (`fedimint_client::error`): `Federation` and `Module { instance_id, source }` for `create_backup` and the eight other public backup functions the original inventory missed (they hid behind a bare `use anyhow::Result` import).
- `EventHandlerError<E>` (in `fedimint_eventlog`, re-exported through `fedimint_client::error`): lets `Client::handle_events`/`handle_historical_events` and `fedimint_eventlog::{handle_events, handle_trimable_events}` be generic over the application's own handler error, kept apart from the event log's own `Tracker` failure.

Several functions turned out to have exactly one way to fail and now return that type directly instead of `anyhow::Result`: `chain_id`, `get_internal_payment_markers`, `get_metrics`, `get_operation_fees`, `get_operations_vis`, `get_transactions_vis`, `ClientContext::get_operation`, `OperationLog::set_operation_outcome`, `ClientBuilder::preview` (now `Result<ClientPreview, ClientConfigDownloadError>`).

Seven functions turned out to be infallible and lost their `Result` entirely: `Client::builder`, `Client::load_or_generate_client_secret`, `Client::fetch_common_api_versions`, `Client::wait_for_all_active_state_machines`, `ClientBuilder::preview_with_existing_config`, and the private `ClientBuilder::preview_inner` and `store_api_announcements_updates_from_peers` (whose already-unreachable "Refreshing api announcements failed" debug log goes with it).

`max_affordable_send_amount` (`fedimint-client-module`) is now generic over its fee-quote closure's error with no bound at all: the solver only cares whether the quote succeeded, so the error type is never inspected.

What stays `anyhow` on purpose, and why: the module->client trait boundary (`ClientModule::{backup, create_final_inputs_and_outputs, await_primary_module_output, leave}`, `ClientModuleInit::*`, `RecoveryFromHistory::*`, `IClientModule*`) is #8821 part E and is out of scope here; this PR carries those failures as boxed causes in `TransactionSubmitError::PrimaryModule`, `ClientBuildError::{ModuleInit, ModuleRecoveryPrepare}`, `BackupError::Module.source` and `RecoveryError::Failed.error: String`, which narrow to real types once that boundary is typed. `ClientModule::{handle_cli_command, handle_rpc}` and `Client::handle_global_rpc` stay `anyhow` by design: they are JSON-in/JSON-out handlers whose errors are stringified into a response regardless of type. `fedimint-client-rpc`'s `RpcResponseKind::Error { error: String }` wire contract is unchanged; instead it now stringifies with `fmt_compact_anyhow` so a typed error's cause survives the crossing. The eventlog tracker traits (`EventLogTracker`, `EventLogTrimableTracker`) keep `anyhow`: they are an external crate's trait boundary with one in-tree implementor whose bodies cannot fail, and their failures are carried in `EventHandlerError::Tracker(Box<dyn Error + Send + Sync>)`. `From<anyhow::Error> for UniffiError` (`fedimint-core/src/util/ffi.rs`) stays until part E, per PR A's ruling.

## Breaking changes

- `Client::builder`, `ClientBuilder::preview_with_existing_config`, `Client::load_or_generate_client_secret`, `Client::fetch_common_api_versions` and `Client::wait_for_all_active_state_machines` return their value directly; call sites drop a trailing `?`/`.expect(..)`.
- `fedimint_metrics::get_metrics` returns `Result<String, prometheus::Error>` instead of `anyhow::Result<String>`, and `max_affordable_send_amount` gained a fourth type parameter for the quote error, so a caller that turbofishes it must add one.
- `Client::root_secret_encoding` is gone (it was an exact duplicate of `Client::get_decoded_client_secret`, which has an in-tree caller and stays); use `Client::get_decoded_client_secret` instead.
- `AddStateMachinesError::Other` is gone, replaced by `UnknownModule`/`StateAlreadyTerminal`/`Database`; the enum is `#[non_exhaustive]`, so an exhaustive `match` needs a catch-all arm regardless.
- Anyone implementing `fedimint_client_module::meta::MetaSource` must change `fetch`'s error to `MetaFetchError`.
- Anyone implementing `ClientContextIface` or `IGlobalClientContext` (in practice only `Client`/`DynGlobalClientContext`) must return the new typed errors from their methods.
- `fedimint_eventlog::{handle_events, handle_trimable_events}` and `Client::{handle_events, handle_historical_events}` are now generic over the handler's error, which must implement `std::error::Error + 'static`; a closure returning `anyhow::Result` no longer compiles there and has to name a concrete type (the in-tree callers use `std::convert::Infallible` or a local error type).
- Every migrated function returns a concrete error type. A plain `?` into an `anyhow`-returning body still works via the blanket `From` conversion, but a variant used as a function pointer (for example `.map_err(SomeVariant)`) or a payload built directly from an `anyhow::Error` needs `.into()` added at the call site; the gateway's `AdminGatewayError`/`LNv1Error` call sites needed this.

## Not changed

No wire, DB or JSON *shape* changed anywhere in this PR: every retyped error only affects how a failure is represented in Rust, not what a peer, gateway or client sees on the wire. No type touched by this PR derives `Serialize`, `Encodable`, `Decodable` or `uniffi::Error` (confirmed by grepping the diff for new such derives; the grep is empty except the two `impl From<..> for UniffiError` blocks this PR adds for `ModuleLookupError` and `RecoveryError`, which are `impl`s, not derives). `fedimint-client-rpc`'s `RpcResponseKind` type and its `error: String` field are untouched.

## Behaviour changes worth a close look

- `Client::finalize_and_submit_transaction` returns `TransactionSubmitError::Database` after exhausting its commit attempts instead of `panic!`king; the same applies to `Executor::add_state_machines`, and neither message carries the attempt count any more (the budget is a fixed constant).
- A failed commit in `ClientContext::manual_operation_start` is now reported as a database error instead of "Operation with id X already exists" (the underlying commit failure was previously masked).
- `ClientContext::get_operation` no longer claims an operation of the wrong kind "is not a lightning operation"; it names both the expected and the actual module kind.
- `fedimint-client-rpc`'s `error` string now carries the whole cause chain (`fmt_compact_anyhow`) instead of only the outermost message, and every error text that reaches it, `fedimint-cli`'s `CliError.error`, or uniffi's `UniffiError` is the new type's `Display` rather than the old ad-hoc message.
- `MetaFetchError::NoEntry` no longer echoes the meta-override URL (SECURITY.md: a URL can carry credentials).
- `fedimint_metrics::get_metrics` now `expect`s that the Prometheus text encoder produced UTF-8 (it only emits ASCII) instead of returning that as an error.
- The gateway's `AdminGatewayError`/`LNv1Error`/`PublicGatewayError` payloads for these calls are now built with `.into()`, so their text is the typed error's `Display` rather than a hand-written wrapper message.

## Compatibility: observable text changes

No behaviour other than the points above changed; everything below is wording only, collected while reviewing each task's diff and re-verified against this tree.

| Where | Before | After |
|---|---|---|
| `fee_quote`/`finalize_and_submit_transaction` (no primary module), `await_primary_bitcoin_module_output`, `ModuleLookupError` balance lookups | "No module to balance a partial transaction (affected unit: X" (unbalanced paren) / "No primary module available" / "Primary module not available" | "No primary module for unit {unit}" (one message, three call sites; `AmountUnit` gains a `Display` that prints `bitcoin` for the reserved unit and the numeric id otherwise) |
| Transaction size check | "The generated transaction would be rejected by the federation for being too large." | "The transaction is {size} bytes, over the limit of {max}" |
| Duplicate operation id | "There already exists an operation with id {id:?}" | "The operation already exists: An operation with id {short} already exists" (full chain when walked) |
| `OperationNotFoundError` (`get_operation_fees`, `get_operations_vis`, `get_transactions_vis`, `ClientContext::get_operation`) | "Operation does not exist" / "Operation not found" | "No operation with id {short}" |
| `ModuleLookupError::NoModuleOfKind` | "No modules found of kind {kind}" | "No module of kind {kind} found" |
| `ModuleLookupError::WrongModuleType` | "Module is not of type {T}" | "Module instance {id} is not of type {T}" |
| `AddStateMachinesError::{UnknownModule, StateAlreadyTerminal}` | "Unknown module" / "State is already terminal, adding it to the executor doesn't make sense." | "Unknown module instance {id}" / "State is already terminal, adding it to the executor does not make sense" |
| `Executor::add_state_machines` commit failure | "Failed to commit after {attempts} attempts: {last_error}" (and the closure error rendered with `{error:?}`) | the typed error's `Display` plus chain; the attempts count is gone |
| `BackupError::{Encryption, Decode, Federation}` | the aead / decode / federation error was the whole message | "The backup could not be encrypted or decrypted" / "The backup could not be decoded" / "The federation could not be reached" (cause via `source()`) |
| `ClientBuildError::{ConfigDownload, ConfigDecode, Migration, Database}` | propagated bare with `?` | a wrapper message each, cause via `source()` |
| `LnPayState::UnexpectedError.error_message` (ln-client, `{e:?}` on the submit error) | `anyhow`'s Debug ("msg\n\nCaused by: ...") | `TransactionSubmitError`'s derived Debug; same information, different shape |
| Primary module failure printed by 4 in-tree consumers (lnv2 `FailedToFundPayment`, ln-client/gw-client `RefundError.error_message`, wallet `DepositStateV2::Failed`) | "The primary module failed" (cause dropped) | "The primary module failed: {cause}" (walks `source()` via `fmt_compact`) |
| gw-client's internal `bail!` on an unexpected `AddStateMachinesError` (diagnostic only, not reachable in practice) | old anyhow string from `Other(..)` | prints the new variant names (`UnknownModule`, `StateAlreadyTerminal`, `Database`) |
| `ClientSecretError::AlreadyExists` | "Encoded client secret already exists, cannot overwrite" | "An encoded client secret already exists and cannot be overwritten" |
| `ClientSecretError::NotPresent` | "Encoded client secret not present in DB" | "No encoded client secret is present in the database" |
| `ClientSecretError::Decode` | "Decoding failed: {cause}" | "The stored client secret could not be decoded" (cause via `source()`) |
| `ClientBuildError::DatabaseNotInitialized` | "Client database not initialized" | "The client database is not initialized" |
| `ClientBuildError::DatabaseAlreadyInitialized` | "Client database already initialized" | "The client database is already initialized" |
| `ClientBuildError` secret mismatch | "Secret hash does not match. Incorrect secret" | "The secret does not match the one this database was created with" |
| `ClientBuildError::ModuleRecoveryPrepare` | "Failed to prepare recovery of module {id}: {cause}" | "Module {id} ({kind}) failed to prepare its recovery" (cause via `source()`) |
| `ClientBuildError::ModuleInit` | the module's own message, unwrapped | "Module {id} ({kind}) failed to initialize" (cause via `source()`) |
| `ClientBuildError::AlreadyStopped` | "Already stopped" | "The client is already stopped" |
| recurringd `preview` failure | "Error registering with recurring payment service: {top message}" (via the `Other` variant) | "Error joining federation: {chain}" (`JoiningFederationFailed`, `fmt_compact`) |
| recurringd `join` failure | "Error joining federation: {top message}" | "Error joining federation: {chain}" (`fmt_compact`, so the module cause survives) |
| `RecoveryError::Failed` | "Module recovery failed: module_instance_id=1, error={msg}" | "Recovery of module 1 failed: {msg}" |
| `RecoveryError::ClientStopped` | "Recovery task completed and update receiver disconnected, but some modules failed to recover" (and a per-kind variant) | "The client shut down before the recovery finished" |
| `MetaFetchError::NoEntry` | "No entry for federation {id} in {url}" | "The meta override source has no entry for federation {federation_id}" (URL dropped) |
| Legacy meta override source with a malformed JSON body | "Meta override could not be parsed as JSON" reported through `reqwest::Error` (`Http` in the first revision of this PR) | `MetaFetchError::Json` with the `serde_json` cause behind `source()`; the body is read and parsed by the client instead of `reqwest::Response::json` |
| `MetaFetchError::Status` | "Meta override request returned non-OK status code: {status}" | "The meta override source answered with status {status}" |
| `BackupError` pending recovery | "Cannot backup while there are pending recoveries" | "Cannot back up while a module recovery is still running" |
| `BackupError` payload too large | "Backup payload too large" | "The backup payload is {size} bytes, over the limit of {max}" |
| `backup.rs` per-peer warn log (internal, not returned to a caller) | `warn!("Invalid backup returned by {peer}: {e}")` | structured `warn!(err = %e.fmt_compact(), %peer, "Invalid backup returned by peer")` |
| `oplog.rs` warn log (internal) | `warn!("Error setting operation outcome: {e}")` | structured `warn!(err = %e.fmt_compact(), ...)` |
| `EventHandlerError` | raw handler/tracker `anyhow` message | "The event handler failed" / "The event log tracker failed" (original message via `source()`) |

Dropped from this table (present in the per-task review notes but not included above, with reason): the `manual_operation_start` commit-failure text and the exhausted-commit-attempts panic-to-error text are deliberate behaviour changes, already covered above rather than repeated here; `MetaFetchError::Http`/`Json` follow the same wrapper-plus-`source()` pattern as `ClientSecretError::Decode` ("Meta override source could not be fetched" becomes "The meta override source could not be fetched", "Meta override could not be parsed as JSON" becomes "The meta override source returned invalid JSON", each with the reqwest/serde cause behind `source()`); `fedimint-cli`'s `DevCmd::WaitComplete` losing its failure mode is an infallibility change, not a text change, and is listed under "What changed" instead.

## Testing

```
cargo check -q --workspace --all-targets
cargo clippy -q --workspace --all-targets -- -D warnings
cargo check -q -p fedimint-client --features uniffi
cargo check -q -p fedimint-client --features tor
cargo doc -q --no-deps -p fedimint-client -p fedimint-client-module
cargo test -q -p fedimint-client -p fedimint-client-module -p fedimint-eventlog
cargo test -q -p fedimint-client-rpc -p fedimint-metrics
cargo test -q -p fedimint-mint-tests -p fedimint-mintv2-tests -p fedimint-wallet-tests -p fedimint-walletv2-tests -p fedimint-ln-tests -p fedimint-lnv2-tests --no-run
```

Plus the `check-wasm` package set (`fedimint-client`, `fedimint-client-wasm`, `fedimint-wasm-tests`, `fedimint-mintv2-client`, `fedimint-walletv2-client` at `wasm32-unknown-unknown`), the pre-commit hook, and `git diff --check` against `origin/master` for whitespace. The end-state script also asserts no `anyhow` remains in the public surface of `fedimint-client`/`fedimint-client-module` outside the part-E allowlist, and that no file re-hides a public signature behind a bare `use anyhow::Result`.

All of the above pass on this branch: workspace check and clippy clean, `cargo doc` with zero warnings, all unit and doc tests green, the six module test crates compile, the wasm package set checks (its 13 warnings are pre-existing at the branch point), the pre-commit hook passes, and the end-state script exits 0.

Part of #8821.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtKSNoo4GVaPc5TRp48kwY
