### PR TITLE
fix(devimint): give esplora an allocated electrum rpc port

### DIFF
--- a/devimint/src/external.rs
+++ b/devimint/src/external.rs
@@ -835,6 +835,7 @@ impl Esplora {
         let btc_rpc_port = process_mgr.globals.FM_PORT_BTC_RPC;
         let esplora_port = process_mgr.globals.FM_PORT_ESPLORA;
         let esplora_monitoring_port = process_mgr.globals.FM_PORT_ESPLORA_MONITORING;
+        let esplora_electrum_port = process_mgr.globals.FM_PORT_ESPLORA_ELECTRUM;
         // spawn esplora
         let cmd = cmd!(
             crate::util::Esplora,
@@ -845,6 +846,8 @@ impl Esplora {
             "--daemon-rpc-addr=127.0.0.1:{btc_rpc_port}",
             "--http-addr=127.0.0.1:{esplora_port}",
             "--monitoring-addr=127.0.0.1:{esplora_monitoring_port}",
+            // esplora binds a fixed Electrum port by default, so two devimints on a host collide
+            "--electrum-rpc-addr=127.0.0.1:{esplora_electrum_port}",
             "--jsonrpc-import", // Workaround for incompatible on-disk format
             "--cors=*",         // Allow CORS for WASM recovery tool
         );

--- a/devimint/src/vars.rs
+++ b/devimint/src/vars.rs
@@ -162,6 +162,7 @@ declare_vars! {
         FM_PORT_LND_REST: u16 = port_alloc(1)?; env: "FM_PORT_LND_REST";
         FM_PORT_ESPLORA: u16 = port_alloc(1)?; env: "FM_PORT_ESPLORA";
         FM_PORT_ESPLORA_MONITORING: u16 = port_alloc(1)?; env: "FM_PORT_ESPLORA_MONITORING";
+        FM_PORT_ESPLORA_ELECTRUM: u16 = port_alloc(1)?; env: "FM_PORT_ESPLORA_ELECTRUM";
         FM_PORT_GW_LND: u16 = match gateway_base_port {
             Some(b) => b + GATEWAY_PORT_OFFSET_LND,
             None => port_alloc(1)?,


### PR DESCRIPTION
## Description

- run two devimints on one host and both esploras serve electrum on the same address. devimint hands esplora allocated ports for its http and monitoring listeners but not for the electrum rpc listener, so every esplora on the host binds the regtest default `127.0.0.1:60401`
- esplora sets SO_REUSEPORT before it binds, so the second one does not fail. the kernel spreads incoming electrum connections across both, and a client on that port can land on either regtest chain. when the two esploras run as different users the second one panics on the bind instead
- allocate the electrum port the same way as the other two and pass `--electrum-rpc-addr`, the same shape as #3894

## Testing

- started two dev feds at once on one linux host through devimint's library api. before, both esplora configs showed `electrum_rpc_addr: 127.0.0.1:60401`. after, they showed 10054 and 10055, and both federations reached ready
