### PR TITLE
chore(wallet): replace anyhow with typed errors in the public API (#8821)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3253,6 +3253,7 @@ version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
+ "assert_matches",
  "async-stream",
  "async-trait",
  "bitcoin",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5147,7 +5147,6 @@ dependencies = [
 name = "fedimint-walletv2-common"
 version = "0.13.0-alpha"
 dependencies = [
- "anyhow",
  "bitcoin",
  "fedimint-core",
  "miniscript",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5184,6 +5184,7 @@ name = "fedimint-walletv2-tests"
 version = "0.13.0-alpha"
 dependencies = [
  "anyhow",
+ "assert_matches",
  "async-stream",
  "bitcoin",
  "bitcoincore-rpc",

--- a/fedimint-client-module/Cargo.toml
+++ b/fedimint-client-module/Cargo.toml
@@ -51,6 +51,9 @@ tokio-stream = { workspace = true, features = ["sync"] }
 tracing = { workspace = true }
 uniffi = { workspace = true, optional = true }
 
+[dev-dependencies]
+assert_matches = { workspace = true }
+
 [build-dependencies]
 fedimint-build = { workspace = true }
 

--- a/fedimint-client-module/src/error.rs
+++ b/fedimint-client-module/src/error.rs
@@ -5,11 +5,32 @@
 //! sides; they live here rather than in `fedimint-client`, which the modules do
 //! not depend on.
 
+use fedimint_core::Amount;
 use fedimint_core::config::{FederationId, ModuleConfigError};
 use fedimint_core::core::{ModuleInstanceId, ModuleKind, OperationId};
 use fedimint_core::db::DatabaseError;
 use fedimint_core::module::AmountUnit;
 use thiserror::Error;
+
+/// The primary module cannot fund a transaction: the balance it holds is
+/// below what the transaction needs.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Error)]
+pub struct InsufficientBalanceError {
+    /// The amount the transaction needed the primary module to fund.
+    pub requested_amount: Amount,
+    /// The total amount the primary module actually holds.
+    pub total_amount: Amount,
+}
+
+impl std::fmt::Display for InsufficientBalanceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Insufficient balance: requested {} but only {} available",
+            self.requested_amount, self.total_amount
+        )
+    }
+}
 
 /// A failure to add state machines to the client's executor.
 #[derive(Debug, Error)]
@@ -106,7 +127,8 @@ pub enum TransactionSubmitError {
     },
 
     /// The primary module failed to balance the transaction or to complete
-    /// its outputs.
+    /// its outputs. An insufficient balance is reported as
+    /// [`Self::InsufficientFunds`] instead.
     // The boxed cause narrows to `ClientModuleError` once the module->client
     // trait boundary is typed (#8821 part E).
     #[error("The primary module failed")]
@@ -119,6 +141,19 @@ pub enum TransactionSubmitError {
     /// The transaction's state machines could not be registered.
     #[error("Failed to add the transaction's state machines")]
     StateMachines(#[from] AddStateMachinesError),
+
+    /// The primary module holds too little balance to fund the transaction.
+    #[error("Insufficient funds")]
+    InsufficientFunds(#[from] InsufficientBalanceError),
+}
+
+impl TransactionSubmitError {
+    /// Whether this failure means the primary module cannot fund the
+    /// transaction, as opposed to a failure of the client, the database or
+    /// the federation.
+    pub fn is_insufficient_funds(&self) -> bool {
+        matches!(self, Self::InsufficientFunds(_))
+    }
 }
 
 /// A failure to find a module able to serve a request.

--- a/fedimint-client-module/src/transaction/builder.rs
+++ b/fedimint-client-module/src/transaction/builder.rs
@@ -19,6 +19,7 @@ use rand::{CryptoRng, Rng, RngCore};
 use secp256k1::Secp256k1;
 use tracing::warn;
 
+use crate::error::TransactionSubmitError;
 use crate::module::{IdxRange, OutPointRange, StateGenerator};
 use crate::sm::{self, DynState};
 use crate::{
@@ -498,7 +499,7 @@ impl FeeQuote {
 /// gross_up(x) + fee_quote(gross_up(x)).total().get_bitcoin() <= balance
 /// ```
 ///
-/// or `None` if even `min_amount` is unaffordable.
+/// or `Ok(None)` if even `min_amount` is unaffordable.
 ///
 /// The cost is not a closed form of `x`: the federation fee is charged per
 /// note, so note selection, denomination rounding, change and dust move it in
@@ -506,8 +507,10 @@ impl FeeQuote {
 /// evaluates the real quote via a monotonic binary search — each step a single,
 /// non-committing `fee_quote` dry-run over the current inventory — and only
 /// ever advances the lower bound to a verified-affordable amount, so the result
-/// never overestimates. A `fee_quote` error (e.g. the balance cannot fund a
-/// value that large) is treated as unaffordable.
+/// never overestimates. An `InsufficientFunds` quote counts as unaffordable;
+/// any other quote failure is returned to the caller (a database or federation
+/// failure will not get better by probing a smaller amount, so the search
+/// aborts on the first one instead).
 ///
 /// To keep those dry-runs cheap the search is *seeded near the top*: a first
 /// pass binary-searches `gross_up` alone (pure arithmetic, no quotes) for the
@@ -517,24 +520,24 @@ impl FeeQuote {
 ///
 /// The LNv2 and LNv1 send-all flows share this solver; they differ only in
 /// `gross_up` (the gateway fee model) and which `fee_quote` they pass.
-pub async fn max_affordable_send_amount<GrossUp, Quote, Fut, E>(
+pub async fn max_affordable_send_amount<GrossUp, Quote, Fut>(
     balance: Amount,
     min_amount: Amount,
     max_amount: Amount,
     gross_up: GrossUp,
     fee_quote: Quote,
-) -> Option<Amount>
+) -> Result<Option<Amount>, TransactionSubmitError>
 where
     GrossUp: Fn(Amount) -> Amount,
     Quote: Fn(Amount) -> Fut,
-    Fut: Future<Output = Result<FeeQuote, E>>,
+    Fut: Future<Output = Result<FeeQuote, TransactionSubmitError>>,
 {
     // Nothing above the balance can ever be funded, so cap the upper bound.
     let hi_bound = max_amount.msats.min(balance.msats);
     let lo_bound = min_amount.msats;
 
     if lo_bound > hi_bound {
-        return None;
+        return Ok(None);
     }
 
     // The maximum is never near the bottom of `[lo_bound, hi_bound]`: it sits
@@ -546,7 +549,7 @@ where
     // the small window the federation fee opens up, instead of the whole balance.
     if gross_up(Amount::from_msats(lo_bound)).msats > balance.msats {
         // The balance can't even fund the smallest amount's gross-up.
-        return None;
+        return Ok(None);
     }
     let fundable_max = {
         let mut lo = lo_bound;
@@ -570,35 +573,42 @@ where
     // the federation fee, less the amount) is monotone non-decreasing, so the
     // overhead here is an upper bound on the overhead at the true maximum, and
     // `balance - overhead` is therefore a proven-affordable, tight lower bound.
-    // If the quote errors — real note selection can't fund a value this large —
-    // the seed is skipped and the search falls back to the full bracket below.
+    // If the quote reports `InsufficientFunds` — real note selection can't fund
+    // a value this large — the seed is skipped and the search falls back to the
+    // full bracket below. Any other failure is fatal and returned immediately.
     let funded = gross_up(Amount::from_msats(fundable_max));
-    if let Ok(quote) = fee_quote(funded).await {
-        let total = funded
-            .msats
-            .saturating_add(quote.total().get_bitcoin().msats);
-        if total <= balance.msats {
-            // Even the largest fundable amount fits once the fee is included.
-            return Some(Amount::from_msats(fundable_max));
+    match fee_quote(funded).await {
+        Ok(quote) => {
+            let total = funded
+                .msats
+                .saturating_add(quote.total().get_bitcoin().msats);
+            if total <= balance.msats {
+                // Even the largest fundable amount fits once the fee is included.
+                return Ok(Some(Amount::from_msats(fundable_max)));
+            }
+            let overhead = total.saturating_sub(fundable_max);
+            let seed = balance
+                .msats
+                .saturating_sub(overhead)
+                .clamp(lo_bound, fundable_max);
+            if send_amount_affordable(Amount::from_msats(seed), balance, &gross_up, &fee_quote)
+                .await?
+            {
+                lo = seed;
+                lo_affordable = true;
+            }
         }
-        let overhead = total.saturating_sub(fundable_max);
-        let seed = balance
-            .msats
-            .saturating_sub(overhead)
-            .clamp(lo_bound, fundable_max);
-        if send_amount_affordable(Amount::from_msats(seed), balance, &gross_up, &fee_quote).await {
-            lo = seed;
-            lo_affordable = true;
-        }
+        Err(e) if e.is_insufficient_funds() => {}
+        Err(e) => return Err(e),
     }
 
     // Without a usable seed the search must still start from a verified
     // affordable lower bound, or give up if even `lo_bound` is unaffordable.
     if !lo_affordable
         && !send_amount_affordable(Amount::from_msats(lo_bound), balance, &gross_up, &fee_quote)
-            .await
+            .await?
     {
-        return None;
+        return Ok(None);
     }
 
     // Exact maximum within the (now tight) `[lo, hi]` bracket.
@@ -606,41 +616,43 @@ where
         // Bias the midpoint up so the search converges toward `hi`.
         let mid = lo + (hi - lo).div_ceil(2);
 
-        if send_amount_affordable(Amount::from_msats(mid), balance, &gross_up, &fee_quote).await {
+        if send_amount_affordable(Amount::from_msats(mid), balance, &gross_up, &fee_quote).await? {
             lo = mid;
         } else {
             hi = mid - 1;
         }
     }
 
-    Some(Amount::from_msats(lo))
+    Ok(Some(Amount::from_msats(lo)))
 }
 
 /// Whether sending `amount` is payable in full out of `balance`: the funded
 /// value `gross_up(amount)` plus its federation `fee_quote` must fit within the
-/// balance. A quote error (the balance cannot fund a value this large) counts
-/// as unaffordable, making this safe as the monotone predicate for
-/// [`max_affordable_send_amount`].
-async fn send_amount_affordable<GrossUp, Quote, Fut, E>(
+/// balance. An `InsufficientFunds` quote counts as unaffordable, making this
+/// safe as the monotone predicate for [`max_affordable_send_amount`]; any other
+/// quote failure is propagated, since it will not get better by probing a
+/// smaller amount.
+async fn send_amount_affordable<GrossUp, Quote, Fut>(
     amount: Amount,
     balance: Amount,
     gross_up: &GrossUp,
     fee_quote: &Quote,
-) -> bool
+) -> Result<bool, TransactionSubmitError>
 where
     GrossUp: Fn(Amount) -> Amount,
     Quote: Fn(Amount) -> Fut,
-    Fut: Future<Output = Result<FeeQuote, E>>,
+    Fut: Future<Output = Result<FeeQuote, TransactionSubmitError>>,
 {
     let funded_amount = gross_up(amount);
 
     if funded_amount > balance {
-        return false;
+        return Ok(false);
     }
 
     match fee_quote(funded_amount).await {
-        Ok(quote) => funded_amount + quote.total().get_bitcoin() <= balance,
-        Err(_) => false,
+        Ok(quote) => Ok(funded_amount + quote.total().get_bitcoin() <= balance),
+        Err(e) if e.is_insufficient_funds() => Ok(false),
+        Err(e) => Err(e),
     }
 }
 

--- a/fedimint-client-module/src/transaction/builder/tests.rs
+++ b/fedimint-client-module/src/transaction/builder/tests.rs
@@ -1,19 +1,20 @@
 use core::fmt;
-use std::convert::Infallible;
 use std::fmt::Write as _;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
+use assert_matches::assert_matches;
 use bitcoin::key::Secp256k1;
 use fedimint_core::Amount;
 use fedimint_core::core::{Input, IntoDynInstance, ModuleKind, Output};
 use fedimint_core::encoding::{Decodable, Encodable};
-use fedimint_core::module::Amounts;
+use fedimint_core::module::{AmountUnit, Amounts};
 
 use super::{
     ClientInputBundle, ClientOutput, ClientOutputBundle, ClientOutputSM, FeeQuote,
     TransactionBuilder, max_affordable_send_amount,
 };
+use crate::error::{InsufficientBalanceError, TransactionSubmitError};
 use crate::module::OutPointRange;
 use crate::transaction::{ClientInput, ClientInputSM};
 
@@ -204,9 +205,10 @@ async fn max_affordable_no_fees_spends_whole_balance() {
         Amount::from_msats(1),
         balance,
         |invoice| invoice, // no gateway fee
-        |_contract| async { Ok::<_, Infallible>(federation_fee(Amount::ZERO)) },
+        |_contract| async { Ok::<_, TransactionSubmitError>(federation_fee(Amount::ZERO)) },
     )
-    .await;
+    .await
+    .expect("no fatal quote failure");
 
     assert_eq!(result, Some(balance));
 }
@@ -222,9 +224,10 @@ async fn max_affordable_leaves_room_for_gateway_fee() {
         Amount::from_msats(1),
         balance,
         gross_up,
-        |_contract| async { Ok::<_, Infallible>(federation_fee(Amount::ZERO)) },
+        |_contract| async { Ok::<_, TransactionSubmitError>(federation_fee(Amount::ZERO)) },
     )
     .await
+    .expect("no fatal quote failure")
     .expect("balance covers a payment")
     .msats;
 
@@ -244,9 +247,12 @@ async fn max_affordable_leaves_room_for_module_fee() {
         Amount::from_msats(1),
         balance,
         |invoice| invoice, // no gateway fee, so contract == invoice
-        move |contract| async move { Ok::<_, Infallible>(federation_fee(module_fee(contract))) },
+        move |contract| async move {
+            Ok::<_, TransactionSubmitError>(federation_fee(module_fee(contract)))
+        },
     )
     .await
+    .expect("no fatal quote failure")
     .expect("balance covers a payment")
     .msats;
 
@@ -274,9 +280,12 @@ async fn max_affordable_handles_stepwise_fee() {
         Amount::from_msats(1),
         balance,
         |invoice| invoice,
-        move |contract| async move { Ok::<_, Infallible>(federation_fee(module_fee(contract))) },
+        move |contract| async move {
+            Ok::<_, TransactionSubmitError>(federation_fee(module_fee(contract)))
+        },
     )
-    .await;
+    .await
+    .expect("no fatal quote failure");
 
     // Above 500_000 the fee jump pushes the total over the balance, so the
     // maximum spendable amount sits exactly at the step.
@@ -292,9 +301,10 @@ async fn max_affordable_respects_max_bound() {
         Amount::from_msats(1),
         Amount::from_msats(100), // cap well below the balance
         |invoice| invoice,
-        |_contract| async { Ok::<_, Infallible>(federation_fee(Amount::ZERO)) },
+        |_contract| async { Ok::<_, TransactionSubmitError>(federation_fee(Amount::ZERO)) },
     )
-    .await;
+    .await
+    .expect("no fatal quote failure");
 
     assert_eq!(result, Some(Amount::from_msats(100)));
 }
@@ -309,18 +319,19 @@ async fn max_affordable_none_when_min_unaffordable() {
         Amount::from_msats(1),
         balance,
         |invoice: Amount| Amount::from_msats(invoice.msats + 1000), // 1000 msat base fee
-        |_contract| async { Ok::<_, Infallible>(federation_fee(Amount::ZERO)) },
+        |_contract| async { Ok::<_, TransactionSubmitError>(federation_fee(Amount::ZERO)) },
     )
-    .await;
+    .await
+    .expect("no fatal quote failure");
 
     assert_eq!(result, None);
 }
 
 #[tokio::test]
 async fn max_affordable_treats_quote_error_as_ceiling() {
-    // The fee quote errors once the contract exceeds what the balance can fund,
-    // exactly as real note selection does. The solver must treat that as the
-    // ceiling rather than overestimating.
+    // The fee quote reports `InsufficientFunds` once the contract exceeds what
+    // the balance can fund, exactly as real note selection does. The solver
+    // must treat that as the ceiling rather than overestimating.
     let cap = 400_000;
     let balance = Amount::from_msats(1_000_000);
 
@@ -331,16 +342,44 @@ async fn max_affordable_treats_quote_error_as_ceiling() {
         |invoice| invoice,
         move |contract: Amount| async move {
             if contract.msats > cap {
-                // The quote error is never inspected, so any type will do.
-                Err("insufficient funds")
+                Err(TransactionSubmitError::InsufficientFunds(
+                    InsufficientBalanceError {
+                        requested_amount: contract,
+                        total_amount: Amount::from_msats(cap),
+                    },
+                ))
             } else {
                 Ok(federation_fee(Amount::ZERO))
             }
         },
     )
-    .await;
+    .await
+    .expect("no fatal quote failure");
 
     assert_eq!(result, Some(Amount::from_msats(cap)));
+}
+
+#[tokio::test]
+async fn max_affordable_surfaces_fatal_quote_failure() {
+    // A quote failure unrelated to the balance (e.g. a database or federation
+    // error) cannot get better by probing a smaller amount, so the solver must
+    // surface it to the caller instead of treating it as unaffordable.
+    let balance = Amount::from_msats(1_000_000);
+
+    let result = max_affordable_send_amount(
+        balance,
+        Amount::from_msats(1),
+        balance,
+        |invoice| invoice,
+        |_contract| async {
+            Err(TransactionSubmitError::NoPrimaryModule {
+                unit: AmountUnit::BITCOIN,
+            })
+        },
+    )
+    .await;
+
+    assert_matches!(result, Err(TransactionSubmitError::NoPrimaryModule { .. }));
 }
 
 #[tokio::test]
@@ -364,10 +403,11 @@ async fn max_affordable_seeds_search_near_the_top() {
         gross_up,
         |contract| {
             quote_calls.fetch_add(1, Ordering::Relaxed);
-            async move { Ok::<_, Infallible>(federation_fee(fed_fee(contract))) }
+            async move { Ok::<_, TransactionSubmitError>(federation_fee(fed_fee(contract))) }
         },
     )
     .await
+    .expect("no fatal quote failure")
     .expect("balance covers a payment")
     .msats;
 

--- a/fedimint-client/src/client.rs
+++ b/fedimint-client/src/client.rs
@@ -92,8 +92,8 @@ use crate::db::{
     apply_migrations_core_client_dbtx, verify_client_db_integrity_dbtx,
 };
 use crate::error::{
-    ApiVersionDiscoveryError, ClientSecretError, ModuleLookupError, OperationAlreadyExistsError,
-    OperationNotFoundError, RecoveryError, TransactionSubmitError,
+    ApiVersionDiscoveryError, ClientSecretError, InsufficientBalanceError, ModuleLookupError,
+    OperationAlreadyExistsError, OperationNotFoundError, RecoveryError, TransactionSubmitError,
 };
 use crate::meta::MetaService;
 use crate::module_init::{ClientModuleInitRegistry, DynClientModuleInit, IClientModuleInit};
@@ -789,7 +789,7 @@ impl Client {
                     output_amount,
                 )
                 .await
-                .map_err(|err| TransactionSubmitError::PrimaryModule(err.into()))?;
+                .map_err(primary_module_error)?;
 
             added_inputs_bundles.push(added_input_bundle);
             added_outputs_bundles.push(added_output_bundle);
@@ -933,7 +933,7 @@ impl Client {
                     balance_output_amount,
                 )
                 .await
-                .map_err(|err| TransactionSubmitError::PrimaryModule(err.into()))?;
+                .map_err(primary_module_error)?;
 
             // Fold the change into the totals. These are a disjoint set of items
             // from the explicit ones (the primary module only sees the scalar
@@ -3044,6 +3044,25 @@ impl ClientContextIface for Client {
             .await
             .map(move |(k, v)| (k.0, v)),
         )
+    }
+}
+
+/// Classifies a primary module's failure to balance a transaction.
+///
+/// The module -> client trait boundary is still `anyhow` (#8821 part E
+/// narrows it), so this walks the error's `source()` chain for the one
+/// condition callers must be able to act on: an [`InsufficientBalanceError`]
+/// means the primary module cannot fund the transaction, as opposed to a
+/// failure of the client, the database or the federation, which stays
+/// [`TransactionSubmitError::PrimaryModule`].
+fn primary_module_error(err: anyhow::Error) -> TransactionSubmitError {
+    let insufficient_balance = err
+        .chain()
+        .find_map(|source| source.downcast_ref::<InsufficientBalanceError>().copied());
+
+    match insufficient_balance {
+        Some(found) => TransactionSubmitError::InsufficientFunds(found),
+        None => TransactionSubmitError::PrimaryModule(err.into()),
     }
 }
 

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -3031,7 +3031,8 @@ impl IAdminGateway for Gateway {
 
         let operation_id = wallet_module
             .withdraw(&address, withdraw_amount, fees, ())
-            .await?;
+            .await
+            .map_err(|e| AdminGatewayError::Unexpected(e.into()))?;
         let mut updates = wallet_module
             .subscribe_withdraw_updates(operation_id)
             .await?

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -1525,7 +1525,8 @@ impl Gateway {
         if let Ok(wallet_module) = client.value().get_first_module::<WalletClientModule>() {
             let address = wallet_module
                 .allocate_deposit_address_expert_only(())
-                .await?
+                .await
+                .map_err(|e| AdminGatewayError::Unexpected(e.into()))?
                 .address;
             Ok(address)
         } else if let Ok(wallet_module) = client

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -1644,7 +1644,8 @@ impl Gateway {
         if let Ok(wallet_module) = client.value().get_first_module::<WalletClientModule>() {
             wallet_module
                 .recheck_pegin_address_by_address(payload.address)
-                .await?;
+                .await
+                .map_err(|e| AdminGatewayError::Unexpected(e.into()))?;
             Ok(())
         } else if client
             .value()

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -550,7 +550,7 @@ async fn calculate_max_withdrawable(
         .max_withdrawable_amount(address, balance)
         .await
         .map_err(|err| AdminGatewayError::WithdrawError {
-            failure_reason: err.fmt_compact_anyhow().to_string(),
+            failure_reason: err.fmt_compact().to_string(),
         })?;
 
     // Everything the balance does not become an on-chain payment or miner fee
@@ -3015,13 +3015,16 @@ impl IAdminGateway for Gateway {
                         .map_err(|err| AdminGatewayError::WithdrawError {
                             failure_reason: format!(
                                 "Insufficient funds. Balance: {balance}: {}",
-                                err.fmt_compact_anyhow()
+                                err.fmt_compact()
                             ),
                         })?
                 }
                 BitcoinAmountOrAll::Amount(amount) => (
                     amount,
-                    wallet_module.get_withdraw_fees(&address, amount).await?,
+                    wallet_module
+                        .get_withdraw_fees(&address, amount)
+                        .await
+                        .map_err(|e| AdminGatewayError::Unexpected(e.into()))?,
                 ),
             },
         };
@@ -3084,7 +3087,8 @@ impl IAdminGateway for Gateway {
                         mint_fees: None,
                         peg_out_fees: wallet_module
                             .get_withdraw_fees(&address_checked, btc_amount)
-                            .await?,
+                            .await
+                            .map_err(|e| AdminGatewayError::Unexpected(e.into()))?,
                     }
                 } else if let Ok(wallet_module) = client
                     .value()

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -431,7 +431,7 @@ async fn withdraw_v2(
         .send_fee()
         .await
         .map_err(|e| AdminGatewayError::WithdrawError {
-            failure_reason: e.to_string(),
+            failure_reason: e.fmt_compact().to_string(),
         })?;
 
     let withdraw_amount = match amount {
@@ -469,7 +469,7 @@ async fn withdraw_v2(
         )
         .await
         .map_err(|e| AdminGatewayError::WithdrawError {
-            failure_reason: e.to_string(),
+            failure_reason: e.fmt_compact().to_string(),
         })?;
 
     let result = wallet_module
@@ -515,7 +515,7 @@ async fn calculate_max_withdrawable(
             .send_fee()
             .await
             .map_err(|e| AdminGatewayError::WithdrawError {
-                failure_reason: e.to_string(),
+                failure_reason: e.fmt_compact().to_string(),
             })?;
 
         let max_withdrawable = wallet_module
@@ -3098,7 +3098,7 @@ impl IAdminGateway for Gateway {
                 ) {
                     let fee = wallet_module.send_fee().await.map_err(|e| {
                         AdminGatewayError::WithdrawError {
-                            failure_reason: e.to_string(),
+                            failure_reason: e.fmt_compact().to_string(),
                         }
                     })?;
                     WithdrawDetails {

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -453,7 +453,7 @@ async fn withdraw_v2(
                 .map_err(|err| AdminGatewayError::WithdrawError {
                     failure_reason: format!(
                         "Insufficient funds. Balance: {balance} Fee: {fee}: {}",
-                        err.fmt_compact_anyhow()
+                        err.fmt_compact()
                     ),
                 })?
         }
@@ -476,7 +476,7 @@ async fn withdraw_v2(
         .await_final_send_operation_state(operation_id)
         .await
         .map_err(|e| AdminGatewayError::WithdrawError {
-            failure_reason: e.to_string(),
+            failure_reason: e.fmt_compact().to_string(),
         })?;
 
     let fees = PegOutFees::from_amount(fee);
@@ -522,7 +522,7 @@ async fn calculate_max_withdrawable(
             .max_sendable_amount(balance, fee)
             .await
             .map_err(|err| AdminGatewayError::WithdrawError {
-                failure_reason: err.fmt_compact_anyhow().to_string(),
+                failure_reason: err.fmt_compact().to_string(),
             })?;
 
         // Everything the balance does not become an on-chain payment or miner

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -3035,7 +3035,8 @@ impl IAdminGateway for Gateway {
             .map_err(|e| AdminGatewayError::Unexpected(e.into()))?;
         let mut updates = wallet_module
             .subscribe_withdraw_updates(operation_id)
-            .await?
+            .await
+            .map_err(|e| AdminGatewayError::Unexpected(e.into()))?
             .into_stream();
 
         while let Some(update) = updates.next().await {

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -41,6 +41,7 @@ use db::{
 };
 use fedimint_api_client::api::{DynModuleApi, ServerError};
 use fedimint_client_module::db::{ClientModuleMigrationFn, migrate_state};
+use fedimint_client_module::error::TransactionSubmitError;
 use fedimint_client_module::module::init::{ClientModuleInit, ClientModuleInitArgs};
 use fedimint_client_module::module::recovery::NoModuleBackup;
 use fedimint_client_module::module::{ClientContext, ClientModule, IClientModule, OutPointRange};
@@ -1872,7 +1873,7 @@ impl LightningClientModule {
     /// The gateway's off-chain Lightning fee is deliberately excluded: it is
     /// part of the contract `amount` the gateway claims, not the on-federation
     /// transaction fee. So `amount` is the full outgoing contract value.
-    pub async fn send_fee_quote(&self, amount: Amount) -> anyhow::Result<FeeQuote> {
+    pub async fn send_fee_quote(&self, amount: Amount) -> Result<FeeQuote, TransactionSubmitError> {
         self.client_ctx
             .fee_quote(
                 OperationId::new_random(),
@@ -1884,7 +1885,6 @@ impl LightningClientModule {
                 },
             )
             .await
-            .map_err(anyhow::Error::from)
     }
 
     /// Computes the largest invoice amount the client can pay in full out of
@@ -1937,7 +1937,7 @@ impl LightningClientModule {
             |invoice_amount: Amount| invoice_amount + gateway.fees.to_amount(&invoice_amount),
             |contract_amount: Amount| self.send_fee_quote(contract_amount),
         )
-        .await
+        .await?
         .ok_or_else(|| anyhow!("Balance is too low to send any amount after fees"))
     }
 

--- a/modules/fedimint-lnv2-client/src/lib.rs
+++ b/modules/fedimint-lnv2-client/src/lib.rs
@@ -22,6 +22,7 @@ use bitcoin::hashes::{Hash, sha256};
 use bitcoin::secp256k1;
 use db::{DbKeyPrefix, GatewayKey, IncomingContractStreamIndexKey};
 use fedimint_api_client::api::DynModuleApi;
+use fedimint_client_module::error::TransactionSubmitError;
 use fedimint_client_module::module::init::{ClientModuleInit, ClientModuleInitArgs};
 use fedimint_client_module::module::recovery::NoModuleBackup;
 use fedimint_client_module::module::{ClientContext, ClientModule, OutPointRange};
@@ -1190,7 +1191,7 @@ impl LightningClientModule {
     /// part of the contract `amount` the gateway claims, not the on-federation
     /// transaction fee. So `amount` is the full outgoing contract value
     /// (`send_fee.add_to(invoice_amount)`).
-    pub async fn send_fee_quote(&self, amount: Amount) -> anyhow::Result<FeeQuote> {
+    pub async fn send_fee_quote(&self, amount: Amount) -> Result<FeeQuote, TransactionSubmitError> {
         self.client_ctx
             .fee_quote(
                 OperationId::new_random(),
@@ -1202,7 +1203,6 @@ impl LightningClientModule {
                 },
             )
             .await
-            .map_err(anyhow::Error::from)
     }
 
     /// Computes the largest invoice amount the client can pay in full out of
@@ -1268,7 +1268,7 @@ impl LightningClientModule {
             |invoice_amount: Amount| send_fee.add_to(invoice_amount.msats),
             |contract_amount: Amount| self.send_fee_quote(contract_amount),
         )
-        .await
+        .await?
         .ok_or_else(|| anyhow::anyhow!("Balance is too low to send any amount after fees"))
     }
 

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -59,6 +59,7 @@ use client_db::{
 use events::{NoteSpent, OOBNotesReissued, OOBNotesSpent, ReceivePaymentEvent, SendPaymentEvent};
 use fedimint_api_client::api::{DynModuleApi, FederationResult};
 use fedimint_client_module::db::{ClientModuleMigrationFn, migrate_state};
+pub use fedimint_client_module::error::InsufficientBalanceError;
 use fedimint_client_module::error::{OperationLookupError, TransactionSubmitError};
 use fedimint_client_module::module::init::{
     ClientModuleInit, ClientModuleInitArgs, ClientModuleRecoverArgs, RecoveryMode,
@@ -110,7 +111,6 @@ use output::MintOutputStatesCreatedMulti;
 use serde::{Deserialize, Serialize};
 use strum::IntoEnumIterator;
 use tbs::AggregatePublicKey;
-use thiserror::Error;
 use tracing::{debug, warn};
 
 use crate::backup::EcashBackup;
@@ -2973,22 +2973,6 @@ async fn select_notes_from_stream<Note>(
                 total_amount,
             });
         }
-    }
-}
-
-#[derive(Debug, Clone, Error)]
-pub struct InsufficientBalanceError {
-    pub requested_amount: Amount,
-    pub total_amount: Amount,
-}
-
-impl std::fmt::Display for InsufficientBalanceError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "Insufficient balance: requested {} but only {} available",
-            self.requested_amount, self.total_amount
-        )
     }
 }
 

--- a/modules/fedimint-mintv2-client/src/lib.rs
+++ b/modules/fedimint-mintv2-client/src/lib.rs
@@ -36,7 +36,9 @@ use fedimint_client::transaction::{
     ClientOutputSM, FeeQuote, FeeQuoteRequest, TransactionBuilder,
 };
 use fedimint_client_module::db::ClientModuleMigrationFn;
-use fedimint_client_module::error::{OperationLookupError, TransactionSubmitError};
+use fedimint_client_module::error::{
+    InsufficientBalanceError, OperationLookupError, TransactionSubmitError,
+};
 use fedimint_client_module::module::init::{
     ClientModuleInit, ClientModuleInitArgs, ClientModuleRecoverArgs,
     ClientModuleRecoveryPrepareArgs, RecoveryMode,
@@ -498,10 +500,17 @@ impl ClientModule for MintClientModule {
             anyhow::bail!("Module can only handle its configured amount unit");
         }
 
-        let funding_notes = self
-            .select_funding_input(dbtx, output_amount.saturating_sub(input_amount))
-            .await
-            .context("Insufficient funds")?;
+        let requested_amount = output_amount.saturating_sub(input_amount);
+        // `select_funding_input` only reads notes, so the balance it left behind is
+        // still accurate for reporting a total below.
+        let Some(funding_notes) = self.select_funding_input(dbtx, requested_amount).await else {
+            let total_amount = self.get_balance(dbtx, unit).await;
+            return Err(InsufficientBalanceError {
+                requested_amount,
+                total_amount,
+            }
+            .into());
+        };
 
         for note in &funding_notes {
             self.remove_spendable_note(dbtx, note).await;
@@ -936,7 +945,10 @@ impl MintClientModule {
                 TransactionBuilder::new().with_outputs(output),
             )
             .await
-            .map_err(|_| SendECashError::InsufficientBalance)?;
+            .map_err(|error| match error {
+                TransactionSubmitError::InsufficientFunds(_) => SendECashError::InsufficientBalance,
+                other => SendECashError::Failed(other),
+            })?;
 
         for outpoint in range {
             self.await_output_sm_success(operation_id, outpoint)
@@ -1052,8 +1064,9 @@ impl MintClientModule {
                 TransactionSubmitError::OperationAlreadyExists(_) => {
                     ReceiveECashError::AlreadyReceived
                 }
-                TransactionSubmitError::NoPrimaryModule { .. }
-                | TransactionSubmitError::PrimaryModule(..) => ReceiveECashError::InsufficientFunds,
+                TransactionSubmitError::InsufficientFunds(_) => {
+                    ReceiveECashError::InsufficientFunds
+                }
                 other => ReceiveECashError::Failed(other),
             })?;
 
@@ -1344,7 +1357,7 @@ async fn download_slice(
 }
 
 /// A failure to send e-cash by preparing notes to hand to the recipient.
-#[derive(Error, Debug, Clone, Eq, PartialEq)]
+#[derive(Error, Debug)]
 #[non_exhaustive]
 pub enum SendECashError {
     /// The client needs to reissue notes to make change, but has no
@@ -1358,6 +1371,10 @@ pub enum SendECashError {
     /// recover from.
     #[error("A non-recoverable error has occurred")]
     Failure,
+    /// The change-making reissue transaction could not be submitted for a
+    /// reason unrelated to funding.
+    #[error("The reissue transaction could not be submitted")]
+    Failed(#[source] TransactionSubmitError),
 }
 
 /// A failure to receive e-cash by reissuing it.

--- a/modules/fedimint-mintv2-tests/tests/tests.rs
+++ b/modules/fedimint-mintv2-tests/tests/tests.rs
@@ -689,13 +689,13 @@ async fn send_without_funds_reports_insufficient_balance() -> anyhow::Result<()>
     // Deliberately no `issue_ecash` call: the wallet is empty.
     let client = fed.new_client().await;
 
-    assert_eq!(
+    assert_matches!(
         client
             .get_first_module::<MintClientModule>()?
             .send(Amount::from_sats(1_000), Value::Null, false)
             .await
             .map(|(_operation_id, ecash)| ecash.amount()),
-        Err(SendECashError::InsufficientBalance),
+        Err(SendECashError::InsufficientBalance)
     );
 
     Ok(())

--- a/modules/fedimint-wallet-client/src/api.rs
+++ b/modules/fedimint-wallet-client/src/api.rs
@@ -1,4 +1,3 @@
-use anyhow::anyhow;
 use bitcoin::{Address, Amount};
 use fedimint_api_client::api::{
     FederationApiExt, FederationError, FederationGeneralError, FederationResult,
@@ -42,11 +41,14 @@ pub trait WalletFederationApi {
     async fn activate_consensus_version_voting(&self, auth: ApiAuth) -> FederationResult<()>;
 
     /// Returns the total number of recovery items stored on the federation
-    async fn fetch_recovery_count(&self) -> anyhow::Result<u64>;
+    async fn fetch_recovery_count(&self) -> FederationResult<u64>;
 
     /// Fetches recovery items in the range `[start, end)` via consensus
-    async fn fetch_recovery_slice(&self, start: u64, end: u64)
-    -> anyhow::Result<Vec<RecoveryItem>>;
+    async fn fetch_recovery_slice(
+        &self,
+        start: u64,
+        end: u64,
+    ) -> FederationResult<Vec<RecoveryItem>>;
 }
 
 #[apply(async_trait_maybe_send!)]
@@ -214,25 +216,23 @@ where
         .await
     }
 
-    async fn fetch_recovery_count(&self) -> anyhow::Result<u64> {
+    async fn fetch_recovery_count(&self) -> FederationResult<u64> {
         self.request_current_consensus::<u64>(
             RECOVERY_COUNT_ENDPOINT.to_string(),
             ApiRequestErased::default(),
         )
         .await
-        .map_err(|e| anyhow!("{e}"))
     }
 
     async fn fetch_recovery_slice(
         &self,
         start: u64,
         end: u64,
-    ) -> anyhow::Result<Vec<RecoveryItem>> {
+    ) -> FederationResult<Vec<RecoveryItem>> {
         self.request_current_consensus::<Vec<RecoveryItem>>(
             RECOVERY_SLICE_ENDPOINT.to_string(),
             ApiRequestErased::new((start, end)),
         )
         .await
-        .map_err(|e| anyhow!("{e}"))
     }
 }

--- a/modules/fedimint-wallet-client/src/error.rs
+++ b/modules/fedimint-wallet-client/src/error.rs
@@ -208,6 +208,10 @@ pub enum MaxWithdrawableAmountError {
         /// The destination's dust limit, the smallest output it can receive.
         dust_limit: bitcoin::Amount,
     },
+
+    /// The fee probe failed for a reason unrelated to the balance.
+    #[error("The fee quote for the withdrawal failed")]
+    Quote(#[source] TransactionSubmitError),
 }
 
 /// A failure to start an on-chain withdrawal from a peg-out request.

--- a/modules/fedimint-wallet-client/src/error.rs
+++ b/modules/fedimint-wallet-client/src/error.rs
@@ -10,7 +10,9 @@ use fedimint_client_module::error::{
     OperationAlreadyExistsError, OperationLookupError, TransactionSubmitError,
 };
 use fedimint_core::core::OperationId;
-use fedimint_core::db::DatabaseError;
+use fedimint_core::db::{AutocommitError, DatabaseError};
+#[cfg(feature = "uniffi")]
+use fedimint_core::util::FmtCompact as _;
 use thiserror::Error;
 
 use crate::client_db::TweakIdx;
@@ -30,7 +32,7 @@ pub enum PegInError {
 
     /// No deposit address was allocated under this operation.
     #[error("No deposit address belongs to operation {}", .operation_id.fmt_short())]
-    OperationNotFound {
+    NoAddressForOperation {
         /// The operation that was looked up.
         operation_id: OperationId,
     },
@@ -42,7 +44,7 @@ pub enum PegInError {
         tweak_idx: TweakIdx,
     },
 
-    /// The database write that schedules the re-check failed.
+    /// A database operation failed.
     #[error("Database error")]
     Database(#[from] DatabaseError),
 
@@ -60,6 +62,15 @@ pub enum PegInError {
     /// The peg-in monitor stopped, so no further deposit will ever be claimed.
     #[error("The peg-in monitor is no longer running")]
     MonitorStopped,
+}
+
+impl From<AutocommitError<PegInError>> for PegInError {
+    fn from(e: AutocommitError<Self>) -> Self {
+        match e {
+            AutocommitError::ClosureError { error, .. } => error,
+            AutocommitError::CommitFailed { last_error, .. } => Self::Database(last_error),
+        }
+    }
 }
 
 /// A failure to hand out a deposit address.
@@ -104,11 +115,18 @@ pub enum DepositAddressError {
     },
 }
 
+impl From<AutocommitError<DepositAddressError>> for DepositAddressError {
+    fn from(e: AutocommitError<Self>) -> Self {
+        match e {
+            AutocommitError::ClosureError { error, .. } => error,
+            AutocommitError::CommitFailed { last_error, .. } => Self::Database(last_error),
+        }
+    }
+}
+
 #[cfg(feature = "uniffi")]
 impl From<DepositAddressError> for fedimint_core::util::ffi::UniffiError {
     fn from(e: DepositAddressError) -> Self {
-        use fedimint_core::util::FmtCompact as _;
-
         Self::General(e.fmt_compact().to_string())
     }
 }
@@ -122,7 +140,7 @@ pub enum SubscribeDepositError {
     Operation(#[from] OperationLookupError),
 
     /// The operation exists and belongs to the wallet, but it is a withdrawal
-    /// rather than a deposit.
+    /// (or an RBF bump of one) rather than a deposit.
     #[error("The operation is not a deposit")]
     NotADeposit,
 
@@ -148,8 +166,6 @@ pub enum SubscribeDepositError {
 #[cfg(feature = "uniffi")]
 impl From<SubscribeDepositError> for fedimint_core::util::ffi::UniffiError {
     fn from(e: SubscribeDepositError) -> Self {
-        use fedimint_core::util::FmtCompact as _;
-
         Self::General(e.fmt_compact().to_string())
     }
 }
@@ -185,8 +201,13 @@ pub enum MaxWithdrawableAmountError {
 
     /// The balance cannot cover the destination's dust limit plus the fees, so
     /// there is no amount to withdraw.
-    #[error("The balance is too low to withdraw any amount after fees")]
-    BalanceTooLow,
+    #[error("The balance {balance} is too low to cover the dust limit {dust_limit} and fees")]
+    BalanceTooLow {
+        /// The balance the sweep was computed against.
+        balance: fedimint_core::Amount,
+        /// The destination's dust limit, the smallest output it can receive.
+        dust_limit: bitcoin::Amount,
+    },
 }
 
 /// A failure to start an on-chain withdrawal from a peg-out request.
@@ -213,8 +234,6 @@ pub enum PegOutError {
 #[cfg(feature = "uniffi")]
 impl From<PegOutError> for fedimint_core::util::ffi::UniffiError {
     fn from(e: PegOutError) -> Self {
-        use fedimint_core::util::FmtCompact as _;
-
         Self::General(e.fmt_compact().to_string())
     }
 }
@@ -236,8 +255,6 @@ pub enum SubscribeWithdrawError {
 #[cfg(feature = "uniffi")]
 impl From<SubscribeWithdrawError> for fedimint_core::util::ffi::UniffiError {
     fn from(e: SubscribeWithdrawError) -> Self {
-        use fedimint_core::util::FmtCompact as _;
-
         Self::General(e.fmt_compact().to_string())
     }
 }

--- a/modules/fedimint-wallet-client/src/error.rs
+++ b/modules/fedimint-wallet-client/src/error.rs
@@ -3,8 +3,9 @@
 //! Every failure this module reports to its callers is named here, so there is
 //! one place for an integrator to look.
 
+use bitcoin::Network;
 use fedimint_bitcoind::BitcoinRpcError;
-use fedimint_client_module::error::OperationAlreadyExistsError;
+use fedimint_client_module::error::{OperationAlreadyExistsError, OperationLookupError};
 use fedimint_core::core::OperationId;
 use fedimint_core::db::DatabaseError;
 use thiserror::Error;
@@ -103,6 +104,47 @@ pub enum DepositAddressError {
 #[cfg(feature = "uniffi")]
 impl From<DepositAddressError> for fedimint_core::util::ffi::UniffiError {
     fn from(e: DepositAddressError) -> Self {
+        use fedimint_core::util::FmtCompact as _;
+
+        Self::General(e.fmt_compact().to_string())
+    }
+}
+
+/// A failure to follow a deposit operation.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum SubscribeDepositError {
+    /// The operation could not be looked up, or belongs to another module.
+    #[error("The deposit operation could not be looked up")]
+    Operation(#[from] OperationLookupError),
+
+    /// The operation exists and belongs to the wallet, but it is a withdrawal
+    /// rather than a deposit.
+    #[error("The operation is not a deposit")]
+    NotADeposit,
+
+    /// The deposit address recorded with the operation is not valid on the
+    /// network this client is configured for.
+    #[error("The deposit address is not valid on {expected}")]
+    WrongNetwork {
+        /// The network this client expects.
+        expected: Network,
+    },
+
+    /// The deposit predates the 0.4 release, is still pending, and has no
+    /// state machine left to report progress from.
+    #[error("An old pending deposit cannot be subscribed to")]
+    OldPendingDeposit,
+
+    /// The deposit predates the 0.4 release and the outcome recorded for it is
+    /// not one of the final ones.
+    #[error("The recorded outcome of an old deposit is not final")]
+    NonFinalOutcome,
+}
+
+#[cfg(feature = "uniffi")]
+impl From<SubscribeDepositError> for fedimint_core::util::ffi::UniffiError {
+    fn from(e: SubscribeDepositError) -> Self {
         use fedimint_core::util::FmtCompact as _;
 
         Self::General(e.fmt_compact().to_string())

--- a/modules/fedimint-wallet-client/src/error.rs
+++ b/modules/fedimint-wallet-client/src/error.rs
@@ -4,6 +4,7 @@
 //! one place for an integrator to look.
 
 use bitcoin::Network;
+use fedimint_api_client::api::FederationError;
 use fedimint_bitcoind::BitcoinRpcError;
 use fedimint_client_module::error::{OperationAlreadyExistsError, OperationLookupError};
 use fedimint_core::core::OperationId;
@@ -149,4 +150,39 @@ impl From<SubscribeDepositError> for fedimint_core::util::ffi::UniffiError {
 
         Self::General(e.fmt_compact().to_string())
     }
+}
+
+/// A failure to quote the on-chain fees of a peg-out.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum WithdrawFeesError {
+    /// The federation could not be asked, or its guardians disagreed.
+    #[error("The peg-out fees could not be fetched")]
+    Federation(#[source] Box<FederationError>),
+
+    /// The federation was reached and agreed, but it has no quote to give for
+    /// this amount.
+    #[error("The federation did not quote peg-out fees")]
+    NoQuote,
+}
+
+impl From<FederationError> for WithdrawFeesError {
+    fn from(source: FederationError) -> Self {
+        Self::Federation(Box::new(source))
+    }
+}
+
+/// A failure to work out the largest amount a "withdraw everything" sweep can
+/// send.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum MaxWithdrawableAmountError {
+    /// The on-chain fees the answer is computed against could not be quoted.
+    #[error("The peg-out fees could not be quoted")]
+    Fees(#[from] WithdrawFeesError),
+
+    /// The balance cannot cover the destination's dust limit plus the fees, so
+    /// there is no amount to withdraw.
+    #[error("The balance is too low to withdraw any amount after fees")]
+    BalanceTooLow,
 }

--- a/modules/fedimint-wallet-client/src/error.rs
+++ b/modules/fedimint-wallet-client/src/error.rs
@@ -241,3 +241,23 @@ impl From<SubscribeWithdrawError> for fedimint_core::util::ffi::UniffiError {
         Self::General(e.fmt_compact().to_string())
     }
 }
+
+/// A failure to vote for activating the next wallet module consensus version.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum ConsensusVersionVotingError {
+    /// Voting is a guardian action and this client holds no admin
+    /// credentials.
+    #[error("Admin auth is not set")]
+    AdminAuthMissing,
+
+    /// The vote could not be submitted to the federation.
+    #[error("The vote could not be submitted to the federation")]
+    Federation(#[source] Box<FederationError>),
+}
+
+impl From<FederationError> for ConsensusVersionVotingError {
+    fn from(source: FederationError) -> Self {
+        Self::Federation(Box::new(source))
+    }
+}

--- a/modules/fedimint-wallet-client/src/error.rs
+++ b/modules/fedimint-wallet-client/src/error.rs
@@ -3,6 +3,8 @@
 //! Every failure this module reports to its callers is named here, so there is
 //! one place for an integrator to look.
 
+use fedimint_bitcoind::BitcoinRpcError;
+use fedimint_client_module::error::OperationAlreadyExistsError;
 use fedimint_core::core::OperationId;
 use fedimint_core::db::DatabaseError;
 use thiserror::Error;
@@ -54,4 +56,55 @@ pub enum PegInError {
     /// The peg-in monitor stopped, so no further deposit will ever be claimed.
     #[error("The peg-in monitor is no longer running")]
     MonitorStopped,
+}
+
+/// A failure to hand out a deposit address.
+///
+/// Covers both the plain allocation and the pooled one, which can also lose a
+/// race against a deposit landing on the address it was about to reuse.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum DepositAddressError {
+    /// The client has never been online to confirm that the federation's
+    /// wallet module handles every deposit safely.
+    #[error("The federation was not verified to support safe deposits")]
+    SafeDepositUnverified,
+
+    /// An operation for this deposit address already exists.
+    #[error("The deposit address's operation already exists")]
+    OperationAlreadyExists(#[from] OperationAlreadyExistsError),
+
+    /// The bitcoin backend would not start watching the address, so a deposit
+    /// to it would never be noticed.
+    #[error("The bitcoin backend could not watch the deposit address")]
+    BitcoinRpc(#[from] BitcoinRpcError),
+
+    /// The deposit address could not be written to the database.
+    #[error("Database error")]
+    Database(#[from] DatabaseError),
+
+    /// A pooled address vanished from the database between being offered for
+    /// reuse and being reused.
+    #[error("The pooled deposit address {tweak_idx} disappeared while it was being reused")]
+    PooledAddressDisappeared {
+        /// The address index that was being reused.
+        tweak_idx: TweakIdx,
+    },
+
+    /// A deposit landed on a pooled address between it being offered for reuse
+    /// and being reused, so it is no longer free.
+    #[error("The pooled deposit address {tweak_idx} was used while it was being reused")]
+    PooledAddressUsed {
+        /// The address index that was being reused.
+        tweak_idx: TweakIdx,
+    },
+}
+
+#[cfg(feature = "uniffi")]
+impl From<DepositAddressError> for fedimint_core::util::ffi::UniffiError {
+    fn from(e: DepositAddressError) -> Self {
+        use fedimint_core::util::FmtCompact as _;
+
+        Self::General(e.fmt_compact().to_string())
+    }
 }

--- a/modules/fedimint-wallet-client/src/error.rs
+++ b/modules/fedimint-wallet-client/src/error.rs
@@ -1,0 +1,57 @@
+//! Error types of the wallet client.
+//!
+//! Every failure this module reports to its callers is named here, so there is
+//! one place for an integrator to look.
+
+use fedimint_core::core::OperationId;
+use fedimint_core::db::DatabaseError;
+use thiserror::Error;
+
+use crate::client_db::TweakIdx;
+
+/// A failure to look up or drive one of this client's deposit addresses.
+///
+/// The peg-in side of the wallet is address-oriented: a caller names a deposit
+/// by its address, by the operation that allocated it, or by the tweak index
+/// behind both, and then waits for the federation to claim what was sent
+/// there. Every way that can go wrong is named here.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum PegInError {
+    /// The address is not one this client derived.
+    #[error("The address is not one of this client's deposit addresses")]
+    AddressNotDerived,
+
+    /// No deposit address was allocated under this operation.
+    #[error("No deposit address belongs to operation {}", .operation_id.fmt_short())]
+    OperationNotFound {
+        /// The operation that was looked up.
+        operation_id: OperationId,
+    },
+
+    /// The client has no record of this deposit address index.
+    #[error("No deposit address is recorded for {tweak_idx}")]
+    TweakIdxNotFound {
+        /// The index that was looked up.
+        tweak_idx: TweakIdx,
+    },
+
+    /// The database write that schedules the re-check failed.
+    #[error("Database error")]
+    Database(#[from] DatabaseError),
+
+    /// The federation rejected the transaction that would have claimed the
+    /// deposit.
+    ///
+    /// The payload is the message the submission recorded rather than an error
+    /// value, so it is part of this error's own message.
+    #[error("The transaction claiming the deposit was rejected: {reason}")]
+    TransactionRejected {
+        /// What the submission reported.
+        reason: String,
+    },
+
+    /// The peg-in monitor stopped, so no further deposit will ever be claimed.
+    #[error("The peg-in monitor is no longer running")]
+    MonitorStopped,
+}

--- a/modules/fedimint-wallet-client/src/error.rs
+++ b/modules/fedimint-wallet-client/src/error.rs
@@ -6,7 +6,9 @@
 use bitcoin::Network;
 use fedimint_api_client::api::FederationError;
 use fedimint_bitcoind::BitcoinRpcError;
-use fedimint_client_module::error::{OperationAlreadyExistsError, OperationLookupError};
+use fedimint_client_module::error::{
+    OperationAlreadyExistsError, OperationLookupError, TransactionSubmitError,
+};
 use fedimint_core::core::OperationId;
 use fedimint_core::db::DatabaseError;
 use thiserror::Error;
@@ -185,4 +187,34 @@ pub enum MaxWithdrawableAmountError {
     /// there is no amount to withdraw.
     #[error("The balance is too low to withdraw any amount after fees")]
     BalanceTooLow,
+}
+
+/// A failure to start an on-chain withdrawal from a peg-out request.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum PegOutError {
+    /// The destination address is not valid on the network this client is
+    /// configured for.
+    #[error("The destination address is not valid on {expected}")]
+    WrongNetwork {
+        /// The network this client expects.
+        expected: Network,
+    },
+
+    /// The on-chain fees of the withdrawal could not be quoted.
+    #[error("The peg-out fees could not be quoted")]
+    Fees(#[from] WithdrawFeesError),
+
+    /// The withdrawal transaction could not be built or submitted.
+    #[error("The withdrawal transaction could not be submitted")]
+    Transaction(#[from] TransactionSubmitError),
+}
+
+#[cfg(feature = "uniffi")]
+impl From<PegOutError> for fedimint_core::util::ffi::UniffiError {
+    fn from(e: PegOutError) -> Self {
+        use fedimint_core::util::FmtCompact as _;
+
+        Self::General(e.fmt_compact().to_string())
+    }
 }

--- a/modules/fedimint-wallet-client/src/error.rs
+++ b/modules/fedimint-wallet-client/src/error.rs
@@ -218,3 +218,26 @@ impl From<PegOutError> for fedimint_core::util::ffi::UniffiError {
         Self::General(e.fmt_compact().to_string())
     }
 }
+
+/// A failure to follow a withdrawal operation.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum SubscribeWithdrawError {
+    /// The operation could not be looked up, or belongs to another module.
+    #[error("The withdrawal operation could not be looked up")]
+    Operation(#[from] OperationLookupError),
+
+    /// The operation exists and belongs to the wallet, but it is a deposit
+    /// rather than a withdrawal.
+    #[error("The operation is not a withdrawal")]
+    NotAWithdrawal,
+}
+
+#[cfg(feature = "uniffi")]
+impl From<SubscribeWithdrawError> for fedimint_core::util::ffi::UniffiError {
+    fn from(e: SubscribeWithdrawError) -> Self {
+        use fedimint_core::util::FmtCompact as _;
+
+        Self::General(e.fmt_compact().to_string())
+    }
+}

--- a/modules/fedimint-wallet-client/src/ffi.rs
+++ b/modules/fedimint-wallet-client/src/ffi.rs
@@ -4,6 +4,7 @@ use bitcoin::address::NetworkUnchecked;
 use bitcoin::{Address, Amount, OutPoint, Txid};
 use fedimint_core::core::OperationId;
 use fedimint_core::runtime::ffi_spawn_subscription;
+use fedimint_core::util::FmtCompact as _;
 use fedimint_core::util::ffi::UniffiError;
 use fedimint_wallet_common::WalletSummary;
 use futures::StreamExt as _;
@@ -48,12 +49,16 @@ uniffi::custom_type!(Txid, String, {
 impl WalletClientModule {
     #[uniffi::method(name = "get_wallet_summary")]
     pub async fn get_wallet_summary_uniffi(&self) -> Result<WalletSummary> {
-        Ok(self.get_wallet_summary().await?)
+        self.get_wallet_summary()
+            .await
+            .map_err(|e| UniffiError::General(e.fmt_compact().to_string()))
     }
 
     #[uniffi::method(name = "get_block_count_local")]
     pub async fn get_block_count_local_uniffi(&self) -> Result<u32> {
-        Ok(self.get_block_count_local().await?)
+        self.get_block_count_local()
+            .await
+            .map_err(|e| UniffiError::General(e.fmt_compact().to_string()))
     }
 
     #[uniffi::method(name = "peg_in")]

--- a/modules/fedimint-wallet-client/src/ffi.rs
+++ b/modules/fedimint-wallet-client/src/ffi.rs
@@ -1,5 +1,6 @@
 use std::str::FromStr;
 
+use anyhow::anyhow;
 use bitcoin::address::NetworkUnchecked;
 use bitcoin::{Address, Amount, OutPoint, Txid};
 use fedimint_core::core::OperationId;
@@ -12,7 +13,7 @@ use serde_json::Value;
 
 use crate::{
     DepositStateV2, PegInRequest, PegInResponse, PegOutRequest, PegOutResponse, WalletClientModule,
-    WithdrawState, anyhow,
+    WithdrawState,
 };
 
 type Result<T> = std::result::Result<T, UniffiError>;

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -96,8 +96,8 @@ use crate::client_db::{
 };
 use crate::deposit::DepositStateMachine;
 pub use crate::error::{
-    DepositAddressError, MaxWithdrawableAmountError, PegInError, SubscribeDepositError,
-    WithdrawFeesError,
+    DepositAddressError, MaxWithdrawableAmountError, PegInError, PegOutError,
+    SubscribeDepositError, WithdrawFeesError,
 };
 use crate::withdraw::{CreatedWithdrawState, WithdrawStateMachine, WithdrawStates};
 
@@ -712,7 +712,7 @@ impl ClientModule for WalletClientModule {
                     let req: PegOutRequest = serde_json::from_value(request)?;
                     let response = self.peg_out(req)
                         .await
-                        .map_err(|e| anyhow::anyhow!("peg_out failed: {e}"))?;
+                        .map_err(|e| anyhow::anyhow!("peg_out failed: {}", e.fmt_compact()))?;
                     let result = serde_json::to_value(&response)?;
                     yield result;
                 },
@@ -1007,7 +1007,7 @@ impl WalletClientModule {
         address: bitcoin::Address,
         amount: bitcoin::Amount,
         fees: PegOutFees,
-    ) -> anyhow::Result<ClientOutputBundle<WalletOutput, WalletClientStates>> {
+    ) -> ClientOutputBundle<WalletOutput, WalletClientStates> {
         let output = WalletOutput::new_v0_peg_out(address, amount, fees);
 
         let amount = output.maybe_v0_ref().expect("v0 output").amount().into();
@@ -1026,7 +1026,7 @@ impl WalletClientModule {
             })]
         };
 
-        Ok(ClientOutputBundle::new(
+        ClientOutputBundle::new(
             vec![ClientOutput::<WalletOutput> {
                 output,
                 amounts: Amounts::new_bitcoin(amount),
@@ -1034,7 +1034,7 @@ impl WalletClientModule {
             vec![ClientOutputSM::<WalletClientStates> {
                 state_machines: Arc::new(sm_gen),
             }],
-        ))
+        )
     }
 
     pub async fn peg_in(&self, req: PegInRequest) -> Result<PegInResponse, DepositAddressError> {
@@ -1046,17 +1046,18 @@ impl WalletClientModule {
         })
     }
 
-    pub async fn peg_out(&self, req: PegOutRequest) -> anyhow::Result<PegOutResponse> {
+    pub async fn peg_out(&self, req: PegOutRequest) -> Result<PegOutResponse, PegOutError> {
         let amount = bitcoin::Amount::from_sat(req.amount_sat);
+        let network = self.get_network();
         let destination = req
             .destination_address
-            .require_network(self.get_network())?;
+            .require_network(network)
+            .map_err(|_| PegOutError::WrongNetwork { expected: network })?;
 
         let fees = self.get_withdraw_fees(&destination, amount).await?;
         let operation_id = self
             .withdraw(&destination, amount, fees, req.extra_meta)
-            .await
-            .context("Failed to initiate withdraw")?;
+            .await?;
 
         Ok(PegOutResponse { operation_id })
     }
@@ -1065,7 +1066,7 @@ impl WalletClientModule {
         &self,
         operation_id: OperationId,
         rbf: &Rbf,
-    ) -> anyhow::Result<ClientOutputBundle<WalletOutput, WalletClientStates>> {
+    ) -> ClientOutputBundle<WalletOutput, WalletClientStates> {
         let output = WalletOutput::new_v0_rbf(rbf.fees, rbf.txid);
 
         let amount = output.maybe_v0_ref().expect("v0 output").amount().into();
@@ -1084,7 +1085,7 @@ impl WalletClientModule {
             })]
         };
 
-        Ok(ClientOutputBundle::new(
+        ClientOutputBundle::new(
             vec![ClientOutput::<WalletOutput> {
                 output,
                 amounts: Amounts::new_bitcoin(amount),
@@ -1092,7 +1093,7 @@ impl WalletClientModule {
             vec![ClientOutputSM::<WalletClientStates> {
                 state_machines: Arc::new(sm_gen),
             }],
-        ))
+        )
     }
 
     pub async fn btc_tx_has_no_size_limit(&self) -> FederationResult<bool> {
@@ -1858,12 +1859,12 @@ impl WalletClientModule {
         amount: bitcoin::Amount,
         fee: PegOutFees,
         extra_meta: M,
-    ) -> anyhow::Result<OperationId> {
+    ) -> Result<OperationId, TransactionSubmitError> {
         {
             let operation_id = OperationId(thread_rng().r#gen());
 
             let withdraw_output =
-                self.create_withdraw_output(operation_id, address.clone(), amount, fee)?;
+                self.create_withdraw_output(operation_id, address.clone(), amount, fee);
             let tx_builder = TransactionBuilder::new()
                 .with_outputs(self.client_ctx.make_client_outputs(withdraw_output));
 
@@ -1920,10 +1921,10 @@ impl WalletClientModule {
         &self,
         rbf: Rbf,
         extra_meta: M,
-    ) -> anyhow::Result<OperationId> {
+    ) -> Result<OperationId, TransactionSubmitError> {
         let operation_id = OperationId(thread_rng().r#gen());
 
-        let withdraw_output = self.create_rbf_withdraw_output(operation_id, &rbf)?;
+        let withdraw_output = self.create_rbf_withdraw_output(operation_id, &rbf);
         let tx_builder = TransactionBuilder::new()
             .with_outputs(self.client_ctx.make_client_outputs(withdraw_output));
 

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -42,6 +42,7 @@ use bitcoin::{Address, Network, ScriptBuf};
 use client_db::{DbKeyPrefix, PegInTweakIndexKey, SupportsSafeDepositKey, TweakIdx};
 use fedimint_api_client::api::{DynModuleApi, FederationResult};
 use fedimint_bitcoind::{BitcoindTracked, DynBitcoindRpc, IBitcoindRpc, create_esplora_rpc};
+use fedimint_client_module::error::TransactionSubmitError;
 use fedimint_client_module::module::init::{
     ClientModuleInit, ClientModuleInitArgs, ClientModuleRecoverArgs, RecoveryMode,
 };
@@ -94,7 +95,10 @@ use crate::client_db::{
     RecoveryStateKey, SupportsSafeDepositPrefix,
 };
 use crate::deposit::DepositStateMachine;
-pub use crate::error::{DepositAddressError, PegInError, SubscribeDepositError};
+pub use crate::error::{
+    DepositAddressError, MaxWithdrawableAmountError, PegInError, SubscribeDepositError,
+    WithdrawFeesError,
+};
 use crate::withdraw::{CreatedWithdrawState, WithdrawStateMachine, WithdrawStates};
 
 const WALLET_TWEAK_CHILD_ID: ChildId = ChildId(0);
@@ -871,11 +875,11 @@ impl WalletClientModule {
         &self,
         address: &bitcoin::Address,
         amount: bitcoin::Amount,
-    ) -> anyhow::Result<PegOutFees> {
+    ) -> Result<PegOutFees, WithdrawFeesError> {
         self.module_api
             .fetch_peg_out_fees(address, amount)
             .await?
-            .context("Federation didn't return peg-out fees")
+            .ok_or(WithdrawFeesError::NoQuote)
     }
 
     /// Computes the federation fee a peg-out of an on-chain output worth
@@ -892,7 +896,10 @@ impl WalletClientModule {
     /// The on-chain Bitcoin miner fee is deliberately excluded: it is part of
     /// the output `amount` (see [`Self::get_withdraw_fees`]), not the
     /// on-federation transaction fee.
-    pub async fn send_fee_quote(&self, amount: bitcoin::Amount) -> anyhow::Result<FeeQuote> {
+    pub async fn send_fee_quote(
+        &self,
+        amount: bitcoin::Amount,
+    ) -> Result<FeeQuote, TransactionSubmitError> {
         let amount = fedimint_core::Amount::from_sats(amount.to_sat());
         self.client_ctx
             .fee_quote(
@@ -905,7 +912,6 @@ impl WalletClientModule {
                 },
             )
             .await
-            .map_err(anyhow::Error::from)
     }
 
     /// Finds the largest amount that can be withdrawn in full out of
@@ -945,7 +951,7 @@ impl WalletClientModule {
         &self,
         address: &bitcoin::Address,
         balance: fedimint_core::Amount,
-    ) -> anyhow::Result<(bitcoin::Amount, PegOutFees)> {
+    ) -> Result<(bitcoin::Amount, PegOutFees), MaxWithdrawableAmountError> {
         // Upper bound on the miner fee: the weight only grows as the federation
         // has to reach for more UTXOs, so no smaller withdrawal costs more.
         let max_fees = self
@@ -971,7 +977,7 @@ impl WalletClientModule {
             },
         )
         .await
-        .ok_or_else(|| anyhow!("Balance is too low to withdraw any amount after fees"))?;
+        .ok_or(MaxWithdrawableAmountError::BalanceTooLow)?;
 
         // `gross_up` rounded up to whole satoshis, so the largest affordable
         // amount already sits on a satoshi boundary; no value is lost here.

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -945,8 +945,9 @@ impl WalletClientModule {
     /// set or feerate moves before the peg-out is processed it is rejected, and
     /// the caller should retry with a fresh quote.
     ///
-    /// Returns an error if the balance cannot cover the destination's dust
-    /// limit plus fees.
+    /// Returns [`MaxWithdrawableAmountError::BalanceTooLow`] if the balance
+    /// cannot cover the destination's dust limit plus fees, or
+    /// [`MaxWithdrawableAmountError::Quote`] if the fee probe itself failed.
     pub async fn max_withdrawable_amount(
         &self,
         address: &bitcoin::Address,
@@ -978,6 +979,7 @@ impl WalletClientModule {
             },
         )
         .await
+        .map_err(MaxWithdrawableAmountError::Quote)?
         .ok_or(MaxWithdrawableAmountError::BalanceTooLow {
             balance,
             dust_limit,

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -57,8 +57,7 @@ use fedimint_client_module::transaction::{
 use fedimint_client_module::{DynGlobalClientContext, sm_enum_variant_translation};
 use fedimint_core::core::{Decoder, IntoDynInstance, ModuleInstanceId, ModuleKind, OperationId};
 use fedimint_core::db::{
-    AutocommitError, Committable, Database, DatabaseError, DatabaseTransaction,
-    IDatabaseTransactionOpsCoreTyped,
+    Committable, Database, DatabaseError, DatabaseTransaction, IDatabaseTransactionOpsCoreTyped,
 };
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::envs::{BitcoinRpcConfig, is_running_in_test_env};
@@ -962,10 +961,11 @@ impl WalletClientModule {
             )
             .await?;
         let max_fee_msats = fedimint_core::Amount::from_sats(max_fees.amount().to_sat());
+        let dust_limit = address.script_pubkey().minimal_non_dust();
 
         let max = max_affordable_send_amount(
             balance,
-            fedimint_core::Amount::from_sats(address.script_pubkey().minimal_non_dust().to_sat()),
+            fedimint_core::Amount::from_sats(dust_limit.to_sat()),
             balance,
             // A peg-out funds a whole number of sats, so round the probe up to
             // the next sat before adding the miner fee; the solver searches
@@ -978,7 +978,10 @@ impl WalletClientModule {
             },
         )
         .await
-        .ok_or(MaxWithdrawableAmountError::BalanceTooLow)?;
+        .ok_or(MaxWithdrawableAmountError::BalanceTooLow {
+            balance,
+            dust_limit,
+        })?;
 
         // `gross_up` rounded up to whole satoshis, so the largest affordable
         // amount already sits on a satoshi boundary; no value is lost here.
@@ -1213,13 +1216,7 @@ impl WalletClientModule {
                 },
                 Some(100),
             )
-            .await
-            .map_err(|e| match e {
-                AutocommitError::ClosureError { error, .. } => error,
-                AutocommitError::CommitFailed { last_error, .. } => {
-                    DepositAddressError::Database(last_error)
-                }
-            })?;
+            .await?;
 
         Ok(deposit_address)
     }
@@ -1337,13 +1334,7 @@ impl WalletClientModule {
                 },
                 Some(100),
             )
-            .await
-            .map_err(|e| match e {
-                AutocommitError::ClosureError { error, .. } => error,
-                AutocommitError::CommitFailed { last_error, .. } => {
-                    DepositAddressError::Database(last_error)
-                }
-            })?;
+            .await?;
 
         Ok(result)
     }
@@ -1477,13 +1468,7 @@ impl WalletClientModule {
                 },
                 Some(100),
             )
-            .await
-            .map_err(|e| match e {
-                AutocommitError::ClosureError { error, .. } => error,
-                AutocommitError::CommitFailed { last_error, .. } => {
-                    DepositAddressError::Database(last_error)
-                }
-            })?;
+            .await?;
 
         Ok(result)
     }
@@ -1660,7 +1645,7 @@ impl WalletClientModule {
             .filter(|(_k, v)| future::ready(v.operation_id == operation_id))
             .next()
             .await
-            .ok_or(PegInError::OperationNotFound { operation_id })?
+            .ok_or(PegInError::NoAddressForOperation { operation_id })?
             .0
             .0)
     }
@@ -1764,13 +1749,7 @@ impl WalletClientModule {
                 },
                 Some(100),
             )
-            .await
-            .map_err(|e| match e {
-                AutocommitError::ClosureError { error, .. } => error,
-                AutocommitError::CommitFailed { last_error, .. } => {
-                    PegInError::Database(last_error)
-                }
-            })?;
+            .await?;
 
         Ok(())
     }

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -94,7 +94,7 @@ use crate::client_db::{
     RecoveryStateKey, SupportsSafeDepositPrefix,
 };
 use crate::deposit::DepositStateMachine;
-pub use crate::error::{DepositAddressError, PegInError};
+pub use crate::error::{DepositAddressError, PegInError, SubscribeDepositError};
 use crate::withdraw::{CreatedWithdrawState, WithdrawStateMachine, WithdrawStates};
 
 const WALLET_TWEAK_CHILD_ID: ChildId = ChildId(0);
@@ -1488,16 +1488,8 @@ impl WalletClientModule {
     pub async fn subscribe_deposit(
         &self,
         operation_id: OperationId,
-    ) -> anyhow::Result<UpdateStreamOrOutcome<DepositStateV2>> {
-        let operation = self
-            .client_ctx
-            .get_operation(operation_id)
-            .await
-            .with_context(|| anyhow!("Operation not found: {}", operation_id.fmt_short()))?;
-
-        if operation.operation_module_kind() != WalletCommonInit::KIND.as_str() {
-            bail!("Operation is not a wallet operation");
-        }
+    ) -> Result<UpdateStreamOrOutcome<DepositStateV2>, SubscribeDepositError> {
+        let operation = self.client_ctx.get_operation(operation_id).await?;
 
         let operation_meta = operation.meta::<WalletOperationMeta>();
 
@@ -1505,10 +1497,13 @@ impl WalletClientModule {
             address, tweak_idx, ..
         } = operation_meta.variant
         else {
-            bail!("Operation is not a deposit operation");
+            return Err(SubscribeDepositError::NotADeposit);
         };
 
-        let address = address.require_network(self.cfg().network.0)?;
+        let network = self.cfg().network.0;
+        let address = address
+            .require_network(network)
+            .map_err(|_| SubscribeDepositError::WrongNetwork { expected: network })?;
 
         // The old deposit operations don't have tweak_idx set
         let Some(tweak_idx) = tweak_idx else {
@@ -1517,7 +1512,7 @@ impl WalletClientModule {
             // the final state though if it reached any.
             let outcome_v1 = operation
                 .outcome::<DepositStateV1>()
-                .context("Old pending deposit, can't subscribe to updates")?;
+                .ok_or(SubscribeDepositError::OldPendingDeposit)?;
 
             let outcome_v2 = match outcome_v1 {
                 DepositStateV1::Claimed(tx_info) => DepositStateV2::Claimed {
@@ -1528,7 +1523,7 @@ impl WalletClientModule {
                     },
                 },
                 DepositStateV1::Failed(error) => DepositStateV2::Failed(error),
-                _ => bail!("Non-final outcome in operation log"),
+                _ => return Err(SubscribeDepositError::NonFinalOutcome),
             };
 
             return Ok(UpdateStreamOrOutcome::Outcome(outcome_v2));

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -33,7 +33,9 @@ use std::future;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
-use anyhow::{Context as AnyhowContext, anyhow, bail};
+use anyhow::Context as AnyhowContext;
+#[cfg(feature = "uniffi")]
+use anyhow::anyhow;
 use async_stream::{stream, try_stream};
 use backup::WalletModuleBackup;
 use bitcoin::address::NetworkUnchecked;
@@ -97,7 +99,7 @@ use crate::client_db::{
 use crate::deposit::DepositStateMachine;
 pub use crate::error::{
     DepositAddressError, MaxWithdrawableAmountError, PegInError, PegOutError,
-    SubscribeDepositError, WithdrawFeesError,
+    SubscribeDepositError, SubscribeWithdrawError, WithdrawFeesError,
 };
 use crate::withdraw::{CreatedWithdrawState, WithdrawStateMachine, WithdrawStates};
 
@@ -1950,23 +1952,15 @@ impl WalletClientModule {
     pub async fn subscribe_withdraw_updates(
         &self,
         operation_id: OperationId,
-    ) -> anyhow::Result<UpdateStreamOrOutcome<WithdrawState>> {
-        let operation = self
-            .client_ctx
-            .get_operation(operation_id)
-            .await
-            .with_context(|| anyhow!("Operation not found: {}", operation_id.fmt_short()))?;
-
-        if operation.operation_module_kind() != WalletCommonInit::KIND.as_str() {
-            bail!("Operation is not a wallet operation");
-        }
+    ) -> Result<UpdateStreamOrOutcome<WithdrawState>, SubscribeWithdrawError> {
+        let operation = self.client_ctx.get_operation(operation_id).await?;
 
         let operation_meta = operation.meta::<WalletOperationMeta>();
 
         let (WalletOperationMetaVariant::Withdraw { change, .. }
         | WalletOperationMetaVariant::RbfWithdraw { change, .. }) = operation_meta.variant
         else {
-            bail!("Operation is not a withdraw operation");
+            return Err(SubscribeWithdrawError::NotAWithdrawal);
         };
 
         let mut operation_stream = self.notifier.subscribe(operation_id).await;

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -33,7 +33,7 @@ use std::future;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
-use anyhow::{Context as AnyhowContext, anyhow, bail, ensure};
+use anyhow::{Context as AnyhowContext, anyhow, bail};
 use async_stream::{stream, try_stream};
 use backup::WalletModuleBackup;
 use bitcoin::address::NetworkUnchecked;
@@ -94,7 +94,7 @@ use crate::client_db::{
     RecoveryStateKey, SupportsSafeDepositPrefix,
 };
 use crate::deposit::DepositStateMachine;
-pub use crate::error::PegInError;
+pub use crate::error::{DepositAddressError, PegInError};
 use crate::withdraw::{CreatedWithdrawState, WithdrawStateMachine, WithdrawStates};
 
 const WALLET_TWEAK_CHILD_ID: ChildId = ChildId(0);
@@ -700,7 +700,7 @@ impl ClientModule for WalletClientModule {
                     let req: PegInRequest = serde_json::from_value(request)?;
                     let response = self.peg_in(req)
                         .await
-                        .map_err(|e| anyhow::anyhow!("peg_in failed: {e}"))?;
+                        .map_err(|e| anyhow::anyhow!("peg_in failed: {}", e.fmt_compact()))?;
                     let result = serde_json::to_value(&response)?;
                     yield result;
                 },
@@ -1031,16 +1031,11 @@ impl WalletClientModule {
         ))
     }
 
-    pub async fn peg_in(&self, req: PegInRequest) -> anyhow::Result<PegInResponse> {
+    pub async fn peg_in(&self, req: PegInRequest) -> Result<PegInResponse, DepositAddressError> {
         let deposit_address = self.safe_allocate_deposit_address(req.extra_meta).await?;
 
         Ok(PegInResponse {
-            deposit_address: Address::from_script(
-                &deposit_address.address.script_pubkey(),
-                self.get_network(),
-            )?
-            .as_unchecked()
-            .clone(),
+            deposit_address: deposit_address.address.into_unchecked(),
             operation_id: deposit_address.operation_id,
         })
     }
@@ -1126,14 +1121,13 @@ impl WalletClientModule {
     pub async fn safe_allocate_deposit_address<M>(
         &self,
         extra_meta: M,
-    ) -> anyhow::Result<DepositAddressInfo>
+    ) -> Result<DepositAddressInfo, DepositAddressError>
     where
         M: Serialize + MaybeSend + MaybeSync,
     {
-        ensure!(
-            self.supports_safe_deposit().await,
-            "Could not verify that the wallet module consensus version supports safe deposits",
-        );
+        if !self.supports_safe_deposit().await {
+            return Err(DepositAddressError::SafeDepositUnverified);
+        }
 
         self.allocate_deposit_address_expert_only(extra_meta).await
     }
@@ -1158,7 +1152,7 @@ impl WalletClientModule {
     pub async fn allocate_deposit_address_expert_only<M>(
         &self,
         extra_meta: M,
-    ) -> anyhow::Result<DepositAddressInfo>
+    ) -> Result<DepositAddressInfo, DepositAddressError>
     where
         M: Serialize + MaybeSend + MaybeSync,
     {
@@ -1213,11 +1207,10 @@ impl WalletClientModule {
             )
             .await
             .map_err(|e| match e {
-                AutocommitError::CommitFailed {
-                    last_error,
-                    attempts,
-                } => anyhow!("Failed to commit after {attempts} attempts: {last_error}"),
                 AutocommitError::ClosureError { error, .. } => error,
+                AutocommitError::CommitFailed { last_error, .. } => {
+                    DepositAddressError::Database(last_error)
+                }
             })?;
 
         Ok(deposit_address)
@@ -1263,7 +1256,7 @@ impl WalletClientModule {
     pub async fn allocate_deposit_address_pooled_stateless(
         &self,
         max_gap_size: usize,
-    ) -> anyhow::Result<MaybeNewAddress> {
+    ) -> Result<MaybeNewAddress, DepositAddressError> {
         let max_gap_size_u64 = u64::try_from(max_gap_size).unwrap_or(u64::MAX);
         let extra_meta_value = serde_json::Value::Null;
         let result = self
@@ -1291,7 +1284,7 @@ impl WalletClientModule {
                                 })
                                 .collect();
 
-                            return Ok::<_, anyhow::Error>(
+                            return Ok::<_, DepositAddressError>(
                                 MaybeNewAddress::TooManyUnusedAddresses(addresses),
                             );
                         }
@@ -1338,11 +1331,10 @@ impl WalletClientModule {
             )
             .await
             .map_err(|e| match e {
-                AutocommitError::CommitFailed {
-                    last_error,
-                    attempts,
-                } => anyhow!("Failed to commit after {attempts} attempts: {last_error}"),
                 AutocommitError::ClosureError { error, .. } => error,
+                AutocommitError::CommitFailed { last_error, .. } => {
+                    DepositAddressError::Database(last_error)
+                }
             })?;
 
         Ok(result)
@@ -1396,7 +1388,7 @@ impl WalletClientModule {
     pub async fn allocate_deposit_address_pooled(
         &self,
         max_gap_size: usize,
-    ) -> anyhow::Result<(DepositAddressInfo, AllocateDepositOutcome)> {
+    ) -> Result<(DepositAddressInfo, AllocateDepositOutcome), DepositAddressError> {
         let stateless = self
             .allocate_deposit_address_pooled_stateless(max_gap_size)
             .await?;
@@ -1429,18 +1421,15 @@ impl WalletClientModule {
                         let existing = dbtx
                             .get_value(&PegInTweakIndexKey(reused_address.tweak_idx))
                             .await
-                            .with_context(|| {
-                                format!(
-                                    "Pooled address disappeared while reusing {}",
-                                    reused_address.tweak_idx
-                                )
+                            .ok_or(DepositAddressError::PooledAddressDisappeared {
+                                tweak_idx: reused_address.tweak_idx,
                             })?;
 
-                        ensure!(
-                            existing.claimed.is_empty(),
-                            "Pooled address was used while reusing {}",
-                            reused_address.tweak_idx
-                        );
+                        if !existing.claimed.is_empty() {
+                            return Err(DepositAddressError::PooledAddressUsed {
+                                tweak_idx: reused_address.tweak_idx,
+                            });
+                        }
 
                         dbtx.insert_entry(&PegInPoolCursorKey, &reused_address.tweak_idx.next())
                             .await;
@@ -1470,7 +1459,7 @@ impl WalletClientModule {
                             sender.send_replace(());
                         });
 
-                        Ok::<_, anyhow::Error>((
+                        Ok::<_, DepositAddressError>((
                             reused_address,
                             AllocateDepositOutcome::Reused {
                                 original_tweak_idx: existing_tweak_idx,
@@ -1482,11 +1471,10 @@ impl WalletClientModule {
             )
             .await
             .map_err(|e| match e {
-                AutocommitError::CommitFailed {
-                    last_error,
-                    attempts,
-                } => anyhow!("Failed to commit after {attempts} attempts: {last_error}"),
                 AutocommitError::ClosureError { error, .. } => error,
+                AutocommitError::CommitFailed { last_error, .. } => {
+                    DepositAddressError::Database(last_error)
+                }
             })?;
 
         Ok(result)

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -995,12 +995,12 @@ impl WalletClientModule {
     }
 
     /// Returns a summary of the wallet's coins
-    pub async fn get_wallet_summary(&self) -> anyhow::Result<WalletSummary> {
-        Ok(self.module_api.fetch_wallet_summary().await?)
+    pub async fn get_wallet_summary(&self) -> FederationResult<WalletSummary> {
+        self.module_api.fetch_wallet_summary().await
     }
 
-    pub async fn get_block_count_local(&self) -> anyhow::Result<u32> {
-        Ok(self.module_api.fetch_block_count_local().await?)
+    pub async fn get_block_count_local(&self) -> FederationResult<u32> {
+        self.module_api.fetch_block_count_local().await
     }
 
     pub fn create_withdraw_output(

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -18,6 +18,8 @@ pub mod client_db;
 /// Legacy, state-machine based peg-ins, replaced by `pegin_monitor`
 /// but retained for time being to ensure existing peg-ins complete.
 mod deposit;
+/// Error types of the wallet client.
+pub mod error;
 pub mod events;
 use events::SendPaymentEvent;
 #[cfg(feature = "uniffi")]
@@ -92,6 +94,7 @@ use crate::client_db::{
     RecoveryStateKey, SupportsSafeDepositPrefix,
 };
 use crate::deposit::DepositStateMachine;
+pub use crate::error::PegInError;
 use crate::withdraw::{CreatedWithdrawState, WithdrawStateMachine, WithdrawStates};
 
 const WALLET_TWEAK_CHILD_ID: ChildId = ChildId(0);
@@ -1631,7 +1634,7 @@ impl WalletClientModule {
     pub async fn find_tweak_idx_by_address(
         &self,
         address: bitcoin::Address<NetworkUnchecked>,
-    ) -> anyhow::Result<TweakIdx> {
+    ) -> Result<TweakIdx, PegInError> {
         let data = self.data.clone();
         let Some((tweak_idx, _)) = self
             .db
@@ -1646,7 +1649,7 @@ impl WalletClientModule {
             .next()
             .await
         else {
-            bail!("Address not found in the list of derived keys");
+            return Err(PegInError::AddressNotDerived);
         };
 
         Ok(tweak_idx.0)
@@ -1654,7 +1657,7 @@ impl WalletClientModule {
     pub async fn find_tweak_idx_by_operation_id(
         &self,
         operation_id: OperationId,
-    ) -> anyhow::Result<TweakIdx> {
+    ) -> Result<TweakIdx, PegInError> {
         Ok(self
             .client_ctx
             .module_db()
@@ -1666,7 +1669,7 @@ impl WalletClientModule {
             .filter(|(_k, v)| future::ready(v.operation_id == operation_id))
             .next()
             .await
-            .ok_or_else(|| anyhow::format_err!("OperationId not found"))?
+            .ok_or(PegInError::OperationNotFound { operation_id })?
             .0
             .0)
     }
@@ -1674,7 +1677,7 @@ impl WalletClientModule {
     pub async fn get_pegin_tweak_idx(
         &self,
         tweak_idx: TweakIdx,
-    ) -> anyhow::Result<PegInTweakIndexData> {
+    ) -> Result<PegInTweakIndexData, PegInError> {
         self.client_ctx
             .module_db()
             .clone()
@@ -1682,7 +1685,7 @@ impl WalletClientModule {
             .await
             .get_value(&PegInTweakIndexKey(tweak_idx))
             .await
-            .ok_or_else(|| anyhow::format_err!("TweakIdx not found"))
+            .ok_or(PegInError::TweakIdxNotFound { tweak_idx })
     }
 
     pub async fn get_claimed_pegins(
@@ -1724,7 +1727,7 @@ impl WalletClientModule {
     pub async fn recheck_pegin_address_by_op_id(
         &self,
         operation_id: OperationId,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), PegInError> {
         let tweak_idx = self.find_tweak_idx_by_operation_id(operation_id).await?;
 
         self.recheck_pegin_address(tweak_idx).await
@@ -1734,13 +1737,13 @@ impl WalletClientModule {
     pub async fn recheck_pegin_address_by_address(
         &self,
         address: bitcoin::Address<NetworkUnchecked>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), PegInError> {
         self.recheck_pegin_address(self.find_tweak_idx_by_address(address).await?)
             .await
     }
 
     /// Schedule given address for immediate re-check for deposits
-    pub async fn recheck_pegin_address(&self, tweak_idx: TweakIdx) -> anyhow::Result<()> {
+    pub async fn recheck_pegin_address(&self, tweak_idx: TweakIdx) -> Result<(), PegInError> {
         self.db
             .autocommit(
                 |dbtx, _| {
@@ -1749,7 +1752,7 @@ impl WalletClientModule {
                         let db_val = dbtx
                             .get_value(&db_key)
                             .await
-                            .ok_or_else(|| anyhow::format_err!("DBKey not found"))?;
+                            .ok_or(PegInError::TweakIdxNotFound { tweak_idx })?;
 
                         dbtx.insert_entry(
                             &db_key,
@@ -1765,12 +1768,18 @@ impl WalletClientModule {
                             sender.send_replace(());
                         });
 
-                        Ok::<_, anyhow::Error>(())
+                        Ok::<_, PegInError>(())
                     })
                 },
                 Some(100),
             )
-            .await?;
+            .await
+            .map_err(|e| match e {
+                AutocommitError::ClosureError { error, .. } => error,
+                AutocommitError::CommitFailed { last_error, .. } => {
+                    PegInError::Database(last_error)
+                }
+            })?;
 
         Ok(())
     }
@@ -1780,7 +1789,7 @@ impl WalletClientModule {
         &self,
         operation_id: OperationId,
         num_deposits: usize,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), PegInError> {
         let tweak_idx = self.find_tweak_idx_by_operation_id(operation_id).await?;
         self.await_num_deposits(tweak_idx, num_deposits).await
     }
@@ -1789,7 +1798,7 @@ impl WalletClientModule {
         &self,
         address: bitcoin::Address<NetworkUnchecked>,
         num_deposits: usize,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), PegInError> {
         self.await_num_deposits(self.find_tweak_idx_by_address(address).await?, num_deposits)
             .await
     }
@@ -1799,7 +1808,7 @@ impl WalletClientModule {
         &self,
         tweak_idx: TweakIdx,
         num_deposits: usize,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), PegInError> {
         let operation_id = self.get_pegin_tweak_idx(tweak_idx).await?.operation_id;
 
         let mut receiver = self.pegin_claimed_receiver.clone();
@@ -1817,7 +1826,10 @@ impl WalletClientModule {
                 debug!(target: LOG_CLIENT_MODULE_WALLET, has=pegins.len(), "Not enough deposits");
                 self.recheck_pegin_address(tweak_idx).await?;
                 runtime::sleep(backoff.next().unwrap_or_default()).await;
-                receiver.changed().await?;
+                receiver
+                    .changed()
+                    .await
+                    .map_err(|_| PegInError::MonitorStopped)?;
                 continue;
             }
 
@@ -1832,8 +1844,8 @@ impl WalletClientModule {
                 debug!(target: LOG_CLIENT_MODULE_WALLET, out_points=?change, "Ensuring deposists claimed");
                 let tx_subscriber = self.client_ctx.transaction_updates(operation_id).await;
 
-                if let Err(e) = tx_subscriber.await_tx_accepted(transaction_id).await {
-                    bail!("{e}");
+                if let Err(reason) = tx_subscriber.await_tx_accepted(transaction_id).await {
+                    return Err(PegInError::TransactionRejected { reason });
                 }
 
                 debug!(target: LOG_CLIENT_MODULE_WALLET, out_points=?change, "Ensuring outputs claimed");

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -34,8 +34,6 @@ use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
 use anyhow::Context as AnyhowContext;
-#[cfg(feature = "uniffi")]
-use anyhow::anyhow;
 use async_stream::{stream, try_stream};
 use backup::WalletModuleBackup;
 use bitcoin::address::NetworkUnchecked;
@@ -98,8 +96,8 @@ use crate::client_db::{
 };
 use crate::deposit::DepositStateMachine;
 pub use crate::error::{
-    DepositAddressError, MaxWithdrawableAmountError, PegInError, PegOutError,
-    SubscribeDepositError, SubscribeWithdrawError, WithdrawFeesError,
+    ConsensusVersionVotingError, DepositAddressError, MaxWithdrawableAmountError, PegInError,
+    PegOutError, SubscribeDepositError, SubscribeWithdrawError, WithdrawFeesError,
 };
 use crate::withdraw::{CreatedWithdrawState, WithdrawStateMachine, WithdrawStates};
 
@@ -766,7 +764,8 @@ pub struct PegInRequest {
 #[cfg(feature = "uniffi")]
 uniffi::custom_type!(PegInRequest, String, {
     lower: |v| serde_json::to_string(&v).expect("PegInRequest serialization cannot fail"),
-    try_lift: |s| serde_json::from_str::<PegInRequest>(&s).map_err(|e| anyhow!("Failed to parse PegInRequest: {e}")),
+    try_lift: |s| serde_json::from_str::<PegInRequest>(&s)
+        .map_err(|e| anyhow::anyhow!("Failed to parse PegInRequest: {e}")),
 });
 
 #[derive(Deserialize)]
@@ -2011,13 +2010,15 @@ impl WalletClientModule {
         ))
     }
 
-    fn admin_auth(&self) -> anyhow::Result<ApiAuth> {
+    fn admin_auth(&self) -> Result<ApiAuth, ConsensusVersionVotingError> {
         self.admin_auth
             .clone()
-            .ok_or_else(|| anyhow::format_err!("Admin auth not set"))
+            .ok_or(ConsensusVersionVotingError::AdminAuthMissing)
     }
 
-    pub async fn activate_consensus_version_voting(&self) -> anyhow::Result<()> {
+    pub async fn activate_consensus_version_voting(
+        &self,
+    ) -> Result<(), ConsensusVersionVotingError> {
         self.module_api
             .activate_consensus_version_voting(self.admin_auth()?)
             .await?;

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -32,9 +32,9 @@ use fedimint_testing_core::config::API_AUTH;
 use fedimint_wallet_client::api::WalletFederationApi;
 use fedimint_wallet_client::client_db::{SupportsSafeDepositKey, TweakIdx};
 use fedimint_wallet_client::{
-    AllocateDepositOutcome, DepositStateV2, MaybeNewAddress, PegInError, PegOutError,
-    PegOutRequest, SubscribeDepositError, SubscribeWithdrawError, WalletClientInit,
-    WalletClientModule, WithdrawFeesError, WithdrawState,
+    AllocateDepositOutcome, ConsensusVersionVotingError, DepositStateV2, MaybeNewAddress,
+    PegInError, PegOutError, PegOutRequest, SubscribeDepositError, SubscribeWithdrawError,
+    WalletClientInit, WalletClientModule, WithdrawFeesError, WithdrawState,
 };
 use fedimint_wallet_common::config::WalletConfig;
 use fedimint_wallet_common::tweakable::Tweakable;
@@ -2633,6 +2633,26 @@ async fn subscribing_to_an_unknown_withdrawal_reports_not_found() -> anyhow::Res
         Err(SubscribeWithdrawError::Operation(
             OperationLookupError::NotFound(_)
         ))
+    );
+
+    Ok(())
+}
+
+/// Voting is an admin action, and a client without admin credentials is told
+/// exactly that instead of being handed a generic failure.
+#[tokio::test(flavor = "multi_thread")]
+async fn voting_without_admin_auth_says_so() -> anyhow::Result<()> {
+    skip_if_not_wallet_test_group!("1");
+    let fixtures = fixtures();
+    let fed = fixtures.new_fed_degraded().await;
+    let client = fed.new_client().await;
+
+    assert_matches!(
+        client
+            .get_first_module::<WalletClientModule>()?
+            .activate_consensus_version_voting()
+            .await,
+        Err(ConsensusVersionVotingError::AdminAuthMissing)
     );
 
     Ok(())

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -33,7 +33,7 @@ use fedimint_wallet_client::api::WalletFederationApi;
 use fedimint_wallet_client::client_db::{SupportsSafeDepositKey, TweakIdx};
 use fedimint_wallet_client::{
     AllocateDepositOutcome, DepositStateV2, MaybeNewAddress, PegInError, SubscribeDepositError,
-    WalletClientInit, WalletClientModule, WithdrawState,
+    WalletClientInit, WalletClientModule, WithdrawFeesError, WithdrawState,
 };
 use fedimint_wallet_common::config::WalletConfig;
 use fedimint_wallet_common::tweakable::Tweakable;
@@ -681,10 +681,11 @@ async fn peg_outs_must_wait_for_available_utxos() -> anyhow::Result<()> {
     // See: https://github.com/fedimint/fedimint/issues/3604
     let address = bitcoin.get_new_address().await;
     let peg_out2 = PEG_OUT_AMOUNT_SATS;
-    let fees2 = wallet_module
+    // Must fail because change UTXOs are still being confirmed, and the caller
+    // gets the wallet's own fee-quote error rather than an opaque one.
+    let fees2: Result<PegOutFees, WithdrawFeesError> = wallet_module
         .get_withdraw_fees(&address, bsats(peg_out2))
         .await;
-    // Must fail because change UTXOs are still being confirmed
     assert!(fees2.is_err());
 
     let current_block = dyn_bitcoin_rpc.get_block_count().await?;

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -2554,7 +2554,7 @@ async fn peg_in_lookups_name_what_was_not_found() -> anyhow::Result<()> {
         wallet_module
             .find_tweak_idx_by_operation_id(operation_id)
             .await,
-        Err(PegInError::OperationNotFound { operation_id: found }) if found == operation_id
+        Err(PegInError::NoAddressForOperation { operation_id: found }) if found == operation_id
     );
 
     let tweak_idx = TweakIdx(u64::MAX);

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -104,6 +104,11 @@ async fn peg_in<'a>(
     let op = deposit_address.operation_id;
     let address = deposit_address.address;
     info!(?address, "Peg-in address generated");
+
+    assert_matches!(
+        wallet_module.subscribe_withdraw_updates(op).await,
+        Err(SubscribeWithdrawError::NotAWithdrawal)
+    );
     let (_proof, tx) = bitcoin
         .send_and_mine_block(
             &address,
@@ -384,6 +389,11 @@ async fn on_chain_peg_in_and_peg_out_happy_case() -> anyhow::Result<()> {
         sats(PEG_IN_AMOUNT_SATS - PEG_OUT_AMOUNT_SATS - fees.amount().to_sat());
     assert_eq!(client.get_balance_for_btc().await?, balance_after_peg_out);
     assert_eq!(balance_sub.ok().await?, balance_after_peg_out);
+
+    assert_matches!(
+        wallet_module.subscribe_deposit(op).await,
+        Err(SubscribeDepositError::NotADeposit)
+    );
 
     let sub = wallet_module.subscribe_withdraw_updates(op).await?;
     let mut sub = sub.into_stream();
@@ -687,7 +697,7 @@ async fn peg_outs_must_wait_for_available_utxos() -> anyhow::Result<()> {
     let fees2: Result<PegOutFees, WithdrawFeesError> = wallet_module
         .get_withdraw_fees(&address, bsats(peg_out2))
         .await;
-    assert!(fees2.is_err());
+    assert_matches!(fees2, Err(WithdrawFeesError::NoQuote));
 
     let current_block = dyn_bitcoin_rpc.get_block_count().await?;
     bitcoin.mine_blocks(finality_delay + 1).await;
@@ -2561,6 +2571,15 @@ async fn peg_in_lookups_name_what_was_not_found() -> anyhow::Result<()> {
     assert_matches!(
         wallet_module.get_pegin_tweak_idx(tweak_idx).await,
         Err(PegInError::TweakIdxNotFound { tweak_idx: found }) if found == tweak_idx
+    );
+
+    let foreign_address: bitcoin::Address<bitcoin::address::NetworkUnchecked> =
+        "1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2".parse()?;
+    assert_matches!(
+        wallet_module
+            .find_tweak_idx_by_address(foreign_address)
+            .await,
+        Err(PegInError::AddressNotDerived)
     );
 
     Ok(())

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -32,8 +32,9 @@ use fedimint_testing_core::config::API_AUTH;
 use fedimint_wallet_client::api::WalletFederationApi;
 use fedimint_wallet_client::client_db::{SupportsSafeDepositKey, TweakIdx};
 use fedimint_wallet_client::{
-    AllocateDepositOutcome, DepositStateV2, MaybeNewAddress, PegInError, SubscribeDepositError,
-    WalletClientInit, WalletClientModule, WithdrawFeesError, WithdrawState,
+    AllocateDepositOutcome, DepositStateV2, MaybeNewAddress, PegInError, PegOutError,
+    PegOutRequest, SubscribeDepositError, WalletClientInit, WalletClientModule, WithdrawFeesError,
+    WithdrawState,
 };
 use fedimint_wallet_common::config::WalletConfig;
 use fedimint_wallet_common::tweakable::Tweakable;
@@ -2578,6 +2579,34 @@ async fn subscribing_to_an_unknown_deposit_reports_not_found() -> anyhow::Result
         Err(SubscribeDepositError::Operation(
             OperationLookupError::NotFound(_)
         ))
+    );
+
+    Ok(())
+}
+
+/// A peg-out to an address from another network is refused by name, before
+/// anything is asked of the federation.
+#[tokio::test(flavor = "multi_thread")]
+async fn peg_out_to_a_mainnet_address_is_rejected() -> anyhow::Result<()> {
+    skip_if_not_wallet_test_group!("1");
+    let fixtures = fixtures();
+    let fed = fixtures.new_fed_degraded().await;
+    let client = fed.new_client().await;
+    let wallet_module = client.get_first_module::<WalletClientModule>()?;
+
+    // A well-known mainnet P2PKH address. The federation runs on regtest.
+    let mainnet_address: bitcoin::Address<bitcoin::address::NetworkUnchecked> =
+        "1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2".parse()?;
+
+    assert_matches!(
+        wallet_module
+            .peg_out(PegOutRequest {
+                amount_sat: 100_000,
+                destination_address: mainnet_address,
+                extra_meta: serde_json::Value::Null,
+            })
+            .await,
+        Err(PegOutError::WrongNetwork { .. })
     );
 
     Ok(())

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -1631,7 +1631,11 @@ async fn construct_wallet_summary() -> anyhow::Result<()> {
 
         assert!(expected_available_utxos.insert(expected_available_utxo));
 
-        let wallet_summary = wallet_module.get_wallet_summary().await?;
+        // The summary is a plain federation request, so it reports the
+        // federation's own error rather than an opaque one.
+        let summary: fedimint_api_client::api::FederationResult<_> =
+            wallet_module.get_wallet_summary().await;
+        let wallet_summary = summary?;
         assert_eq!(
             sum_utxos(expected_available_utxos.iter()),
             wallet_summary.total_spendable_balance()

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -10,6 +10,7 @@ use fedimint_api_client::api::DynGlobalApi;
 use fedimint_client::ClientHandleArc;
 use fedimint_client::secret::{PlainRootSecretStrategy, RootSecretStrategy};
 use fedimint_connectors::ConnectorRegistry;
+use fedimint_core::core::OperationId;
 use fedimint_core::db::mem_impl::MemDatabase;
 use fedimint_core::db::{
     DatabaseError, DatabaseTransaction, IDatabaseTransactionOpsCoreTyped, IRawDatabaseExt,
@@ -28,10 +29,10 @@ use fedimint_testing::federation::FederationTest;
 use fedimint_testing::fixtures::Fixtures;
 use fedimint_testing_core::config::API_AUTH;
 use fedimint_wallet_client::api::WalletFederationApi;
-use fedimint_wallet_client::client_db::SupportsSafeDepositKey;
+use fedimint_wallet_client::client_db::{SupportsSafeDepositKey, TweakIdx};
 use fedimint_wallet_client::{
-    AllocateDepositOutcome, DepositStateV2, MaybeNewAddress, WalletClientInit, WalletClientModule,
-    WithdrawState,
+    AllocateDepositOutcome, DepositStateV2, MaybeNewAddress, PegInError, WalletClientInit,
+    WalletClientModule, WithdrawState,
 };
 use fedimint_wallet_common::config::WalletConfig;
 use fedimint_wallet_common::tweakable::Tweakable;
@@ -2519,4 +2520,31 @@ fn verify_bitcoind_backend() {
             "mock_kind".into()
         }
     )
+}
+
+/// The three peg-in lookups each say which thing was not found, instead of
+/// three interchangeable strings.
+#[tokio::test(flavor = "multi_thread")]
+async fn peg_in_lookups_name_what_was_not_found() -> anyhow::Result<()> {
+    skip_if_not_wallet_test_group!("1");
+    let fixtures = fixtures();
+    let fed = fixtures.new_fed_degraded().await;
+    let client = fed.new_client().await;
+    let wallet_module = client.get_first_module::<WalletClientModule>()?;
+
+    let operation_id = OperationId::new_random();
+    assert_matches!(
+        wallet_module
+            .find_tweak_idx_by_operation_id(operation_id)
+            .await,
+        Err(PegInError::OperationNotFound { operation_id: found }) if found == operation_id
+    );
+
+    let tweak_idx = TweakIdx(u64::MAX);
+    assert_matches!(
+        wallet_module.get_pegin_tweak_idx(tweak_idx).await,
+        Err(PegInError::TweakIdxNotFound { tweak_idx: found }) if found == tweak_idx
+    );
+
+    Ok(())
 }

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -1334,6 +1334,16 @@ async fn allocate_deposit_address_pooled_zero_gap_reuses_until_used() -> anyhow:
         assert_eq!(deposit_address.tweak_idx, tweak_idx0);
     }
 
+    // The pooled allocator reports its own failures, not an opaque string.
+    let typed: Result<_, fedimint_wallet_client::DepositAddressError> =
+        wallet_module.allocate_deposit_address_pooled(0).await;
+    let (deposit_address, outcome) = typed?;
+    assert_matches!(
+        outcome,
+        AllocateDepositOutcome::Reused { original_tweak_idx } if original_tweak_idx == tweak_idx0
+    );
+    assert_eq!(deposit_address.address, addr0);
+
     let operations = client
         .operation_log()
         .paginate_operations_rev(10, None)

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -9,6 +9,7 @@ use bitcoin::secp256k1;
 use fedimint_api_client::api::DynGlobalApi;
 use fedimint_client::ClientHandleArc;
 use fedimint_client::secret::{PlainRootSecretStrategy, RootSecretStrategy};
+use fedimint_client_module::error::OperationLookupError;
 use fedimint_connectors::ConnectorRegistry;
 use fedimint_core::core::OperationId;
 use fedimint_core::db::mem_impl::MemDatabase;
@@ -31,8 +32,8 @@ use fedimint_testing_core::config::API_AUTH;
 use fedimint_wallet_client::api::WalletFederationApi;
 use fedimint_wallet_client::client_db::{SupportsSafeDepositKey, TweakIdx};
 use fedimint_wallet_client::{
-    AllocateDepositOutcome, DepositStateV2, MaybeNewAddress, PegInError, WalletClientInit,
-    WalletClientModule, WithdrawState,
+    AllocateDepositOutcome, DepositStateV2, MaybeNewAddress, PegInError, SubscribeDepositError,
+    WalletClientInit, WalletClientModule, WithdrawState,
 };
 use fedimint_wallet_common::config::WalletConfig;
 use fedimint_wallet_common::tweakable::Tweakable;
@@ -2554,6 +2555,28 @@ async fn peg_in_lookups_name_what_was_not_found() -> anyhow::Result<()> {
     assert_matches!(
         wallet_module.get_pegin_tweak_idx(tweak_idx).await,
         Err(PegInError::TweakIdxNotFound { tweak_idx: found }) if found == tweak_idx
+    );
+
+    Ok(())
+}
+
+/// Subscribing to an operation that does not exist says so, instead of
+/// "Operation not found: <id>" glued in front of the real lookup error.
+#[tokio::test(flavor = "multi_thread")]
+async fn subscribing_to_an_unknown_deposit_reports_not_found() -> anyhow::Result<()> {
+    skip_if_not_wallet_test_group!("1");
+    let fixtures = fixtures();
+    let fed = fixtures.new_fed_degraded().await;
+    let client = fed.new_client().await;
+
+    assert_matches!(
+        client
+            .get_first_module::<WalletClientModule>()?
+            .subscribe_deposit(OperationId::new_random())
+            .await,
+        Err(SubscribeDepositError::Operation(
+            OperationLookupError::NotFound(_)
+        ))
     );
 
     Ok(())

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -33,8 +33,8 @@ use fedimint_wallet_client::api::WalletFederationApi;
 use fedimint_wallet_client::client_db::{SupportsSafeDepositKey, TweakIdx};
 use fedimint_wallet_client::{
     AllocateDepositOutcome, DepositStateV2, MaybeNewAddress, PegInError, PegOutError,
-    PegOutRequest, SubscribeDepositError, WalletClientInit, WalletClientModule, WithdrawFeesError,
-    WithdrawState,
+    PegOutRequest, SubscribeDepositError, SubscribeWithdrawError, WalletClientInit,
+    WalletClientModule, WithdrawFeesError, WithdrawState,
 };
 use fedimint_wallet_common::config::WalletConfig;
 use fedimint_wallet_common::tweakable::Tweakable;
@@ -2607,6 +2607,28 @@ async fn peg_out_to_a_mainnet_address_is_rejected() -> anyhow::Result<()> {
             })
             .await,
         Err(PegOutError::WrongNetwork { .. })
+    );
+
+    Ok(())
+}
+
+/// Subscribing to a withdrawal that does not exist says so, and says it with
+/// the shared operation-lookup error rather than a local string.
+#[tokio::test(flavor = "multi_thread")]
+async fn subscribing_to_an_unknown_withdrawal_reports_not_found() -> anyhow::Result<()> {
+    skip_if_not_wallet_test_group!("1");
+    let fixtures = fixtures();
+    let fed = fixtures.new_fed_degraded().await;
+    let client = fed.new_client().await;
+
+    assert_matches!(
+        client
+            .get_first_module::<WalletClientModule>()?
+            .subscribe_withdraw_updates(OperationId::new_random())
+            .await,
+        Err(SubscribeWithdrawError::Operation(
+            OperationLookupError::NotFound(_)
+        ))
     );
 
     Ok(())

--- a/modules/fedimint-walletv2-client/src/lib.rs
+++ b/modules/fedimint-walletv2-client/src/lib.rs
@@ -31,6 +31,7 @@ use fedimint_client::transaction::{
     ClientOutputSM, FeeQuote, FeeQuoteRequest, TransactionBuilder, max_affordable_send_amount,
 };
 use fedimint_client_module::db::ClientModuleMigrationFn;
+use fedimint_client_module::error::{OperationLookupError, TransactionSubmitError};
 use fedimint_client_module::module::init::{ClientModuleInit, ClientModuleInitArgs};
 use fedimint_client_module::module::recovery::NoModuleBackup;
 use fedimint_client_module::module::{ClientContext, ClientModule, OutPointRange};
@@ -281,7 +282,10 @@ impl WalletClientModule {
     /// The on-chain Bitcoin miner fee is deliberately excluded: it is part of
     /// the output `amount` (see [`Self::send_fee`]), not the on-federation
     /// transaction fee.
-    pub async fn send_fee_quote(&self, amount: bitcoin::Amount) -> anyhow::Result<FeeQuote> {
+    pub async fn send_fee_quote(
+        &self,
+        amount: bitcoin::Amount,
+    ) -> Result<FeeQuote, TransactionSubmitError> {
         let amount = Amount::from_sats(amount.to_sat());
         self.client_ctx
             .fee_quote(
@@ -294,7 +298,6 @@ impl WalletClientModule {
                 },
             )
             .await
-            .map_err(anyhow::Error::from)
     }
 
     /// Finds the largest value that can be sent on chain in full out of
@@ -329,13 +332,13 @@ impl WalletClientModule {
     /// federation's own on-chain constraints — a send whose change UTXO would
     /// fall below the dust limit is still rejected by the guardians.
     ///
-    /// Returns an error if the balance cannot cover even the dust limit plus
-    /// fees.
+    /// Returns [`SendError::InsufficientFunds`] if the balance cannot cover
+    /// the dust limit plus fees.
     pub async fn max_sendable_amount(
         &self,
         balance: Amount,
         fee: bitcoin::Amount,
-    ) -> anyhow::Result<bitcoin::Amount> {
+    ) -> Result<bitcoin::Amount, SendError> {
         let fee_msats = Amount::from_sats(fee.to_sat());
 
         let max = max_affordable_send_amount(
@@ -350,7 +353,7 @@ impl WalletClientModule {
             |funded: Amount| self.send_fee_quote(bitcoin::Amount::from_sat(funded.msats / 1000)),
         )
         .await
-        .ok_or_else(|| anyhow!("Balance is too low to send any amount on chain after fees"))?;
+        .ok_or(SendError::InsufficientFunds)?;
 
         // `gross_up` rounded up to whole satoshis, so the largest affordable
         // amount already sits on a satoshi boundary; no value is lost here.
@@ -471,7 +474,7 @@ impl WalletClientModule {
     pub async fn await_final_send_operation_state(
         &self,
         operation_id: OperationId,
-    ) -> anyhow::Result<FinalSendOperationState> {
+    ) -> Result<FinalSendOperationState, OperationLookupError> {
         let operation = self.client_ctx.get_operation(operation_id).await?;
         let mut stream = self.notifier.subscribe(operation_id).await;
 
@@ -515,7 +518,7 @@ impl WalletClientModule {
     pub async fn await_final_receive_operation_state(
         &self,
         operation_id: OperationId,
-    ) -> anyhow::Result<FinalReceiveOperationState> {
+    ) -> Result<FinalReceiveOperationState, OperationLookupError> {
         let operation = self.client_ctx.get_operation(operation_id).await?;
         let mut stream = self.notifier.subscribe(operation_id).await;
 
@@ -599,7 +602,7 @@ impl WalletClientModule {
     pub async fn await_receive(
         &self,
         position: EventLogId,
-    ) -> anyhow::Result<(FinalReceiveOperationState, EventLogId)> {
+    ) -> Result<(FinalReceiveOperationState, EventLogId), AwaitReceiveError> {
         let mut position = position;
 
         loop {
@@ -1020,6 +1023,19 @@ pub enum ReceiveError {
     FederationError(String),
     #[error("No consensus feerate is available at this time")]
     NoConsensusFeerateAvailable,
+}
+
+/// A failure to wait for the next on-chain payment to be received.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum AwaitReceiveError {
+    /// The receive operation could not be looked up.
+    #[error("The receive operation could not be looked up")]
+    Operation(#[from] OperationLookupError),
+
+    /// The deposit was claimed, but the ecash it mints was never issued.
+    #[error("The ecash for the claimed deposit could not be issued")]
+    Issuance(#[from] TransactionSubmitError),
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]

--- a/modules/fedimint-walletv2-client/src/lib.rs
+++ b/modules/fedimint-walletv2-client/src/lib.rs
@@ -24,7 +24,7 @@ use bitcoin::address::NetworkUnchecked;
 use bitcoin::{Address, ScriptBuf};
 use db::{NextOutputIndexKey, ValidAddressIndexKey, ValidAddressIndexPrefix};
 use events::{ReceivePaymentEvent, SendPaymentEvent};
-use fedimint_api_client::api::{DynModuleApi, FederationResult};
+use fedimint_api_client::api::{DynModuleApi, FederationError, FederationResult};
 use fedimint_client::DynGlobalClientContext;
 use fedimint_client::transaction::{
     ClientInput, ClientInputBundle, ClientInputSM, ClientOutput, ClientOutputBundle,
@@ -264,7 +264,7 @@ impl WalletClientModule {
         self.module_api
             .send_fee()
             .await
-            .map_err(|e| SendError::FederationError(e.to_string()))?
+            .map_err(|e| SendError::Federation(Box::new(e)))?
             .ok_or(SendError::NoConsensusFeerateAvailable)
     }
 
@@ -365,7 +365,7 @@ impl WalletClientModule {
         self.module_api
             .receive_fee()
             .await
-            .map_err(|e| ReceiveError::FederationError(e.to_string()))?
+            .map_err(|e| ReceiveError::Federation(Box::new(e)))?
             .ok_or(ReceiveError::NoConsensusFeerateAvailable)
     }
 
@@ -391,7 +391,7 @@ impl WalletClientModule {
                 .module_api
                 .send_fee()
                 .await
-                .map_err(|e| SendError::FederationError(e.to_string()))?
+                .map_err(|e| SendError::Federation(Box::new(e)))?
                 .ok_or(SendError::NoConsensusFeerateAvailable)?,
         };
 
@@ -449,7 +449,11 @@ impl WalletClientModule {
                 TransactionBuilder::new().with_outputs(client_output_bundle),
             )
             .await
-            .map_err(|_| SendError::InsufficientFunds)?;
+            .map_err(|error| match error {
+                TransactionSubmitError::NoPrimaryModule { .. }
+                | TransactionSubmitError::PrimaryModule(..) => SendError::InsufficientFunds,
+                error => SendError::Failed(error),
+            })?;
 
         let mut dbtx = self.client_ctx.module_db().begin_transaction().await;
 
@@ -1001,26 +1005,51 @@ impl WalletClientModule {
     }
 }
 
-#[derive(Error, Debug, Clone, Eq, PartialEq)]
+/// A failure to send an on-chain payment.
+#[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum SendError {
-    #[error("Address is from a different network than the federation.")]
+    /// The destination address is not valid on the federation's network.
+    #[error("Address is from a different network than the federation")]
     WrongNetwork,
+
+    /// The value to send is below the federation's dust limit.
     #[error("The value is too small")]
     DustValue,
-    #[error("Federation returned an error: {0}")]
-    FederationError(String),
+
+    /// The federation could not be asked for the current on-chain fee.
+    #[error("The federation returned an error")]
+    Federation(#[source] Box<FederationError>),
+
+    /// The guardians have not agreed a feerate yet, so no on-chain fee can be
+    /// quoted.
     #[error("No consensus feerate is available at this time")]
     NoConsensusFeerateAvailable,
+
+    /// The client cannot fund the wallet output this send needs.
     #[error("The client does not have sufficient funds to send the payment")]
     InsufficientFunds,
+
+    /// The destination is not an address type the federation can pay.
     #[error("Unsupported address type")]
     UnsupportedAddress,
+
+    /// The send transaction could not be submitted for a reason that is not
+    /// about funding.
+    #[error("The send transaction could not be submitted")]
+    Failed(#[source] TransactionSubmitError),
 }
 
-#[derive(Error, Debug, Clone, Eq, PartialEq)]
+/// A failure to quote the fee for claiming an on-chain deposit.
+#[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum ReceiveError {
-    #[error("Federation returned an error: {0}")]
-    FederationError(String),
+    /// The federation could not be asked for the current claim fee.
+    #[error("The federation returned an error")]
+    Federation(#[source] Box<FederationError>),
+
+    /// The guardians have not agreed a feerate yet, so no claim fee can be
+    /// quoted.
     #[error("No consensus feerate is available at this time")]
     NoConsensusFeerateAvailable,
 }

--- a/modules/fedimint-walletv2-client/src/lib.rs
+++ b/modules/fedimint-walletv2-client/src/lib.rs
@@ -333,7 +333,8 @@ impl WalletClientModule {
     /// fall below the dust limit is still rejected by the guardians.
     ///
     /// Returns [`SendError::InsufficientFunds`] if the balance cannot cover
-    /// the dust limit plus fees.
+    /// the dust limit plus fees, or [`SendError::Failed`] if the fee probe
+    /// itself failed.
     pub async fn max_sendable_amount(
         &self,
         balance: Amount,
@@ -353,6 +354,7 @@ impl WalletClientModule {
             |funded: Amount| self.send_fee_quote(bitcoin::Amount::from_sat(funded.msats / 1000)),
         )
         .await
+        .map_err(SendError::Failed)?
         .ok_or(SendError::InsufficientFunds)?;
 
         // `gross_up` rounded up to whole satoshis, so the largest affordable
@@ -450,8 +452,7 @@ impl WalletClientModule {
             )
             .await
             .map_err(|error| match error {
-                TransactionSubmitError::NoPrimaryModule { .. }
-                | TransactionSubmitError::PrimaryModule(..) => SendError::InsufficientFunds,
+                TransactionSubmitError::InsufficientFunds(_) => SendError::InsufficientFunds,
                 error => SendError::Failed(error),
             })?;
 

--- a/modules/fedimint-walletv2-common/Cargo.toml
+++ b/modules/fedimint-walletv2-common/Cargo.toml
@@ -16,7 +16,6 @@ name = "fedimint_walletv2_common"
 path = "src/lib.rs"
 
 [dependencies]
-anyhow = { workspace = true }
 bitcoin = { workspace = true }
 fedimint-core = { workspace = true }
 miniscript = { workspace = true, features = ["serde"] }

--- a/modules/fedimint-walletv2-common/src/config.rs
+++ b/modules/fedimint-walletv2-common/src/config.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 
 use bitcoin::Network;
 use bitcoin::hashes::{Hash, sha256};
+use fedimint_core::config::ExcessiveRelativeFeeError;
 use fedimint_core::core::ModuleKind;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::{Amount, PeerId, plugin_types_trait_impl_config, weight_to_vbytes};
@@ -147,13 +148,17 @@ impl FeeConsensus {
     /// percent.
     ///
     /// # Errors
-    /// - This constructor returns an error if the relative fee is in excess of
-    ///   ten thousand parts per million.
-    pub fn new(parts_per_million: u64) -> anyhow::Result<Self> {
-        anyhow::ensure!(
-            parts_per_million <= 10_000,
-            "Relative fee over ten thousand parts per million is excessive"
-        );
+    /// - Returns [`ExcessiveRelativeFeeError`] if the relative fee is in excess
+    ///   of ten thousand parts per million.
+    pub fn new(parts_per_million: u64) -> Result<Self, ExcessiveRelativeFeeError> {
+        const MAX_PARTS_PER_MILLION: u64 = 10_000;
+
+        if parts_per_million > MAX_PARTS_PER_MILLION {
+            return Err(ExcessiveRelativeFeeError {
+                parts_per_million,
+                max: MAX_PARTS_PER_MILLION,
+            });
+        }
 
         Ok(Self {
             base: Amount::from_sats(100),
@@ -172,6 +177,15 @@ impl FeeConsensus {
             .checked_add(self.base.msats)
             .expect("The division creates sufficient headroom to add the base fee")
     }
+}
+
+#[test]
+fn a_relative_fee_over_the_limit_is_rejected() {
+    let err: ExcessiveRelativeFeeError =
+        FeeConsensus::new(10_001).expect_err("A fee over one percent is excessive");
+
+    assert_eq!(err.parts_per_million, 10_001);
+    assert_eq!(err.max, 10_000);
 }
 
 #[test]

--- a/modules/fedimint-walletv2-common/src/lib.rs
+++ b/modules/fedimint-walletv2-common/src/lib.rs
@@ -12,6 +12,7 @@ use bitcoin::hashes::{Hash, hash160, sha256};
 use bitcoin::key::TapTweak;
 use bitcoin::{Address, PubkeyHash, ScriptBuf, ScriptHash, Txid, WPubkeyHash, WScriptHash};
 use config::WalletClientConfig;
+pub use fedimint_core::config::ExcessiveRelativeFeeError;
 use fedimint_core::core::{Decoder, ModuleInstanceId, ModuleKind};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::{CommonModuleInit, ModuleCommon, ModuleConsensusVersion};

--- a/modules/fedimint-walletv2-tests/Cargo.toml
+++ b/modules/fedimint-walletv2-tests/Cargo.toml
@@ -43,3 +43,6 @@ serde_json = { workspace = true }
 strum = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+
+[dev-dependencies]
+assert_matches = { workspace = true }

--- a/modules/fedimint-walletv2-tests/tests/tests.rs
+++ b/modules/fedimint-walletv2-tests/tests/tests.rs
@@ -251,7 +251,7 @@ async fn send_to_a_mainnet_address_is_rejected() -> anyhow::Result<()> {
     let mainnet_address: bitcoin::Address<bitcoin::address::NetworkUnchecked> =
         "1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2".parse()?;
 
-    assert_eq!(
+    assert_matches!(
         client
             .get_first_module::<WalletClientModule>()?
             .send(
@@ -260,9 +260,8 @@ async fn send_to_a_mainnet_address_is_rejected() -> anyhow::Result<()> {
                 None,
                 serde_json::Value::Null,
             )
-            .await
-            .err(),
-        Some(SendError::WrongNetwork),
+            .await,
+        Err(SendError::WrongNetwork)
     );
 
     Ok(())
@@ -277,13 +276,12 @@ async fn send_below_the_dust_limit_is_rejected() -> anyhow::Result<()> {
 
     let address = bitcoin.get_new_address().await.as_unchecked().clone();
 
-    assert_eq!(
+    assert_matches!(
         client
             .get_first_module::<WalletClientModule>()?
             .send(address, Amount::from_sat(1), None, serde_json::Value::Null)
-            .await
-            .err(),
-        Some(SendError::DustValue),
+            .await,
+        Err(SendError::DustValue)
     );
 
     Ok(())

--- a/modules/fedimint-walletv2-tests/tests/tests.rs
+++ b/modules/fedimint-walletv2-tests/tests/tests.rs
@@ -2,9 +2,12 @@ use std::pin::pin;
 use std::sync::Arc;
 use std::time::Duration;
 
+use assert_matches::assert_matches;
 use async_stream::stream;
 use bitcoin::Amount;
 use fedimint_client::ClientHandleArc;
+use fedimint_client::error::OperationLookupError;
+use fedimint_core::core::OperationId;
 use fedimint_core::task::sleep_in_test;
 use fedimint_dummy_client::DummyClientInit;
 use fedimint_dummy_server::DummyInit;
@@ -751,4 +754,23 @@ mod db {
         )
         .await
     }
+}
+
+/// Awaiting an operation that was never started reports the shared
+/// operation-lookup error, not an opaque one.
+#[tokio::test(flavor = "multi_thread")]
+async fn awaiting_an_unknown_send_operation_reports_not_found() -> anyhow::Result<()> {
+    let fixtures = fixtures();
+    let fed = fixtures.new_fed_not_degraded().await;
+    let client = fed.new_client().await;
+
+    assert_matches!(
+        client
+            .get_first_module::<WalletClientModule>()?
+            .await_final_send_operation_state(OperationId::new_random())
+            .await,
+        Err(OperationLookupError::NotFound(_))
+    );
+
+    Ok(())
 }


### PR DESCRIPTION
## Summary

Sixth PR of the #8821 series (after #9082, #9103, #9115, #9118 and #9127, all merged); rebased on master after #9127 merged. This PR removes `anyhow` from the public API of `fedimint-wallet-client`, `fedimint-walletv2-client` and `fedimint-walletv2-common`. `fedimint-wallet-common` is in the same crate family but had no `anyhow` to remove from its public API. Nothing outside those crates changes except the call sites they force, in `gateway/fedimint-gateway-server`, `modules/fedimint-wallet-tests` and `modules/fedimint-walletv2-tests`.

## What changed

Nine new types live in `fedimint_wallet_client::error` and are re-exported at that crate's root, plus one new type in `fedimint_walletv2_client`:

- `PegInError` (`AddressNotDerived`, `NoAddressForOperation`, `TweakIdxNotFound`, `Database`, `TransactionRejected`, `MonitorStopped`): the shared failure for the nine peg-in lookup, re-check and await-deposit methods (`find_tweak_idx_by_address`, `find_tweak_idx_by_operation_id`, `get_pegin_tweak_idx`, `recheck_pegin_address_by_op_id`, `recheck_pegin_address_by_address`, `recheck_pegin_address`, `await_num_deposits_by_operation_id`, `await_num_deposits_by_address`, `await_num_deposits`).
- `DepositAddressError` (`SafeDepositUnverified`, `OperationAlreadyExists`, `BitcoinRpc`, `Database`, `PooledAddressDisappeared { tweak_idx }`, `PooledAddressUsed { tweak_idx }`): for `peg_in` and the four deposit-address allocation methods (`safe_allocate_deposit_address`, `allocate_deposit_address_expert_only`, `allocate_deposit_address_pooled_stateless`, `allocate_deposit_address_pooled`).
- `SubscribeDepositError` (`Operation`, `NotADeposit`, `WrongNetwork { expected }`, `OldPendingDeposit`, `NonFinalOutcome`): for `subscribe_deposit`; drops a dead "wrong module kind" check the shared operation lookup already performs.
- `WithdrawFeesError` (`Federation`, `NoQuote`) and `MaxWithdrawableAmountError` (`Fees`, `BalanceTooLow { balance, dust_limit }`): for `get_withdraw_fees` and `max_withdrawable_amount`. `BalanceTooLow` carries both the wallet's balance and the destination's dust limit so the message can state why nothing is withdrawable.
- `PegOutError` (`WrongNetwork { expected }`, `Fees`, `Transaction`): for `peg_out`, `withdraw` and the deprecated `rbf_withdraw`.
- `SubscribeWithdrawError` (`Operation`, `NotAWithdrawal`): for `subscribe_withdraw_updates`.
- `ConsensusVersionVotingError` (`AdminAuthMissing`, `Federation`): for `admin_auth` and `activate_consensus_version_voting`.
- `AwaitReceiveError` (`Operation`, `Issuance`), in `fedimint_walletv2_client`: for `await_receive`.

`fedimint_wallet_client`'s `get_wallet_summary`, `get_block_count_local`, `fetch_recovery_count` and `fetch_recovery_slice` turned out to have exactly one way to fail and now return `FederationResult` (i.e. `FederationError`) directly instead of wrapping it in `anyhow`; `send_fee_quote` (wallet), `withdraw` and `rbf_withdraw` likewise now return `TransactionSubmitError` directly. In `fedimint_walletv2_client`, `send_fee_quote`, `max_sendable_amount` (via `SendError`), and `await_final_send_operation_state` / `await_final_receive_operation_state` now return `TransactionSubmitError` / `SendError` / `OperationLookupError` directly.

`create_withdraw_output` and `create_rbf_withdraw_output` turned out to be infallible and lost their `Result` entirely.

`fedimint_walletv2_common::config::FeeConsensus::new` now returns `fedimint_core::config::ExcessiveRelativeFeeError` (the shared type #9127 added) instead of its own `anyhow::ensure!`-based guard, so a third module reuses that type instead of carrying its own copy of the same three-line check.

`fedimint_walletv2_client`'s `SendError` and `ReceiveError` are re-cut: both are now `#[non_exhaustive]`, both lose `Clone`, `Eq` and `PartialEq`, and the `FederationError(String)` variant on each is replaced by `Federation(Box<FederationError>)`, which carries the error itself instead of its `Display` text. `SendError` also gains a `Failed(TransactionSubmitError)` variant, appended last — see "Behaviour changes worth a close look" for what it changes.

Review feedback on the first push showed that the two "largest affordable amount" helpers (`max_withdrawable_amount`, walletv2's `max_sendable_amount`) reported *every* failed fee probe as a balance condition, hiding fatal quote failures such as a missing primary module or a note-decode failure during the mint's consolidation. The fix gives "insufficient funds" a typed identity that survives the still-`anyhow` module->client trait boundary: `InsufficientBalanceError` moves from `fedimint_mint_client` to `fedimint_client_module::error` (the old paths still resolve through re-exports; the type gains `Copy`, `Eq`, `PartialEq`), `TransactionSubmitError` gains an appended `InsufficientFunds(InsufficientBalanceError)` variant, `fedimint-client` recovers it from the primary module's error chain at both balancing sites, and mintv2's funding path produces it too. `max_affordable_send_amount` now takes a `TransactionSubmitError`-returning quote closure and returns `Result<Option<Amount>, TransactionSubmitError>`: an `InsufficientFunds` quote still means "probe lower", any other quote failure aborts the search and is returned with its cause. `max_withdrawable_amount` reports that as the new `MaxWithdrawableAmountError::Quote(TransactionSubmitError)`, `max_sendable_amount` as `SendError::Failed`; the ln and lnv2 `send_fee_quote` passthroughs return `TransactionSubmitError` directly so their `spendable_amount` helpers can use the same solver. mintv2's `SendECashError` gains an appended `Failed(TransactionSubmitError)` variant for the same reason.

## Breaking for integrators

- `SendError` and `ReceiveError` (`fedimint_walletv2_client`) are `#[non_exhaustive]` and no longer derive `Clone`, `Eq` or `PartialEq`; their `FederationError(String)` variant is renamed to `Federation(Box<FederationError>)`. Within this repo, two `assert_eq!` call sites on these types moved to `assert_matches!`.
- `create_withdraw_output` and `create_rbf_withdraw_output` (`fedimint_wallet_client`) return their output bundle directly instead of a `Result`; call sites drop a trailing `?`. Neither has a caller outside the crate.
- walletv2's `send` no longer maps every submission failure to `SendError::InsufficientFunds`; only a genuine `TransactionSubmitError::InsufficientFunds` still means that. See "Behaviour changes worth a close look" below.
- `fedimint_client_module::transaction::max_affordable_send_amount` changes signature: the quote closure must return `Result<FeeQuote, TransactionSubmitError>` (it was generic over the error type) and the function returns `Result<Option<Amount>, TransactionSubmitError>` instead of `Option<Amount>`.
- `TransactionSubmitError` gains an appended `InsufficientFunds(InsufficientBalanceError)` variant (the enum is `#[non_exhaustive]`); a primary-module balance shortfall is no longer reported as `PrimaryModule(..)`.
- `InsufficientBalanceError` now lives in `fedimint_client_module::error`; `fedimint_mint_client::InsufficientBalanceError` and `fedimint_mint_client::error::InsufficientBalanceError` are re-exports of it.
- mintv2's `SendECashError` gains an appended `Failed(TransactionSubmitError)` variant and therefore loses `Clone`, `Eq` and `PartialEq`; `fedimint_mintv2_client::MintClientModule::send` now reports non-balance failures as `Failed` instead of `InsufficientBalance`, and `receive` likewise maps only a genuine shortfall to `InsufficientFunds`.
- `LightningClientModule::send_fee_quote` in both `fedimint-ln-client` and `fedimint-lnv2-client` returns `Result<FeeQuote, TransactionSubmitError>` instead of `anyhow::Result<FeeQuote>` (pure passthroughs; no callers outside their crates).
- `fedimint-walletv2-common` no longer depends on `anyhow` at all; the dependency is removed from its `Cargo.toml`, so `cargo udeps` would catch a reintroduction.
- Every migrated function now returns a concrete error. A plain `?` into an `anyhow`-returning body still compiles via the blanket `From` conversion, but a variant used as a function pointer (e.g. `.map_err(SomeVariant)`) or a payload built directly from an `anyhow::Error` needs `.into()` added at the call site, and `format!("{e:#}")` on a retyped error silently stops printing the cause — that formatter is `anyhow`-only and degrades to plain `Display` on a `thiserror` type; use `e.fmt_compact()` instead.
- Six call sites in `gateway/fedimint-gateway-server` needed `.map_err(|e| AdminGatewayError::Unexpected(e.into()))` because a bare `?` no longer converts; any downstream crate doing the same against one of these functions will need the same change.

Every method whose return type changed, by crate:

- `fedimint-wallet-client`: `find_tweak_idx_by_address`, `find_tweak_idx_by_operation_id`, `get_pegin_tweak_idx`, `recheck_pegin_address_by_op_id`, `recheck_pegin_address_by_address`, `recheck_pegin_address`, `await_num_deposits_by_operation_id`, `await_num_deposits_by_address`, `await_num_deposits` (all `-> PegInError`); `peg_in`, `safe_allocate_deposit_address`, `allocate_deposit_address_expert_only`, `allocate_deposit_address_pooled_stateless`, `allocate_deposit_address_pooled` (all `-> DepositAddressError`); `subscribe_deposit` (`-> SubscribeDepositError`); `get_withdraw_fees` (`-> WithdrawFeesError`); `max_withdrawable_amount` (`-> MaxWithdrawableAmountError`); `peg_out` (`-> PegOutError`); `withdraw`, `rbf_withdraw`, `send_fee_quote` (`-> TransactionSubmitError`); `subscribe_withdraw_updates` (`-> SubscribeWithdrawError`); `admin_auth`, `activate_consensus_version_voting` (`-> ConsensusVersionVotingError`); `get_wallet_summary`, `get_block_count_local`, `fetch_recovery_count`, `fetch_recovery_slice` (`-> FederationResult<..>`); `create_withdraw_output`, `create_rbf_withdraw_output` (no `Result` at all).
- `fedimint-walletv2-client`: `send_fee_quote` (`-> TransactionSubmitError`); `max_sendable_amount` (`-> SendError`); `await_final_send_operation_state`, `await_final_receive_operation_state` (`-> OperationLookupError`); `await_receive` (`-> AwaitReceiveError`).
- `fedimint-walletv2-common`: `FeeConsensus::new` (`-> ExcessiveRelativeFeeError`, the shared type from #9127 instead of a local one).
- `fedimint-client-module`: `max_affordable_send_amount` (`-> Result<Option<Amount>, TransactionSubmitError>`).
- `fedimint-ln-client`, `fedimint-lnv2-client`: `send_fee_quote` (`-> TransactionSubmitError`).

## Not changed

The module -> client trait boundary is deliberately still `anyhow` and stays that way until a later PR in this series: `ClientModuleInit::{init, recover}`, `ClientModule::{backup, handle_rpc}` and every `RecoveryFromHistory` method in `fedimint-wallet-client`, and `ClientModuleInit::init` in `fedimint-walletv2-client`. `handle_cli_command` (both crates) and `handle_rpc` stay `anyhow` by design: they are JSON-in/JSON-out handlers whose errors are stringified into a response regardless of type. `fedimint-wallet-client`'s `backup`, `deposit` and `withdraw` modules and `pegin_monitor` module, and `fedimint-walletv2-client`'s `api` and `cli` modules, are private, so nothing in them is public API; `fedimint-wallet-common`'s private `validate_peg_in_proof` stays `anyhow` for the same reason (that crate keeps the dependency for its uniffi glue).

No wire, DB or JSON *shape* changed anywhere in this PR: every retyped error only affects how a failure is represented in Rust, not what a peer, gateway or client sees on the wire. No type this PR touches derives `Serialize`, `Deserialize`, `Encodable`, `Decodable` or `uniffi::Error` (confirmed by grepping the diff for a newly added derive of any of them — empty). The state and meta enums the CLI, RPC and uniffi consumers serialize — `DepositStateV1`, `DepositStateV2`, `WithdrawState`, `WalletOperationMetaVariant`, `FinalSendOperationState`, `FinalReceiveOperationState` — are untouched; their variant lists and order are byte-identical to base. `fedimint-core` is untouched.

## Behaviour changes worth a close look

- walletv2's `send` stops reporting *every* submission failure as "not enough funds"; only `TransactionSubmitError::InsufficientFunds`, the primary module's typed balance shortfall, still maps to `SendError::InsufficientFunds`. Every other cause — no primary module, a database error, an oversized transaction, a state-machine registration failure, a note-decode failure inside the primary module — now surfaces as the new `SendError::Failed(TransactionSubmitError)`, "The send transaction could not be submitted", with the real cause behind `source()`. mintv2's `receive` and `send` get the same exact classification (`ReceiveECashError::Failed` / the new `SendECashError::Failed`). A caller that special-cased "insufficient funds" text for one of those other causes now sees different text.
- `max_withdrawable_amount` and walletv2's `max_sendable_amount` distinguish "the balance cannot cover the dust limit plus fees" (`BalanceTooLow { balance, dust_limit }` / `SendError::InsufficientFunds`) from a fee probe that failed for another reason (`MaxWithdrawableAmountError::Quote(..)` / `SendError::Failed(..)`, with the cause). Before, every probe failure was reported as the balance condition and the solver silently searched lower.
- `SendError` and `ReceiveError` carry the `FederationError` itself (`Federation(Box<FederationError>)`) instead of its `Display` text, so per-peer detail survives — at the cost of `Clone`, `Eq` and `PartialEq`.
- Four `autocommit` call sites (three deposit-address allocations and the peg-in re-check) now return `DepositAddressError::Database` / `PegInError::Database` ("Database error") after exhausting their hundred commit attempts, instead of a message that named the attempt count and dropped the underlying database error; the two error types each gained a `From<AutocommitError<Self>>` impl to do this without repeating four match arms.
- `ClientContext::get_operation` already checks the operation's module kind itself, so the wallet's own "Operation is not a wallet operation" checks are gone; the shared `OperationLookupError` names both the expected and the actual module kind.
- `WalletFederationApi::{fetch_recovery_count, fetch_recovery_slice}`, `get_wallet_summary` and `get_block_count_local` no longer rebuild the federation error from its own `Display` text via `anyhow::anyhow!("{e}")`; they return the pre-existing `FederationResult` directly, so per-peer detail now reaches the caller intact.
- `peg_in` no longer re-derives its own address from its script pubkey just to obtain a second failure mode; it uses `into_unchecked()` on the address it already has.
- Every error text that reaches `fedimint-cli`'s `CliError`, uniffi's `UniffiError` or the gateway's `failure_reason` is now the new type's `Display` plus its cause chain (via `fmt_compact()`), rather than the old ad-hoc message.

## Compatibility

No `Encodable`, `Decodable`, `Serialize` or `Deserialize` type this PR touches changed, no variant was inserted or reordered into one that derives any of them, and no database migration is needed. `fedimint-core` is untouched.

| Check | Result |
|---|---|
| New `Serialize`/`Deserialize`/`Encodable`/`Decodable`/`uniffi::Error` derive added anywhere in the diff | none (grep empty) |
| `DepositStateV1`, `DepositStateV2`, `WithdrawState`, `WalletOperationMetaVariant`, `FinalSendOperationState`, `FinalReceiveOperationState` variant lists and order | byte-identical to base |
| `client_db.rs`, `deposit.rs`, `withdraw.rs` (wallet-client) | untouched (empty diff against base) |
| `fedimint-wallet-common/` | untouched |
| `fedimint-walletv2-common/src/lib.rs` | exactly one added line, `pub use fedimint_core::config::ExcessiveRelativeFeeError;` |
| `fedimint-core/` | untouched |
| `Cargo.lock` | one `anyhow` dependency-list deletion (`fedimint-walletv2-common`) plus one dev-only `assert_matches` addition (`fedimint-walletv2-tests`); no version bump of any existing crate |

## User-visible text changes

Every `Display`-message or behaviour change a caller could now observe, with the consumer that renders it.

| # | Type / function | Before | After |
|---|---|---|---|
| 1 | `DepositAddressError::SafeDepositUnverified` (`peg_in` and friends) | "Could not verify that the wallet module consensus version supports safe deposits" | "The federation was not verified to support safe deposits" |
| 2 | `DepositAddressError::Database` / `PegInError::Database` (three deposit-address allocation sites plus the peg-in re-check) | "Failed to commit after 100 attempts: `<db error>`" | "Database error", underlying failure now behind `source()` |
| 3 | `DepositAddressError::PooledAddressDisappeared` | "Pooled address disappeared while reusing TweakIdx(N)" | "The pooled deposit address TweakIdx(N) disappeared while it was being reused" |
| 4 | `DepositAddressError::PooledAddressUsed` | "Pooled address was used while reusing TweakIdx(N)" | "The pooled deposit address TweakIdx(N) was used while it was being reused" |
| 5 | Gateway `handle_address_msg` failure text | raw `anyhow` context from a bare `?` | `DepositAddressError`'s `Display` plus its cause chain via `fmt_compact()` |
| 6 | `OperationLookupError` (via `SubscribeDepositError::Operation`, `SubscribeWithdrawError::Operation`) | "Operation not found: `<short id>`" | "The operation does not exist", with "No operation with id `<short id>`" behind `source()` |
| 7 | Wrong-module-kind check on deposit/withdraw operations | "Operation is not a wallet operation" | Disappears — the shared lookup names both the expected and actual module kind ("Operation `<id>` was started by module X, not wallet") |
| 8 | `SubscribeDepositError::NotADeposit` | "Operation is not a deposit operation" | "The operation is not a deposit" |
| 9 | `SubscribeDepositError::OldPendingDeposit` | "Old pending deposit, can't subscribe to updates" | "An old pending deposit cannot be subscribed to" |
| 10 | `SubscribeDepositError::NonFinalOutcome` | "Non-final outcome in operation log" | "The recorded outcome of an old deposit is not final" |
| 11 | `SubscribeDepositError::WrongNetwork` | bitcoin's own address-parse error text | "The deposit address is not valid on bitcoin" |
| 12 | `WithdrawFeesError::NoQuote` | "Federation didn't return peg-out fees" | "The federation did not quote peg-out fees" |
| 13 | `WithdrawFeesError::Federation` | a federation failure while quoting peg-out fees, whole `anyhow` chain flattened into one string | "The peg-out fees could not be fetched", per-peer detail behind `source()` |
| 14 | `MaxWithdrawableAmountError::BalanceTooLow` | "Balance is too low to withdraw any amount after fees" | "The balance `{balance}` is too low to cover the dust limit `{dust_limit}` and fees" — the variant now carries both amounts as fields |
| 15 | `create_withdraw_output` / `create_rbf_withdraw_output` | returned a `Result` | both are now infallible (no `Result`); no external caller observes this (crate-internal only) |
| 16 | `PegOutError::Transaction` (`withdraw`, `rbf_withdraw`, `peg_out`) | "Failed to initiate withdraw" glued in front of the `anyhow` chain | `TransactionSubmitError`'s own text plus its cause via `source()` |
| 17 | `PegOutError::WrongNetwork` | bitcoin's own address-parse error text | "The destination address is not valid on bitcoin" |
| 18 | `SubscribeWithdrawError::NotAWithdrawal` | "Operation is not a withdraw operation" | "The operation is not a withdrawal" |
| 19 | `ConsensusVersionVotingError::AdminAuthMissing` | "Admin auth not set" | "Admin auth is not set" |
| 20 | `ConsensusVersionVotingError::Federation` | a federation failure while voting on the consensus version, ad hoc `anyhow` chain text | "The vote could not be submitted to the federation", per-peer detail behind `source()` |
| 21 | walletv2 `SendError::InsufficientFunds` | "Balance is too low to send any amount on chain after fees" (ad hoc `anyhow!`) | "The client does not have sufficient funds to send the payment" |
| 22 | walletv2 `OperationLookupError` (awaiting an unknown/mismatched send or receive operation) | flattened `anyhow` chain | `OperationLookupError`'s own text |
| 23 | walletv2 `SendError::Federation` | `SendError::FederationError(String)` rendered as "Federation returned an error: `<flattened text>`" | `Federation(Box<FederationError>)` renders "The federation returned an error", detail behind `source()` |
| 24 | walletv2 `ReceiveError::Federation` | `ReceiveError::FederationError(String)`, same shape | `Federation(Box<FederationError>)`, same rendering change |
| 25 | walletv2 `SendError::WrongNetwork` | "Address is from a different network than the federation." (trailing period) | Same text, no trailing period |
| 26 | walletv2 `send()` submission-failure classification (behaviour change) | any submission failure, including a database error or a non-funding failure, mapped to `SendError::InsufficientFunds` | only `TransactionSubmitError::{NoPrimaryModule, PrimaryModule}` still map to `InsufficientFunds`; every other cause now surfaces as `SendError::Failed(TransactionSubmitError)`, "The send transaction could not be submitted", real cause behind `source()` |
| 27 | walletv2 `SendError` / `ReceiveError` derives (breaking change) | derived `Clone`, `Eq`, `PartialEq` | derive only `Error`, `Debug` (plus `#[non_exhaustive]`); downstream code that cloned or compared these types no longer compiles. Within this repo, two `assert_eq!` call sites moved to `assert_matches!` |
| 28 | walletv2 `SendError` / `ReceiveError` variant name | `FederationError(String)` on both enums | renamed to `Federation(Box<FederationError>)` |
| 29 | `FeeConsensus::new`'s error type | a local `anyhow::Error` (via `anyhow::ensure!`), message "Relative fee over ten thousand parts per million is excessive" | returns the shared `fedimint_core::config::ExcessiveRelativeFeeError`, `Display` text "The relative fee of `{parts_per_million}` parts per million is over the limit of `{max}`". The two `.expect(...)` call sites in `fedimint-walletv2-server` are unreachable in practice (both always pass `0`, which is always within the limit), so this row is a type/API change only, not a reachable panic-text change |
| 30 | `TransactionSubmitError::InsufficientFunds` (`fedimint-client-module`, new) | a primary-module shortfall rendered as "The primary module failed" + the boxed anyhow text | "Insufficient funds" + source "Insufficient balance: requested `<a>` but only `<b>` available" (the mint's existing text, now reachable typed from every consumer) |
| 31 | `MaxWithdrawableAmountError::Quote` (new) | reported as "Balance is too low to withdraw any amount after fees" | "The fee quote for the withdrawal failed" + the `TransactionSubmitError` chain |
| 32 | `SendECashError::Failed` (mintv2, new) | "The clients balance is insufficient" for every submit failure | "The reissue transaction could not be submitted" (the send's change-making reissue) + the `TransactionSubmitError` chain for non-balance failures |
| 33 | `PegInError` variant name | n/a — this type is new in this PR | `NoAddressForOperation` (message unchanged: "No deposit address belongs to operation `<id>`"); named `NoAddressForOperation` rather than the initially-drafted `OperationNotFound` to avoid reading as if the operation itself were missing. Since `PegInError` does not exist before this PR, this is not a breaking rename for any integrator |

Rows 26 and 27 are the two changes with real behavioural/compatibility weight (a text a caller may have pattern-matched changes meaning, and a derive removal is a compile-time break for any downstream crate); everything else is a message reword or a restructuring of an already-opaque `anyhow` chain into a typed `source()` chain with equivalent information.

## Verification

```
cargo clippy --workspace --all-targets -- -D warnings
cargo clippy -p <crate> --all-targets --no-deps -- -D warnings   # authoritative gate, see note below
cargo nextest run --workspace --all-targets
RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p fedimint-wallet-client -p fedimint-wallet-common -p fedimint-walletv2-client -p fedimint-walletv2-common -p fedimint-gateway-server
cargo test --doc -p fedimint-wallet-client -p fedimint-wallet-common -p fedimint-walletv2-client -p fedimint-walletv2-common
cargo check -p <crate> --all-features / --no-default-features
  for fedimint-wallet-client, fedimint-wallet-common, fedimint-walletv2-client, fedimint-walletv2-common
cargo check -p fedimint-wallet-client --features uniffi
<wasm target set: fedimint-client, fedimint-client-wasm, fedimint-wasm-tests, fedimint-mintv2-client, fedimint-walletv2-client>
pre-commit hook
git diff --check origin/master...HEAD
nix build -L .#nightly.test.workspaceCargoUdeps
```

`cargo nextest run --workspace --all-targets` and the per-crate `--all-features` / `--no-default-features` checks were run locally precisely because the earlier #9118 in this series was bounced by both in CI. Results:

| Command | Result |
|---|---|
| `cargo clippy --workspace --all-targets -- -D warnings` | pass, clean, exit 0 |
| Per-crate `--no-deps` clippy (`fedimint-wallet-client`, `fedimint-wallet-tests`, `fedimint-walletv2-client`, `fedimint-walletv2-common`, `fedimint-walletv2-tests`, `fedimint-gateway-server`) | all six pass, exit 0 (a pre-existing, unrelated `fedimint-lnv2-client` dead-code warning shows up as dependency-build output on three of them, never elevated to an error) |
| `cargo nextest run --workspace --all-targets` | 661 tests run, 661 passed (3 slow), 1 skipped |
| `cargo doc --no-deps` for each of `fedimint-wallet-client`, `fedimint-wallet-common`, `fedimint-walletv2-client`, `fedimint-walletv2-common`, `fedimint-gateway-server` | exit 0 for every crate |
| `cargo test --doc` for the four wallet/walletv2 crates | 0 doc tests in each, `test result: ok` |
| `cargo check --all-features` / `--no-default-features` for the four wallet/walletv2 crates | exit 0 for all eight combinations |
| `cargo check -p fedimint-wallet-client --features uniffi` | exit 0 |
| wasm check (`fedimint-client`, `fedimint-client-wasm`, `fedimint-wasm-tests`, `fedimint-mintv2-client`, `fedimint-walletv2-client`, target `wasm32-unknown-unknown`) | exit 0, only pre-existing warnings unrelated to this PR |
| `nix build -L .#nightly.test.workspaceCargoUdeps` | exit 0, "All deps seem to have been used." |
| pre-commit hook | exit 0, clean |
| `git diff --check` against the base | exit 0, empty |

Part of #8821.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Af1e5wQPxu7JCw8tHoHxz5
