### PR TITLE
chore(mint): replace anyhow with typed errors in the public API (#8821 part D1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4542,6 +4542,7 @@ name = "fedimint-mintv2-tests"
 version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
+ "assert_matches",
  "async-stream",
  "bitcoin_hashes",
  "bls12_381",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4390,7 +4390,6 @@ dependencies = [
 name = "fedimint-mint-common"
 version = "0.13.0-alpha"
 dependencies = [
- "anyhow",
  "bitcoin_hashes",
  "fedimint-core",
  "fedimint-tbs",
@@ -4505,7 +4504,6 @@ dependencies = [
 name = "fedimint-mintv2-common"
 version = "0.13.0-alpha"
 dependencies = [
- "anyhow",
  "bitcoin_hashes",
  "fedimint-core",
  "fedimint-tbs",

--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -1459,9 +1459,7 @@ impl FedimintCli {
                     .map_err_cli_msg("can't get mint module")?;
 
                 for _ in 0..count {
-                    mint.advance_note_idx(amount)
-                        .await
-                        .map_err_cli_msg("failed to advance the note_idx")?;
+                    mint.advance_note_idx(amount).await;
                 }
 
                 Ok(CliOutput::Raw(serde_json::Value::Null))

--- a/fedimint-client-rpc/src/lib.rs
+++ b/fedimint-client-rpc/src/lib.rs
@@ -20,7 +20,7 @@ use fedimint_core::{Amount, TieredCounts, impl_db_record};
 use fedimint_derive_secret::{ChildId, DerivableSecret};
 use fedimint_ln_client::{LightningClientInit, LightningClientModule};
 use fedimint_meta_client::{MetaClientInit, MetaClientModule};
-use fedimint_mint_client::{MintClientInit, MintClientModule, OOBNotes};
+use fedimint_mint_client::{MintClientInit, MintClientModule, OOBNotes, OOBNotesParseError};
 use fedimint_wallet_client::{WalletClientInit, WalletClientModule};
 use futures::StreamExt;
 use futures::future::{AbortHandle, Abortable};
@@ -646,9 +646,8 @@ impl RpcGlobalState {
     }
 }
 
-pub fn parse_oob_notes(oob_notes_str: &str) -> anyhow::Result<ParsedNoteDetails> {
-    let oob_notes =
-        OOBNotes::from_str(oob_notes_str).context("Failed to parse OOB notes string")?;
+pub fn parse_oob_notes(oob_notes_str: &str) -> Result<ParsedNoteDetails, OOBNotesParseError> {
+    let oob_notes = OOBNotes::from_str(oob_notes_str)?;
 
     let total_amount = oob_notes.total_amount();
     let federation_id_prefix = oob_notes.federation_id_prefix();

--- a/fedimint-core/src/config.rs
+++ b/fedimint-core/src/config.rs
@@ -964,6 +964,20 @@ pub fn load_from_file<T: DeserializeOwned>(path: &Path) -> Result<T, ConfigFileE
     })
 }
 
+/// A module's configured relative fee is above what the module accepts.
+///
+/// Every module that charges a relative fee validates it the same way in its
+/// own `FeeConsensus::new`, so the failure is named once here rather than once
+/// per module.
+#[derive(Debug, Error)]
+#[error("The relative fee of {parts_per_million} parts per million is over the limit of {max}")]
+pub struct ExcessiveRelativeFeeError {
+    /// The fee that was asked for.
+    pub parts_per_million: u64,
+    /// The largest relative fee the module accepts.
+    pub max: u64,
+}
+
 /// Failure to look up or cast a module configuration.
 #[derive(Debug, Error)]
 #[non_exhaustive]

--- a/fedimint-core/src/config/tests.rs
+++ b/fedimint-core/src/config/tests.rs
@@ -262,3 +262,18 @@ fn dkg_message_deserialize_reports_the_whole_decode_chain() {
         "{err}"
     );
 }
+
+#[test]
+fn an_excessive_relative_fee_names_the_fee_and_the_limit() {
+    use crate::config::ExcessiveRelativeFeeError;
+
+    let err = ExcessiveRelativeFeeError {
+        parts_per_million: 1_001,
+        max: 1_000,
+    };
+
+    assert_eq!(
+        err.to_string(),
+        "The relative fee of 1001 parts per million is over the limit of 1000"
+    );
+}

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -1757,7 +1757,7 @@ impl Gateway {
                 .receive(ecash, serde_json::Value::Null)
                 .await
                 .map_err(|e| PublicGatewayError::ReceiveEcashError {
-                    failure_reason: e.to_string(),
+                    failure_reason: e.fmt_compact().to_string(),
                 })?;
 
             let final_state = mint

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -1706,7 +1706,7 @@ impl Gateway {
 
             let operation_id = mint.reissue_external_notes(notes, ()).await.map_err(|e| {
                 PublicGatewayError::ReceiveEcashError {
-                    failure_reason: e.to_string(),
+                    failure_reason: e.fmt_compact().to_string(),
                 }
             })?;
 

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -1714,7 +1714,10 @@ impl Gateway {
                 .subscribe_reissue_external_notes(operation_id)
                 .await
                 .map_err(|e| PublicGatewayError::ReceiveEcashError {
-                    failure_reason: format!("Could not subscribe to reissue operation: {e}"),
+                    failure_reason: format!(
+                        "Could not subscribe to reissue operation: {}",
+                        e.fmt_compact()
+                    ),
                 })?
                 .into_stream();
 

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -1764,7 +1764,7 @@ impl Gateway {
                 .await_final_receive_operation_state(operation_id)
                 .await
                 .map_err(|e| PublicGatewayError::ReceiveEcashError {
-                    failure_reason: e.to_string(),
+                    failure_reason: e.fmt_compact().to_string(),
                 })?;
             match final_state {
                 fedimint_mintv2_client::FinalReceiveOperationState::Success => {}

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -1696,7 +1696,10 @@ impl Gateway {
         if let Ok(mint) = client.value().get_first_module::<MintClientModule>() {
             let notes = OOBNotes::from_str(&payload.notes).map_err(|e| {
                 PublicGatewayError::ReceiveEcashError {
-                    failure_reason: format!("Expected OOBNotes for MintV1 federation: {e}"),
+                    failure_reason: format!(
+                        "Expected OOBNotes for MintV1 federation: {}",
+                        e.fmt_compact()
+                    ),
                 }
             })?;
             let amount = notes.total_amount();

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -2870,7 +2870,10 @@ impl IAdminGateway for Gateway {
             .into_value();
 
         if let Ok(mint_module) = client.get_first_module::<MintClientModule>() {
-            let notes = mint_module.send_oob_notes(payload.amount, ()).await?;
+            let notes = mint_module
+                .send_oob_notes(payload.amount, ())
+                .await
+                .map_err(|e| AdminGatewayError::Unexpected(e.into()))?;
             debug!(target: LOG_GATEWAY, ?notes, "Spend ecash notes");
             Ok(SpendEcashResponse {
                 notes: notes.to_string(),

--- a/modules/fedimint-mint-client/src/api.rs
+++ b/modules/fedimint-mint-client/src/api.rs
@@ -1,4 +1,6 @@
-use fedimint_api_client::api::{FederationApiExt, FederationResult, IModuleFederationApi};
+use fedimint_api_client::api::{
+    FederationApiExt, FederationResult, IModuleFederationApi, ServerResult,
+};
 use fedimint_core::bitcoin::hashes::sha256;
 use fedimint_core::module::registry::ModuleRegistry;
 use fedimint_core::module::{ApiRequestErased, SerdeModuleEncodingBase64};
@@ -9,6 +11,8 @@ use fedimint_mint_common::endpoint_constants::{
     RECOVERY_COUNT_ENDPOINT, RECOVERY_SLICE_ENDPOINT, RECOVERY_SLICE_HASH_ENDPOINT,
 };
 use fedimint_mint_common::{BlindNonce, Nonce, RecoveryItem};
+
+use crate::error::FetchRecoverySliceError;
 
 #[apply(async_trait_maybe_send!)]
 pub trait MintFederationApi {
@@ -25,21 +29,17 @@ pub trait MintFederationApi {
         &self,
         peer: PeerId,
         blind_nonce: BlindNonce,
-    ) -> anyhow::Result<bool>;
+    ) -> ServerResult<bool>;
 
     /// Asks a single peer if the note identified by `nonce` was already spent.
     ///
     /// Unlike [`MintFederationApi::check_note_spent`] this does not wait for a
     /// threshold of peers to agree, which makes it possible to observe
     /// disagreement between peers.
-    async fn check_note_spent_single_peer(
-        &self,
-        peer: PeerId,
-        nonce: Nonce,
-    ) -> anyhow::Result<bool>;
+    async fn check_note_spent_single_peer(&self, peer: PeerId, nonce: Nonce) -> ServerResult<bool>;
 
     /// Returns the total number of recovery items stored on the federation.
-    async fn fetch_recovery_count(&self) -> anyhow::Result<u64>;
+    async fn fetch_recovery_count(&self) -> FederationResult<u64>;
 
     /// Returns the consensus hash of recovery items in the range `[start,
     /// end)`.
@@ -51,13 +51,13 @@ pub trait MintFederationApi {
         peer: PeerId,
         start: u64,
         end: u64,
-    ) -> anyhow::Result<Vec<RecoveryItem>>;
+    ) -> Result<Vec<RecoveryItem>, FetchRecoverySliceError>;
 
     /// Returns the outpoints where the given blind nonces were used.
     async fn fetch_blind_nonce_outpoints(
         &self,
         blind_nonces: Vec<BlindNonce>,
-    ) -> anyhow::Result<Vec<OutPoint>>;
+    ) -> FederationResult<Vec<OutPoint>>;
 }
 
 #[apply(async_trait_maybe_send!)]
@@ -85,37 +85,30 @@ where
         &self,
         peer: PeerId,
         blind_nonce: BlindNonce,
-    ) -> anyhow::Result<bool> {
-        Ok(self
-            .request_single_peer::<bool>(
-                BLIND_NONCE_USED_ENDPOINT.to_string(),
-                ApiRequestErased::new(blind_nonce),
-                peer,
-            )
-            .await?)
+    ) -> ServerResult<bool> {
+        self.request_single_peer::<bool>(
+            BLIND_NONCE_USED_ENDPOINT.to_string(),
+            ApiRequestErased::new(blind_nonce),
+            peer,
+        )
+        .await
     }
 
-    async fn check_note_spent_single_peer(
-        &self,
-        peer: PeerId,
-        nonce: Nonce,
-    ) -> anyhow::Result<bool> {
-        Ok(self
-            .request_single_peer::<bool>(
-                NOTE_SPENT_ENDPOINT.to_string(),
-                ApiRequestErased::new(nonce),
-                peer,
-            )
-            .await?)
+    async fn check_note_spent_single_peer(&self, peer: PeerId, nonce: Nonce) -> ServerResult<bool> {
+        self.request_single_peer::<bool>(
+            NOTE_SPENT_ENDPOINT.to_string(),
+            ApiRequestErased::new(nonce),
+            peer,
+        )
+        .await
     }
 
-    async fn fetch_recovery_count(&self) -> anyhow::Result<u64> {
+    async fn fetch_recovery_count(&self) -> FederationResult<u64> {
         self.request_current_consensus::<u64>(
             RECOVERY_COUNT_ENDPOINT.to_string(),
             ApiRequestErased::default(),
         )
         .await
-        .map_err(|e| anyhow::anyhow!("{e}"))
     }
 
     async fn fetch_recovery_slice_hash(&self, start: u64, end: u64) -> sha256::Hash {
@@ -131,7 +124,7 @@ where
         peer: PeerId,
         start: u64,
         end: u64,
-    ) -> anyhow::Result<Vec<RecoveryItem>> {
+    ) -> Result<Vec<RecoveryItem>, FetchRecoverySliceError> {
         let result = self
             .request_single_peer::<SerdeModuleEncodingBase64<Vec<RecoveryItem>>>(
                 RECOVERY_SLICE_ENDPOINT.to_owned(),
@@ -146,12 +139,11 @@ where
     async fn fetch_blind_nonce_outpoints(
         &self,
         blind_nonces: Vec<BlindNonce>,
-    ) -> anyhow::Result<Vec<OutPoint>> {
+    ) -> FederationResult<Vec<OutPoint>> {
         self.request_current_consensus::<Vec<OutPoint>>(
             RECOVERY_BLIND_NONCE_OUTPOINTS_ENDPOINT.to_string(),
             ApiRequestErased::new(blind_nonces),
         )
         .await
-        .map_err(|e| anyhow::anyhow!("{e}"))
     }
 }

--- a/modules/fedimint-mint-client/src/backup.rs
+++ b/modules/fedimint-mint-client/src/backup.rs
@@ -7,6 +7,7 @@ use fedimint_mint_common::KIND;
 use serde::{Deserialize, Serialize};
 
 use super::MintClientModule;
+use crate::error::PrepareEcashBackupError;
 use crate::output::{MintOutputStateMachine, NoteIssuanceRequest};
 use crate::{MintClientStateMachines, NoteIndex, SpendableNote};
 
@@ -78,7 +79,7 @@ impl MintClientModule {
     pub async fn prepare_plaintext_ecash_backup(
         &self,
         dbtx: &mut DatabaseTransaction<'_>,
-    ) -> anyhow::Result<EcashBackup> {
+    ) -> Result<EcashBackup, PrepareEcashBackupError> {
         // fetch consensus height first - so we dont miss anything when scanning
         let session_count = self.client_ctx.global_api().session_count().await?;
 
@@ -133,7 +134,7 @@ impl MintClientModule {
             notes
                 .into_iter_items()
                 .map(|(amt, spendable_note)| Ok((amt, spendable_note.decode()?)))
-                .collect::<anyhow::Result<TieredMulti<_>>>()?,
+                .collect::<Result<TieredMulti<_>, PrepareEcashBackupError>>()?,
             pending_notes,
             session_count,
             next_note_idx,

--- a/modules/fedimint-mint-client/src/cli.rs
+++ b/modules/fedimint-mint-client/src/cli.rs
@@ -7,6 +7,7 @@ use anyhow::{Context, bail};
 use clap::{Parser, Subcommand};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::registry::ModuleDecoderRegistry;
+use fedimint_core::util::FmtCompact as _;
 use fedimint_core::{Amount, PeerId, TieredMulti};
 use futures::StreamExt;
 use futures::future::join_all;
@@ -111,7 +112,7 @@ async fn check_nonce_spent(
         async move {
             let result = match api.check_note_spent_single_peer(peer, nonce).await {
                 Ok(spent) => PeerCheckResult::Answer(spent),
-                Err(e) => PeerCheckResult::Error(format!("error: {e}")),
+                Err(e) => PeerCheckResult::Error(format!("error: {}", e.fmt_compact())),
             };
             (peer, result)
         }
@@ -136,7 +137,7 @@ async fn check_blind_nonce_used(
                 .await
             {
                 Ok(used) => PeerCheckResult::Answer(used),
-                Err(e) => PeerCheckResult::Error(format!("error: {e}")),
+                Err(e) => PeerCheckResult::Error(format!("error: {}", e.fmt_compact())),
             };
             (peer, result)
         }

--- a/modules/fedimint-mint-client/src/error.rs
+++ b/modules/fedimint-mint-client/src/error.rs
@@ -4,7 +4,7 @@
 //! the two types that predate this module and are re-exported from it, so
 //! there is one place to look.
 
-use fedimint_api_client::api::FederationError;
+use fedimint_api_client::api::{FederationError, ServerError};
 use fedimint_client_module::error::{
     AddStateMachinesError, OperationLookupError, TransactionSubmitError,
 };
@@ -247,4 +247,17 @@ pub enum OOBNotesParseError {
     /// The string decodes, but carries no notes.
     #[error("The e-cash notes are empty")]
     Empty,
+}
+
+/// A failure to fetch a slice of the federation's recovery log from one peer.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum FetchRecoverySliceError {
+    /// The peer did not answer, or answered with an error.
+    #[error("The peer did not serve the recovery slice")]
+    Peer(#[from] ServerError),
+
+    /// The peer's answer is not a decodable recovery slice.
+    #[error("The recovery slice could not be decoded")]
+    Decode(#[from] DecodeError),
 }

--- a/modules/fedimint-mint-client/src/error.rs
+++ b/modules/fedimint-mint-client/src/error.rs
@@ -124,6 +124,15 @@ impl From<SpendOOBError> for fedimint_core::util::ffi::UniffiError {
     }
 }
 
+#[cfg(feature = "uniffi")]
+impl From<ReissueExternalNotesError> for fedimint_core::util::ffi::UniffiError {
+    fn from(e: ReissueExternalNotesError) -> Self {
+        use fedimint_core::util::FmtCompact as _;
+
+        Self::General(e.fmt_compact().to_string())
+    }
+}
+
 /// A string that is not a valid serialization of out-of-band e-cash notes.
 ///
 /// Unlike the other errors in this module this one interpolates its cause into

--- a/modules/fedimint-mint-client/src/error.rs
+++ b/modules/fedimint-mint-client/src/error.rs
@@ -63,3 +63,25 @@ impl From<ValidateNotesError> for fedimint_core::util::ffi::UniffiError {
         Self::General(e.fmt_compact().to_string())
     }
 }
+
+/// A string that is not a valid serialization of out-of-band e-cash notes.
+///
+/// Unlike the other errors in this module this one interpolates its cause into
+/// its message: `clap` renders a `FromStr` failure with `Display` alone, and
+/// `OOBNotes`' `Deserialize` impl hands it to `serde::de::Error::custom`, which
+/// keeps only the message. A cause behind `source()` would be dropped by both.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum OOBNotesParseError {
+    /// The string is neither base32 with the fedimint prefix nor base64.
+    #[error("The e-cash notes are not a well-formed base32 or base64 string")]
+    Encoding,
+
+    /// The decoded bytes are not a valid `OOBNotes` encoding.
+    #[error("The e-cash notes could not be decoded: {0}")]
+    Decode(#[from] DecodeError),
+
+    /// The string decodes, but carries no notes.
+    #[error("The e-cash notes are empty")]
+    Empty,
+}

--- a/modules/fedimint-mint-client/src/error.rs
+++ b/modules/fedimint-mint-client/src/error.rs
@@ -1,0 +1,65 @@
+//! Error types of the mint client.
+//!
+//! Every failure this module reports to its callers is named here, including
+//! the two types that predate this module and are re-exported from it, so
+//! there is one place to look.
+
+use fedimint_core::Amount;
+use fedimint_core::config::FederationIdPrefix;
+use fedimint_core::encoding::DecodeError;
+use thiserror::Error;
+
+pub use crate::{InsufficientBalanceError, ReissueExternalNotesError};
+
+/// A note that cannot be spent.
+///
+/// Reported both for notes received out of band and for notes already held in
+/// the wallet, which is why a decoding failure is one of the conditions.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum ValidateNotesError {
+    /// The notes were issued by a different federation.
+    #[error("The notes were issued by federation {found}, not {expected}")]
+    WrongFederationId {
+        /// The federation this client belongs to.
+        expected: FederationIdPrefix,
+        /// The federation the notes name.
+        found: FederationIdPrefix,
+    },
+
+    /// The note claims a denomination the federation does not issue.
+    #[error("Note {index} claims the amount tier {amount}, which the federation does not issue")]
+    InvalidAmountTier {
+        /// The position of the note in the set that was checked.
+        index: usize,
+        /// The tier the note claims.
+        amount: Amount,
+    },
+
+    /// The note does not carry a valid federation signature.
+    #[error("Note {index} does not carry a valid federation signature")]
+    InvalidSignature {
+        /// The position of the note in the set that was checked.
+        index: usize,
+    },
+
+    /// The note cannot be spent with the key that was supplied with it.
+    #[error("Note {index} cannot be spent with the supplied spend key")]
+    WrongSpendKey {
+        /// The position of the note in the set that was checked.
+        index: usize,
+    },
+
+    /// A note held in the wallet could not be decoded.
+    #[error("A stored note could not be decoded")]
+    Decode(#[from] DecodeError),
+}
+
+#[cfg(feature = "uniffi")]
+impl From<ValidateNotesError> for fedimint_core::util::ffi::UniffiError {
+    fn from(e: ValidateNotesError) -> Self {
+        use fedimint_core::util::FmtCompact as _;
+
+        Self::General(e.fmt_compact().to_string())
+    }
+}

--- a/modules/fedimint-mint-client/src/error.rs
+++ b/modules/fedimint-mint-client/src/error.rs
@@ -11,6 +11,34 @@ use thiserror::Error;
 
 pub use crate::{InsufficientBalanceError, ReissueExternalNotesError};
 
+/// A failure to pick notes out of the wallet for a spend.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum SelectNotesError {
+    /// The wallet does not hold enough notes to cover the request.
+    #[error("The wallet does not hold enough notes")]
+    InsufficientBalance(#[from] InsufficientBalanceError),
+
+    /// The requested amount cannot be made exactly from the denominations the
+    /// wallet holds. This does not mean the balance is too low.
+    #[error("The amount {requested} cannot be made exactly; the closest selection is {selected}")]
+    NoExactAmount {
+        /// The amount that was asked for.
+        requested: Amount,
+        /// The total the greedy selection arrived at instead.
+        selected: Amount,
+    },
+
+    /// A note held in the wallet could not be decoded.
+    #[error("A stored note could not be decoded")]
+    Decode(#[from] DecodeError),
+
+    /// A note selector implemented outside this crate failed in a way the
+    /// other variants do not describe.
+    #[error("The note selector failed")]
+    Custom(#[source] Box<dyn std::error::Error + Send + Sync>),
+}
+
 /// A note that cannot be spent.
 ///
 /// Reported both for notes received out of band and for notes already held in

--- a/modules/fedimint-mint-client/src/error.rs
+++ b/modules/fedimint-mint-client/src/error.rs
@@ -261,3 +261,42 @@ pub enum FetchRecoverySliceError {
     #[error("The recovery slice could not be decoded")]
     Decode(#[from] DecodeError),
 }
+
+/// A failure to assemble the wallet's e-cash backup.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum PrepareEcashBackupError {
+    /// The federation could not be asked how far consensus has got, which the
+    /// backup records so a restore knows where to resume scanning.
+    #[error("The federation could not be reached")]
+    Federation(#[source] Box<FederationError>),
+
+    /// A note held in the wallet could not be decoded.
+    #[error("A stored note could not be decoded")]
+    Decode(#[from] DecodeError),
+}
+
+impl From<FederationError> for PrepareEcashBackupError {
+    fn from(source: FederationError) -> Self {
+        Self::Federation(Box::new(source))
+    }
+}
+
+/// A failure to repair an inconsistent wallet.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum RepairWalletError {
+    /// The federation could not be asked whether a note or a nonce was used.
+    #[error("The federation could not be reached")]
+    Federation(#[source] Box<FederationError>),
+
+    /// The repaired wallet could not be written back.
+    #[error("Database error")]
+    Database(#[from] DatabaseError),
+}
+
+impl From<FederationError> for RepairWalletError {
+    fn from(source: FederationError) -> Self {
+        Self::Federation(Box::new(source))
+    }
+}

--- a/modules/fedimint-mint-client/src/error.rs
+++ b/modules/fedimint-mint-client/src/error.rs
@@ -4,8 +4,10 @@
 //! the two types that predate this module and are re-exported from it, so
 //! there is one place to look.
 
+use fedimint_client_module::error::AddStateMachinesError;
 use fedimint_core::Amount;
 use fedimint_core::config::FederationIdPrefix;
+use fedimint_core::db::DatabaseError;
 use fedimint_core::encoding::DecodeError;
 use thiserror::Error;
 
@@ -37,6 +39,27 @@ pub enum SelectNotesError {
     /// other variants do not describe.
     #[error("The note selector failed")]
     Custom(#[source] Box<dyn std::error::Error + Send + Sync>),
+}
+
+/// A failure to hand e-cash notes out of band.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum SpendOOBError {
+    /// A spend of zero has nothing to hand out.
+    #[error("Zero-amount out-of-band spends are not supported")]
+    ZeroAmount,
+
+    /// The notes to hand out could not be picked.
+    #[error("The notes to spend could not be selected")]
+    NoteSelection(#[from] SelectNotesError),
+
+    /// The state machines that watch for a refund could not be registered.
+    #[error("Failed to add the spend's state machines")]
+    StateMachines(#[from] AddStateMachinesError),
+
+    /// The spend could not be written to the database.
+    #[error("Database error")]
+    Database(#[from] DatabaseError),
 }
 
 /// A note that cannot be spent.
@@ -86,6 +109,15 @@ pub enum ValidateNotesError {
 #[cfg(feature = "uniffi")]
 impl From<ValidateNotesError> for fedimint_core::util::ffi::UniffiError {
     fn from(e: ValidateNotesError) -> Self {
+        use fedimint_core::util::FmtCompact as _;
+
+        Self::General(e.fmt_compact().to_string())
+    }
+}
+
+#[cfg(feature = "uniffi")]
+impl From<SpendOOBError> for fedimint_core::util::ffi::UniffiError {
+    fn from(e: SpendOOBError) -> Self {
         use fedimint_core::util::FmtCompact as _;
 
         Self::General(e.fmt_compact().to_string())

--- a/modules/fedimint-mint-client/src/error.rs
+++ b/modules/fedimint-mint-client/src/error.rs
@@ -11,6 +11,8 @@ use fedimint_client_module::error::{
 use fedimint_core::config::FederationIdPrefix;
 use fedimint_core::db::DatabaseError;
 use fedimint_core::encoding::DecodeError;
+#[cfg(feature = "uniffi")]
+use fedimint_core::util::FmtCompact as _;
 use fedimint_core::{Amount, PeerId};
 use thiserror::Error;
 
@@ -185,8 +187,6 @@ pub enum ValidateNotesError {
 #[cfg(feature = "uniffi")]
 impl From<ValidateNotesError> for fedimint_core::util::ffi::UniffiError {
     fn from(e: ValidateNotesError) -> Self {
-        use fedimint_core::util::FmtCompact as _;
-
         Self::General(e.fmt_compact().to_string())
     }
 }
@@ -194,8 +194,6 @@ impl From<ValidateNotesError> for fedimint_core::util::ffi::UniffiError {
 #[cfg(feature = "uniffi")]
 impl From<SpendOOBError> for fedimint_core::util::ffi::UniffiError {
     fn from(e: SpendOOBError) -> Self {
-        use fedimint_core::util::FmtCompact as _;
-
         Self::General(e.fmt_compact().to_string())
     }
 }
@@ -203,8 +201,6 @@ impl From<SpendOOBError> for fedimint_core::util::ffi::UniffiError {
 #[cfg(feature = "uniffi")]
 impl From<ReissueExternalNotesError> for fedimint_core::util::ffi::UniffiError {
     fn from(e: ReissueExternalNotesError) -> Self {
-        use fedimint_core::util::FmtCompact as _;
-
         Self::General(e.fmt_compact().to_string())
     }
 }
@@ -212,8 +208,6 @@ impl From<ReissueExternalNotesError> for fedimint_core::util::ffi::UniffiError {
 #[cfg(feature = "uniffi")]
 impl From<SubscribeReissueExternalNotesError> for fedimint_core::util::ffi::UniffiError {
     fn from(e: SubscribeReissueExternalNotesError) -> Self {
-        use fedimint_core::util::FmtCompact as _;
-
         Self::General(e.fmt_compact().to_string())
     }
 }
@@ -221,8 +215,6 @@ impl From<SubscribeReissueExternalNotesError> for fedimint_core::util::ffi::Unif
 #[cfg(feature = "uniffi")]
 impl From<SubscribeSpendNotesError> for fedimint_core::util::ffi::UniffiError {
     fn from(e: SubscribeSpendNotesError) -> Self {
-        use fedimint_core::util::FmtCompact as _;
-
         Self::General(e.fmt_compact().to_string())
     }
 }

--- a/modules/fedimint-mint-client/src/error.rs
+++ b/modules/fedimint-mint-client/src/error.rs
@@ -4,14 +4,14 @@
 //! the two types that predate this module and are re-exported from it, so
 //! there is one place to look.
 
-use fedimint_api_client::api::{FederationError, ServerError};
+use fedimint_api_client::api::{FederationError, OutputOutcomeError, ServerError};
 use fedimint_client_module::error::{
     AddStateMachinesError, OperationLookupError, TransactionSubmitError,
 };
-use fedimint_core::Amount;
 use fedimint_core::config::FederationIdPrefix;
 use fedimint_core::db::DatabaseError;
 use fedimint_core::encoding::DecodeError;
+use fedimint_core::{Amount, PeerId};
 use thiserror::Error;
 
 pub use crate::{InsufficientBalanceError, ReissueExternalNotesError};
@@ -298,5 +298,38 @@ pub enum RepairWalletError {
 impl From<FederationError> for RepairWalletError {
     fn from(source: FederationError) -> Self {
         Self::Federation(Box::new(source))
+    }
+}
+
+/// A guardian's blind signature share that cannot be used.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum VerifyBlindShareError {
+    /// The guardian's answer is not a decodable output outcome.
+    #[error("The output outcome could not be read")]
+    Outcome(#[source] Box<OutputOutcomeError>),
+
+    /// The share came from a peer this client holds no key for.
+    #[error("No public key share is known for peer {peer}")]
+    UnknownPeer {
+        /// The peer that answered.
+        peer: PeerId,
+    },
+
+    /// The federation does not issue notes of this denomination.
+    #[error("The federation issues no notes of the amount tier {amount}")]
+    InvalidAmountTier {
+        /// The tier the outcome claims.
+        amount: Amount,
+    },
+
+    /// The share does not verify against the peer's public key share.
+    #[error("The blind signature share does not verify")]
+    InvalidSignature,
+}
+
+impl From<OutputOutcomeError> for VerifyBlindShareError {
+    fn from(source: OutputOutcomeError) -> Self {
+        Self::Outcome(Box::new(source))
     }
 }

--- a/modules/fedimint-mint-client/src/error.rs
+++ b/modules/fedimint-mint-client/src/error.rs
@@ -4,7 +4,8 @@
 //! the two types that predate this module and are re-exported from it, so
 //! there is one place to look.
 
-use fedimint_client_module::error::AddStateMachinesError;
+use fedimint_api_client::api::FederationError;
+use fedimint_client_module::error::{AddStateMachinesError, TransactionSubmitError};
 use fedimint_core::Amount;
 use fedimint_core::config::FederationIdPrefix;
 use fedimint_core::db::DatabaseError;
@@ -60,6 +61,49 @@ pub enum SpendOOBError {
     /// The spend could not be written to the database.
     #[error("Database error")]
     Database(#[from] DatabaseError),
+}
+
+/// A transaction's e-cash outputs did not become spendable.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum AwaitOutputFinalizedError {
+    /// The federation rejected the transaction, so its outputs never existed.
+    #[error("The transaction was rejected")]
+    TransactionRejected,
+
+    /// The issuance state machine gave up.
+    ///
+    /// `reason` is the text the state machine recorded in the client database
+    /// when it failed; it is read back here, never rewritten.
+    #[error("The notes could not be issued: {reason}")]
+    Failed {
+        /// What the issuance state machine recorded.
+        reason: String,
+    },
+}
+
+/// A failure to hand out e-cash for a requested amount.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum SendOOBNotesError {
+    /// The federation could not be reached, so the wallet cannot mint itself
+    /// the denominations it is missing.
+    #[error("The federation could not be reached")]
+    Federation(#[source] Box<FederationError>),
+
+    /// The self-reissue that makes the right denominations failed.
+    #[error("The reissue that would make the right denominations failed")]
+    Transaction(#[from] TransactionSubmitError),
+
+    /// The spend could not be written to the database.
+    #[error("Database error")]
+    Database(#[from] DatabaseError),
+}
+
+impl From<FederationError> for SendOOBNotesError {
+    fn from(source: FederationError) -> Self {
+        Self::Federation(Box::new(source))
+    }
 }
 
 /// A note that cannot be spent.

--- a/modules/fedimint-mint-client/src/error.rs
+++ b/modules/fedimint-mint-client/src/error.rs
@@ -5,7 +5,9 @@
 //! there is one place to look.
 
 use fedimint_api_client::api::FederationError;
-use fedimint_client_module::error::{AddStateMachinesError, TransactionSubmitError};
+use fedimint_client_module::error::{
+    AddStateMachinesError, OperationLookupError, TransactionSubmitError,
+};
 use fedimint_core::Amount;
 use fedimint_core::config::FederationIdPrefix;
 use fedimint_core::db::DatabaseError;
@@ -106,6 +108,36 @@ impl From<FederationError> for SendOOBNotesError {
     }
 }
 
+/// A failure to follow a reissue operation.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum SubscribeReissueExternalNotesError {
+    /// No mint operation with this id exists.
+    #[error("The operation could not be looked up")]
+    Operation(#[from] OperationLookupError),
+
+    /// The operation exists, but it is an out-of-band spend.
+    #[error("The operation is an out-of-band spend, not a reissuance")]
+    NotAReissuance,
+
+    /// The operation records no transaction, which a reissuance always has.
+    #[error("The reissue operation records no transaction")]
+    NoTransaction,
+}
+
+/// A failure to follow an out-of-band spend operation.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum SubscribeSpendNotesError {
+    /// No mint operation with this id exists.
+    #[error("The operation could not be looked up")]
+    Operation(#[from] OperationLookupError),
+
+    /// The operation exists, but it is a reissuance.
+    #[error("The operation is a reissuance, not an out-of-band spend")]
+    NotAnOutOfBandSpend,
+}
+
 /// A note that cannot be spent.
 ///
 /// Reported both for notes received out of band and for notes already held in
@@ -171,6 +203,24 @@ impl From<SpendOOBError> for fedimint_core::util::ffi::UniffiError {
 #[cfg(feature = "uniffi")]
 impl From<ReissueExternalNotesError> for fedimint_core::util::ffi::UniffiError {
     fn from(e: ReissueExternalNotesError) -> Self {
+        use fedimint_core::util::FmtCompact as _;
+
+        Self::General(e.fmt_compact().to_string())
+    }
+}
+
+#[cfg(feature = "uniffi")]
+impl From<SubscribeReissueExternalNotesError> for fedimint_core::util::ffi::UniffiError {
+    fn from(e: SubscribeReissueExternalNotesError) -> Self {
+        use fedimint_core::util::FmtCompact as _;
+
+        Self::General(e.fmt_compact().to_string())
+    }
+}
+
+#[cfg(feature = "uniffi")]
+impl From<SubscribeSpendNotesError> for fedimint_core::util::ffi::UniffiError {
+    fn from(e: SubscribeSpendNotesError) -> Self {
         use fedimint_core::util::FmtCompact as _;
 
         Self::General(e.fmt_compact().to_string())

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -47,7 +47,7 @@ use std::str::FromStr;
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
-use anyhow::{Context as _, anyhow, bail, ensure};
+use anyhow::{Context as _, anyhow, bail};
 use api::MintFederationApi;
 use async_stream::{stream, try_stream};
 use backup::recovery::{MintRecovery, RecoveryStateV2};
@@ -60,6 +60,7 @@ use client_db::{
 use events::{NoteSpent, OOBNotesReissued, OOBNotesSpent, ReceivePaymentEvent, SendPaymentEvent};
 use fedimint_api_client::api::DynModuleApi;
 use fedimint_client_module::db::{ClientModuleMigrationFn, migrate_state};
+use fedimint_client_module::error::TransactionSubmitError;
 use fedimint_client_module::module::init::{
     ClientModuleInit, ClientModuleInitArgs, ClientModuleRecoverArgs, RecoveryMode,
 };
@@ -1291,12 +1292,30 @@ struct AwaitSpendOobRefundRequest {
     operation_id: OperationId,
 }
 
-#[derive(thiserror::Error, Debug, Clone)]
+/// A failure to reissue e-cash notes received from a third party.
+#[derive(thiserror::Error, Debug)]
+#[non_exhaustive]
 pub enum ReissueExternalNotesError {
+    /// The notes are worth nothing, so there is nothing to reissue.
+    #[error("Reissuing zero-amount e-cash is not supported")]
+    ZeroAmount,
+
+    /// The notes were issued by a different federation.
     #[error("Federation ID does not match")]
     WrongFederationId,
+
+    /// An operation for these exact notes already exists, so they were already
+    /// handed to this federation.
     #[error("We already reissued these notes")]
     AlreadyReissued,
+
+    /// The notes cannot be spent.
+    #[error("The notes could not be validated")]
+    Notes(#[from] ValidateNotesError),
+
+    /// The reissue transaction could not be built or submitted.
+    #[error("The reissue transaction could not be submitted")]
+    Transaction(#[source] TransactionSubmitError),
 }
 
 impl MintClientModule {
@@ -1896,7 +1915,10 @@ impl MintClientModule {
     /// committed, so the wallet's notes are read but left untouched. The
     /// quote is point-in-time: it depends on the current inventory and can
     /// move as notes change.
-    pub async fn reissue_fee_quote(&self, oob_notes: &OOBNotes) -> anyhow::Result<FeeQuote> {
+    pub async fn reissue_fee_quote(
+        &self,
+        oob_notes: &OOBNotes,
+    ) -> Result<FeeQuote, TransactionSubmitError> {
         // A reissue submits the external notes as explicit inputs and no explicit
         // outputs; the shared, module-agnostic fee quote runs the primary-module
         // balancing (note consolidation + minting change) over the real
@@ -1919,7 +1941,6 @@ impl MintClientModule {
                 },
             )
             .await
-            .map_err(anyhow::Error::from)
     }
 
     /// Computes the fee a `send_oob_notes(amount)` would incur given the
@@ -1935,7 +1956,7 @@ impl MintClientModule {
     /// via the shared, module-agnostic fee quote over the real inventory. The
     /// quote is point-in-time: it depends on the current inventory and can move
     /// as notes change.
-    pub async fn send_fee_quote(&self, amount: Amount) -> anyhow::Result<FeeQuote> {
+    pub async fn send_fee_quote(&self, amount: Amount) -> Result<FeeQuote, TransactionSubmitError> {
         let amount = self.cfg.fee_consensus.round_up(amount);
 
         let mut dbtx = self.client_ctx.module_db().begin_transaction_nc().await;
@@ -1981,18 +2002,28 @@ impl MintClientModule {
                 },
             )
             .await
-            .map_err(anyhow::Error::from)
     }
 
     /// Try to reissue e-cash notes received from a third party to receive them
     /// in our wallet. The progress and outcome can be observed using
     /// [`MintClientModule::subscribe_reissue_external_notes`].
-    /// Can return error of type [`ReissueExternalNotesError`]
+    ///
+    /// ## Errors
+    ///
+    /// - [`ReissueExternalNotesError::ZeroAmount`] if the notes are worth
+    ///   nothing.
+    /// - [`ReissueExternalNotesError::WrongFederationId`] if the notes were
+    ///   issued by a different federation.
+    /// - [`ReissueExternalNotesError::AlreadyReissued`] if these exact notes
+    ///   were already reissued.
+    /// - [`ReissueExternalNotesError::Notes`] if the notes cannot be validated.
+    /// - [`ReissueExternalNotesError::Transaction`] if the reissue transaction
+    ///   could not be built or submitted.
     pub async fn reissue_external_notes<M: Serialize + Send>(
         &self,
         oob_notes: OOBNotes,
         extra_meta: M,
-    ) -> anyhow::Result<OperationId> {
+    ) -> Result<OperationId, ReissueExternalNotesError> {
         let notes = oob_notes.notes().clone();
         let federation_id_prefix = oob_notes.federation_id_prefix();
 
@@ -2005,13 +2036,12 @@ impl MintClientModule {
             "Reissuing external notes"
         );
 
-        ensure!(
-            notes.total_amount() > Amount::ZERO,
-            "Reissuing zero-amount e-cash isn't supported"
-        );
+        if notes.total_amount() == Amount::ZERO {
+            return Err(ReissueExternalNotesError::ZeroAmount);
+        }
 
         if federation_id_prefix != self.federation_id.to_prefix() {
-            bail!(ReissueExternalNotesError::WrongFederationId);
+            return Err(ReissueExternalNotesError::WrongFederationId);
         }
 
         let operation_id = OperationId(
@@ -2051,7 +2081,12 @@ impl MintClientModule {
                 tx,
             )
             .await
-            .context(ReissueExternalNotesError::AlreadyReissued)?;
+            .map_err(|error| match error {
+                TransactionSubmitError::OperationAlreadyExists(_) => {
+                    ReissueExternalNotesError::AlreadyReissued
+                }
+                error => ReissueExternalNotesError::Transaction(error),
+            })?;
 
         let mut dbtx = self.client_ctx.module_db().begin_transaction().await;
 

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -16,6 +16,8 @@ pub mod backup;
 mod cli;
 /// Database keys used throughout the mint client module
 pub mod client_db;
+/// Error types of the mint client
+pub mod error;
 /// FFI for the mint client module
 #[cfg(feature = "uniffi")]
 pub mod ffi;
@@ -25,9 +27,6 @@ mod input;
 mod oob;
 /// State machines for mint outputs
 pub mod output;
-
-/// Error types of the mint client
-pub mod error;
 
 pub mod events;
 
@@ -1772,12 +1771,15 @@ impl MintClientModule {
         Ok((operation_id, state_machines, selected_notes))
     }
 
-    async fn is_no_timeout_oob_spend(&self, operation_id: OperationId) -> anyhow::Result<bool> {
+    async fn is_no_timeout_oob_spend(
+        &self,
+        operation_id: OperationId,
+    ) -> Result<bool, SubscribeSpendNotesError> {
         let operation = self.mint_operation(operation_id).await?;
         let MintOperationMetaVariant::SpendOOB { no_timeout, .. } =
             operation.meta::<MintOperationMeta>().variant
         else {
-            bail!("Operation is not a out-of-band spend");
+            return Err(SubscribeSpendNotesError::NotAnOutOfBandSpend);
         };
 
         Ok(no_timeout)
@@ -3486,7 +3488,7 @@ mod tests {
         assert_eq!(error.total_amount, Amount::from_sats(10));
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn selecting_an_unrepresentable_exact_amount_reports_what_was_selected() {
         let notes = reverse_sorted_note_stream(vec![(Amount::from_msats(4), 1)]);
 

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -60,7 +60,7 @@ use client_db::{
 use events::{NoteSpent, OOBNotesReissued, OOBNotesSpent, ReceivePaymentEvent, SendPaymentEvent};
 use fedimint_api_client::api::DynModuleApi;
 use fedimint_client_module::db::{ClientModuleMigrationFn, migrate_state};
-use fedimint_client_module::error::TransactionSubmitError;
+use fedimint_client_module::error::{OperationLookupError, TransactionSubmitError};
 use fedimint_client_module::module::init::{
     ClientModuleInit, ClientModuleInitArgs, ClientModuleRecoverArgs, RecoveryMode,
 };
@@ -121,7 +121,8 @@ use crate::client_db::{
 };
 pub use crate::error::{
     AwaitOutputFinalizedError, OOBNotesParseError, SelectNotesError, SendOOBNotesError,
-    SpendOOBError, ValidateNotesError,
+    SpendOOBError, SubscribeReissueExternalNotesError, SubscribeSpendNotesError,
+    ValidateNotesError,
 };
 use crate::input::{MintInputCommon, MintInputStateMachine, MintInputStates};
 use crate::oob::{MintOOBStateMachine, MintOOBStates, MintOOBStatesCreatedMulti};
@@ -539,6 +540,10 @@ pub enum ReissueExternalNotesState {
     /// Some error happened and the operation failed.
     Failed(String),
 }
+
+/// The result of [`MintClientModule::subscribe_reissue_external_notes`].
+pub type SubscribeReissueExternalNotesResult =
+    Result<UpdateStreamOrOutcome<ReissueExternalNotesState>, SubscribeReissueExternalNotesError>;
 
 /// The high-level state of a raw e-cash spend operation started with
 /// [`MintClientModule::spend_notes_with_selector`].
@@ -2121,7 +2126,7 @@ impl MintClientModule {
     pub async fn subscribe_reissue_external_notes(
         &self,
         operation_id: OperationId,
-    ) -> anyhow::Result<UpdateStreamOrOutcome<ReissueExternalNotesState>> {
+    ) -> SubscribeReissueExternalNotesResult {
         let operation = self.mint_operation(operation_id).await?;
         let (txid, out_points) = match operation.meta::<MintOperationMeta>().variant {
             MintOperationMetaVariant::Reissuance {
@@ -2133,7 +2138,7 @@ impl MintClientModule {
                 // have a source for the txid
                 let txid = txid
                     .or(legacy_out_point.map(|out_point| out_point.txid))
-                    .context("Empty reissuance not permitted, this should never happen")?;
+                    .ok_or(SubscribeReissueExternalNotesError::NoTransaction)?;
 
                 let out_points = out_point_indices
                     .into_iter()
@@ -2143,7 +2148,9 @@ impl MintClientModule {
 
                 (txid, out_points)
             }
-            MintOperationMetaVariant::SpendOOB { .. } => bail!("Operation is not a reissuance"),
+            MintOperationMetaVariant::SpendOOB { .. } => {
+                return Err(SubscribeReissueExternalNotesError::NotAReissuance);
+            }
         };
 
         let client_ctx = self.client_ctx.clone();
@@ -2627,12 +2634,12 @@ impl MintClientModule {
     pub async fn subscribe_spend_notes(
         &self,
         operation_id: OperationId,
-    ) -> anyhow::Result<UpdateStreamOrOutcome<SpendOOBState>> {
+    ) -> Result<UpdateStreamOrOutcome<SpendOOBState>, SubscribeSpendNotesError> {
         let operation = self.mint_operation(operation_id).await?;
         let MintOperationMetaVariant::SpendOOB { no_timeout, .. } =
             operation.meta::<MintOperationMeta>().variant
         else {
-            bail!("Operation is not a out-of-band spend");
+            return Err(SubscribeSpendNotesError::NotAnOutOfBandSpend);
         };
 
         let client_ctx = self.client_ctx.clone();
@@ -2710,14 +2717,11 @@ impl MintClientModule {
         ))
     }
 
-    async fn mint_operation(&self, operation_id: OperationId) -> anyhow::Result<OperationLogEntry> {
-        let operation = self.client_ctx.get_operation(operation_id).await?;
-
-        if operation.operation_module_kind() != MintCommonInit::KIND.as_str() {
-            bail!("Operation is not a mint operation");
-        }
-
-        Ok(operation)
+    async fn mint_operation(
+        &self,
+        operation_id: OperationId,
+    ) -> Result<OperationLogEntry, OperationLookupError> {
+        self.client_ctx.get_operation(operation_id).await
     }
 
     async fn delete_spendable_note(

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -118,7 +118,7 @@ use crate::client_db::{
     CancelledOOBSpendKey, CancelledOOBSpendKeyPrefix, NextECashNoteIndexKey,
     NextECashNoteIndexKeyPrefix, NoteKey,
 };
-pub use crate::error::ValidateNotesError;
+pub use crate::error::{OOBNotesParseError, ValidateNotesError};
 use crate::input::{MintInputCommon, MintInputStateMachine, MintInputStates};
 use crate::oob::{MintOOBStateMachine, MintOOBStates, MintOOBStatesCreatedMulti};
 use crate::output::{
@@ -225,7 +225,7 @@ pub struct OOBNotes(Vec<OOBNotesPart>);
 #[cfg(feature = "uniffi")]
 uniffi::custom_type!(OOBNotes, String, {
     lower: |n| n.to_string(),
-    try_lift: |s| OOBNotes::from_str(&s),
+    try_lift: |s| Ok(OOBNotes::from_str(&s)?),
 });
 
 /// For extendability [`OOBNotes`] consists of parts, where client can ignore
@@ -456,7 +456,7 @@ const BASE64_URL_SAFE: base64::engine::GeneralPurpose = base64::engine::GeneralP
 );
 
 impl FromStr for OOBNotes {
-    type Err = anyhow::Error;
+    type Err = OOBNotesParseError;
 
     /// Decode a set of out-of-band e-cash notes from a base64 or base32 string.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -471,13 +471,15 @@ impl FromStr for OOBNotes {
         } else if let Ok(oob_notes_bytes) = base64::engine::general_purpose::STANDARD.decode(&s) {
             oob_notes_bytes
         } else {
-            bail!("OOBNotes were not a well-formed base64(URL-safe) or base32 string");
+            return Err(OOBNotesParseError::Encoding);
         };
 
         let oob_notes =
             OOBNotes::consensus_decode_whole(&oob_notes_bytes, &ModuleDecoderRegistry::default())?;
 
-        ensure!(!oob_notes.notes().is_empty(), "OOBNotes cannot be empty");
+        if oob_notes.notes().is_empty() {
+            return Err(OOBNotesParseError::Empty);
+        }
 
         Ok(oob_notes)
     }
@@ -3271,10 +3273,11 @@ mod tests {
     use std::fmt::Display;
     use std::str::FromStr;
 
+    use assert_matches::assert_matches;
     use bitcoin_hashes::Hash;
     use fedimint_core::base32::FEDIMINT_PREFIX;
     use fedimint_core::config::FederationId;
-    use fedimint_core::encoding::Decodable;
+    use fedimint_core::encoding::{Decodable, DecodeError};
     use fedimint_core::invite_code::InviteCode;
     use fedimint_core::module::registry::ModuleRegistry;
     use fedimint_core::{
@@ -3284,6 +3287,7 @@ mod tests {
     use itertools::Itertools;
     use serde_json::json;
 
+    use crate::error::OOBNotesParseError;
     use crate::{
         MintOperationMetaVariant, OOBNotes, OOBNotesPart, SpendableNote, SpendableNoteUndecoded,
         represent_amount, select_notes_from_stream,
@@ -3641,6 +3645,24 @@ mod tests {
                 oob_notes,
                 no_timeout: false,
             }
+        );
+    }
+
+    #[test]
+    fn parsing_a_non_encoded_string_names_the_encoding() {
+        let err = OOBNotes::from_str("not base32 or base64 $$$")
+            .expect_err("A string that is neither base32 nor base64 cannot be notes");
+
+        assert_matches!(err, OOBNotesParseError::Encoding);
+    }
+
+    #[test]
+    fn the_parse_error_prints_its_cause_because_clap_only_shows_display() {
+        let err = OOBNotesParseError::Decode(DecodeError::from_str("no notes here"));
+
+        assert!(
+            err.to_string().contains("no notes here"),
+            "clap and serde print only Display, so the cause has to be in the message"
         );
     }
 }

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -92,7 +92,7 @@ use fedimint_core::module::{
 use fedimint_core::secp256k1::rand::prelude::IteratorRandom;
 use fedimint_core::secp256k1::rand::thread_rng;
 use fedimint_core::secp256k1::{All, Keypair, Secp256k1};
-use fedimint_core::util::{BoxFuture, BoxStream, NextOrPending, SafeUrl};
+use fedimint_core::util::{BoxFuture, BoxStream, FmtCompact as _, NextOrPending, SafeUrl};
 use fedimint_core::{
     Amount, IdxRange, OutPoint, PeerId, Tiered, TieredCounts, TieredMulti, TransactionId, apply,
     async_trait_maybe_send, base32, push_db_pair_items,
@@ -119,7 +119,10 @@ use crate::client_db::{
     CancelledOOBSpendKey, CancelledOOBSpendKeyPrefix, NextECashNoteIndexKey,
     NextECashNoteIndexKeyPrefix, NoteKey,
 };
-pub use crate::error::{OOBNotesParseError, SelectNotesError, SpendOOBError, ValidateNotesError};
+pub use crate::error::{
+    AwaitOutputFinalizedError, OOBNotesParseError, SelectNotesError, SendOOBNotesError,
+    SpendOOBError, ValidateNotesError,
+};
 use crate::input::{MintInputCommon, MintInputStateMachine, MintInputStates};
 use crate::oob::{MintOOBStateMachine, MintOOBStates, MintOOBStatesCreatedMulti};
 use crate::output::{
@@ -1127,7 +1130,8 @@ impl ClientModule for MintClientModule {
         operation_id: OperationId,
         out_point: OutPoint,
     ) -> anyhow::Result<()> {
-        self.await_output_finalized(operation_id, out_point).await
+        self.await_output_finalized(operation_id, out_point).await?;
+        Ok(())
     }
 
     async fn get_balance(&self, dbtx: &mut DatabaseTransaction<'_>, unit: AmountUnit) -> Amount {
@@ -1567,7 +1571,7 @@ impl MintClientModule {
         &self,
         operation_id: OperationId,
         out_point: OutPoint,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), AwaitOutputFinalizedError> {
         let stream = self
             .notifier
             .subscribe(operation_id)
@@ -1589,11 +1593,14 @@ impl MintClientModule {
 
                 match state.state {
                     MintOutputStates::Succeeded(_) => Some(Ok(())),
-                    MintOutputStates::Aborted(_) => Some(Err(anyhow!("Transaction was rejected"))),
-                    MintOutputStates::Failed(failed) => Some(Err(anyhow!(
-                        "Failed to finalize transaction: {}",
-                        failed.error
-                    ))),
+                    MintOutputStates::Aborted(_) => {
+                        Some(Err(AwaitOutputFinalizedError::TransactionRejected))
+                    }
+                    MintOutputStates::Failed(failed) => {
+                        Some(Err(AwaitOutputFinalizedError::Failed {
+                            reason: failed.error,
+                        }))
+                    }
                     MintOutputStates::Created(_) | MintOutputStates::CreatedMulti(_) => None,
                 }
             });
@@ -2169,7 +2176,7 @@ impl MintClientModule {
 
                 for out_point in out_points {
                     if let Err(e) = client_ctx.self_ref().await_output_finalized(operation_id, out_point).await {
-                        yield ReissueExternalNotesState::Failed(e.to_string());
+                        yield ReissueExternalNotesState::Failed(e.fmt_compact().to_string());
                         return;
                     }
                 }
@@ -2353,7 +2360,7 @@ impl MintClientModule {
         &self,
         amount: Amount,
         extra_meta: M,
-    ) -> anyhow::Result<OOBNotes> {
+    ) -> Result<OOBNotes, SendOOBNotesError> {
         let amount = self.cfg.fee_consensus.round_up(amount);
 
         let extra_meta = serde_json::to_value(extra_meta)
@@ -2367,32 +2374,33 @@ impl MintClientModule {
                 |dbtx, _| {
                     let extra_meta = extra_meta.clone();
                     Box::pin(async {
-                        self.try_spend_exact_notes_dbtx(
-                            dbtx,
-                            amount,
-                            self.federation_id,
-                            extra_meta,
+                        Ok::<Option<OOBNotes>, SendOOBNotesError>(
+                            self.try_spend_exact_notes_dbtx(
+                                dbtx,
+                                amount,
+                                self.federation_id,
+                                extra_meta,
+                            )
+                            .await,
                         )
-                        .await
-                        .map(Ok::<OOBNotes, anyhow::Error>)
-                        .transpose()
                     })
                 },
                 Some(100),
             )
             .await
-            .expect("Failed to commit dbtx after 100 retries");
+            .map_err(|e| match e {
+                AutocommitError::ClosureError { error, .. } => error,
+                AutocommitError::CommitFailed { last_error, .. } => {
+                    SendOOBNotesError::Database(last_error)
+                }
+            })?;
 
         if let Some(oob_notes) = oob_notes {
             return Ok(oob_notes);
         }
 
         // Verify we're online
-        self.client_ctx
-            .global_api()
-            .session_count()
-            .await
-            .context("Cannot reach federation to reissue notes")?;
+        self.client_ctx.global_api().session_count().await?;
 
         let operation_id = OperationId::new_random();
 
@@ -2408,7 +2416,7 @@ impl MintClientModule {
             .autocommit(
                 |dbtx, _| {
                     Box::pin(async {
-                        Ok::<_, anyhow::Error>(
+                        Ok::<_, SendOOBNotesError>(
                             self.create_exact_output(dbtx, operation_id, amount).await,
                         )
                     })
@@ -2416,7 +2424,12 @@ impl MintClientModule {
                 Some(100),
             )
             .await
-            .expect("Failed to commit output creation after 100 retries");
+            .map_err(|e| match e {
+                AutocommitError::ClosureError { error, .. } => error,
+                AutocommitError::CommitFailed { last_error, .. } => {
+                    SendOOBNotesError::Database(last_error)
+                }
+            })?;
 
         // The explicit outputs we just minted (worth exactly `amount`) occupy the
         // first `explicit_output_count` out points of the transaction; the
@@ -2455,8 +2468,7 @@ impl MintClientModule {
                 },
                 TransactionBuilder::new().with_outputs(outputs),
             )
-            .await
-            .context("Failed to submit reissuance transaction")?;
+            .await?;
 
         // Wait for *all* of the transaction's outputs to be finalized — both the
         // change (returned in `out_point_range`) and the explicit exact-amount
@@ -2469,8 +2481,7 @@ impl MintClientModule {
         let all_outputs = OutPointRange::new(txid, IdxRange::from(0..total_output_count));
         self.client_ctx
             .await_primary_module_outputs(operation_id, all_outputs.into_iter().collect())
-            .await
-            .context("Failed to await output finalization")?;
+            .await?;
 
         // Recursively call send_oob_notes to try again with the reissued notes
         Box::pin(self.send_oob_notes(amount, extra_meta)).await
@@ -3324,7 +3335,7 @@ mod tests {
     use itertools::Itertools;
     use serde_json::json;
 
-    use crate::error::{OOBNotesParseError, SelectNotesError};
+    use crate::error::{AwaitOutputFinalizedError, OOBNotesParseError, SelectNotesError};
     use crate::{
         MintOperationMetaVariant, NotesSelector, OOBNotes, OOBNotesPart,
         SelectNotesWithExactAmount, SpendableNote, SpendableNoteUndecoded, represent_amount,
@@ -3717,6 +3728,20 @@ mod tests {
         assert!(
             err.to_string().contains("no notes here"),
             "clap and serde print only Display, so the cause has to be in the message"
+        );
+    }
+
+    #[test]
+    fn a_finalization_failure_carries_the_state_machines_reason() {
+        use fedimint_core::util::FmtCompact as _;
+
+        let err = AwaitOutputFinalizedError::Failed {
+            reason: "guardian refused the blind signature".to_owned(),
+        };
+
+        assert!(
+            err.fmt_compact().to_string().contains("guardian refused"),
+            "the reason the state machine recorded has to survive into the Failed state"
         );
     }
 }

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -123,6 +123,7 @@ pub use crate::error::{
     AwaitOutputFinalizedError, FetchRecoverySliceError, OOBNotesParseError,
     PrepareEcashBackupError, RepairWalletError, SelectNotesError, SendOOBNotesError, SpendOOBError,
     SubscribeReissueExternalNotesError, SubscribeSpendNotesError, ValidateNotesError,
+    VerifyBlindShareError,
 };
 use crate::input::{MintInputCommon, MintInputStateMachine, MintInputStates};
 use crate::oob::{MintOOBStateMachine, MintOOBStates, MintOOBStatesCreatedMulti};
@@ -3744,5 +3745,37 @@ mod tests {
             err.fmt_compact().to_string().contains("guardian refused"),
             "the reason the state machine recorded has to survive into the Failed state"
         );
+    }
+
+    #[test]
+    fn a_share_from_a_peer_we_have_no_key_for_names_the_peer() {
+        use std::collections::BTreeMap;
+
+        use bls12_381::G1Affine;
+        use fedimint_api_client::api::SerdeOutputOutcome;
+        use fedimint_core::core::DynOutputOutcome;
+        use fedimint_core::module::CommonModuleInit;
+        use fedimint_mint_common::{MintCommonInit, MintOutputOutcome};
+        use tbs::{BlindedMessage, BlindedSignatureShare};
+
+        use crate::error::VerifyBlindShareError;
+        use crate::output::verify_blind_share;
+
+        let peer = PeerId::from(7);
+        let decoder = MintCommonInit::decoder();
+        let outcome = MintOutputOutcome::new_v0(BlindedSignatureShare(G1Affine::identity()));
+        let serde_outcome = SerdeOutputOutcome::from(&DynOutputOutcome::from_typed(0, outcome));
+
+        let err = verify_blind_share(
+            peer,
+            &serde_outcome,
+            Amount::from_sats(1),
+            BlindedMessage(G1Affine::identity()),
+            &decoder,
+            &BTreeMap::new(),
+        )
+        .expect_err("no peer keys are known, so no key can be found for the peer");
+
+        assert_matches!(err, VerifyBlindShareError::UnknownPeer { peer: p } if p == peer);
     }
 }

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -58,7 +58,7 @@ use client_db::{
     ReusedNoteIndices, migrate_state_to_v2, migrate_to_v1,
 };
 use events::{NoteSpent, OOBNotesReissued, OOBNotesSpent, ReceivePaymentEvent, SendPaymentEvent};
-use fedimint_api_client::api::DynModuleApi;
+use fedimint_api_client::api::{DynModuleApi, FederationResult};
 use fedimint_client_module::db::{ClientModuleMigrationFn, migrate_state};
 use fedimint_client_module::error::{OperationLookupError, TransactionSubmitError};
 use fedimint_client_module::module::init::{
@@ -120,9 +120,9 @@ use crate::client_db::{
     NextECashNoteIndexKeyPrefix, NoteKey,
 };
 pub use crate::error::{
-    AwaitOutputFinalizedError, FetchRecoverySliceError, OOBNotesParseError, SelectNotesError,
-    SendOOBNotesError, SpendOOBError, SubscribeReissueExternalNotesError, SubscribeSpendNotesError,
-    ValidateNotesError,
+    AwaitOutputFinalizedError, FetchRecoverySliceError, OOBNotesParseError,
+    PrepareEcashBackupError, RepairWalletError, SelectNotesError, SendOOBNotesError, SpendOOBError,
+    SubscribeReissueExternalNotesError, SubscribeSpendNotesError, ValidateNotesError,
 };
 use crate::input::{MintInputCommon, MintInputStateMachine, MintInputStates};
 use crate::oob::{MintOOBStateMachine, MintOOBStates, MintOOBStatesCreatedMulti};
@@ -1057,7 +1057,7 @@ impl ClientModule for MintClientModule {
             )
             .await
             .map_err(|e| match e {
-                AutocommitError::ClosureError { error, .. } => error,
+                AutocommitError::ClosureError { error, .. } => anyhow::Error::from(error),
                 AutocommitError::CommitFailed { last_error, .. } => {
                     anyhow!("Commit to DB failed: {last_error}")
                 }
@@ -2597,7 +2597,7 @@ impl MintClientModule {
     /// **Caution:** This reduces privacy and can lead to race conditions. **DO
     /// NOT** rely on it for receiving funds unless you really know what you are
     /// doing.
-    pub async fn check_note_spent(&self, oob_notes: &OOBNotes) -> anyhow::Result<bool> {
+    pub async fn check_note_spent(&self, oob_notes: &OOBNotes) -> FederationResult<bool> {
         use crate::api::MintFederationApi;
 
         let api_client = self.client_ctx.module_api();
@@ -2743,21 +2743,21 @@ impl MintClientModule {
         .expect("Must deleted existing spendable note");
     }
 
-    pub async fn advance_note_idx(&self, amount: Amount) -> anyhow::Result<DerivableSecret> {
+    pub async fn advance_note_idx(&self, amount: Amount) -> DerivableSecret {
         let db = self.client_ctx.module_db().clone();
 
-        Ok(db
-            .autocommit(
-                |dbtx, _| {
-                    Box::pin(async {
-                        Ok::<DerivableSecret, anyhow::Error>(
-                            self.new_note_secret(amount, dbtx).await,
-                        )
-                    })
-                },
-                None,
-            )
-            .await?)
+        db.autocommit(
+            |dbtx, _| {
+                Box::pin(async {
+                    Ok::<DerivableSecret, std::convert::Infallible>(
+                        self.new_note_secret(amount, dbtx).await,
+                    )
+                })
+            },
+            None,
+        )
+        .await
+        .expect("The commit is retried until it succeeds and the closure cannot fail")
     }
 
     /// Returns secrets for the note indices that were reused by previous

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -118,7 +118,7 @@ use crate::client_db::{
     CancelledOOBSpendKey, CancelledOOBSpendKeyPrefix, NextECashNoteIndexKey,
     NextECashNoteIndexKeyPrefix, NoteKey,
 };
-pub use crate::error::{OOBNotesParseError, ValidateNotesError};
+pub use crate::error::{OOBNotesParseError, SelectNotesError, ValidateNotesError};
 use crate::input::{MintInputCommon, MintInputStateMachine, MintInputStates};
 use crate::oob::{MintOOBStateMachine, MintOOBStates, MintOOBStatesCreatedMulti};
 use crate::output::{
@@ -1795,7 +1795,7 @@ impl MintClientModule {
         notes_selector: &impl NotesSelector,
         requested_amount: Amount,
         fee_consensus: FeeConsensus,
-    ) -> anyhow::Result<TieredMulti<SpendableNote>> {
+    ) -> Result<TieredMulti<SpendableNote>, SelectNotesError> {
         let note_stream = dbtx
             .find_by_prefix_sorted_descending(&NoteKeyPrefix)
             .await
@@ -1806,7 +1806,7 @@ impl MintClientModule {
             .await?
             .into_iter_items()
             .map(|(amt, snote)| Ok((amt, snote.decode()?)))
-            .collect::<anyhow::Result<TieredMulti<_>>>()
+            .collect::<Result<TieredMulti<_>, SelectNotesError>>()
     }
 
     async fn get_all_spendable_notes(
@@ -2764,7 +2764,7 @@ pub trait NotesSelector<Note = SpendableNoteUndecoded>: Send + Sync {
         #[cfg(target_family = "wasm")] stream: impl futures::Stream<Item = (Amount, Note)>,
         requested_amount: Amount,
         fee_consensus: FeeConsensus,
-    ) -> anyhow::Result<TieredMulti<Note>>;
+    ) -> Result<TieredMulti<Note>, SelectNotesError>;
 }
 
 /// Select notes with total amount of *at least* `request_amount`. If more than
@@ -2782,7 +2782,7 @@ impl<Note: Send> NotesSelector<Note> for SelectNotesWithAtleastAmount {
         #[cfg(target_family = "wasm")] stream: impl futures::Stream<Item = (Amount, Note)>,
         requested_amount: Amount,
         fee_consensus: FeeConsensus,
-    ) -> anyhow::Result<TieredMulti<Note>> {
+    ) -> Result<TieredMulti<Note>, SelectNotesError> {
         Ok(select_notes_from_stream(stream, requested_amount, fee_consensus).await?)
     }
 }
@@ -2800,15 +2800,15 @@ impl<Note: Send> NotesSelector<Note> for SelectNotesWithExactAmount {
         #[cfg(target_family = "wasm")] stream: impl futures::Stream<Item = (Amount, Note)>,
         requested_amount: Amount,
         fee_consensus: FeeConsensus,
-    ) -> anyhow::Result<TieredMulti<Note>> {
+    ) -> Result<TieredMulti<Note>, SelectNotesError> {
         let notes = select_notes_from_stream(stream, requested_amount, fee_consensus).await?;
 
-        if notes.total_amount() != requested_amount {
-            bail!(
-                "Could not select notes with exact amount. Requested amount: {}. Selected amount: {}",
-                requested_amount,
-                notes.total_amount()
-            );
+        let selected = notes.total_amount();
+        if selected != requested_amount {
+            return Err(SelectNotesError::NoExactAmount {
+                requested: requested_amount,
+                selected,
+            });
         }
 
         Ok(notes)
@@ -3287,10 +3287,11 @@ mod tests {
     use itertools::Itertools;
     use serde_json::json;
 
-    use crate::error::OOBNotesParseError;
+    use crate::error::{OOBNotesParseError, SelectNotesError};
     use crate::{
-        MintOperationMetaVariant, OOBNotes, OOBNotesPart, SpendableNote, SpendableNoteUndecoded,
-        represent_amount, select_notes_from_stream,
+        MintOperationMetaVariant, NotesSelector, OOBNotes, OOBNotesPart,
+        SelectNotesWithExactAmount, SpendableNote, SpendableNoteUndecoded, represent_amount,
+        select_notes_from_stream,
     };
 
     #[test]
@@ -3425,6 +3426,22 @@ mod tests {
             .await
             .unwrap_err();
         assert_eq!(error.total_amount, Amount::from_sats(10));
+    }
+
+    #[tokio::test]
+    async fn selecting_an_unrepresentable_exact_amount_reports_what_was_selected() {
+        let notes = reverse_sorted_note_stream(vec![(Amount::from_msats(4), 1)]);
+
+        let err = SelectNotesWithExactAmount
+            .select_notes(notes, Amount::from_msats(3), FeeConsensus::zero())
+            .await
+            .expect_err("Three msats cannot be made from a single four-msat note");
+
+        assert_matches!(
+            err,
+            SelectNotesError::NoExactAmount { requested, selected }
+                if requested == Amount::from_msats(3) && selected == Amount::from_msats(4)
+        );
     }
 
     fn reverse_sorted_note_stream(

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -120,8 +120,8 @@ use crate::client_db::{
     NextECashNoteIndexKeyPrefix, NoteKey,
 };
 pub use crate::error::{
-    AwaitOutputFinalizedError, OOBNotesParseError, SelectNotesError, SendOOBNotesError,
-    SpendOOBError, SubscribeReissueExternalNotesError, SubscribeSpendNotesError,
+    AwaitOutputFinalizedError, FetchRecoverySliceError, OOBNotesParseError, SelectNotesError,
+    SendOOBNotesError, SpendOOBError, SubscribeReissueExternalNotesError, SubscribeSpendNotesError,
     ValidateNotesError,
 };
 use crate::input::{MintInputCommon, MintInputStateMachine, MintInputStates};
@@ -192,12 +192,9 @@ async fn download_slice_with_hash(
         let peer = peer_selector.choose_peer();
         let start_time = fedimint_core::time::now();
 
-        match tokio::time::timeout(TIMEOUT, module_api.fetch_recovery_slice(peer, start, end))
-            .await
-            .map_err(Into::into)
-            .and_then(|r| r)
+        match tokio::time::timeout(TIMEOUT, module_api.fetch_recovery_slice(peer, start, end)).await
         {
-            Ok(data) => {
+            Ok(Ok(data)) => {
                 let elapsed = fedimint_core::time::now()
                     .duration_since(start_time)
                     .unwrap_or(Duration::ZERO);
@@ -210,7 +207,7 @@ async fn download_slice_with_hash(
 
                 peer_selector.remove(peer);
             }
-            Err(..) => {
+            Ok(Err(..)) | Err(..) => {
                 peer_selector.report(peer, TIMEOUT);
             }
         }

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -1308,8 +1308,13 @@ pub enum ReissueExternalNotesError {
     ZeroAmount,
 
     /// The notes were issued by a different federation.
-    #[error("Federation ID does not match")]
-    WrongFederationId,
+    #[error("The notes were issued by federation {found}, not {expected}")]
+    WrongFederationId {
+        /// The federation this client belongs to.
+        expected: FederationIdPrefix,
+        /// The federation the notes name.
+        found: FederationIdPrefix,
+    },
 
     /// An operation for these exact notes already exists, so they were already
     /// handed to this federation.
@@ -2051,7 +2056,10 @@ impl MintClientModule {
         }
 
         if federation_id_prefix != self.federation_id.to_prefix() {
-            return Err(ReissueExternalNotesError::WrongFederationId);
+            return Err(ReissueExternalNotesError::WrongFederationId {
+                expected: self.federation_id.to_prefix(),
+                found: federation_id_prefix,
+            });
         }
 
         let operation_id = OperationId(

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -118,7 +118,7 @@ use crate::client_db::{
     CancelledOOBSpendKey, CancelledOOBSpendKeyPrefix, NextECashNoteIndexKey,
     NextECashNoteIndexKeyPrefix, NoteKey,
 };
-pub use crate::error::{OOBNotesParseError, SelectNotesError, ValidateNotesError};
+pub use crate::error::{OOBNotesParseError, SelectNotesError, SpendOOBError, ValidateNotesError};
 use crate::input::{MintInputCommon, MintInputStateMachine, MintInputStates};
 use crate::oob::{MintOOBStateMachine, MintOOBStates, MintOOBStatesCreatedMulti};
 use crate::output::{
@@ -1697,15 +1697,17 @@ impl MintClientModule {
         notes_selector: &impl NotesSelector,
         amount: Amount,
         try_cancel_after: Option<Duration>,
-    ) -> anyhow::Result<(
-        OperationId,
-        Vec<MintClientStateMachines>,
-        TieredMulti<SpendableNote>,
-    )> {
-        ensure!(
-            amount > Amount::ZERO,
-            "zero-amount out-of-band spends are not supported"
-        );
+    ) -> Result<
+        (
+            OperationId,
+            Vec<MintClientStateMachines>,
+            TieredMulti<SpendableNote>,
+        ),
+        SpendOOBError,
+    > {
+        if amount == Amount::ZERO {
+            return Err(SpendOOBError::ZeroAmount);
+        }
 
         let selected_notes =
             Self::select_notes(dbtx, notes_selector, amount, FeeConsensus::zero()).await?;
@@ -2163,7 +2165,7 @@ impl MintClientModule {
         try_cancel_after: Option<Duration>,
         include_invite: bool,
         extra_meta: M,
-    ) -> anyhow::Result<(OperationId, OOBNotes)> {
+    ) -> Result<(OperationId, OOBNotes), SpendOOBError> {
         self.spend_notes_with_selector(
             &SelectNotesWithAtleastAmount,
             min_amount,
@@ -2197,7 +2199,7 @@ impl MintClientModule {
         try_cancel_after: Option<Duration>,
         include_invite: bool,
         extra_meta: M,
-    ) -> anyhow::Result<(OperationId, OOBNotes)> {
+    ) -> Result<(OperationId, OOBNotes), SpendOOBError> {
         let federation_id_prefix = self.federation_id.to_prefix();
         let extra_meta = serde_json::to_value(extra_meta)
             .expect("MintClientModule::spend_notes extra_meta is serializable");
@@ -2272,7 +2274,7 @@ impl MintClientModule {
                             )
                             .await;
 
-                        Ok((operation_id, oob_notes))
+                        Ok::<_, SpendOOBError>((operation_id, oob_notes))
                     })
                 },
                 Some(100),
@@ -2281,7 +2283,7 @@ impl MintClientModule {
             .map_err(|e| match e {
                 AutocommitError::ClosureError { error, .. } => error,
                 AutocommitError::CommitFailed { last_error, .. } => {
-                    anyhow!("Commit to DB failed: {last_error}")
+                    SpendOOBError::Database(last_error)
                 }
             })
     }

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -26,6 +26,9 @@ mod oob;
 /// State machines for mint outputs
 pub mod output;
 
+/// Error types of the mint client
+pub mod error;
+
 pub mod events;
 
 /// API client impl for mint-specific requests
@@ -115,6 +118,7 @@ use crate::client_db::{
     CancelledOOBSpendKey, CancelledOOBSpendKeyPrefix, NextECashNoteIndexKey,
     NextECashNoteIndexKeyPrefix, NoteKey,
 };
+pub use crate::error::ValidateNotesError;
 use crate::input::{MintInputCommon, MintInputStateMachine, MintInputStates};
 use crate::oob::{MintOOBStateMachine, MintOOBStates, MintOOBStatesCreatedMulti};
 use crate::output::{
@@ -1586,7 +1590,7 @@ impl MintClientModule {
     pub async fn consolidate_notes(
         &self,
         dbtx: &mut DatabaseTransaction<'_>,
-    ) -> anyhow::Result<Vec<(ClientInput<MintInput>, SpendableNote)>> {
+    ) -> Result<Vec<(ClientInput<MintInput>, SpendableNote)>, ValidateNotesError> {
         /// At how many notes of the same denomination should we try to
         /// consolidate
         const MAX_NOTES_PER_TIER_TRIGGER: usize = 8;
@@ -1656,20 +1660,20 @@ impl MintClientModule {
     pub fn create_input_from_notes(
         &self,
         notes: TieredMulti<SpendableNote>,
-    ) -> anyhow::Result<Vec<(ClientInput<MintInput>, SpendableNote)>> {
+    ) -> Result<Vec<(ClientInput<MintInput>, SpendableNote)>, ValidateNotesError> {
         let mut inputs_and_notes = Vec::new();
 
-        for (amount, spendable_note) in notes.into_iter_items() {
+        for (index, (amount, spendable_note)) in notes.into_iter_items().enumerate() {
             let key = self
                 .cfg
                 .tbs_pks
                 .get(amount)
-                .ok_or(anyhow!("Invalid amount tier: {amount}"))?;
+                .ok_or(ValidateNotesError::InvalidAmountTier { index, amount })?;
 
             let note = spendable_note.note();
 
             if !note.verify(*key) {
-                bail!("Invalid note");
+                return Err(ValidateNotesError::InvalidSignature { index });
             }
 
             inputs_and_notes.push((
@@ -2501,29 +2505,33 @@ impl MintClientModule {
     /// - the federation ID is correct
     /// - the note has a valid signature
     /// - the spend key is correct.
-    pub fn validate_notes(&self, oob_notes: &OOBNotes) -> anyhow::Result<Amount> {
+    pub fn validate_notes(&self, oob_notes: &OOBNotes) -> Result<Amount, ValidateNotesError> {
         let federation_id_prefix = oob_notes.federation_id_prefix();
         let notes = oob_notes.notes().clone();
 
-        if federation_id_prefix != self.federation_id.to_prefix() {
-            bail!("Federation ID does not match");
+        let expected = self.federation_id.to_prefix();
+        if federation_id_prefix != expected {
+            return Err(ValidateNotesError::WrongFederationId {
+                expected,
+                found: federation_id_prefix,
+            });
         }
 
         let tbs_pks = &self.cfg.tbs_pks;
 
-        for (idx, (amt, snote)) in notes.iter_items().enumerate() {
+        for (index, (amt, snote)) in notes.iter_items().enumerate() {
             let key = tbs_pks
                 .get(amt)
-                .ok_or_else(|| anyhow!("Note {idx} uses an invalid amount tier {amt}"))?;
+                .ok_or(ValidateNotesError::InvalidAmountTier { index, amount: amt })?;
 
             let note = snote.note();
             if !note.verify(*key) {
-                bail!("Note {idx} has an invalid federation signature");
+                return Err(ValidateNotesError::InvalidSignature { index });
             }
 
             let expected_nonce = Nonce(snote.spend_key.public_key());
             if note.nonce != expected_nonce {
-                bail!("Note {idx} cannot be spent using the supplied spend key");
+                return Err(ValidateNotesError::WrongSpendKey { index });
             }
         }
 
@@ -3093,7 +3101,7 @@ impl SpendableNoteUndecoded {
         Nonce(self.spend_key.public_key())
     }
 
-    pub fn decode(self) -> anyhow::Result<SpendableNote> {
+    pub fn decode(self) -> Result<SpendableNote, DecodeError> {
         Ok(SpendableNote {
             signature: Decodable::consensus_decode_partial_from_finite_reader(
                 &mut self.signature.as_slice(),

--- a/modules/fedimint-mint-client/src/output.rs
+++ b/modules/fedimint-mint-client/src/output.rs
@@ -2,7 +2,6 @@ use std::collections::BTreeMap;
 use std::hash;
 use std::time::Duration;
 
-use anyhow::{anyhow, bail};
 use assert_matches::assert_matches;
 use fedimint_api_client::api::{
     FederationApiExt, SerdeOutputOutcome, ServerError,
@@ -18,7 +17,7 @@ use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::endpoint_constants::AWAIT_OUTPUTS_OUTCOMES_ENDPOINT;
 use fedimint_core::module::ApiRequestErased;
 use fedimint_core::secp256k1::{Keypair, Secp256k1, Signing};
-use fedimint_core::util::FmtCompactAnyhow as _;
+use fedimint_core::util::FmtCompact as _;
 use fedimint_core::{Amount, NumPeersExt, OutPoint, PeerId, Tiered, TransactionId, crit};
 use fedimint_derive_secret::{ChildId, DerivableSecret};
 use fedimint_logging::LOG_CLIENT_MODULE_MINT;
@@ -34,6 +33,7 @@ use tbs::{
 use tracing::{debug, warn};
 
 use crate::client_db::NoteKey;
+use crate::error::VerifyBlindShareError;
 use crate::events::{NoteCreated, ReceivePaymentStatus, ReceivePaymentUpdateEvent};
 use crate::{MintClientContext, MintClientModule, SpendableNote};
 
@@ -344,9 +344,7 @@ impl MintOutputStatesCreated {
                             &module_decoder,
                             &tbs_pks,
                         )
-                        .map_err(|err| {
-                            ServerError::InvalidResponse(err.fmt_compact_anyhow().to_string())
-                        })
+                        .map_err(|err| ServerError::InvalidResponse(err.fmt_compact().to_string()))
                     },
                     global_context.api().all_peers().to_num_peers(),
                 ),
@@ -621,12 +619,12 @@ impl MintOutputStatesCreatedMulti {
                                         tracing::warn!(
                                             target: LOG_CLIENT_MODULE_MINT,
                                             %peer,
-                                            err = %err.fmt_compact_anyhow(),
+                                            err = %err.fmt_compact(),
                                             out_point = %OutPoint { txid: common.txid(), out_idx},
                                             "Invalid signature share from peer"
                                         );
                                         return Err(ServerError::InvalidResponse(
-                                            err.fmt_compact_anyhow().to_string(),
+                                            err.fmt_compact().to_string(),
                                         ));
                                     }
                                 }
@@ -698,7 +696,7 @@ impl MintOutputStatesCreatedMulti {
                                 &tbs_pks,
                             )
                             .map_err(|err| {
-                                ServerError::InvalidResponse(err.fmt_compact_anyhow().to_string())
+                                ServerError::InvalidResponse(err.fmt_compact().to_string())
                             })
                         },
                         api.all_peers().to_num_peers(),
@@ -737,7 +735,7 @@ impl MintOutputStatesCreatedMulti {
                                         )
                                         .map_err(|err| {
                                             ServerError::InvalidResponse(
-                                                err.fmt_compact_anyhow().to_string(),
+                                                err.fmt_compact().to_string(),
                                             )
                                         })
                                     },
@@ -863,7 +861,7 @@ pub fn verify_blind_share(
     blinded_message: BlindedMessage,
     decoder: &Decoder,
     peer_tbs_pks: &BTreeMap<PeerId, Tiered<PublicKeyShare>>,
-) -> anyhow::Result<BlindedSignatureShare> {
+) -> Result<BlindedSignatureShare, VerifyBlindShareError> {
     let outcome = deserialize_outcome::<MintOutputOutcome>(outcome, decoder)?;
 
     let blinded_signature_share = outcome
@@ -873,12 +871,12 @@ pub fn verify_blind_share(
 
     let amount_key = peer_tbs_pks
         .get(&peer)
-        .ok_or(anyhow!("Unknown peer"))?
+        .ok_or(VerifyBlindShareError::UnknownPeer { peer })?
         .tier(&amount)
-        .map_err(|_| anyhow!("Invalid Amount Tier"))?;
+        .map_err(|_| VerifyBlindShareError::InvalidAmountTier { amount })?;
 
     if !tbs::verify_signature_share(blinded_message, blinded_signature_share, *amount_key) {
-        bail!("Invalid blind signature")
+        return Err(VerifyBlindShareError::InvalidSignature);
     }
 
     Ok(blinded_signature_share)

--- a/modules/fedimint-mint-client/src/repair_wallet.rs
+++ b/modules/fedimint-mint-client/src/repair_wallet.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
-use fedimint_api_client::api::DynModuleApi;
-use fedimint_core::db::IDatabaseTransactionOpsCoreTyped;
+use fedimint_api_client::api::{DynModuleApi, FederationError, FederationResult};
+use fedimint_core::db::{AutocommitError, IDatabaseTransactionOpsCoreTyped};
 use fedimint_core::util::backoff_util::aggressive_backoff;
 use fedimint_core::util::retry;
 use fedimint_core::{Amount, TieredCounts};
@@ -11,6 +11,7 @@ use crate::api::MintFederationApi;
 use crate::client_db::{
     NextECashNoteIndexKey, NextECashNoteIndexKeyPrefix, NoteKey, NoteKeyPrefix,
 };
+use crate::error::RepairWalletError;
 use crate::output::NoteIssuanceRequest;
 use crate::{MintClientModule, NoteIndex};
 
@@ -42,7 +43,10 @@ impl MintClientModule {
     /// When invalid notes are found, they are removed from the wallet. Make
     /// sure that the user has a backup of their seed before running this
     /// function.
-    pub async fn try_repair_wallet(&self, gap_limit: u64) -> anyhow::Result<RepairSummary> {
+    pub async fn try_repair_wallet(
+        &self,
+        gap_limit: u64,
+    ) -> Result<RepairSummary, RepairWalletError> {
         let module_api = self.client_ctx.module_api();
 
         self.client_ctx
@@ -102,28 +106,33 @@ impl MintClientModule {
                                 .inc(amount, (next_index - old_index) as usize);
                         }
 
-                        Ok::<_, anyhow::Error>(summary)
+                        Ok::<_, RepairWalletError>(summary)
                     })
                 },
                 Some(100),
             )
             .await
-            .map_err(anyhow::Error::from)
+            .map_err(|e| match e {
+                AutocommitError::ClosureError { error, .. } => error,
+                AutocommitError::CommitFailed { last_error, .. } => {
+                    RepairWalletError::Database(last_error)
+                }
+            })
     }
 
     async fn find_spent_notes(
         module_api: &DynModuleApi,
         note_keys: Vec<NoteKey>,
-    ) -> anyhow::Result<Vec<NoteKey>> {
+    ) -> FederationResult<Vec<NoteKey>> {
         stream::iter(note_keys.into_iter())
             .map(|key| {
                 let module_api_inner = module_api.clone();
                 async move {
                     let spent = retry("fetch e-cash spentness", aggressive_backoff(), || async {
-                        anyhow::Ok(module_api_inner.check_note_spent(key.nonce).await?)
+                        module_api_inner.check_note_spent(key.nonce).await
                     })
                     .await?;
-                    anyhow::Ok(if spent { Some(key) } else { None })
+                    Ok(if spent { Some(key) } else { None })
                 }
             })
             .buffer_unordered(CHECK_PARALLELISM)
@@ -137,7 +146,7 @@ impl MintClientModule {
         module_api: &DynModuleApi,
         next_indices: BTreeMap<Amount, u64>,
         gap_limit: u64,
-    ) -> anyhow::Result<Vec<(Amount, u64)>> {
+    ) -> FederationResult<Vec<(Amount, u64)>> {
         stream::iter(next_indices.into_iter())
             .map(|(amount, original_next_index)| {
                 let module_api_inner = module_api.clone();
@@ -166,7 +175,7 @@ impl MintClientModule {
                         }
                     };
 
-                    Result::<_, anyhow::Error>::Ok(maybe_advanced_index)
+                    Result::<_, FederationError>::Ok(maybe_advanced_index)
                 }
             })
             .buffer_unordered(CHECK_PARALLELISM)
@@ -187,7 +196,7 @@ impl MintClientModule {
         amount: Amount,
         base_index: u64,
         gap_limit: u64,
-    ) -> anyhow::Result<Option<u64>> {
+    ) -> FederationResult<Option<u64>> {
         for gap in 0..gap_limit {
             let idx = base_index + gap;
             let note_secret = Self::new_note_secret_static(&self.secret, amount, NoteIndex(idx));
@@ -195,7 +204,7 @@ impl MintClientModule {
             let nonce_used = retry(
                 "checking if blind nonce was already used",
                 aggressive_backoff(),
-                || async { anyhow::Ok(module_api.check_blind_nonce_used(blind_nonce).await?) },
+                || async { module_api.check_blind_nonce_used(blind_nonce).await },
             )
             .await?;
             if nonce_used {

--- a/modules/fedimint-mint-common/Cargo.toml
+++ b/modules/fedimint-mint-common/Cargo.toml
@@ -16,7 +16,6 @@ name = "fedimint_mint_common"
 path = "src/lib.rs"
 
 [dependencies]
-anyhow = { workspace = true }
 bitcoin_hashes = { workspace = true }
 fedimint-core = { workspace = true }
 serde = { workspace = true }

--- a/modules/fedimint-mint-common/src/common.rs
+++ b/modules/fedimint-mint-common/src/common.rs
@@ -55,14 +55,14 @@ impl BackupRequest {
         self.consensus_hash()
     }
 
-    pub fn sign(self, keypair: &Keypair) -> anyhow::Result<SignedBackupRequest> {
+    pub fn sign(self, keypair: &Keypair) -> SignedBackupRequest {
         let signature =
             SECP256K1.sign_schnorr(&Message::from_digest(*self.hash().as_ref()), keypair);
 
-        Ok(SignedBackupRequest {
+        SignedBackupRequest {
             request: self,
             signature,
-        })
+        }
     }
 }
 

--- a/modules/fedimint-mint-common/src/config.rs
+++ b/modules/fedimint-mint-common/src/config.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 
+use fedimint_core::config::ExcessiveRelativeFeeError;
 use fedimint_core::core::ModuleKind;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::serde_json;
@@ -77,13 +78,17 @@ impl FeeConsensus {
     /// tenth of one percent.
     ///
     /// # Errors
-    /// - This constructor returns an error if the relative fee is in excess of
-    ///   one thousand parts per million.
-    pub fn new(parts_per_million: u64) -> anyhow::Result<Self> {
-        anyhow::ensure!(
-            parts_per_million <= 1_000,
-            "Relative fee over one thousand parts per million is excessive"
-        );
+    /// - Returns [`ExcessiveRelativeFeeError`] if the relative fee is in excess
+    ///   of one thousand parts per million.
+    pub fn new(parts_per_million: u64) -> Result<Self, ExcessiveRelativeFeeError> {
+        const MAX_PARTS_PER_MILLION: u64 = 1_000;
+
+        if parts_per_million > MAX_PARTS_PER_MILLION {
+            return Err(ExcessiveRelativeFeeError {
+                parts_per_million,
+                max: MAX_PARTS_PER_MILLION,
+            });
+        }
 
         Ok(Self {
             base: Amount::from_msats(100),
@@ -157,4 +162,12 @@ fn test_fee_consensus() {
         fee_consensus.fee(Amount::from_bitcoins(100_000)),
         Amount::from_bitcoins(100) + Amount::from_msats(100)
     );
+}
+
+#[test]
+fn a_relative_fee_over_the_limit_is_rejected() {
+    let err: ExcessiveRelativeFeeError =
+        FeeConsensus::new(1_001).expect_err("A fee over one per mille is excessive");
+
+    assert_eq!(err.parts_per_million, 1_001);
 }

--- a/modules/fedimint-mint-common/src/lib.rs
+++ b/modules/fedimint-mint-common/src/lib.rs
@@ -12,6 +12,7 @@ use bitcoin_hashes::Hash as _;
 use bitcoin_hashes::hex::DisplayHex;
 pub use common::{BackupRequest, SignedBackupRequest};
 use config::MintClientConfig;
+pub use fedimint_core::config::ExcessiveRelativeFeeError;
 use fedimint_core::core::{Decoder, ModuleInstanceId, ModuleKind};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::{CommonModuleInit, ModuleCommon, ModuleConsensusVersion};

--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -24,8 +24,8 @@ use fedimint_mint_client::api::MintFederationApi;
 use fedimint_mint_client::client_db::{NextECashNoteIndexKey, NoteKey};
 use fedimint_mint_client::{
     MintClientInit, MintClientModule, Note, OOBNotes, ReissueExternalNotesState,
-    SelectNotesWithAtleastAmount, SelectNotesWithExactAmount, SpendOOBState, SpendableNote,
-    SpendableNoteUndecoded, ValidateNotesError,
+    SelectNotesWithAtleastAmount, SelectNotesWithExactAmount, SpendOOBError, SpendOOBState,
+    SpendableNote, SpendableNoteUndecoded, ValidateNotesError,
 };
 use fedimint_mint_common::{MintInput, MintInputV0, Nonce};
 use fedimint_mint_server::MintInit;
@@ -844,7 +844,7 @@ async fn error_zero_value_oob_spend() -> anyhow::Result<()> {
         .await?;
 
     // Spend from client1 to client2
-    let err_msg = client1
+    let err = client1
         .get_first_module::<MintClientModule>()?
         .spend_notes_with_selector(
             &SelectNotesWithAtleastAmount,
@@ -854,9 +854,8 @@ async fn error_zero_value_oob_spend() -> anyhow::Result<()> {
             (),
         )
         .await
-        .expect_err("Zero-amount spends should be forbidden")
-        .to_string();
-    assert!(err_msg.contains("zero-amount"));
+        .expect_err("Zero-amount spends should be forbidden");
+    assert_matches!(err, SpendOOBError::ZeroAmount);
 
     Ok(())
 }

--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -15,7 +15,7 @@ use fedimint_core::module::registry::ModuleRegistry;
 use fedimint_core::module::{AmountUnit, Amounts};
 use fedimint_core::task::sleep_in_test;
 use fedimint_core::util::backoff_util::aggressive_backoff;
-use fedimint_core::util::{NextOrPending, retry};
+use fedimint_core::util::{FmtCompact as _, NextOrPending, retry};
 use fedimint_core::{Amount, TieredMulti, sats, secp256k1};
 use fedimint_dummy_client::{DummyClientInit, DummyClientModule};
 use fedimint_dummy_server::DummyInit;
@@ -309,7 +309,9 @@ async fn send_oob_notes_reissue_without_settling() -> anyhow::Result<()> {
         mint.send_fee_quote(Amount::from_msats(5_000_000)).await?;
         mint.send_oob_notes(Amount::from_msats(5_000_000), ())
             .await
-            .map_err(|e| anyhow::anyhow!("iteration {i}: send_oob_notes failed: {e:#}"))?;
+            .map_err(|e| {
+                anyhow::anyhow!("iteration {i}: send_oob_notes failed: {}", e.fmt_compact())
+            })?;
     }
 
     Ok(())

--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -23,9 +23,9 @@ use fedimint_logging::LOG_TEST;
 use fedimint_mint_client::api::MintFederationApi;
 use fedimint_mint_client::client_db::{NextECashNoteIndexKey, NoteKey};
 use fedimint_mint_client::{
-    MintClientInit, MintClientModule, Note, OOBNotes, ReissueExternalNotesState,
-    SelectNotesWithAtleastAmount, SelectNotesWithExactAmount, SpendOOBError, SpendOOBState,
-    SpendableNote, SpendableNoteUndecoded, ValidateNotesError,
+    MintClientInit, MintClientModule, Note, OOBNotes, ReissueExternalNotesError,
+    ReissueExternalNotesState, SelectNotesWithAtleastAmount, SelectNotesWithExactAmount,
+    SpendOOBError, SpendOOBState, SpendableNote, SpendableNoteUndecoded, ValidateNotesError,
 };
 use fedimint_mint_common::{MintInput, MintInputV0, Nonce};
 use fedimint_mint_server::MintInit;
@@ -871,16 +871,49 @@ async fn error_zero_value_oob_receive() -> anyhow::Result<()> {
         .await?;
 
     // Spend from client1 to client2
-    let err_msg = client1
+    let err = client1
         .get_first_module::<MintClientModule>()?
         .reissue_external_notes(
             OOBNotes::new(client1.federation_id().to_prefix(), Default::default()),
             (),
         )
         .await
-        .expect_err("Zero-amount receives should be forbidden")
-        .to_string();
-    assert!(err_msg.contains("zero-amount"));
+        .expect_err("Zero-amount receives should be forbidden");
+    assert_matches!(err, ReissueExternalNotesError::ZeroAmount);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn reissuing_the_same_notes_twice_reports_already_reissued() -> anyhow::Result<()> {
+    let fed = fixtures().new_fed_degraded().await;
+    let (client1, client2) = fed.two_clients().await;
+    issue_ecash(&client1, sats(1000)).await?;
+
+    let (_op, notes) = client1
+        .get_first_module::<MintClientModule>()?
+        .spend_notes_with_selector(&SelectNotesWithAtleastAmount, sats(500), None, false, ())
+        .await?;
+
+    let client2_mint = client2.get_first_module::<MintClientModule>()?;
+    let op = client2_mint
+        .reissue_external_notes(notes.clone(), ())
+        .await?;
+    assert_matches!(
+        client2_mint
+            .subscribe_reissue_external_notes(op)
+            .await?
+            .await_outcome()
+            .await,
+        Some(ReissueExternalNotesState::Done)
+    );
+
+    // The operation id is the hash of the notes, so a second reissue of the
+    // same notes finds the existing operation instead of submitting again.
+    assert_matches!(
+        client2_mint.reissue_external_notes(notes, ()).await,
+        Err(ReissueExternalNotesError::AlreadyReissued)
+    );
 
     Ok(())
 }

--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -1722,9 +1722,9 @@ async fn test_send_oob_notes() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// A syntactically valid note. Its signature is never checked in the tests
-/// that use it below: both the cross-federation and unissued-tier checks in
-/// `validate_notes` return before a note's signature is verified.
+/// A syntactically valid note. Its signature is never checked here: both the
+/// cross-federation and unissued-tier checks in `validate_notes` return
+/// before a note's signature is verified.
 fn dummy_spendable_note() -> SpendableNote {
     const NOTE_HEX: &str = "a5dd3ebacad1bc48bd8718eed5a8da1d68f91323bef2848ac4fa2e6f8eed710f317\
         8fd4aef047cc234e6b1127086f33cc408b39818781d9521475360de6b205f3328e490a6d99d5e2553a4553\
@@ -1794,6 +1794,26 @@ async fn subscribing_to_an_unknown_operation_reports_not_found() -> anyhow::Resu
         Err(SubscribeSpendNotesError::Operation(
             OperationLookupError::NotFound(_)
         ))
+    );
+
+    issue_ecash(&client, sats(1000)).await?;
+
+    let (spend_op, notes) = mint
+        .spend_notes_with_selector(&SelectNotesWithAtleastAmount, sats(500), None, false, ())
+        .await?;
+
+    // A spend operation is not a reissuance.
+    assert_matches!(
+        mint.subscribe_reissue_external_notes(spend_op).await,
+        Err(SubscribeReissueExternalNotesError::NotAReissuance)
+    );
+
+    let reissue_op = mint.reissue_external_notes(notes, ()).await?;
+
+    // A reissue operation is not an out-of-band spend.
+    assert_matches!(
+        mint.subscribe_spend_notes(reissue_op).await,
+        Err(SubscribeSpendNotesError::NotAnOutOfBandSpend)
     );
 
     Ok(())

--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -7,8 +7,11 @@ use fedimint_client::ClientHandleArc;
 use fedimint_client::backup::{ClientBackup, Metadata};
 use fedimint_client::transaction::{ClientInput, ClientInputBundle, TransactionBuilder};
 use fedimint_client_module::ClientModule;
+use fedimint_core::config::FederationId;
 use fedimint_core::core::OperationId;
 use fedimint_core::db::IDatabaseTransactionOpsCoreTyped;
+use fedimint_core::encoding::Decodable;
+use fedimint_core::module::registry::ModuleRegistry;
 use fedimint_core::module::{AmountUnit, Amounts};
 use fedimint_core::task::sleep_in_test;
 use fedimint_core::util::backoff_util::aggressive_backoff;
@@ -21,8 +24,8 @@ use fedimint_mint_client::api::MintFederationApi;
 use fedimint_mint_client::client_db::{NextECashNoteIndexKey, NoteKey};
 use fedimint_mint_client::{
     MintClientInit, MintClientModule, Note, OOBNotes, ReissueExternalNotesState,
-    SelectNotesWithAtleastAmount, SelectNotesWithExactAmount, SpendOOBState,
-    SpendableNoteUndecoded,
+    SelectNotesWithAtleastAmount, SelectNotesWithExactAmount, SpendOOBState, SpendableNote,
+    SpendableNoteUndecoded, ValidateNotesError,
 };
 use fedimint_mint_common::{MintInput, MintInputV0, Nonce};
 use fedimint_mint_server::MintInit;
@@ -1679,6 +1682,60 @@ async fn test_send_oob_notes() -> anyhow::Result<()> {
             .send_oob_notes(Amount::from_sats(100), ())
             .await?;
     }
+
+    Ok(())
+}
+
+/// A syntactically valid note. Its signature is never checked in the tests
+/// that use it below: both the cross-federation and unissued-tier checks in
+/// `validate_notes` return before a note's signature is verified.
+fn dummy_spendable_note() -> SpendableNote {
+    const NOTE_HEX: &str = "a5dd3ebacad1bc48bd8718eed5a8da1d68f91323bef2848ac4fa2e6f8eed710f317\
+        8fd4aef047cc234e6b1127086f33cc408b39818781d9521475360de6b205f3328e490a6d99d5e2553a4553\
+        207c8bd";
+
+    SpendableNote::consensus_decode_hex(NOTE_HEX, &ModuleRegistry::default())
+        .expect("hex note is well-formed")
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn validating_notes_from_another_federation_names_both_ids() -> anyhow::Result<()> {
+    let fed = fixtures().new_fed_degraded().await;
+    let client = fed.new_client().await;
+    let mint_module = client.get_first_module::<MintClientModule>()?;
+
+    let other = FederationId::dummy().to_prefix();
+    let notes = OOBNotes::new(other, TieredMulti::default());
+
+    let err = mint_module
+        .validate_notes(&notes)
+        .expect_err("Notes from another federation are not valid here");
+
+    assert_matches!(err, ValidateNotesError::WrongFederationId { found, .. } if found == other);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn validating_a_note_of_an_unissued_tier_reports_the_tier() -> anyhow::Result<()> {
+    let fed = fixtures().new_fed_degraded().await;
+    let client = fed.new_client().await;
+    let mint_module = client.get_first_module::<MintClientModule>()?;
+
+    let amount = Amount::from_msats(7);
+    let notes = OOBNotes::new(
+        client.federation_id().to_prefix(),
+        [(amount, dummy_spendable_note())].into_iter().collect(),
+    );
+
+    let err = mint_module
+        .validate_notes(&notes)
+        .expect_err("The federation does not issue this tier");
+
+    assert_matches!(
+        err,
+        ValidateNotesError::InvalidAmountTier { amount: a, .. } if a == amount
+    );
 
     Ok(())
 }

--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -7,6 +7,7 @@ use fedimint_client::ClientHandleArc;
 use fedimint_client::backup::{ClientBackup, Metadata};
 use fedimint_client::transaction::{ClientInput, ClientInputBundle, TransactionBuilder};
 use fedimint_client_module::ClientModule;
+use fedimint_client_module::error::OperationLookupError;
 use fedimint_core::config::FederationId;
 use fedimint_core::core::OperationId;
 use fedimint_core::db::IDatabaseTransactionOpsCoreTyped;
@@ -25,7 +26,8 @@ use fedimint_mint_client::client_db::{NextECashNoteIndexKey, NoteKey};
 use fedimint_mint_client::{
     MintClientInit, MintClientModule, Note, OOBNotes, ReissueExternalNotesError,
     ReissueExternalNotesState, SelectNotesWithAtleastAmount, SelectNotesWithExactAmount,
-    SpendOOBError, SpendOOBState, SpendableNote, SpendableNoteUndecoded, ValidateNotesError,
+    SpendOOBError, SpendOOBState, SpendableNote, SpendableNoteUndecoded,
+    SubscribeReissueExternalNotesError, SubscribeSpendNotesError, ValidateNotesError,
 };
 use fedimint_mint_common::{MintInput, MintInputV0, Nonce};
 use fedimint_mint_server::MintInit;
@@ -1769,6 +1771,29 @@ async fn validating_a_note_of_an_unissued_tier_reports_the_tier() -> anyhow::Res
     assert_matches!(
         err,
         ValidateNotesError::InvalidAmountTier { amount: a, .. } if a == amount
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn subscribing_to_an_unknown_operation_reports_not_found() -> anyhow::Result<()> {
+    let fed = fixtures().new_fed_degraded().await;
+    let client = fed.new_client().await;
+    let mint = client.get_first_module::<MintClientModule>()?;
+    let operation_id = OperationId::new_random();
+
+    assert_matches!(
+        mint.subscribe_reissue_external_notes(operation_id).await,
+        Err(SubscribeReissueExternalNotesError::Operation(
+            OperationLookupError::NotFound(_)
+        ))
+    );
+    assert_matches!(
+        mint.subscribe_spend_notes(operation_id).await,
+        Err(SubscribeSpendNotesError::Operation(
+            OperationLookupError::NotFound(_)
+        ))
     );
 
     Ok(())

--- a/modules/fedimint-mintv2-client/src/lib.rs
+++ b/modules/fedimint-mintv2-client/src/lib.rs
@@ -65,7 +65,7 @@ use fedimint_mintv2_common::config::{FeeConsensus, MintClientConfig, client_deno
 use fedimint_mintv2_common::{
     Denomination, KIND, MintCommonInit, MintInput, MintModuleTypes, MintOutput, Note, RecoveryItem,
 };
-use futures::{StreamExt, TryFutureExt, pin_mut};
+use futures::{StreamExt, pin_mut};
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -1019,10 +1019,6 @@ impl MintClientModule {
     ) -> Result<OperationId, ReceiveECashError> {
         let operation_id = OperationId::from_encodable(&ecash);
 
-        if self.client_ctx.operation_exists(operation_id).await {
-            return Err(ReceiveECashError::AlreadyReceived);
-        }
-
         if ecash.mint() != Some(self.federation_id) {
             return Err(ReceiveECashError::WrongFederation);
         }
@@ -1051,14 +1047,15 @@ impl MintClientModule {
                 },
                 TransactionBuilder::new().with_inputs(input),
             )
-            .or_else(|_| async {
-                if self.client_ctx.operation_exists(operation_id).await {
-                    Err(ReceiveECashError::AlreadyReceived)
-                } else {
-                    Err(ReceiveECashError::InsufficientFunds)
+            .await
+            .map_err(|error| match error {
+                TransactionSubmitError::OperationAlreadyExists(_) => {
+                    ReceiveECashError::AlreadyReceived
                 }
-            })
-            .await?;
+                TransactionSubmitError::NoPrimaryModule { .. }
+                | TransactionSubmitError::PrimaryModule(..) => ReceiveECashError::InsufficientFunds,
+                _ => ReceiveECashError::Failed,
+            })?;
 
         let mut dbtx = self.client_ctx.module_db().begin_transaction().await;
 
@@ -1346,26 +1343,48 @@ async fn download_slice(
     }
 }
 
+/// A failure to send e-cash by preparing notes to hand to the recipient.
 #[derive(Error, Debug, Clone, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum SendECashError {
+    /// The client needs to reissue notes to make change, but has no
+    /// connection to the federation to do so.
     #[error("We need to reissue notes but the client is offline")]
     Offline,
+    /// The client's balance cannot cover the amount requested.
     #[error("The clients balance is insufficient")]
     InsufficientBalance,
+    /// The client failed to prepare the notes for a reason it cannot
+    /// recover from.
     #[error("A non-recoverable error has occurred")]
     Failure,
 }
 
+/// A failure to receive e-cash by reissuing it.
 #[derive(Error, Debug, Clone, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum ReceiveECashError {
+    /// The e-cash was issued by a different federation.
     #[error("The ECash is from a different federation")]
     WrongFederation,
+
+    /// One of the notes is worth no more than the fee to reissue it.
     #[error("ECash contains an uneconomical denomination")]
     UneconomicalDenomination,
+
+    /// The client cannot cover the fee the reissue costs.
     #[error("Receiving ecash requires additional funds")]
     InsufficientFunds,
+
+    /// An operation for this exact e-cash already exists, so it was already
+    /// received.
     #[error("The ECash was already received")]
     AlreadyReceived,
+
+    /// The reissue transaction could not be submitted for a reason that is
+    /// not about funding.
+    #[error("The reissue transaction could not be submitted")]
+    Failed,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]

--- a/modules/fedimint-mintv2-client/src/lib.rs
+++ b/modules/fedimint-mintv2-client/src/lib.rs
@@ -36,6 +36,7 @@ use fedimint_client::transaction::{
     ClientOutputSM, FeeQuote, FeeQuoteRequest, TransactionBuilder,
 };
 use fedimint_client_module::db::ClientModuleMigrationFn;
+use fedimint_client_module::error::{OperationLookupError, TransactionSubmitError};
 use fedimint_client_module::module::init::{
     ClientModuleInit, ClientModuleInitArgs, ClientModuleRecoverArgs,
     ClientModuleRecoveryPrepareArgs, RecoveryMode,
@@ -1085,7 +1086,10 @@ impl MintClientModule {
     /// rather than committed, so the client's notes are read but left
     /// untouched. The quote is point-in-time: it depends on the current
     /// inventory and can move as notes change.
-    pub async fn receive_fee_quote(&self, ecash: &ECash) -> anyhow::Result<FeeQuote> {
+    pub async fn receive_fee_quote(
+        &self,
+        ecash: &ECash,
+    ) -> Result<FeeQuote, TransactionSubmitError> {
         // A receive submits the ecash notes as explicit inputs and no explicit
         // outputs; the shared, module-agnostic fee quote runs the primary-module
         // balancing (rebalancing + minting change) over the real inventory.
@@ -1107,7 +1111,6 @@ impl MintClientModule {
                 },
             )
             .await
-            .map_err(anyhow::Error::from)
     }
 
     /// Computes the fee a `send(amount)` would incur given the client's current
@@ -1123,7 +1126,7 @@ impl MintClientModule {
     /// inputs) via the shared, module-agnostic fee quote over the real
     /// inventory. The quote is point-in-time: it depends on the current
     /// inventory and can move as notes change.
-    pub async fn send_fee_quote(&self, amount: Amount) -> anyhow::Result<FeeQuote> {
+    pub async fn send_fee_quote(&self, amount: Amount) -> Result<FeeQuote, TransactionSubmitError> {
         let amount = round_to_multiple(amount, client_denominations().next().unwrap().amount());
 
         // Exact-change path: handing out existing notes never costs a fee.
@@ -1152,7 +1155,6 @@ impl MintClientModule {
                 },
             )
             .await
-            .map_err(anyhow::Error::from)
     }
 
     /// Returns whether the client's current notes can be handed out to cover
@@ -1203,7 +1205,7 @@ impl MintClientModule {
     pub async fn await_final_receive_operation_state(
         &self,
         operation_id: OperationId,
-    ) -> anyhow::Result<FinalReceiveOperationState> {
+    ) -> Result<FinalReceiveOperationState, OperationLookupError> {
         let operation = self.client_ctx.get_operation(operation_id).await?;
         let mut stream = self.notifier.subscribe(operation_id).await;
 

--- a/modules/fedimint-mintv2-client/src/lib.rs
+++ b/modules/fedimint-mintv2-client/src/lib.rs
@@ -1054,7 +1054,7 @@ impl MintClientModule {
                 }
                 TransactionSubmitError::NoPrimaryModule { .. }
                 | TransactionSubmitError::PrimaryModule(..) => ReceiveECashError::InsufficientFunds,
-                _ => ReceiveECashError::Failed,
+                other => ReceiveECashError::Failed(other),
             })?;
 
         let mut dbtx = self.client_ctx.module_db().begin_transaction().await;
@@ -1361,7 +1361,7 @@ pub enum SendECashError {
 }
 
 /// A failure to receive e-cash by reissuing it.
-#[derive(Error, Debug, Clone, Eq, PartialEq)]
+#[derive(Error, Debug)]
 #[non_exhaustive]
 pub enum ReceiveECashError {
     /// The e-cash was issued by a different federation.
@@ -1381,10 +1381,10 @@ pub enum ReceiveECashError {
     #[error("The ECash was already received")]
     AlreadyReceived,
 
-    /// The reissue transaction could not be submitted for a reason that is
-    /// not about funding.
+    /// The reissue transaction could not be submitted for a reason unrelated
+    /// to funding.
     #[error("The reissue transaction could not be submitted")]
-    Failed,
+    Failed(#[source] TransactionSubmitError),
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]

--- a/modules/fedimint-mintv2-common/Cargo.toml
+++ b/modules/fedimint-mintv2-common/Cargo.toml
@@ -16,7 +16,6 @@ name = "fedimint_mintv2_common"
 path = "src/lib.rs"
 
 [dependencies]
-anyhow = { workspace = true }
 bitcoin_hashes = { workspace = true }
 fedimint-core = { workspace = true }
 serde = { workspace = true }

--- a/modules/fedimint-mintv2-common/src/config.rs
+++ b/modules/fedimint-mintv2-common/src/config.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 
+use fedimint_core::config::ExcessiveRelativeFeeError;
 use fedimint_core::core::ModuleKind;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::{AmountUnit, serde_json};
@@ -83,13 +84,17 @@ impl FeeConsensus {
     /// tenth of one percent.
     ///
     /// # Errors
-    /// - This constructor returns an error if the relative fee is in excess of
-    ///   one thousand parts per million.
-    pub fn new(parts_per_million: u64) -> anyhow::Result<Self> {
-        anyhow::ensure!(
-            parts_per_million <= 1_000,
-            "Relative fee over one thousand parts per million is excessive"
-        );
+    /// - Returns [`ExcessiveRelativeFeeError`] if the relative fee is in excess
+    ///   of one thousand parts per million.
+    pub fn new(parts_per_million: u64) -> Result<Self, ExcessiveRelativeFeeError> {
+        const MAX_PARTS_PER_MILLION: u64 = 1_000;
+
+        if parts_per_million > MAX_PARTS_PER_MILLION {
+            return Err(ExcessiveRelativeFeeError {
+                parts_per_million,
+                max: MAX_PARTS_PER_MILLION,
+            });
+        }
 
         Ok(Self {
             base: Amount::from_msats(100),
@@ -150,4 +155,12 @@ fn test_fee_consensus() {
         fee_consensus.fee(Amount::from_bitcoins(100_000)),
         Amount::from_bitcoins(100) + Amount::from_msats(100)
     );
+}
+
+#[test]
+fn a_relative_fee_over_the_limit_is_rejected() {
+    let err: ExcessiveRelativeFeeError =
+        FeeConsensus::new(1_001).expect_err("A fee over one per mille is excessive");
+
+    assert_eq!(err.parts_per_million, 1_001);
 }

--- a/modules/fedimint-mintv2-common/src/lib.rs
+++ b/modules/fedimint-mintv2-common/src/lib.rs
@@ -10,6 +10,7 @@ use std::hash::Hash;
 
 use bitcoin_hashes::hash160;
 use config::MintClientConfig;
+pub use fedimint_core::config::ExcessiveRelativeFeeError;
 use fedimint_core::core::{Decoder, ModuleInstanceId, ModuleKind};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::{CommonModuleInit, ModuleCommon, ModuleConsensusVersion};
@@ -20,7 +21,6 @@ use tbs::{BlindedMessage, Message};
 use thiserror::Error;
 
 pub mod config;
-pub use fedimint_core::config::ExcessiveRelativeFeeError;
 pub mod endpoint_constants;
 
 pub const KIND: ModuleKind = ModuleKind::from_static_str("mintv2");

--- a/modules/fedimint-mintv2-common/src/lib.rs
+++ b/modules/fedimint-mintv2-common/src/lib.rs
@@ -20,6 +20,7 @@ use tbs::{BlindedMessage, Message};
 use thiserror::Error;
 
 pub mod config;
+pub use fedimint_core::config::ExcessiveRelativeFeeError;
 pub mod endpoint_constants;
 
 pub const KIND: ModuleKind = ModuleKind::from_static_str("mintv2");

--- a/modules/fedimint-mintv2-tests/Cargo.toml
+++ b/modules/fedimint-mintv2-tests/Cargo.toml
@@ -43,6 +43,7 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
+assert_matches = { workspace = true }
 fedimint-dummy-client = { workspace = true }
 fedimint-dummy-common = { workspace = true }
 fedimint-dummy-server = { workspace = true }

--- a/modules/fedimint-mintv2-tests/tests/tests.rs
+++ b/modules/fedimint-mintv2-tests/tests/tests.rs
@@ -1,7 +1,9 @@
 use std::pin::pin;
 
 use anyhow::ensure;
+use assert_matches::assert_matches;
 use async_stream::stream;
+use fedimint_client::error::OperationLookupError;
 use fedimint_client::secret::{PlainRootSecretStrategy, RootSecretStrategy};
 use fedimint_client::transaction::TransactionBuilder;
 use fedimint_client::{ClientHandleArc, ModuleRecoveryCompleted, RootSecret};
@@ -186,6 +188,24 @@ async fn send_and_receive() -> anyhow::Result<()> {
     }
 
     ensure!(client_receive.get_balance_for_btc().await? >= Amount::from_sats(9900));
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn awaiting_an_unknown_receive_operation_reports_not_found() -> anyhow::Result<()> {
+    let fixtures = fixtures();
+    let fed = fixtures.new_fed_not_degraded().await;
+    let client = fed.new_client().await;
+    let operation_id = OperationId::new_random();
+
+    assert_matches!(
+        client
+            .get_first_module::<MintClientModule>()?
+            .await_final_receive_operation_state(operation_id)
+            .await,
+        Err(OperationLookupError::NotFound(_))
+    );
 
     Ok(())
 }

--- a/modules/fedimint-mintv2-tests/tests/tests.rs
+++ b/modules/fedimint-mintv2-tests/tests/tests.rs
@@ -602,12 +602,12 @@ async fn receive_rejects_ecash_from_another_federation() -> anyhow::Result<()> {
     // checks the mint id before submitting anything to consensus.
     let foreign_ecash = ECash::new(FederationId::dummy(), ecash.notes());
 
-    assert_eq!(
+    assert_matches!(
         client
             .get_first_module::<MintClientModule>()?
             .receive(foreign_ecash, Value::Null)
             .await,
-        Err(ReceiveECashError::WrongFederation),
+        Err(ReceiveECashError::WrongFederation)
     );
 
     Ok(())
@@ -642,12 +642,12 @@ async fn receiving_the_same_ecash_twice_is_rejected() -> anyhow::Result<()> {
     // The operation id is derived from the ecash itself, so a second receive of
     // the identical notes finds the existing operation and refuses rather than
     // submitting a duplicate transaction.
-    assert_eq!(
+    assert_matches!(
         client
             .get_first_module::<MintClientModule>()?
             .receive(ecash, Value::Null)
             .await,
-        Err(ReceiveECashError::AlreadyReceived),
+        Err(ReceiveECashError::AlreadyReceived)
     );
 
     Ok(())
@@ -670,12 +670,12 @@ async fn receive_rejects_notes_below_the_base_fee() -> anyhow::Result<()> {
 
     let dust_ecash = ECash::new(client.federation_id(), vec![dust_note]);
 
-    assert_eq!(
+    assert_matches!(
         client
             .get_first_module::<MintClientModule>()?
             .receive(dust_ecash, Value::Null)
             .await,
-        Err(ReceiveECashError::UneconomicalDenomination),
+        Err(ReceiveECashError::UneconomicalDenomination)
     );
 
     Ok(())


### PR DESCRIPTION
## Summary

Fifth PR of the #8821 series (after #9082, #9103, #9115 and #9118, all merged). This one removes `anyhow` from the public API of `fedimint-mint-client`, `fedimint-mint-common`, `fedimint-mintv2-client` and `fedimint-mintv2-common`, and is the first PR to build on the types #9118 landed. It also adds one shared type to `fedimint-core` (see "What changed" below), which is the only change outside the four mint crates and the call sites they force.

## What changed

All twelve new types live in `fedimint_mint_client::error`, the single place to look, except `ExcessiveRelativeFeeError`, which lives in `fedimint_core::config` and is re-exported at the root of both `-common` crates (and, through the existing `pub use fedimint_mint_common::*;` glob, at `fedimint_mint_client`'s root too).

- `ValidateNotesError` (`WrongFederationId`, `InvalidAmountTier`, `InvalidSignature`, `WrongSpendKey`, `Decode`): the shared failure for `validate_notes`, `create_input_from_notes` and `consolidate_notes` — a note that cannot be spent, whether it arrived out of band or was already in the wallet.
- `OOBNotesParseError` (`Encoding`, `Decode`, `Empty`): `OOBNotes`'s new `FromStr::Err`, also used by `fedimint_client_rpc::parse_oob_notes`; the one type in this PR that inlines its cause into its own `Display` message, because clap and `serde::de::Error::custom` only ever render `Display`.
- `SelectNotesError` (`InsufficientBalance`, `NoExactAmount { requested, selected }`, `Decode`, `Custom(Box<dyn Error + Send + Sync>)`): the `NotesSelector::select_notes` trait's error, implemented by both built-in selectors and by anyone outside this crate; `Custom` is there for a failure the built-ins never produce.
- `SpendOOBError` (`ZeroAmount`, `NoteSelection`, `StateMachines`, `Database`): for `spend_notes` (deprecated) and `spend_notes_with_selector`.
- `AwaitOutputFinalizedError` (`TransactionRejected`, `Failed { reason }`): for `await_output_finalized`.
- `SendOOBNotesError` (`Federation(Box<FederationError>)`, `Transaction`, `Database`): for `send_oob_notes`.
- `SubscribeReissueExternalNotesError` (`Operation`, `NotAReissuance`, `NoTransaction`) and `SubscribeSpendNotesError` (`Operation`, `NotAnOutOfBandSpend`): for `subscribe_reissue_external_notes` and `subscribe_spend_notes`; both wrap `OperationLookupError`, which `ClientContext::get_operation` already checks on its own, so mint's own "wrong module kind" check is gone.
- `FetchRecoverySliceError` (`Peer(ServerError)`, `Decode`): for `MintFederationApi::fetch_recovery_slice`.
- `PrepareEcashBackupError` (`Federation(Box<FederationError>)`, `Decode`): for `prepare_plaintext_ecash_backup`.
- `RepairWalletError` (`Federation(Box<FederationError>)`, `Database`): for `try_repair_wallet` and its three private helpers.
- `VerifyBlindShareError` (`Outcome(Box<OutputOutcomeError>)`, `UnknownPeer { peer }`, `InvalidAmountTier { amount }`, `InvalidSignature`): for `verify_blind_share`.
- `fedimint_core::config::ExcessiveRelativeFeeError { parts_per_million, max }`: the one type this PR adds outside the four mint crates. Mint and mintv2 each define the exact same relative-fee guard in their own `FeeConsensus::new`; it now lives once, next to `ModuleConfigError` and `ConfigFileError`, so `fedimint-lnv2-common` and `fedimint-walletv2-common` can reuse it in D2 and D4 instead of adding copies three and four.
- `ReissueExternalNotesError` is re-cut from a two-variant `Clone` enum (`WrongFederationId`, `AlreadyReissued`) into a five-variant, non-`Clone`, `#[non_exhaustive]` one (`ZeroAmount`, `WrongFederationId { expected, found }`, `AlreadyReissued`, `Notes(ValidateNotesError)`, `Transaction(TransactionSubmitError)`) for `reissue_external_notes`; `WrongFederationId` now names both federations, with the same wording `ValidateNotesError::WrongFederationId` uses. See "Behaviour changes" for why `AlreadyReissued` now means something narrower than before.
- Five functions turned out to have exactly one way to fail and now return an existing type directly instead of wrapping it in `anyhow`: `check_blind_nonce_used_single_peer` / `check_note_spent_single_peer` return `ServerError`; `fetch_recovery_count` / `fetch_blind_nonce_outpoints` / `check_note_spent` return `FederationError`; `reissue_fee_quote` / `send_fee_quote` and mintv2's `receive_fee_quote` / `send_fee_quote` return `TransactionSubmitError`; mintv2's `await_final_receive_operation_state` returns `OperationLookupError`; `SpendableNoteUndecoded::decode` returns `DecodeError`.
- Two functions turned out to be infallible and lost their `Result` entirely: `MintClientModule::advance_note_idx` and `fedimint-mint-common`'s `BackupRequest::sign`.

## Breaking for integrators

- `MintClientModule::advance_note_idx(&self, amount: Amount) -> DerivableSecret` and `fedimint_mint_common::common::BackupRequest::sign(self, keypair: &Keypair) -> SignedBackupRequest` return their value directly; call sites drop a trailing `?` or `.expect(..)` (`fedimint-cli`'s `AdvanceNoteIdx` dev command needed this).
- `ReissueExternalNotesError` is no longer `Clone` and is `#[non_exhaustive]`. `ReceiveECashError` and `SendECashError` (mintv2) are also newly `#[non_exhaustive]`. `SendECashError` keeps `Clone`, `Eq` and `PartialEq` since every one of its variants is a unit variant, but `ReceiveECashError` loses all three: its `Failed` variant carries a `TransactionSubmitError`, which is not `Clone`.
- `ReceiveECashError` gains a `Failed` variant, appended last: a `receive` submission that fails for a reason unrelated to funding (a database error, an oversized transaction, a state-machine registration failure) no longer reports `InsufficientFunds`. `Failed` carries the `TransactionSubmitError` as its `source()`, so the real cause is not lost.
- `fedimint-mint-common` and `fedimint-mintv2-common` no longer depend on `anyhow` at all; the dependency is removed from both `Cargo.toml`s, and `cargo udeps` would now catch a reintroduction.
- `OOBNotes: FromStr` now has `type Err = OOBNotesParseError` instead of `anyhow::Error`. clap and serde consumers see no difference, since both only ever render `Display`, but code that matched the old error with `.downcast_ref::<SomeType>()` does.
- Anyone implementing `NotesSelector` must return `SelectNotesError` from `select_notes`; the `Custom` variant exists for a failure none of the built-in selectors produce.
- Every migrated function now returns a concrete error. A plain `?` into an `anyhow`-returning body still compiles via the blanket `From` conversion, but a variant used as a function pointer (for example `.map_err(SomeVariant)`) or a payload built directly from an `anyhow::Error` needs `.into()` added at the call site, and `format!("{e:#}")` on a retyped error silently stops printing the cause — that formatter is `anyhow`-only and degrades to plain `Display` on a `thiserror` type; use `e.fmt_compact()` instead.

## Not changed

The module -> client trait boundary is deliberately still `anyhow` and stays that way until part E of #8821: `ClientModule::{backup, create_final_inputs_and_outputs, await_primary_module_output, leave}` and every `ClientModuleInit` / `RecoveryFromHistory` method, in both `fedimint-mint-client` and `fedimint-mintv2-client`. `handle_cli_command` and `handle_rpc` stay `anyhow` by design in both crates: they are JSON-in/JSON-out handlers whose errors are stringified into a response regardless of type. mintv2's private `api` and `output` modules (`fetch_recovery_count`, `fetch_recovery_slice`, `verify_blind_shares`) are declared `pub` but live inside a private `mod`, so they are not public API and are untouched.

No wire, DB or JSON *shape* changed anywhere in this PR: every retyped error only affects how a failure is represented in Rust, not what a peer, gateway or client sees on the wire. No type this PR touches derives `Serialize`, `Deserialize`, `Encodable`, `Decodable` or `uniffi::Error` (confirmed by grepping the diff for a newly added derive of any of them — empty). The state enums the CLI and RPC serialize — `ReissueExternalNotesState`, `SpendOOBState`, `FinalReceiveOperationState` — are untouched; their variant lists and order are byte-identical to `origin/master`.

## Behaviour changes worth a close look

- `reissue_external_notes` stops reporting *every* submission failure as "we already reissued these notes"; only the transaction layer's own duplicate-operation error now maps to `AlreadyReissued`. A database error, an oversized transaction or a state-machine registration failure now surfaces as `ReissueExternalNotesError::Transaction` instead.
- mintv2's `receive` reads the duplicate-operation signal off the submission error instead of reading the operation log twice (the two `operation_exists` probes were racy against each other), and reports the new `ReceiveECashError::Failed` instead of claiming a database failure or an oversized transaction means the client needs more funds.
- `ReceiveECashError::Failed` carries the `TransactionSubmitError` as its `source()` rather than being a bare unit variant, so a caller can still tell a busy database from an oversized transaction. The cost is that `ReceiveECashError` can no longer derive `Clone`, `Eq` or `PartialEq` (`TransactionSubmitError` does not derive them either); `SendECashError` is unaffected and keeps all three.
- `send_oob_notes` returns `SendOOBNotesError::Database` after exhausting its commit attempts instead of `panic!`king.
- `ClientContext::get_operation` already checks the operation's module kind itself, so mint's own "Operation is not a mint operation" check is gone; the shared `OperationLookupError` names both the expected and the actual module kind.
- `MintFederationApi::{fetch_recovery_count, fetch_blind_nonce_outpoints}` no longer rebuild the federation error from its own `Display` text via `anyhow::anyhow!("{e}")`; they return the pre-existing `FederationResult` directly, so per-peer detail now reaches the caller intact.
- Every error text that reaches `fedimint-cli`'s `CliError.error`, `fedimint-client-rpc`'s `error` string, uniffi's `UniffiError`, or the gateway's `failure_reason` is now the new type's `Display` plus its cause chain (via `fmt_compact()`), rather than the old ad-hoc message.

## Compatibility

No `Encodable`, `Decodable`, `Serialize` or `Deserialize` type this PR touches changed, no variant was inserted or reordered into one that derives any of them, and no database migration is needed. `MintOutputStatesFailed.error` (a `String` written once by the server-side state machine) is read by some of this PR's new types but never rewritten, so its wire shape is untouched. The one change outside the four mint crates and the call sites they force is `fedimint_core::config::ExcessiveRelativeFeeError`, which is purely additive: one new `pub struct`, no existing item in `fedimint-core` changed, and `fedimint-core/Cargo.toml` is untouched.

| Check | Result |
|---|---|
| New `Serialize`/`Deserialize`/`Encodable`/`Decodable`/`uniffi::Error` derive added anywhere in the diff | none (grep empty) |
| `ReissueExternalNotesState`, `SpendOOBState`, `FinalReceiveOperationState` variant lists and order | byte-identical to `origin/master` |
| `MintInputStateError`, `MintOutputStatesFailed`, any `impl_db_record!`/`impl_db_lookup!` invocation | untouched |
| `MintInputError`, `MintOutputError`, any `extensible_associated_module_type!` invocation | untouched |
| `fedimint-client-rpc`'s `RpcResponseKind::Error { error: String }` | unchanged; still one `error: String` construction |
| `fedimint-core/Cargo.toml` | untouched |
| `Cargo.lock` | two `anyhow` dependency-list deletions (`fedimint-mint-common`, `fedimint-mintv2-common`) plus one dev-only `assert_matches` addition (`fedimint-mintv2-tests`); no version bump of any existing crate |

## User-visible text changes

Every `Display`-message or behaviour change a caller could now observe, with the consumer that renders it.

| Where | Type / function | Before | After |
|---|---|---|---|
| CLI / RPC / uniffi | `ValidateNotesError::WrongFederationId` (`validate_notes`, `create_input_from_notes`, `consolidate_notes`) | "Federation ID does not match" | "The notes were issued by federation {found}, not {expected}" |
| CLI / RPC / uniffi | `ValidateNotesError::InvalidAmountTier` | "Invalid amount tier: {amount}" / "Note {idx} uses an invalid amount tier {amt}" | "Note {index} claims the amount tier {amount}, which the federation does not issue" |
| CLI / RPC / uniffi | `ValidateNotesError::InvalidSignature` | "Invalid note" / "Note {idx} has an invalid federation signature" | "Note {index} does not carry a valid federation signature" |
| CLI / RPC / uniffi | `ValidateNotesError::WrongSpendKey` | "Note {idx} cannot be spent using the supplied spend key" | "Note {index} cannot be spent with the supplied spend key" |
| CLI (clap arg parse) / RPC JSON (serde) | `OOBNotesParseError::Encoding` (`OOBNotes::from_str`) | "OOBNotes were not a well-formed base64(URL-safe) or base32 string" | "The e-cash notes are not a well-formed base32 or base64 string" |
| CLI (clap arg parse) / RPC JSON (serde) | `OOBNotesParseError::Empty` | "OOBNotes cannot be empty" | "The e-cash notes are empty" |
| CLI (clap arg parse) / RPC JSON (serde) | `OOBNotesParseError::Decode` | a decode failure bubbled up `anyhow`'s own decode text | "The e-cash notes could not be decoded: {0}" (cause inlined, per the R12 carve-out) |
| gateway HTTP body (`handle_receive_ecash_msg`, MintV1 branch) | `OOBNotesParseError` stringification | `e.to_string()` | `e.fmt_compact()` (same text today; chain-safe if `Decode`'s source ever grows) |
| CLI / RPC / uniffi (via `SpendOOBError::NoteSelection`) | `SelectNotesError::NoExactAmount` (`NotesSelector::select_notes`) | "Could not select notes with exact amount. Requested amount: {r}. Selected amount: {s}" | "The amount {requested} cannot be made exactly; the closest selection is {selected}" |
| CLI / RPC / uniffi | `SpendOOBError::ZeroAmount` (`spend_notes`, `spend_notes_with_selector`) | "zero-amount out-of-band spends are not supported" | "Zero-amount out-of-band spends are not supported" (capitalised) |
| CLI / RPC / uniffi | `SpendOOBError::Database` | "Commit to DB failed: {db error}" | "Database error" (cause behind `source()`) |
| CLI / RPC / uniffi | `ReissueExternalNotesError::ZeroAmount` (`reissue_external_notes`) | "Reissuing zero-amount e-cash isn't supported" | "Reissuing zero-amount e-cash is not supported" |
| CLI / RPC / uniffi | `ReissueExternalNotesError::WrongFederationId` (`reissue_external_notes`) | "Federation ID does not match" | "The notes were issued by federation {found}, not {expected}" (now a struct variant naming both federations, wording matching `ValidateNotesError::WrongFederationId`) |
| CLI / RPC / uniffi | `ReissueExternalNotesError::{AlreadyReissued, Transaction}` | a database failure, oversized transaction or state-machine registration failure reported as "We already reissued these notes" | "The reissue transaction could not be submitted" (`Transaction`, real cause behind `source()`); `AlreadyReissued` now fires only for the real duplicate |
| state JSON (`ReissueExternalNotesState::Failed`, surfaced via CLI/RPC) | `AwaitOutputFinalizedError` (`await_output_finalized`) | "Transaction was rejected" / "Failed to finalize transaction: X" | "The transaction was rejected" / "The notes could not be issued: X" |
| CLI / RPC (`send_oob_notes`) | `SendOOBNotesError::Federation` | "Cannot reach federation to reissue notes" | "The federation could not be reached" (federation error now behind `source()`) |
| CLI / RPC (`send_oob_notes`) | `SendOOBNotesError::Transaction` | "Failed to submit reissuance transaction" / "Failed to await output finalization" | "The reissue that would make the right denominations failed" (submit error behind `source()`) |
| internal, no consumer (behaviour change) | `send_oob_notes` commit exhaustion | panicked: "Failed to commit dbtx after 100 retries" | returns `SendOOBNotesError::Database` instead of panicking |
| CLI / RPC / uniffi | `SubscribeReissueExternalNotesError::Operation` / `SubscribeSpendNotesError::Operation` (`subscribe_reissue_external_notes`, `subscribe_spend_notes`) | "Operation is not a mint operation" | "The operation could not be looked up" |
| CLI / RPC / uniffi | `SubscribeReissueExternalNotesError::NotAReissuance` | "Operation is not a reissuance" | "The operation is an out-of-band spend, not a reissuance" |
| CLI / RPC / uniffi | `SubscribeSpendNotesError::NotAnOutOfBandSpend` | "Operation is not a out-of-band spend" | "The operation is a reissuance, not an out-of-band spend" |
| CLI / RPC / uniffi | `SubscribeReissueExternalNotesError::NoTransaction` | "Empty reissuance not permitted, this should never happen" | "The reissue operation records no transaction" |
| none (text unchanged) | `check_blind_nonce_used_single_peer`, `check_note_spent_single_peer`, `fetch_recovery_count`, `fetch_blind_nonce_outpoints` | `.map_err(|e| anyhow::anyhow!("{e}"))` re-wrap whose message was already just `"{e}"` | no text change; only the type is now concrete |
| CLI dev command | `advance_note_idx` (now infallible) | `fedimint-cli`'s `AdvanceNoteIdx` command could report "failed to advance the note_idx" | there is no failure to report; the `.map_err_cli_msg(..)` call is gone |
| CLI dev command | `try_repair_wallet` commit exhaustion | an anyhow-wrapped `AutocommitError` whose `Display` interpolated the underlying error text directly | `RepairWalletError::Database`'s "Database error" (cause behind `source()`) |
| log line (`output.rs`, blind-share verification) | `VerifyBlindShareError::UnknownPeer` | "Unknown peer" | "No public key share is known for peer {peer}" |
| log line | `VerifyBlindShareError::InvalidAmountTier` | "Invalid Amount Tier" | "The federation issues no notes of the amount tier {amount}" |
| log line | `VerifyBlindShareError::InvalidSignature` | "Invalid blind signature" | "The blind signature share does not verify" |
| log line | `VerifyBlindShareError::Outcome` | a decode failure surfaced as anyhow's own decode-error text | "The output outcome could not be read" (`OutputOutcomeError` as `source()`) |
| internal panic message, unreachable with a well-formed federation config | `ExcessiveRelativeFeeError`, seen only in `.expect("Relative fee is within range")` in `fedimint-mint-server` and `fedimint-mintv2-server` | "Relative fee over one thousand parts per million is excessive" | "The relative fee of {parts_per_million} parts per million is over the limit of {max}" |
| gateway HTTP body (`handle_receive_ecash_msg`, mintv2 branch) | mintv2's `await_final_receive_operation_state`, unknown operation id | "The operation does not exist" | "The operation does not exist: No operation with id {short id}" (`fmt_compact()` now walks the `#[from]` chain a plain `anyhow::Error::to_string()` never did) |
| gateway HTTP body (`failure_reason`, mintv2 `receive`) | `ReceiveECashError::{InsufficientFunds, Failed}` | a submission failure unrelated to funding reported as `InsufficientFunds` -> "Receiving ecash requires additional funds"; rendered via plain `.to_string()` | reported as the new `Failed` -> "The reissue transaction could not be submitted", rendered via `.fmt_compact().to_string()` so the underlying `TransactionSubmitError` cause is now appended to the message |
| gateway HTTP body | `ReceiveECashError::AlreadyReceived` | detected via two extra DB reads around the submit call, racy against each other | detected directly from `TransactionSubmitError::OperationAlreadyExists` on the submission error; same text, same variant, only the detection mechanism changed |
| uniffi (`UniffiError::General`) | `reissue_notes`, `subscribe_reissue_external_notes`, `spend_notes`, `spend_notes_expert`, `validate_notes`, `subscribe_spend_notes` | the old `From<anyhow::Error> for UniffiError` path rendered only the outermost message, via `.to_string()` | the five new `From<..> for UniffiError` impls (for `ValidateNotesError`, `SpendOOBError`, `ReissueExternalNotesError`, `SubscribeReissueExternalNotesError`, `SubscribeSpendNotesError`) use `fmt_compact()` instead, so `UniffiError::General` now carries the full cause chain |
| `fedimint-cli dev` JSON (`cli.rs:115,140`) | `PeerCheckResult::Error` (`check_note_spent`, `check_blind_nonce_used`) | `format!("error: {e}")`, the outermost message only | `format!("error: {}", e.fmt_compact())`, so the chain is included; shape unchanged, same text for most `ServerError` variants, but `InvalidPeerUrl` now also shows its `ConnectorError` cause |

## Verification

```
cargo clippy --workspace --all-targets -- -D warnings
cargo nextest run --workspace --all-targets
RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p fedimint-core -p fedimint-mint-client -p fedimint-mint-common -p fedimint-mintv2-client -p fedimint-mintv2-common -p fedimint-client-rpc -p fedimint-gateway-server
cargo test --doc -p fedimint-core -p fedimint-mint-client -p fedimint-mint-common -p fedimint-mintv2-client -p fedimint-mintv2-common
cargo check -p <crate> --all-features / --no-default-features
  for fedimint-core, fedimint-mint-client, fedimint-mint-common,
  fedimint-mintv2-client, fedimint-mintv2-common, fedimint-client-rpc,
  fedimint-gateway-server, fedimint-cli
<wasm target set: fedimint-client, fedimint-client-wasm, fedimint-wasm-tests,
  fedimint-mintv2-client, fedimint-walletv2-client, wasm32-unknown-unknown>
pre-commit hook
git diff --check origin/master...HEAD
nix build -L .#nightly.test.workspaceCargoUdeps
```

`cargo nextest run --workspace --all-targets` and the per-crate `--all-features` / `--no-default-features` checks were run locally precisely because the previous PR in this series (#9118) was bounced by both in CI. Results:

| Command | Result |
|---|---|
| `cargo clippy --workspace --all-targets -- -D warnings` | pass, clean, exit 0 |
| `cargo nextest run --workspace --all-targets` | `Summary [ 77.866s] 654 tests run: 654 passed (4 slow), 1 skipped` |
| `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` for each of `fedimint-core`, `fedimint-mint-client`, `fedimint-mint-common`, `fedimint-mintv2-client`, `fedimint-mintv2-common`, `fedimint-client-rpc`, `fedimint-gateway-server` | exit 0 for every crate |
| `cargo test --doc -p fedimint-core -p fedimint-mint-client -p fedimint-mint-common -p fedimint-mintv2-client -p fedimint-mintv2-common` | `fedimint_core`: 8 passed, 0 failed; the other four crates: 0 doctests each, `test result: ok` |
| `cargo check --all-features` / `--no-default-features` for `fedimint-core`, `fedimint-mint-client`, `fedimint-mint-common`, `fedimint-mintv2-client`, `fedimint-mintv2-common`, `fedimint-client-rpc`, `fedimint-gateway-server`, `fedimint-cli` | exit 0 for all 16 combinations |
| wasm check (`fedimint-client`, `fedimint-client-wasm`, `fedimint-wasm-tests`, `fedimint-mintv2-client`, `fedimint-walletv2-client`, target `wasm32-unknown-unknown`) | exit 0; 0 error lines, 30 warning lines, all pre-existing and in files this PR's diff never touches |
| pre-commit hook | exit 0, clean |
| `git diff --check origin/master...HEAD` | exit 0, empty |
| `nix build -L .#nightly.test.workspaceCargoUdeps` | `All deps seem to have been used.`, exit 0 |

Part of #8821.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBPWG2LzLfynoMPuY7ZSXL
