### PR TITLE
fix(server): drive p2p I/O concurrently with bounded retirement

### DIFF
--- a/fedimint-server/src/net/p2p.rs
+++ b/fedimint-server/src/net/p2p.rs
@@ -24,7 +24,8 @@ use fedimint_server_core::dashboard_ui::P2PConnectionStatus;
 use futures::future::select_all;
 use futures::{FutureExt, StreamExt};
 use tokio::sync::watch;
-use tokio::time::{Instant, sleep_until};
+use tokio::time::{Instant, sleep_until, timeout};
+use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, debug, info, info_span, warn};
 
 use crate::metrics::{PEER_CONNECT_COUNT, PEER_DISCONNECT_COUNT, PEER_MESSAGES_COUNT};
@@ -270,6 +271,19 @@ enum P2PConnectionSMState<M> {
     Connected(DynP2PConnection<M>),
 }
 
+/// How often live connection metadata (currently only the round-trip time) is
+/// re-published while a connection stays up.
+const METADATA_REFRESH_INTERVAL: Duration = Duration::from_secs(10);
+
+/// Bound graceful retirement even when a transport stays alive but stops
+/// making progress. This is a grace period, not a delivery guarantee.
+const CONNECTION_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
+
+enum ConnectionRetirement<M> {
+    Replaced(DynP2PConnection<M>),
+    MaxAge,
+}
+
 impl<M: Send + 'static> P2PConnectionStateMachine<M> {
     async fn state_transition(mut self) -> Option<Self> {
         match self.state {
@@ -288,17 +302,8 @@ impl<M: Send + 'static> P2PConnectionStateMachine<M> {
                 // Subscribe before taking the snapshot so an update racing with
                 // the snapshot remains queued for the connected transition.
                 let status_updates = connection.connection_status_updates();
-                let status = P2PConnectionStatus {
-                    conn_type: connection
-                        .connection_type()
-                        .or_else(|| self.common.connector.connection_type(self.common.peer_id)),
-                    rtt: connection.rtt(),
-                };
 
-                self.common.status_sender.send_replace(P2PConnectionState {
-                    connected: Some(status),
-                    last_error: None,
-                });
+                self.common.refresh_status(&connection);
 
                 self.common
                     .transition_connected(connection, status_updates)
@@ -315,58 +320,168 @@ impl<M: Send + 'static> P2PConnectionStateMachine<M> {
 impl<M: Send + 'static> P2PConnectionSMCommon<M> {
     async fn transition_connected(
         &mut self,
-        mut connection: DynP2PConnection<M>,
+        connection: DynP2PConnection<M>,
         mut status_updates: Option<DynConnectionStatusUpdates>,
     ) -> Option<P2PConnectionSMState<M>> {
-        tokio::select! {
-            Some(()) = async {
-                match status_updates.as_mut() {
-                    Some(status_updates) => status_updates.next().await,
-                    None => std::future::pending().await,
-                }
-            } => {
-                Some(P2PConnectionSMState::Connected(connection))
-            },
-            () = async {
-                match self.connection_deadline {
-                    Some(deadline) => sleep_until(deadline).await,
-                    None => std::future::pending().await,
-                }
-            } => {
-                Some(self.disconnect(anyhow!("Connection exceeded the maximum age")))
-            },
-            message = self.outgoing_receiver.recv() => {
-                Some(self.send_message(connection, message.ok()?).await)
-            },
-            connection = self.incoming_connections.recv() => {
-                info!(target: LOG_NET_PEER, "Connected to peer");
+        // Keep both halves alive across metadata updates: a write parked on
+        // flow control must not prevent reads (or cancel an in-flight frame).
+        // These futures belong to the state machine, including on shutdown.
+        let retiring = CancellationToken::new();
+        let send_loop = Self::send_loop(
+            &connection,
+            &self.outgoing_receiver,
+            &retiring,
+            &self.our_id_str,
+            &self.peer_id_str,
+        );
+        let receive_loop = Self::receive_loop(
+            &connection,
+            &self.incoming_sender,
+            &retiring,
+            &self.our_id_str,
+            &self.peer_id_str,
+        );
+        tokio::pin!(send_loop, receive_loop);
 
-                self.connection_deadline = self.max_connection_age.map(|age| Instant::now() + age);
+        let retirement = loop {
+            tokio::select! {
+                result = &mut send_loop => {
+                    return result.err().map(|e| self.disconnect(e));
+                },
+                result = &mut receive_loop => {
+                    return result.err().map(|e| self.disconnect(e));
+                },
+                connection = self.incoming_connections.recv() => {
+                    break ConnectionRetirement::Replaced(connection.ok()?);
+                },
+                () = async {
+                    match self.connection_deadline {
+                        Some(deadline) => sleep_until(deadline).await,
+                        None => std::future::pending().await,
+                    }
+                } => break ConnectionRetirement::MaxAge,
+                Some(()) = async {
+                    match status_updates.as_mut() {
+                        Some(status_updates) => status_updates.next().await,
+                        None => std::future::pending().await,
+                    }
+                } => {
+                    self.refresh_status(&connection);
+                },
+                () = sleep(METADATA_REFRESH_INTERVAL) => {
+                    self.refresh_status(&connection);
+                },
+            }
+        };
 
-                Some(P2PConnectionSMState::Connected(connection.ok()?))
-            },
-            message = connection.receive() => {
-                let mut message = match message {
-                    Ok(message) => message,
-                    Err(e) => return Some(self.disconnect(e)),
-                };
-
-                match message.read_to_end().await {
-                    Ok(message) => {
-                        PEER_MESSAGES_COUNT
-                            .with_label_values(&[self.our_id_str.as_str(), self.peer_id_str.as_str(), "incoming"])
-                            .inc();
-
-                        if self.incoming_sender.try_send(message).is_err() {
-                            debug!(target: LOG_NET_PEER, "Incoming message channel is full");
-                        }
-                    },
-                    Err(e) => return Some(self.disconnect(e)),
-                }
-
-                Some(P2PConnectionSMState::Connected(connection))
-            },
+        // Stop accepting new messages on the old connection, but finish the
+        // non-cancel-safe send/read_to_end already in flight. A stalled peer
+        // must not prevent replacement or max-age recovery indefinitely.
+        // On timeout or transport failure, abandon both halves and never reuse
+        // this connection. Delivery of the in-flight messages is unknown; do
+        // not replay them here since that could duplicate delivery. Consensus
+        // tolerates loss, but a one-shot DKG may need to be restarted. Even a
+        // completed send is not an acknowledgement by the remote application.
+        // Shutdown cancels both halves immediately via the owning task group.
+        retiring.cancel();
+        match timeout(CONNECTION_DRAIN_TIMEOUT, async {
+            tokio::try_join!(&mut send_loop, &mut receive_loop)
+        })
+        .await
+        {
+            Ok(Ok(_)) => {}
+            Ok(Err(error)) => {
+                warn!(target: LOG_NET_PEER, error = %error.fmt_compact_anyhow(),
+                    "Retiring connection failed; in-flight delivery is unknown");
+            }
+            Err(_) => {
+                warn!(target: LOG_NET_PEER,
+                    "Connection drain timed out; in-flight delivery is unknown");
+            }
         }
+
+        match retirement {
+            ConnectionRetirement::Replaced(connection) => {
+                info!(target: LOG_NET_PEER, "Connected to peer");
+                self.connection_deadline = self.max_connection_age.map(|age| Instant::now() + age);
+                Some(P2PConnectionSMState::Connected(connection))
+            }
+            ConnectionRetirement::MaxAge => {
+                Some(self.disconnect(anyhow!("Connection exceeded the maximum age")))
+            }
+        }
+    }
+
+    async fn send_loop(
+        connection: &DynP2PConnection<M>,
+        outgoing_receiver: &Receiver<M>,
+        retiring: &CancellationToken,
+        our_id_str: &str,
+        peer_id_str: &str,
+    ) -> anyhow::Result<()> {
+        loop {
+            let message = tokio::select! {
+                // Both branches are cancel-safe. Prioritize retirement so a
+                // ready queue cannot start another send during draining.
+                biased;
+                () = retiring.cancelled() => return Ok(()),
+                message = outgoing_receiver.recv() => match message {
+                    Ok(message) => message,
+                    Err(_) => return Ok(()),
+                },
+            };
+
+            PEER_MESSAGES_COUNT
+                .with_label_values(&[our_id_str, peer_id_str, "outgoing"])
+                .inc();
+
+            connection.send(message).await?;
+        }
+    }
+
+    async fn receive_loop(
+        connection: &DynP2PConnection<M>,
+        incoming_sender: &Sender<M>,
+        retiring: &CancellationToken,
+        our_id_str: &str,
+        peer_id_str: &str,
+    ) -> anyhow::Result<()> {
+        loop {
+            let mut frame = tokio::select! {
+                // `receive` is cancel-safe; `read_to_end` below is not.
+                // Retirement must win over another ready frame.
+                biased;
+                () = retiring.cancelled() => return Ok(()),
+                frame = connection.receive() => frame?,
+            };
+
+            let message = frame.read_to_end().await?;
+            PEER_MESSAGES_COUNT
+                .with_label_values(&[our_id_str, peer_id_str, "incoming"])
+                .inc();
+
+            if incoming_sender.try_send(message).is_err() {
+                debug!(target: LOG_NET_PEER, "Incoming message channel is full");
+            }
+        }
+    }
+
+    /// Publishes a fresh metadata snapshot for the live connection.
+    ///
+    /// Refreshing in place rather than re-entering the connected state means a
+    /// send already in flight is never cancelled by a status event.
+    fn refresh_status(&self, connection: &DynP2PConnection<M>) {
+        let status = P2PConnectionStatus {
+            conn_type: connection
+                .connection_type()
+                .or_else(|| self.connector.connection_type(self.peer_id)),
+            rtt: connection.rtt(),
+        };
+
+        self.status_sender.send_replace(P2PConnectionState {
+            connected: Some(status),
+            last_error: None,
+        });
     }
 
     fn disconnect(&self, error: anyhow::Error) -> P2PConnectionSMState<M> {
@@ -386,26 +501,6 @@ impl<M: Send + 'static> P2PConnectionSMCommon<M> {
             backoff: api_networking_backoff(),
             last_error: Some(last_error),
         }
-    }
-
-    async fn send_message(
-        &mut self,
-        mut connection: DynP2PConnection<M>,
-        peer_message: M,
-    ) -> P2PConnectionSMState<M> {
-        PEER_MESSAGES_COUNT
-            .with_label_values(&[
-                self.our_id_str.as_str(),
-                self.peer_id_str.as_str(),
-                "outgoing",
-            ])
-            .inc();
-
-        if let Err(e) = connection.send(peer_message).await {
-            return self.disconnect(e);
-        }
-
-        P2PConnectionSMState::Connected(connection)
     }
 
     async fn transition_disconnected(

--- a/fedimint-server/src/net/p2p/tests.rs
+++ b/fedimint-server/src/net/p2p/tests.rs
@@ -16,7 +16,7 @@ use super::{
     P2PConnectionSMCommon, P2PConnectionSMState, P2PConnectionState, P2PConnectionStateMachine,
 };
 use crate::net::p2p_connection::{
-    DynConnectionStatusUpdates, DynIP2PFrame, DynP2PConnection, IP2PConnection,
+    DynConnectionStatusUpdates, DynIP2PFrame, DynP2PConnection, IP2PConnection, IP2PFrame,
 };
 use crate::net::p2p_connector::{DynP2PConnector, IP2PConnector};
 
@@ -97,11 +97,11 @@ impl FakeConnection {
 
 #[async_trait]
 impl IP2PConnection<u64> for FakeConnection {
-    async fn send(&mut self, _message: u64) -> anyhow::Result<()> {
+    async fn send(&self, _message: u64) -> anyhow::Result<()> {
         Ok(())
     }
 
-    async fn receive(&mut self) -> anyhow::Result<DynIP2PFrame<u64>> {
+    async fn receive(&self) -> anyhow::Result<DynIP2PFrame<u64>> {
         self.control.disconnect.notified().await;
         Err(anyhow!("fake connection disconnected"))
     }
@@ -183,8 +183,8 @@ impl IP2PConnector<u64> for PendingConnector {
 struct StatusMachineHarness {
     connection_sender: async_channel::Sender<DynP2PConnection<u64>>,
     status_receiver: watch::Receiver<P2PConnectionState>,
-    _outgoing_sender: async_channel::Sender<u64>,
-    _incoming_receiver: async_channel::Receiver<u64>,
+    outgoing_sender: async_channel::Sender<u64>,
+    incoming_receiver: async_channel::Receiver<u64>,
     task: JoinHandle<()>,
 }
 
@@ -200,6 +200,14 @@ impl StatusMachineHarness {
     }
 
     fn spawn_with_fallback(connection: FakeConnection, fallback: Option<ConnectionType>) -> Self {
+        Self::spawn_with_max_age(Box::new(connection), fallback, None)
+    }
+
+    fn spawn_with_max_age(
+        connection: DynP2PConnection<u64>,
+        fallback: Option<ConnectionType>,
+        max_connection_age: Option<Duration>,
+    ) -> Self {
         let (connection_sender, incoming_connections) = async_channel::bounded(4);
         let (outgoing_sender, outgoing_receiver) = async_channel::bounded(5);
         let (incoming_sender, incoming_receiver) = async_channel::bounded(5);
@@ -209,7 +217,7 @@ impl StatusMachineHarness {
         });
         let connector: DynP2PConnector<u64> = Arc::new(PendingConnector { fallback });
         let mut state_machine = P2PConnectionStateMachine {
-            state: P2PConnectionSMState::Connected(Box::new(connection)),
+            state: P2PConnectionSMState::Connected(connection),
             common: P2PConnectionSMCommon {
                 incoming_sender,
                 outgoing_receiver,
@@ -220,8 +228,9 @@ impl StatusMachineHarness {
                 connector,
                 incoming_connections,
                 status_sender,
-                max_connection_age: None,
-                connection_deadline: None,
+                max_connection_age,
+                connection_deadline: max_connection_age
+                    .map(|age| tokio::time::Instant::now() + age),
             },
         };
         let task = runtime::spawn("p2p-status-machine-test", async move {
@@ -233,8 +242,8 @@ impl StatusMachineHarness {
         Self {
             connection_sender,
             status_receiver,
-            _outgoing_sender: outgoing_sender,
-            _incoming_receiver: incoming_receiver,
+            outgoing_sender,
+            incoming_receiver,
             task,
         }
     }
@@ -309,10 +318,14 @@ async fn subscribes_before_snapshot_to_close_status_update_race() {
     control.update_status_during_next_snapshot(ConnectionType::Direct);
     let mut harness = StatusMachineHarness::spawn(FakeConnection::new(control.clone()));
 
+    // An update emitted while the initial snapshot is taken must still be seen.
+    // The connected state now holds one subscription for the lifetime of the
+    // connection and refreshes in place, rather than re-entering (and so
+    // re-subscribing) once per status event.
     harness
         .wait_for_status(ExpectedStatus::Connected(ConnectionType::Direct))
         .await;
-    assert!(control.subscriptions() >= 2);
+    assert_eq!(control.subscriptions(), 1);
 }
 
 #[tokio::test]
@@ -377,4 +390,231 @@ async fn closed_status_stream_does_not_spin() {
     control.disconnect();
     harness.wait_for_status(ExpectedStatus::Disconnected).await;
     assert_eq!(harness.current_status(), None);
+}
+
+/// Both operations suspend *inside* the non-cancel-safe part of a message.
+struct PausedIoConnection {
+    dropped: Arc<AtomicUsize>,
+    send_started: async_channel::Sender<u64>,
+    finish_send: async_channel::Receiver<()>,
+    sends_completed: Arc<AtomicUsize>,
+    frame_started: async_channel::Sender<()>,
+    finish_frame: async_channel::Receiver<u64>,
+}
+
+impl Drop for PausedIoConnection {
+    fn drop(&mut self) {
+        self.dropped.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+#[async_trait]
+impl IP2PConnection<u64> for PausedIoConnection {
+    async fn send(&self, message: u64) -> anyhow::Result<()> {
+        self.send_started.try_send(message)?;
+        self.finish_send.recv().await?;
+        self.sends_completed.fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    }
+
+    async fn receive(&self) -> anyhow::Result<DynIP2PFrame<u64>> {
+        Ok(PausedFrame {
+            started: self.frame_started.clone(),
+            finish: self.finish_frame.clone(),
+        }
+        .into_dyn())
+    }
+
+    fn rtt(&self) -> Option<Duration> {
+        None
+    }
+}
+
+struct PausedFrame {
+    started: async_channel::Sender<()>,
+    finish: async_channel::Receiver<u64>,
+}
+
+#[async_trait]
+impl IP2PFrame<u64> for PausedFrame {
+    async fn read_to_end(&mut self) -> anyhow::Result<u64> {
+        self.started.try_send(())?;
+        Ok(self.finish.recv().await?)
+    }
+}
+
+#[derive(Clone, Copy)]
+enum Retirement {
+    Replacement,
+    MaxAge,
+}
+
+struct PausedIoHarness {
+    machine: StatusMachineHarness,
+    send_started: async_channel::Receiver<u64>,
+    finish_send: async_channel::Sender<()>,
+    sends_completed: Arc<AtomicUsize>,
+    frame_started: async_channel::Receiver<()>,
+    finish_frame: async_channel::Sender<u64>,
+    connections_dropped: Arc<AtomicUsize>,
+}
+
+impl PausedIoHarness {
+    async fn spawn(retirement: Retirement) -> Self {
+        let (send_started, send_observed) = async_channel::bounded(2);
+        let (finish_send, send_finished) = async_channel::bounded(1);
+        let (frame_started, frame_observed) = async_channel::bounded(2);
+        let (finish_frame, frame_finished) = async_channel::bounded(1);
+        let sends_completed = Arc::new(AtomicUsize::new(0));
+        let connections_dropped = Arc::new(AtomicUsize::new(0));
+        let connection = Box::new(PausedIoConnection {
+            dropped: connections_dropped.clone(),
+            send_started,
+            finish_send: send_finished,
+            sends_completed: sends_completed.clone(),
+            frame_started,
+            finish_frame: frame_finished,
+        });
+        let max_age = match retirement {
+            Retirement::Replacement => None,
+            Retirement::MaxAge => Some(Duration::from_secs(60)),
+        };
+        let machine = StatusMachineHarness::spawn_with_max_age(connection, None, max_age);
+        machine
+            .outgoing_sender
+            .try_send(7)
+            .expect("queue first send");
+        machine
+            .outgoing_sender
+            .try_send(8)
+            .expect("queue second send");
+        // Neither half may prevent the other from reaching its in-flight
+        // operation, even while both are parked on transport flow control.
+        timeout(Duration::from_secs(1), async {
+            assert_eq!(send_observed.recv().await.expect("send started"), 7);
+            frame_observed.recv().await.expect("frame read started");
+        })
+        .await
+        .expect("send and frame read must make progress concurrently");
+        Self {
+            machine,
+            send_started: send_observed,
+            finish_send,
+            sends_completed,
+            frame_started: frame_observed,
+            finish_frame,
+            connections_dropped,
+        }
+    }
+
+    async fn retire(&self, retirement: Retirement) {
+        match retirement {
+            Retirement::Replacement => {
+                self.machine
+                    .connection_sender
+                    .try_send(Box::new(FakeConnection::new(FakeConnectionControl::new(
+                        ConnectionType::Relay,
+                    ))))
+                    .expect("queue replacement");
+                timeout(Duration::from_secs(1), async {
+                    while !self.machine.connection_sender.is_empty() {
+                        runtime::sleep(Duration::from_millis(1)).await;
+                    }
+                })
+                .await
+                .expect("replacement must be observed while I/O is parked");
+            }
+            Retirement::MaxAge => {
+                tokio::time::advance(Duration::from_secs(60)).await;
+                tokio::task::yield_now().await;
+            }
+        }
+    }
+
+    async fn assert_retired(&mut self, retirement: Retirement) {
+        self.machine
+            .wait_for_status(match retirement {
+                Retirement::Replacement => ExpectedStatus::Connected(ConnectionType::Relay),
+                Retirement::MaxAge => ExpectedStatus::Disconnected,
+            })
+            .await;
+        assert!(
+            self.connections_dropped.load(Ordering::Relaxed) == 1,
+            "old connection must be dropped"
+        );
+        assert!(
+            self.send_started.is_closed(),
+            "old send future must be dropped"
+        );
+        assert!(
+            self.frame_started.is_closed(),
+            "old frame future must be dropped"
+        );
+        assert!(
+            self.send_started.is_empty(),
+            "do not start queued sends while retiring"
+        );
+        assert!(
+            self.frame_started.is_empty(),
+            "do not accept more frames while retiring"
+        );
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn retirement_finishes_in_flight_messages() {
+    for retirement in [Retirement::Replacement, Retirement::MaxAge] {
+        let mut harness = PausedIoHarness::spawn(retirement).await;
+        harness.retire(retirement).await;
+        tokio::time::advance(super::CONNECTION_DRAIN_TIMEOUT / 2).await;
+        assert!(
+            harness.connections_dropped.load(Ordering::Relaxed) == 0,
+            "allow a grace period"
+        );
+        harness.finish_send.try_send(()).expect("finish old send");
+        harness.finish_frame.try_send(9).expect("finish old frame");
+        assert_eq!(
+            timeout(
+                Duration::from_secs(1),
+                harness.machine.incoming_receiver.recv()
+            )
+            .await
+            .expect("finish the in-flight read before retiring")
+            .expect("deliver frame"),
+            9
+        );
+        harness.assert_retired(retirement).await;
+        assert_eq!(harness.sends_completed.load(Ordering::Relaxed), 1);
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn retirement_bounds_permanently_parked_io() {
+    for retirement in [Retirement::Replacement, Retirement::MaxAge] {
+        let mut harness = PausedIoHarness::spawn(retirement).await;
+        harness.retire(retirement).await;
+        tokio::time::advance(super::CONNECTION_DRAIN_TIMEOUT).await;
+        harness.assert_retired(retirement).await;
+        assert_eq!(harness.sends_completed.load(Ordering::Relaxed), 0);
+        assert!(
+            harness.machine.incoming_receiver.is_empty(),
+            "no partial frame delivered"
+        );
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn shutdown_drops_in_flight_io_during_retirement() {
+    let harness = PausedIoHarness::spawn(Retirement::Replacement).await;
+    harness.retire(Retirement::Replacement).await;
+    harness.machine.task.abort();
+    while !harness.machine.task.is_finished() {
+        tokio::task::yield_now().await;
+    }
+    assert!(
+        harness.connections_dropped.load(Ordering::Relaxed) == 1,
+        "shutdown must not detach I/O"
+    );
+    assert!(harness.send_started.is_closed());
+    assert!(harness.frame_started.is_closed());
 }

--- a/fedimint-server/src/net/p2p_connection.rs
+++ b/fedimint-server/src/net/p2p_connection.rs
@@ -11,6 +11,7 @@ use bytes::{Bytes, BytesMut};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_server_core::dashboard_ui::ConnectionType;
+use futures::stream::{SplitSink, SplitStream};
 use futures::{SinkExt, Stream, StreamExt};
 use iroh_next::endpoint::{Connection as IrohV1Connection, RecvStream as IrohV1RecvStream};
 use serde::Serialize;
@@ -46,14 +47,24 @@ pub trait IP2PFrame<M>: Send + 'static {
 }
 
 #[async_trait]
-pub trait IP2PConnection<M>: Send + 'static {
+pub trait IP2PConnection<M>: Send + Sync + 'static {
     /// Send a message over the connection. This is *not* required to be
     /// cancel-safe.
-    async fn send(&mut self, message: M) -> anyhow::Result<()>;
+    ///
+    /// Takes `&self` so that the send and receive halves can be driven
+    /// concurrently. A send parked on transport flow control must never stop
+    /// the peer's stream from being drained, or two peers that are both
+    /// sending an oversized message deadlock permanently.
+    ///
+    /// While `send` and `receive` may run concurrently with each other, each
+    /// of them must have at most one caller at a time: a second concurrent
+    /// `receive` would steal frames from the first and silently reorder the
+    /// message stream.
+    async fn send(&self, message: M) -> anyhow::Result<()>;
 
     /// Receive a p2p frame from the connection. This is *required* to be
-    /// cancel-safe.
-    async fn receive(&mut self) -> anyhow::Result<DynIP2PFrame<M>>;
+    /// cancel-safe. See [`Self::send`] for the concurrency contract.
+    async fn receive(&self) -> anyhow::Result<DynIP2PFrame<M>>;
 
     /// Get the round-trip time of the connection.
     fn rtt(&self) -> Option<Duration>;
@@ -98,23 +109,59 @@ where
     }
 }
 
+type TlsFramed = Framed<TlsStream<TcpStream>, LengthDelimitedCodec>;
+
+/// A TLS p2p connection.
+///
+/// A single `Framed` cannot serve both directions at once, so the sink and
+/// stream halves are split and guarded separately. That is what lets a send
+/// parked on socket buffers coexist with a concurrent receive.
+pub struct TlsP2PConnection {
+    sink: tokio::sync::Mutex<SplitSink<TlsFramed, Bytes>>,
+    stream: tokio::sync::Mutex<SplitStream<TlsFramed>>,
+}
+
+impl TlsP2PConnection {
+    pub fn new(framed: TlsFramed) -> Self {
+        let (sink, stream) = framed.split();
+
+        Self {
+            sink: tokio::sync::Mutex::new(sink),
+            stream: tokio::sync::Mutex::new(stream),
+        }
+    }
+}
+
 #[async_trait]
-impl<M> IP2PConnection<M> for Framed<TlsStream<TcpStream>, LengthDelimitedCodec>
+impl<M> IP2PConnection<M> for TlsP2PConnection
 where
     M: Encodable + Decodable + Serialize + DeserializeOwned + Send + 'static,
 {
-    async fn send(&mut self, message: M) -> anyhow::Result<()> {
+    async fn send(&self, message: M) -> anyhow::Result<()> {
         let mut bytes = Vec::new();
 
         bincode::serialize_into(&mut bytes, &message)?;
 
-        SinkExt::send(self, Bytes::from_owner(bytes)).await?;
+        // The locks are never contended by contract — see the trait doc — so
+        // a second concurrent caller fails loudly instead of queuing behind
+        // the lock and interleaving with the first.
+        let mut sink = self
+            .sink
+            .try_lock()
+            .expect("send has at most one caller at a time");
+
+        SinkExt::send(&mut *sink, Bytes::from_owner(bytes)).await?;
 
         Ok(())
     }
 
-    async fn receive(&mut self) -> anyhow::Result<DynIP2PFrame<M>> {
-        let message = self
+    async fn receive(&self) -> anyhow::Result<DynIP2PFrame<M>> {
+        let mut stream = self
+            .stream
+            .try_lock()
+            .expect("receive has at most one caller at a time");
+
+        let message = stream
             .next()
             .await
             .context("Framed stream is closed")??
@@ -155,7 +202,7 @@ impl<M> IP2PConnection<M> for iroh::endpoint::Connection
 where
     M: Encodable + Decodable + Serialize + DeserializeOwned + Send + 'static,
 {
-    async fn send(&mut self, message: M) -> anyhow::Result<()> {
+    async fn send(&self, message: M) -> anyhow::Result<()> {
         let mut bytes = Vec::new();
 
         bincode::serialize_into(&mut bytes, &message)?;
@@ -168,7 +215,7 @@ where
         Ok(())
     }
 
-    async fn receive(&mut self) -> anyhow::Result<DynIP2PFrame<M>> {
+    async fn receive(&self) -> anyhow::Result<DynIP2PFrame<M>> {
         Ok(self.accept_uni().await?.into_dyn())
     }
 
@@ -200,7 +247,7 @@ impl<M> IP2PConnection<M> for IrohV1Connection
 where
     M: Encodable + Decodable + Serialize + DeserializeOwned + Send + 'static,
 {
-    async fn send(&mut self, message: M) -> anyhow::Result<()> {
+    async fn send(&self, message: M) -> anyhow::Result<()> {
         let mut bytes = Vec::new();
 
         bincode::serialize_into(&mut bytes, &message)?;
@@ -214,7 +261,7 @@ where
         Ok(())
     }
 
-    async fn receive(&mut self) -> anyhow::Result<DynIP2PFrame<M>> {
+    async fn receive(&self) -> anyhow::Result<DynIP2PFrame<M>> {
         Ok(self.accept_uni().await?.into_dyn())
     }
 

--- a/fedimint-server/src/net/p2p_connector/iroh/tests.rs
+++ b/fedimint-server/src/net/p2p_connector/iroh/tests.rs
@@ -82,8 +82,7 @@ async fn production_connectors_exchange_messages_over_direct_override() -> anyho
         <IrohConnector as IP2PConnector<u64>>::connect(&connector_a, peer_b),
         <IrohConnector as IP2PConnector<u64>>::accept(&connector_b),
     )?;
-    let (authenticated_peer, mut incoming) = incoming;
-    let mut outgoing = outgoing;
+    let (authenticated_peer, incoming) = incoming;
     assert_eq!(authenticated_peer, peer_a);
 
     outgoing.send(42).await?;

--- a/fedimint-server/src/net/p2p_connector/tls.rs
+++ b/fedimint-server/src/net/p2p_connector/tls.rs
@@ -20,7 +20,7 @@ use tokio_util::codec::LengthDelimitedCodec;
 
 use super::IP2PConnector;
 use super::iroh::parse_p2p;
-use crate::net::p2p_connection::{DynP2PConnection, IP2PConnection as _};
+use crate::net::p2p_connection::{DynP2PConnection, IP2PConnection as _, TlsP2PConnection};
 
 #[derive(Debug, Clone)]
 pub struct TlsConfig {
@@ -148,7 +148,7 @@ where
             .length_field_type::<u64>()
             .new_framed(TlsStream::Client(tls));
 
-        Ok(framed.into_dyn())
+        Ok(TlsP2PConnection::new(framed).into_dyn())
     }
 
     async fn accept(&self) -> anyhow::Result<(PeerId, DynP2PConnection<M>)> {
@@ -176,7 +176,7 @@ where
             .length_field_type::<u64>()
             .new_framed(TlsStream::Server(tls));
 
-        Ok((auth_peer, framed.into_dyn()))
+        Ok((auth_peer, TlsP2PConnection::new(framed).into_dyn()))
     }
 
     fn connection_type(&self, _peer: PeerId) -> Option<ConnectionType> {


### PR DESCRIPTION
## Summary

Alternative to #9097: fix the same P2P flow-control deadlock while addressing [DPC's retirement and cancellation review](https://github.com/fedimint/fedimint/pull/9097#issuecomment-5575792651). Send and receive run concurrently, but replacement and max-age recovery remain bounded, with no detached I/O tasks.

## Details

- Drive two long-lived futures within the connection state machine so a parked write cannot block reads. Refresh connection metadata in place without cancelling either half.
- On replacement or max-age, stop starting messages on the old connection and allow the current send and frame read up to five seconds to finish. Then retire the connection even if its transport remains alive but stalled.
- On drain timeout or transport failure, abandon the old connection with unknown delivery and no automatic replay. Shutdown cancels the scoped futures immediately.
- Use `&self`/`Sync` on the connection trait and separately guarded TLS sink/stream halves. Retain `Box` ownership, existing frame limits, and wire formats.

One commit, five networking files. This intentionally omits the daily 19-guardian CI job, shared connection ownership, and frame-limit changes from #9097. No new dependencies or unrelated refactoring.

## Reviewing

This remains an unreliable networking layer, not an exactly-once delivery protocol. Even a completed send is not an acknowledgement from the remote application. The five-second grace period avoids immediately discarding accepted frames, but forced retirement can still lose messages; one-shot DKG may need restarting. The timeout is a deliberate liveness bound, not a delivery guarantee.

## Testing

- Deterministic regression tests cover simultaneous parked send/frame-read progress, graceful completion, permanently parked I/O for both replacement and max-age, and shutdown cleanup. They also verify that retirement starts no additional old-connection messages.
- `cargo test -q -p fedimint-server --lib net::`: 16 passed after rebasing onto `f6138e7116f`.
- `just final-lint`: passed after rebase, including workspace/all-target Clippy with warnings denied.
- Full `just final-check` (workspace tests, doctests, WASM) passed before rebase; all five changed files are identical after rebase.

Local validation used a workspace-local Cargo target directory and `RUSTDOCFLAGS='-C link-arg=-lstdc++'` for the environment's doctest linker.
