### PR TITLE
feat(lnv2-client): pay and receive under gateway terms the caller checked

### DIFF
--- a/modules/fedimint-lnv2-client/src/lib.rs
+++ b/modules/fedimint-lnv2-client/src/lib.rs
@@ -563,6 +563,57 @@ impl LightningClientModule {
         .await
     }
 
+    /// Pays `invoice` through `gateway` at the terms the caller already
+    /// checked.
+    ///
+    /// [`Self::send`] reads the gateway's terms itself, so a caller that showed
+    /// the user a fee and asked for approval has no guarantee the funded
+    /// contract carries that fee: the gateway may change its schedule between
+    /// the two reads. This variant takes the `send_fee` and `expiration_delta`
+    /// the caller obtained from [`RoutingInfo::send_parameters`] and refuses
+    /// with [`SendWithTermsError::TermsChanged`], before funding anything, if
+    /// the gateway currently reports different terms. A cheaper fee counts
+    /// as changed too, so the funded contract always matches what was
+    /// approved. This binds the funded contract to the approved terms, not
+    /// the gateway's acceptance: a gateway that raises its schedule after the
+    /// check can still refuse the contract, in which case the payment is
+    /// refunded. The error carries the current terms for re-quoting.
+    pub async fn send_with_terms(
+        &self,
+        invoice: Bolt11Invoice,
+        gateway: SafeUrl,
+        send_fee: PaymentFee,
+        expiration_delta: u64,
+        custom_meta: Value,
+    ) -> Result<OperationId, SendWithTermsError> {
+        let (amount, operation_id) = self.validate_send_invoice(&invoice).await?;
+
+        let (gateway_api, routing_info) =
+            self.resolve_send_gateway(&invoice, Some(gateway)).await?;
+
+        let current = routing_info.send_parameters(&invoice);
+
+        if current != (send_fee, expiration_delta) {
+            return Err(SendWithTermsError::TermsChanged {
+                send_fee: current.0,
+                expiration_delta: current.1,
+            });
+        }
+
+        let operation_id = self
+            .fund_outgoing_contract(
+                invoice,
+                amount,
+                operation_id,
+                gateway_api,
+                routing_info,
+                custom_meta,
+            )
+            .await?;
+
+        Ok(operation_id)
+    }
+
     /// Checks that `invoice` is payable by this client and has not been
     /// attempted before, returning its amount in millisatoshis and the
     /// operation id a payment of it uses.
@@ -1504,6 +1555,22 @@ pub enum SendPaymentError {
         invoice_currency: Currency,
         federation_currency: Currency,
     },
+}
+
+/// A failure of [`LightningClientModule::send_with_terms`].
+#[derive(Error, Debug, Clone, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum SendWithTermsError {
+    /// The gateway's current send terms differ from the ones the caller
+    /// checked. Carries the current terms so the caller can re-quote.
+    #[error("Gateway's send terms changed since they were checked")]
+    TermsChanged {
+        send_fee: PaymentFee,
+        expiration_delta: u64,
+    },
+    /// Any failure [`LightningClientModule::send`] can report.
+    #[error(transparent)]
+    Send(#[from] SendPaymentError),
 }
 
 #[derive(Error, Debug, Clone, Eq, PartialEq)]

--- a/modules/fedimint-lnv2-client/src/lib.rs
+++ b/modules/fedimint-lnv2-client/src/lib.rs
@@ -959,6 +959,53 @@ impl LightningClientModule {
         .await
     }
 
+    /// Requests an invoice from `gateway` at the receive fee the caller
+    /// already checked.
+    ///
+    /// [`Self::receive`] reads the gateway's fee itself, so a caller that
+    /// showed the user a fee has no guarantee the incoming contract is
+    /// created at that fee: the gateway may change its schedule between the
+    /// two reads. This variant takes the `receive_fee` the caller obtained
+    /// from [`RoutingInfo::receive_fee`] and refuses with
+    /// [`ReceiveWithTermsError::TermsChanged`], before creating anything, if
+    /// the gateway currently reports a different fee. A cheaper fee counts as
+    /// changed too, so the contract always matches what was approved; the
+    /// error carries the current fee for re-quoting.
+    pub async fn receive_with_terms(
+        &self,
+        amount: Amount,
+        expiry_secs: u32,
+        description: Bolt11InvoiceDescription,
+        gateway: SafeUrl,
+        receive_fee: PaymentFee,
+        custom_meta: Value,
+    ) -> Result<(Bolt11Invoice, OperationId), ReceiveWithTermsError> {
+        if expiry_secs > MAX_INVOICE_EXPIRY_SECS {
+            return Err(ReceiveError::InvoiceExpiryTooLong.into());
+        }
+
+        let (gateway, routing_info) = self.resolve_receive_gateway(Some(gateway)).await?;
+
+        if routing_info.receive_fee != receive_fee {
+            return Err(ReceiveWithTermsError::TermsChanged {
+                receive_fee: routing_info.receive_fee,
+            });
+        }
+
+        let (invoice, operation_id) = self
+            .receive_with_routing_info(
+                amount,
+                expiry_secs,
+                description,
+                gateway,
+                routing_info,
+                custom_meta,
+            )
+            .await?;
+
+        Ok((invoice, operation_id))
+    }
+
     /// Resolves the gateway to request an invoice from and its current
     /// routing info: the given one, or an automatically selected one when
     /// `None`.
@@ -1602,6 +1649,19 @@ pub enum ReceiveError {
     IncorrectInvoiceAmount,
     #[error("Requested invoice expiry exceeds the maximum of one day")]
     InvoiceExpiryTooLong,
+}
+
+/// A failure of [`LightningClientModule::receive_with_terms`].
+#[derive(Error, Debug, Clone, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum ReceiveWithTermsError {
+    /// The gateway's current receive fee differs from the one the caller
+    /// checked. Carries the current fee so the caller can re-quote.
+    #[error("Gateway's receive fee changed since it was checked")]
+    TermsChanged { receive_fee: PaymentFee },
+    /// Any failure [`LightningClientModule::receive`] can report.
+    #[error(transparent)]
+    Receive(#[from] ReceiveError),
 }
 
 #[derive(Error, Debug, Clone, Eq, PartialEq)]

--- a/modules/fedimint-lnv2-client/src/lib.rs
+++ b/modules/fedimint-lnv2-client/src/lib.rs
@@ -542,13 +542,34 @@ impl LightningClientModule {
     ///
     /// The absolute fee for a payment can be calculated from the operation meta
     /// to be shown to the user in the transaction history.
-    #[allow(clippy::too_many_lines)]
     pub async fn send(
         &self,
         invoice: Bolt11Invoice,
         gateway: Option<SafeUrl>,
         custom_meta: Value,
     ) -> Result<OperationId, SendPaymentError> {
+        let (amount, operation_id) = self.validate_send_invoice(&invoice).await?;
+
+        let (gateway_api, routing_info) = self.resolve_send_gateway(&invoice, gateway).await?;
+
+        self.fund_outgoing_contract(
+            invoice,
+            amount,
+            operation_id,
+            gateway_api,
+            routing_info,
+            custom_meta,
+        )
+        .await
+    }
+
+    /// Checks that `invoice` is payable by this client and has not been
+    /// attempted before, returning its amount in millisatoshis and the
+    /// operation id a payment of it uses.
+    async fn validate_send_invoice(
+        &self,
+        invoice: &Bolt11Invoice,
+    ) -> Result<(u64, OperationId), SendPaymentError> {
         let amount = invoice
             .amount_milli_satoshis()
             .ok_or(SendPaymentError::InvoiceMissingAmount)?;
@@ -573,25 +594,48 @@ impl LightningClientModule {
             return Err(SendPaymentError::DuplicatePaymentAttempt(operation_id));
         }
 
-        let (ephemeral_tweak, ephemeral_pk) = tweak::generate(self.keypair.public_key());
+        Ok((amount, operation_id))
+    }
 
-        let refund_keypair = SecretKey::from_slice(&ephemeral_tweak)
-            .expect("32 bytes, within curve order")
-            .keypair(secp256k1::SECP256K1);
-
-        let (gateway_api, routing_info) = match gateway {
-            Some(gateway_api) => (
+    /// Resolves the gateway to pay `invoice` through and its current routing
+    /// info: the given one, or an automatically selected one when `None`.
+    async fn resolve_send_gateway(
+        &self,
+        invoice: &Bolt11Invoice,
+        gateway: Option<SafeUrl>,
+    ) -> Result<(SafeUrl, RoutingInfo), SendPaymentError> {
+        match gateway {
+            Some(gateway_api) => Ok((
                 gateway_api.clone(),
                 self.routing_info(&gateway_api)
                     .await
                     .map_err(|e| SendPaymentError::FailedToConnectToGateway(e.to_string()))?
                     .ok_or(SendPaymentError::FederationNotSupported)?,
-            ),
+            )),
             None => self
                 .select_gateway(Some(invoice.clone()))
                 .await
-                .map_err(SendPaymentError::SelectGateway)?,
-        };
+                .map_err(SendPaymentError::SelectGateway),
+        }
+    }
+
+    /// Funds an outgoing contract for `invoice` at the terms in `routing_info`
+    /// and starts the state machine that hands it to `gateway_api`.
+    #[allow(clippy::too_many_lines)]
+    async fn fund_outgoing_contract(
+        &self,
+        invoice: Bolt11Invoice,
+        amount: u64,
+        operation_id: OperationId,
+        gateway_api: SafeUrl,
+        routing_info: RoutingInfo,
+        custom_meta: Value,
+    ) -> Result<OperationId, SendPaymentError> {
+        let (ephemeral_tweak, ephemeral_pk) = tweak::generate(self.keypair.public_key());
+
+        let refund_keypair = SecretKey::from_slice(&ephemeral_tweak)
+            .expect("32 bytes, within curve order")
+            .keypair(secp256k1::SECP256K1);
 
         let (send_fee, expiration_delta) = routing_info.send_parameters(&invoice);
 

--- a/modules/fedimint-lnv2-client/src/lib.rs
+++ b/modules/fedimint-lnv2-client/src/lib.rs
@@ -57,7 +57,7 @@ use fedimint_lnv2_common::{
 use fedimint_logging::LOG_CLIENT_MODULE_LNV2;
 use futures::StreamExt;
 use lightning_invoice::{Bolt11Invoice, Currency};
-use secp256k1::{Keypair, PublicKey, Scalar, SecretKey, ecdh};
+use secp256k1::{Keypair, Scalar, SecretKey, ecdh};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use strum::IntoEnumIterator as _;
@@ -942,15 +942,128 @@ impl LightningClientModule {
         gateway: Option<SafeUrl>,
         custom_meta: Value,
     ) -> Result<(Bolt11Invoice, OperationId), ReceiveError> {
-        let (gateway, contract, invoice) = self
-            .create_contract_and_fetch_invoice(
-                self.keypair.public_key(),
-                amount,
-                expiry_secs,
-                description,
-                gateway,
+        if expiry_secs > MAX_INVOICE_EXPIRY_SECS {
+            return Err(ReceiveError::InvoiceExpiryTooLong);
+        }
+
+        let (gateway, routing_info) = self.resolve_receive_gateway(gateway).await?;
+
+        self.receive_with_routing_info(
+            amount,
+            expiry_secs,
+            description,
+            gateway,
+            routing_info,
+            custom_meta,
+        )
+        .await
+    }
+
+    /// Resolves the gateway to request an invoice from and its current
+    /// routing info: the given one, or an automatically selected one when
+    /// `None`.
+    async fn resolve_receive_gateway(
+        &self,
+        gateway: Option<SafeUrl>,
+    ) -> Result<(SafeUrl, RoutingInfo), ReceiveError> {
+        match gateway {
+            Some(gateway) => Ok((
+                gateway.clone(),
+                self.routing_info(&gateway)
+                    .await
+                    .map_err(|e| ReceiveError::FailedToConnectToGateway(e.to_string()))?
+                    .ok_or(ReceiveError::FederationNotSupported)?,
+            )),
+            None => self
+                .select_gateway(None)
+                .await
+                .map_err(ReceiveError::SelectGateway),
+        }
+    }
+
+    /// Creates the incoming contract locked to a public key derived from our
+    /// static module public key, fetches its invoice from `gateway` at the
+    /// terms in `routing_info`, then starts the receive operation.
+    async fn receive_with_routing_info(
+        &self,
+        amount: Amount,
+        expiry_secs: u32,
+        description: Bolt11InvoiceDescription,
+        gateway: SafeUrl,
+        routing_info: RoutingInfo,
+        custom_meta: Value,
+    ) -> Result<(Bolt11Invoice, OperationId), ReceiveError> {
+        let recipient_static_pk = self.keypair.public_key();
+
+        let (ephemeral_tweak, ephemeral_pk) = tweak::generate(recipient_static_pk);
+
+        let encryption_seed = ephemeral_tweak
+            .consensus_hash::<sha256::Hash>()
+            .to_byte_array();
+
+        let preimage = encryption_seed
+            .consensus_hash::<sha256::Hash>()
+            .to_byte_array();
+
+        if !routing_info
+            .receive_fee
+            .is_within(&PaymentFee::RECEIVE_FEE_LIMIT)
+        {
+            return Err(ReceiveError::GatewayFeeExceedsLimit);
+        }
+
+        let contract_amount = routing_info.receive_fee.subtract_from(amount.msats);
+
+        // Quoting the claim against this federation's fee consensus is exact, where a
+        // fixed floor is either too permissive or too strict depending on how the
+        // federation is configured.
+        if !self.is_worth_claiming(contract_amount).await {
+            return Err(ReceiveError::AmountTooSmall);
+        }
+
+        let expiration = duration_since_epoch()
+            .as_secs()
+            .saturating_add(u64::from(expiry_secs));
+
+        let claim_pk = recipient_static_pk
+            .mul_tweak(
+                secp256k1::SECP256K1,
+                &Scalar::from_be_bytes(ephemeral_tweak).expect("Within curve order"),
             )
-            .await?;
+            .expect("Tweak is valid");
+
+        let contract = IncomingContract::new(
+            self.cfg.tpe_agg_pk,
+            encryption_seed,
+            preimage,
+            PaymentImage::Hash(preimage.consensus_hash()),
+            contract_amount,
+            expiration,
+            claim_pk,
+            routing_info.module_public_key,
+            ephemeral_pk,
+        );
+
+        let invoice = self
+            .gateway_conn
+            .bolt11_invoice(
+                gateway.clone(),
+                self.federation_id,
+                contract.clone(),
+                amount,
+                description,
+                expiry_secs,
+            )
+            .await
+            .map_err(|e| ReceiveError::FailedToConnectToGateway(e.to_string()))?;
+
+        if invoice.payment_hash() != &preimage.consensus_hash() {
+            return Err(ReceiveError::InvalidInvoice);
+        }
+
+        if invoice.amount_milli_satoshis() != Some(amount.msats) {
+            return Err(ReceiveError::IncorrectInvoiceAmount);
+        }
 
         let operation_id = self
             .receive_incoming_contract(
@@ -1110,108 +1223,6 @@ impl LightningClientModule {
         )
         .await
         .ok_or_else(|| anyhow::anyhow!("Balance is too low to send any amount after fees"))
-    }
-
-    /// Create an incoming contract locked to a public key derived from the
-    /// recipient's static module public key and fetches the corresponding
-    /// invoice.
-    async fn create_contract_and_fetch_invoice(
-        &self,
-        recipient_static_pk: PublicKey,
-        amount: Amount,
-        expiry_secs: u32,
-        description: Bolt11InvoiceDescription,
-        gateway: Option<SafeUrl>,
-    ) -> Result<(SafeUrl, IncomingContract, Bolt11Invoice), ReceiveError> {
-        if expiry_secs > MAX_INVOICE_EXPIRY_SECS {
-            return Err(ReceiveError::InvoiceExpiryTooLong);
-        }
-
-        let (ephemeral_tweak, ephemeral_pk) = tweak::generate(recipient_static_pk);
-
-        let encryption_seed = ephemeral_tweak
-            .consensus_hash::<sha256::Hash>()
-            .to_byte_array();
-
-        let preimage = encryption_seed
-            .consensus_hash::<sha256::Hash>()
-            .to_byte_array();
-
-        let (gateway, routing_info) = match gateway {
-            Some(gateway) => (
-                gateway.clone(),
-                self.routing_info(&gateway)
-                    .await
-                    .map_err(|e| ReceiveError::FailedToConnectToGateway(e.to_string()))?
-                    .ok_or(ReceiveError::FederationNotSupported)?,
-            ),
-            None => self
-                .select_gateway(None)
-                .await
-                .map_err(ReceiveError::SelectGateway)?,
-        };
-
-        if !routing_info
-            .receive_fee
-            .is_within(&PaymentFee::RECEIVE_FEE_LIMIT)
-        {
-            return Err(ReceiveError::GatewayFeeExceedsLimit);
-        }
-
-        let contract_amount = routing_info.receive_fee.subtract_from(amount.msats);
-
-        // Quoting the claim against this federation's fee consensus is exact, where a
-        // fixed floor is either too permissive or too strict depending on how the
-        // federation is configured.
-        if !self.is_worth_claiming(contract_amount).await {
-            return Err(ReceiveError::AmountTooSmall);
-        }
-
-        let expiration = duration_since_epoch()
-            .as_secs()
-            .saturating_add(u64::from(expiry_secs));
-
-        let claim_pk = recipient_static_pk
-            .mul_tweak(
-                secp256k1::SECP256K1,
-                &Scalar::from_be_bytes(ephemeral_tweak).expect("Within curve order"),
-            )
-            .expect("Tweak is valid");
-
-        let contract = IncomingContract::new(
-            self.cfg.tpe_agg_pk,
-            encryption_seed,
-            preimage,
-            PaymentImage::Hash(preimage.consensus_hash()),
-            contract_amount,
-            expiration,
-            claim_pk,
-            routing_info.module_public_key,
-            ephemeral_pk,
-        );
-
-        let invoice = self
-            .gateway_conn
-            .bolt11_invoice(
-                gateway.clone(),
-                self.federation_id,
-                contract.clone(),
-                amount,
-                description,
-                expiry_secs,
-            )
-            .await
-            .map_err(|e| ReceiveError::FailedToConnectToGateway(e.to_string()))?;
-
-        if invoice.payment_hash() != &preimage.consensus_hash() {
-            return Err(ReceiveError::InvalidInvoice);
-        }
-
-        if invoice.amount_milli_satoshis() != Some(amount.msats) {
-            return Err(ReceiveError::IncorrectInvoiceAmount);
-        }
-
-        Ok((gateway, contract, invoice))
     }
 
     // Receive an incoming contract locked to a public key derived from our

--- a/modules/fedimint-lnv2-tests/tests/tests.rs
+++ b/modules/fedimint-lnv2-tests/tests/tests.rs
@@ -28,8 +28,8 @@ use fedimint_lnv2_client::events::{
 };
 use fedimint_lnv2_client::{
     FinalReceiveOperationState, InvoiceSendStatus, LightningClientInit, LightningClientModule,
-    LightningOperationMeta, ReceiveOperationState, SendOperationState, SendPaymentError,
-    SendWithTermsError,
+    LightningOperationMeta, ReceiveOperationState, ReceiveWithTermsError, SendOperationState,
+    SendPaymentError, SendWithTermsError,
 };
 use fedimint_lnv2_common::contracts::{IncomingContract, PaymentImage};
 use fedimint_lnv2_common::gateway_api::PaymentFee;
@@ -570,6 +570,100 @@ async fn receive_operation_expires() -> anyhow::Result<()> {
 
     assert_eq!(sub.ok().await?, ReceiveOperationState::Pending);
     assert_eq!(sub.ok().await?, ReceiveOperationState::Expired);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn receive_with_terms_creates_the_contract_at_the_checked_fee() -> anyhow::Result<()> {
+    let fixtures = fixtures();
+    let fed = fixtures.new_fed_degraded().await;
+    let client = fed.new_client().await;
+
+    let lightning = client.get_first_module::<LightningClientModule>()?;
+    let gateway = mock::gateway();
+    let amount = Amount::from_sats(1000);
+
+    let receive_fee = lightning
+        .routing_info(&gateway)
+        .await?
+        .expect("Mock gateway supports the federation")
+        .receive_fee;
+
+    let (invoice, operation_id) = lightning
+        .receive_with_terms(
+            amount,
+            60,
+            Bolt11InvoiceDescription::Direct(String::new()),
+            gateway,
+            receive_fee,
+            Value::Null,
+        )
+        .await?;
+
+    assert_eq!(invoice.amount_milli_satoshis(), Some(amount.msats));
+
+    let meta = client
+        .operation_log()
+        .get_operation(operation_id)
+        .await
+        .expect("Operation exists")
+        .meta::<LightningOperationMeta>();
+    let LightningOperationMeta::Receive(meta) = meta else {
+        panic!("Expected a receive operation");
+    };
+    // The created contract carries exactly the approved fee.
+    assert_eq!(
+        meta.contract.commitment.amount,
+        receive_fee.subtract_from(amount.msats)
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn receive_with_terms_refuses_when_the_gateway_fee_changed() -> anyhow::Result<()> {
+    let fixtures = fixtures();
+    let fed = fixtures.new_fed_degraded().await;
+    let client = fed.new_client().await;
+
+    let lightning = client.get_first_module::<LightningClientModule>()?;
+    let gateway = mock::gateway();
+
+    let receive_fee = lightning
+        .routing_info(&gateway)
+        .await?
+        .expect("Mock gateway supports the federation")
+        .receive_fee;
+
+    let stale_fee = PaymentFee {
+        base: Amount::from_sats(1),
+        parts_per_million: 1,
+    };
+    assert_ne!(stale_fee, receive_fee);
+
+    assert_eq!(
+        lightning
+            .receive_with_terms(
+                Amount::from_sats(1000),
+                60,
+                Bolt11InvoiceDescription::Direct(String::new()),
+                gateway,
+                stale_fee,
+                Value::Null,
+            )
+            .await,
+        Err(ReceiveWithTermsError::TermsChanged { receive_fee }),
+    );
+
+    // Nothing was created.
+    assert!(
+        client
+            .operation_log()
+            .paginate_operations_rev(10, None)
+            .await
+            .is_empty()
+    );
 
     Ok(())
 }

--- a/modules/fedimint-lnv2-tests/tests/tests.rs
+++ b/modules/fedimint-lnv2-tests/tests/tests.rs
@@ -29,8 +29,10 @@ use fedimint_lnv2_client::events::{
 use fedimint_lnv2_client::{
     FinalReceiveOperationState, InvoiceSendStatus, LightningClientInit, LightningClientModule,
     LightningOperationMeta, ReceiveOperationState, SendOperationState, SendPaymentError,
+    SendWithTermsError,
 };
 use fedimint_lnv2_common::contracts::{IncomingContract, PaymentImage};
+use fedimint_lnv2_common::gateway_api::PaymentFee;
 use fedimint_lnv2_common::lnurl::LnurlRequest;
 use fedimint_lnv2_common::{
     Bolt11InvoiceDescription, KIND, LightningInput, LightningInputV0, LightningOutput,
@@ -190,6 +192,138 @@ async fn can_pay_external_invoice_exactly_once() -> anyhow::Result<()> {
             .get_invoice_send_status(&invoice)
             .await?,
         InvoiceSendStatus::Succeeded(operation_id),
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn send_with_terms_funds_the_contract_at_the_checked_terms() -> anyhow::Result<()> {
+    let fixtures = fixtures();
+    let fed = fixtures.new_fed_degraded().await;
+    let client = fed.new_client().await;
+
+    client
+        .get_first_module::<DummyClientModule>()?
+        .mock_receive(sats(10_000), AmountUnit::BITCOIN)
+        .await?;
+
+    let lightning = client.get_first_module::<LightningClientModule>()?;
+    let gateway = mock::gateway();
+    let invoice = mock::payable_invoice();
+    let amount = invoice
+        .amount_milli_satoshis()
+        .expect("Invoice has an amount");
+
+    // The terms a caller would show the user before asking for approval.
+    let routing_info = lightning
+        .routing_info(&gateway)
+        .await?
+        .expect("Mock gateway supports the federation");
+    let (send_fee, expiration_delta) = routing_info.send_parameters(&invoice);
+
+    let operation_id = lightning
+        .send_with_terms(
+            invoice.clone(),
+            gateway,
+            send_fee,
+            expiration_delta,
+            Value::Null,
+        )
+        .await?;
+
+    // The funded contract carries exactly the approved fee.
+    let meta = client
+        .operation_log()
+        .get_operation(operation_id)
+        .await
+        .expect("Operation exists")
+        .meta::<LightningOperationMeta>();
+    let LightningOperationMeta::Send(meta) = meta else {
+        panic!("Expected a send operation");
+    };
+    assert_eq!(meta.contract.amount, send_fee.add_to(amount));
+
+    let mut sub = lightning
+        .subscribe_send_operation_state_updates(operation_id)
+        .await?
+        .into_stream();
+
+    assert_eq!(sub.ok().await?, SendOperationState::Funding);
+    assert_eq!(sub.ok().await?, SendOperationState::Funded);
+    assert_eq!(
+        sub.ok().await?,
+        SendOperationState::Success(MOCK_INVOICE_PREIMAGE)
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn send_with_terms_refuses_when_the_gateway_terms_changed() -> anyhow::Result<()> {
+    let fixtures = fixtures();
+    let fed = fixtures.new_fed_degraded().await;
+    let client = fed.new_client().await;
+
+    client
+        .get_first_module::<DummyClientModule>()?
+        .mock_receive(sats(10_000), AmountUnit::BITCOIN)
+        .await?;
+
+    let lightning = client.get_first_module::<LightningClientModule>()?;
+    let gateway = mock::gateway();
+    let invoice = mock::payable_invoice();
+
+    let routing_info = lightning
+        .routing_info(&gateway)
+        .await?
+        .expect("Mock gateway supports the federation");
+    let (send_fee, expiration_delta) = routing_info.send_parameters(&invoice);
+
+    // The caller checked a fee the gateway no longer offers.
+    let stale_fee = PaymentFee {
+        base: Amount::from_sats(1),
+        parts_per_million: 1,
+    };
+    assert_ne!(stale_fee, send_fee);
+
+    assert_eq!(
+        lightning
+            .send_with_terms(
+                invoice.clone(),
+                gateway.clone(),
+                stale_fee,
+                expiration_delta,
+                Value::Null,
+            )
+            .await,
+        Err(SendWithTermsError::TermsChanged {
+            send_fee,
+            expiration_delta,
+        }),
+    );
+
+    // The caller checked an expiration delta the gateway no longer offers.
+    assert_eq!(
+        lightning
+            .send_with_terms(
+                invoice.clone(),
+                gateway,
+                send_fee,
+                expiration_delta + 1,
+                Value::Null,
+            )
+            .await,
+        Err(SendWithTermsError::TermsChanged {
+            send_fee,
+            expiration_delta,
+        }),
+    );
+
+    // Nothing was funded.
+    assert_eq!(
+        lightning.get_invoice_send_status(&invoice).await?,
+        InvoiceSendStatus::NotAttempted,
     );
 
     Ok(())


### PR DESCRIPTION
## Summary

Adds `send_with_terms` and `receive_with_terms` to the lnv2 client module so an embedder can pay an invoice, or request one, under the gateway terms it already showed the user. Fixes #9124.

## Details

- `send` and `receive` read the gateway's routing info themselves and use whatever fee and expiration delta they find at that moment. An embedder that quotes a fee, gets the user's approval, then calls `send` has nothing tying the payment to that quote. If the gateway changes its schedule in between, the funded contract carries a different fee and the embedder only learns that by reading the operation meta back afterwards
- the new variants take the terms the caller checked (`send_fee` and `expiration_delta` from `RoutingInfo::send_parameters`, or `receive_fee`), re-read the gateway's routing info, and refuse with a `TermsChanged` error before funding or creating anything if the current terms differ. The error carries the current terms so the caller can re-quote
- each new method has its own error type (`SendWithTermsError`, `ReceiveWithTermsError`) that wraps the existing `SendPaymentError`/`ReceiveError`, so the shared enums are unchanged and existing `send`/`receive` callers matching on them are unaffected
- the comparison is exact. A cheaper fee is refused too, since the point is that the caller's record equals what gets funded
- this binds the contract, not the gateway's acceptance. A gateway that raises its fee after the check can still refuse the contract at claim time and the payment is refunded, same as with `send` today
- passing the caller's `RoutingInfo` straight in, the issue's other suggestion, was not taken. Re-reading costs no extra round-trip compared to `send` and detects a changed schedule instead of funding a contract the gateway will reject
- `send` and `receive` keep their signature and behaviour. The refactor commits split them into private helpers so both entry points share every check

## Testing

- new lnv2 integration tests cover both variants: matching terms fund or create a contract whose amount is exactly the approved fee applied, and a stale fee or expiration delta is refused with the gateway's current terms in the error and no operation created
