### PR TITLE
fix(gateway): harden Lightning payment paths (backport to v0.11) and bump to 0.11.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2248,7 +2248,7 @@ dependencies = [
 
 [[package]]
 name = "devimint"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -2708,7 +2708,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fedimint-aead"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "argon2",
@@ -2740,7 +2740,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-api-client"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2766,7 +2766,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-bip39"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "bip39",
  "fedimint-client",
@@ -2777,7 +2777,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-bitcoind"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2792,14 +2792,14 @@ dependencies = [
 
 [[package]]
 name = "fedimint-build"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "fedimint-cli"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2842,7 +2842,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2874,7 +2874,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client-module"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -2905,7 +2905,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client-rpc"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2933,7 +2933,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client-uniffi"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "fedimint-build",
@@ -2951,7 +2951,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client-wasm"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2969,7 +2969,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-connectors"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "arti-client",
@@ -3004,7 +3004,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-core"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3070,7 +3070,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-cursed-redb"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3090,7 +3090,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-db-locked"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3102,7 +3102,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dbtool"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3138,7 +3138,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-derive"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
@@ -3148,7 +3148,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-derive-secret"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",
@@ -3160,11 +3160,11 @@ dependencies = [
 
 [[package]]
 name = "fedimint-docs"
-version = "0.11.3-alpha"
+version = "0.11.3"
 
 [[package]]
 name = "fedimint-dummy-client"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3186,7 +3186,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dummy-common"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -3196,7 +3196,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dummy-server"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3212,7 +3212,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-empty-client"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3229,7 +3229,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-empty-common"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -3239,7 +3239,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-empty-server"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3255,7 +3255,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-eventlog"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3273,7 +3273,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-fountain"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3285,7 +3285,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-fuzz"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "fedimint-core",
  "fedimint-ln-common",
@@ -3298,7 +3298,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-client"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "bcrypt",
@@ -3323,7 +3323,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-common"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -3340,7 +3340,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-server"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3421,7 +3421,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-server-db"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -3449,7 +3449,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-ui"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "async-trait",
  "axum 0.8.8",
@@ -3481,7 +3481,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gw-client"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3512,7 +3512,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gwv2-client"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3539,7 +3539,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-hkdf"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "bitcoin_hashes",
 ]
@@ -3587,7 +3587,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lightning"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3614,7 +3614,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-client"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3648,7 +3648,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-common"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3671,7 +3671,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-server"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3697,7 +3697,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-tests"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3726,7 +3726,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnurl"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "bech32",
  "lightning-invoice",
@@ -3738,7 +3738,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-client"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3770,7 +3770,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-common"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3790,7 +3790,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-server"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3814,7 +3814,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-tests"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3851,7 +3851,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-load-test-tool"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -3879,7 +3879,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-logging"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "console-subscriber",
@@ -3892,7 +3892,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-client"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3913,7 +3913,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-common"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -3927,7 +3927,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-server"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3946,7 +3946,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-tests"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -3960,7 +3960,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-metrics"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -3972,7 +3972,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-client"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -4013,7 +4013,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-common"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",
@@ -4026,7 +4026,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-server"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4053,7 +4053,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-tests"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4087,7 +4087,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mintv2-client"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -4126,7 +4126,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mintv2-common"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",
@@ -4139,7 +4139,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mintv2-server"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4164,7 +4164,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mintv2-tests"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4197,7 +4197,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-portalloc"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "dirs",
@@ -4211,7 +4211,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-recoverytool"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -4234,7 +4234,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-recurringd"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -4265,7 +4265,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-recurringd-tests"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "devimint",
@@ -4279,7 +4279,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-recurringdv2"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -4300,7 +4300,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-rocksdb"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4317,7 +4317,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -4374,7 +4374,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server-bitcoin-rpc"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4390,7 +4390,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server-core"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4408,7 +4408,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server-tests"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "bitcoin",
  "fedimint-api-client",
@@ -4428,7 +4428,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server-ui"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4455,7 +4455,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-tbs"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "bls12_381",
  "criterion",
@@ -4470,7 +4470,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-testing"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4510,7 +4510,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-testing-core"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -4571,7 +4571,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-tpe"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "bitcoin_hashes",
  "bls12_381",
@@ -4585,7 +4585,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ui-common"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "axum 0.8.8",
  "axum-extra",
@@ -4597,7 +4597,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-unknown-common"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -4607,7 +4607,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-unknown-server"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4621,14 +4621,14 @@ dependencies = [
 
 [[package]]
 name = "fedimint-util-error"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "fedimint-wallet-client"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -4658,7 +4658,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-common"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -4674,7 +4674,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-server"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4701,7 +4701,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-tests"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4734,7 +4734,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-walletv2-client"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4762,7 +4762,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-walletv2-common"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -4775,7 +4775,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-walletv2-server"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4797,7 +4797,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-walletv2-tests"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4827,7 +4827,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wasm-tests"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "fedimint-client",
@@ -4848,7 +4848,7 @@ dependencies = [
 
 [[package]]
 name = "fedimintd"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -4885,7 +4885,7 @@ dependencies = [
 
 [[package]]
 name = "fedimintd-envs"
-version = "0.11.3-alpha"
+version = "0.11.3"
 
 [[package]]
 name = "ff"
@@ -5201,7 +5201,7 @@ dependencies = [
 
 [[package]]
 name = "gateway-tests"
-version = "0.11.3-alpha"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,7 +107,7 @@ keywords = ["bitcoin", "lightning", "chaumian", "e-cash", "federated"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/fedimint/fedimint"
-version = "0.11.3-alpha"
+version = "0.11.3"
 
 [workspace.metadata]
 authors = ["The Fedimint Developers"]
@@ -168,7 +168,7 @@ criterion = "0.5.1"
 # We need to pin this arti's `curve25519-dalek` dependency, due to `https://rustsec.org/advisories/RUSTSEC-2024-0344` vulnerability
 # It's been updated by https://gitlab.torproject.org/tpo/core/arti/-/merge_requests/2211, should be removed in next release.
 curve25519-dalek = ">=4.1.3"
-devimint = { path = "./devimint", version = "=0.11.3-alpha" }
+devimint = { path = "./devimint", version = "=0.11.3" }
 dirs = "6.0.0"
 erased-serde = "0.4"
 esplora-client = { version = "0.12.3", default-features = false, features = [
@@ -178,70 +178,70 @@ esplora-client = { version = "0.12.3", default-features = false, features = [
 ] }
 tor-rtcompat = { version = "0.33.0" }
 
-fedimint-aead = { path = "./crypto/aead", version = "=0.11.3-alpha" }
-fedimint-api-client = { path = "./fedimint-api-client", version = "=0.11.3-alpha" }
-fedimint-bip39 = { path = "./fedimint-bip39", version = "=0.11.3-alpha" }
-fedimint-bitcoind = { path = "./fedimint-bitcoind", version = "=0.11.3-alpha" }
-fedimint-build = { path = "./fedimint-build", version = "=0.11.3-alpha" }
-fedimint-client = { path = "./fedimint-client", version = "=0.11.3-alpha" }
-fedimint-client-module = { path = "./fedimint-client-module", version = "=0.11.3-alpha" }
-fedimint-client-rpc = { path = "./fedimint-client-rpc", version = "=0.11.3-alpha" }
-fedimint-connectors = { path = "./fedimint-connectors", version = "=0.11.3-alpha" }
-fedimint-core = { path = "./fedimint-core", version = "=0.11.3-alpha" }
-fedimint-cursed-redb = { path = "./fedimint-cursed-redb", version = "=0.11.3-alpha" }
-fedimint-db-locked = { path = "./fedimint-db-locked", version = "=0.11.3-alpha" }
-fedimint-derive = { path = "./fedimint-derive", version = "=0.11.3-alpha" }
-fedimint-derive-secret = { path = "./crypto/derive-secret", version = "=0.11.3-alpha" }
-fedimint-dummy-client = { path = "./modules/fedimint-dummy-client", version = "=0.11.3-alpha" }
-fedimint-dummy-common = { path = "./modules/fedimint-dummy-common", version = "=0.11.3-alpha" }
-fedimint-dummy-server = { path = "./modules/fedimint-dummy-server", version = "=0.11.3-alpha" }
-fedimint-empty-common = { path = "./modules/fedimint-empty-common", version = "=0.11.3-alpha" }
-fedimint-eventlog = { path = "./fedimint-eventlog", version = "=0.11.3-alpha" }
-fedimint-gateway-common = { package = "fedimint-gateway-common", path = "./gateway/fedimint-gateway-common", version = "=0.11.3-alpha" }
-fedimint-gateway-server = { package = "fedimint-gateway-server", path = "./gateway/fedimint-gateway-server", version = "=0.11.3-alpha" }
-fedimint-gateway-server-db = { package = "fedimint-gateway-server-db", path = "./gateway/fedimint-gateway-server-db", version = "=0.11.3-alpha" }
-fedimint-gateway-ui = { package = "fedimint-gateway-ui", path = "./gateway/fedimint-gateway-ui", version = "=0.11.3-alpha" }
-fedimint-gw-client = { path = "./modules/fedimint-gw-client", version = "=0.11.3-alpha" }
-fedimint-gwv2-client = { path = "./modules/fedimint-gwv2-client", version = "=0.11.3-alpha" }
-fedimint-lightning = { package = "fedimint-lightning", path = "./gateway/fedimint-lightning", version = "=0.11.3-alpha" }
-fedimint-ln-client = { path = "./modules/fedimint-ln-client", version = "=0.11.3-alpha" }
-fedimint-ln-common = { path = "./modules/fedimint-ln-common", version = "=0.11.3-alpha" }
-fedimint-ln-server = { path = "./modules/fedimint-ln-server", version = "=0.11.3-alpha" }
-fedimint-lnurl = { path = "./fedimint-lnurl", version = "=0.11.3-alpha" }
-fedimint-lnv2-client = { path = "./modules/fedimint-lnv2-client", version = "=0.11.3-alpha" }
-fedimint-lnv2-common = { path = "./modules/fedimint-lnv2-common", version = "=0.11.3-alpha" }
-fedimint-lnv2-server = { path = "./modules/fedimint-lnv2-server", version = "=0.11.3-alpha" }
-fedimint-logging = { path = "./fedimint-logging", version = "=0.11.3-alpha" }
-fedimint-meta-client = { path = "./modules/fedimint-meta-client", version = "=0.11.3-alpha" }
-fedimint-meta-common = { path = "./modules/fedimint-meta-common", version = "=0.11.3-alpha" }
-fedimint-meta-server = { path = "./modules/fedimint-meta-server", version = "=0.11.3-alpha" }
-fedimint-metrics = { path = "./fedimint-metrics", version = "=0.11.3-alpha" }
-fedimint-mint-client = { path = "./modules/fedimint-mint-client", version = "=0.11.3-alpha" }
-fedimint-mint-common = { path = "./modules/fedimint-mint-common", version = "=0.11.3-alpha" }
-fedimint-mint-server = { path = "./modules/fedimint-mint-server", version = "=0.11.3-alpha" }
-fedimint-mintv2-client = { path = "./modules/fedimint-mintv2-client", version = "=0.11.3-alpha" }
-fedimint-mintv2-common = { path = "./modules/fedimint-mintv2-common", version = "=0.11.3-alpha" }
-fedimint-mintv2-server = { path = "./modules/fedimint-mintv2-server", version = "=0.11.3-alpha" }
-fedimint-portalloc = { path = "utils/portalloc", version = "=0.11.3-alpha" }
-fedimint-rocksdb = { path = "./fedimint-rocksdb", version = "=0.11.3-alpha" }
-fedimint-server = { path = "./fedimint-server", version = "=0.11.3-alpha" }
-fedimint-server-bitcoin-rpc = { path = "./fedimint-server-bitcoin-rpc", version = "=0.11.3-alpha" }
-fedimint-server-core = { path = "./fedimint-server-core", version = "=0.11.3-alpha" }
-fedimint-server-ui = { path = "./fedimint-server-ui", version = "=0.11.3-alpha" }
-fedimint-testing = { path = "./fedimint-testing", version = "=0.11.3-alpha" }
-fedimint-testing-core = { path = "./fedimint-testing-core", version = "=0.11.3-alpha" }
-fedimint-ui-common = { path = "./fedimint-ui-common", version = "=0.11.3-alpha" }
-fedimint-unknown-common = { path = "./modules/fedimint-unknown-common", version = "=0.11.3-alpha" }
-fedimint-unknown-server = { path = "./modules/fedimint-unknown-server", version = "=0.11.3-alpha" }
-fedimint-util-error = { path = "./fedimint-util-error", version = "=0.11.3-alpha" }
-fedimint-wallet-client = { path = "./modules/fedimint-wallet-client", version = "=0.11.3-alpha" }
-fedimint-wallet-common = { path = "./modules/fedimint-wallet-common", version = "=0.11.3-alpha" }
-fedimint-wallet-server = { path = "./modules/fedimint-wallet-server", version = "=0.11.3-alpha" }
-fedimint-walletv2-client = { path = "./modules/fedimint-walletv2-client", version = "=0.11.3-alpha" }
-fedimint-walletv2-common = { path = "./modules/fedimint-walletv2-common", version = "=0.11.3-alpha" }
-fedimint-walletv2-server = { path = "./modules/fedimint-walletv2-server", version = "=0.11.3-alpha" }
-fedimintd = { path = "./fedimintd", version = "=0.11.3-alpha" }
-fedimintd-envs = { path = "./fedimintd-envs", version = "=0.11.3-alpha" }
+fedimint-aead = { path = "./crypto/aead", version = "=0.11.3" }
+fedimint-api-client = { path = "./fedimint-api-client", version = "=0.11.3" }
+fedimint-bip39 = { path = "./fedimint-bip39", version = "=0.11.3" }
+fedimint-bitcoind = { path = "./fedimint-bitcoind", version = "=0.11.3" }
+fedimint-build = { path = "./fedimint-build", version = "=0.11.3" }
+fedimint-client = { path = "./fedimint-client", version = "=0.11.3" }
+fedimint-client-module = { path = "./fedimint-client-module", version = "=0.11.3" }
+fedimint-client-rpc = { path = "./fedimint-client-rpc", version = "=0.11.3" }
+fedimint-connectors = { path = "./fedimint-connectors", version = "=0.11.3" }
+fedimint-core = { path = "./fedimint-core", version = "=0.11.3" }
+fedimint-cursed-redb = { path = "./fedimint-cursed-redb", version = "=0.11.3" }
+fedimint-db-locked = { path = "./fedimint-db-locked", version = "=0.11.3" }
+fedimint-derive = { path = "./fedimint-derive", version = "=0.11.3" }
+fedimint-derive-secret = { path = "./crypto/derive-secret", version = "=0.11.3" }
+fedimint-dummy-client = { path = "./modules/fedimint-dummy-client", version = "=0.11.3" }
+fedimint-dummy-common = { path = "./modules/fedimint-dummy-common", version = "=0.11.3" }
+fedimint-dummy-server = { path = "./modules/fedimint-dummy-server", version = "=0.11.3" }
+fedimint-empty-common = { path = "./modules/fedimint-empty-common", version = "=0.11.3" }
+fedimint-eventlog = { path = "./fedimint-eventlog", version = "=0.11.3" }
+fedimint-gateway-common = { package = "fedimint-gateway-common", path = "./gateway/fedimint-gateway-common", version = "=0.11.3" }
+fedimint-gateway-server = { package = "fedimint-gateway-server", path = "./gateway/fedimint-gateway-server", version = "=0.11.3" }
+fedimint-gateway-server-db = { package = "fedimint-gateway-server-db", path = "./gateway/fedimint-gateway-server-db", version = "=0.11.3" }
+fedimint-gateway-ui = { package = "fedimint-gateway-ui", path = "./gateway/fedimint-gateway-ui", version = "=0.11.3" }
+fedimint-gw-client = { path = "./modules/fedimint-gw-client", version = "=0.11.3" }
+fedimint-gwv2-client = { path = "./modules/fedimint-gwv2-client", version = "=0.11.3" }
+fedimint-lightning = { package = "fedimint-lightning", path = "./gateway/fedimint-lightning", version = "=0.11.3" }
+fedimint-ln-client = { path = "./modules/fedimint-ln-client", version = "=0.11.3" }
+fedimint-ln-common = { path = "./modules/fedimint-ln-common", version = "=0.11.3" }
+fedimint-ln-server = { path = "./modules/fedimint-ln-server", version = "=0.11.3" }
+fedimint-lnurl = { path = "./fedimint-lnurl", version = "=0.11.3" }
+fedimint-lnv2-client = { path = "./modules/fedimint-lnv2-client", version = "=0.11.3" }
+fedimint-lnv2-common = { path = "./modules/fedimint-lnv2-common", version = "=0.11.3" }
+fedimint-lnv2-server = { path = "./modules/fedimint-lnv2-server", version = "=0.11.3" }
+fedimint-logging = { path = "./fedimint-logging", version = "=0.11.3" }
+fedimint-meta-client = { path = "./modules/fedimint-meta-client", version = "=0.11.3" }
+fedimint-meta-common = { path = "./modules/fedimint-meta-common", version = "=0.11.3" }
+fedimint-meta-server = { path = "./modules/fedimint-meta-server", version = "=0.11.3" }
+fedimint-metrics = { path = "./fedimint-metrics", version = "=0.11.3" }
+fedimint-mint-client = { path = "./modules/fedimint-mint-client", version = "=0.11.3" }
+fedimint-mint-common = { path = "./modules/fedimint-mint-common", version = "=0.11.3" }
+fedimint-mint-server = { path = "./modules/fedimint-mint-server", version = "=0.11.3" }
+fedimint-mintv2-client = { path = "./modules/fedimint-mintv2-client", version = "=0.11.3" }
+fedimint-mintv2-common = { path = "./modules/fedimint-mintv2-common", version = "=0.11.3" }
+fedimint-mintv2-server = { path = "./modules/fedimint-mintv2-server", version = "=0.11.3" }
+fedimint-portalloc = { path = "utils/portalloc", version = "=0.11.3" }
+fedimint-rocksdb = { path = "./fedimint-rocksdb", version = "=0.11.3" }
+fedimint-server = { path = "./fedimint-server", version = "=0.11.3" }
+fedimint-server-bitcoin-rpc = { path = "./fedimint-server-bitcoin-rpc", version = "=0.11.3" }
+fedimint-server-core = { path = "./fedimint-server-core", version = "=0.11.3" }
+fedimint-server-ui = { path = "./fedimint-server-ui", version = "=0.11.3" }
+fedimint-testing = { path = "./fedimint-testing", version = "=0.11.3" }
+fedimint-testing-core = { path = "./fedimint-testing-core", version = "=0.11.3" }
+fedimint-ui-common = { path = "./fedimint-ui-common", version = "=0.11.3" }
+fedimint-unknown-common = { path = "./modules/fedimint-unknown-common", version = "=0.11.3" }
+fedimint-unknown-server = { path = "./modules/fedimint-unknown-server", version = "=0.11.3" }
+fedimint-util-error = { path = "./fedimint-util-error", version = "=0.11.3" }
+fedimint-wallet-client = { path = "./modules/fedimint-wallet-client", version = "=0.11.3" }
+fedimint-wallet-common = { path = "./modules/fedimint-wallet-common", version = "=0.11.3" }
+fedimint-wallet-server = { path = "./modules/fedimint-wallet-server", version = "=0.11.3" }
+fedimint-walletv2-client = { path = "./modules/fedimint-walletv2-client", version = "=0.11.3" }
+fedimint-walletv2-common = { path = "./modules/fedimint-walletv2-common", version = "=0.11.3" }
+fedimint-walletv2-server = { path = "./modules/fedimint-walletv2-server", version = "=0.11.3" }
+fedimintd = { path = "./fedimintd", version = "=0.11.3" }
+fedimintd-envs = { path = "./fedimintd-envs", version = "=0.11.3" }
 ff = "0.13.1"
 fs-lock = "=0.1.10"
 fs2 = "0.4.3"
@@ -253,7 +253,7 @@ gloo-timers = "0.3.0"
 group = "0.13.0"
 hex = "0.4.3"
 hex-conservative = "1.0.0"
-hkdf = { package = "fedimint-hkdf", path = "./crypto/hkdf", version = "=0.11.3-alpha" }
+hkdf = { package = "fedimint-hkdf", path = "./crypto/hkdf", version = "=0.11.3" }
 honggfuzz = { version = "=0.5.55", default-features = false } # needs to be pinned to the same version `cargo-fuzz` binary uses
 hyper = "1.6"
 imbl = "5.0.0"
@@ -330,7 +330,7 @@ substring = "1.4.5"
 subtle = "2.6.1"
 syn = "2.0"
 tar = "0.4.45"
-tbs = { package = "fedimint-tbs", path = "./crypto/tbs", version = "=0.11.3-alpha" }
+tbs = { package = "fedimint-tbs", path = "./crypto/tbs", version = "=0.11.3" }
 tempfile = "3.20.0"
 test-log = { version = "0.2", features = ["trace"], default-features = false }
 thiserror = "2.0.18"
@@ -349,7 +349,7 @@ tonic_lnd = { version = "0.4.0", package = "fedimint-tonic-lnd", features = [
 ] }
 tower = { version = "0.4.13", default-features = false }
 tower-http = { version = "0.6.8", features = ["cors"] }
-tpe = { package = "fedimint-tpe", path = "./crypto/tpe", version = "=0.11.3-alpha" }
+tpe = { package = "fedimint-tpe", path = "./crypto/tpe", version = "=0.11.3" }
 tracing = "0.1.44"
 tracing-opentelemetry = "0.29.0"
 tracing-subscriber = "0.3.22"

--- a/fedimint-core/src/amount.rs
+++ b/fedimint-core/src/amount.rs
@@ -45,14 +45,6 @@ pub struct Amount {
 impl Amount {
     pub const ZERO: Self = Self { msats: 0 };
 
-    /// The largest amount that can ever exist, in millisatoshis: the
-    /// 21,000,000 BTC supply cap. No valid payment can exceed this, so callers
-    /// that accept externally-supplied amounts should reject anything larger to
-    /// keep subsequent fee and total arithmetic from overflowing `u64`.
-    pub const MAX_BITCOIN_SUPPLY: Self = Self {
-        msats: 21_000_000 * SATS_PER_BITCOIN * 1000,
-    };
-
     /// Create an amount from a number of millisatoshis.
     pub const fn from_msats(msats: u64) -> Self {
         Self { msats }

--- a/fedimint-core/src/amount.rs
+++ b/fedimint-core/src/amount.rs
@@ -45,6 +45,14 @@ pub struct Amount {
 impl Amount {
     pub const ZERO: Self = Self { msats: 0 };
 
+    /// The largest amount that can ever exist, in millisatoshis: the
+    /// 21,000,000 BTC supply cap. No valid payment can exceed this, so callers
+    /// that accept externally-supplied amounts should reject anything larger to
+    /// keep subsequent fee and total arithmetic from overflowing `u64`.
+    pub const MAX_BITCOIN_SUPPLY: Self = Self {
+        msats: 21_000_000 * SATS_PER_BITCOIN * 1000,
+    };
+
     /// Create an amount from a number of millisatoshis.
     pub const fn from_msats(msats: u64) -> Self {
         Self { msats }

--- a/fedimint-testing/src/ln.rs
+++ b/fedimint-testing/src/ln.rs
@@ -1,5 +1,6 @@
-use std::sync::Arc;
+use std::collections::HashSet;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use async_stream::stream;
@@ -40,6 +41,11 @@ pub struct FakeLightningTest {
     pub gateway_node_pub_key: secp256k1::PublicKey,
     gateway_node_sec_key: secp256k1::SecretKey,
     amount_sent: AtomicU64,
+    /// Payment hashes this node has dispatched, mirroring a real node's
+    /// outbound payment store so `outbound_payment_exists` can distinguish a
+    /// payment sent before a state machine restart from one that never left
+    /// the gateway.
+    outbound_payments: Mutex<HashSet<sha256::Hash>>,
 }
 
 impl FakeLightningTest {
@@ -53,7 +59,15 @@ impl FakeLightningTest {
             gateway_node_sec_key: SecretKey::from_keypair(&kp),
             gateway_node_pub_key: PublicKey::from_keypair(&kp),
             amount_sent,
+            outbound_payments: Mutex::new(HashSet::new()),
         }
+    }
+
+    fn record_outbound_payment(&self, payment_hash: sha256::Hash) {
+        self.outbound_payments
+            .lock()
+            .expect("Not poisoned")
+            .insert(payment_hash);
     }
 }
 
@@ -158,6 +172,8 @@ impl ILnRpcClient for FakeLightningTest {
             });
         }
 
+        self.record_outbound_payment(*invoice.payment_hash());
+
         Ok(PayInvoiceResponse {
             preimage: Preimage(MOCK_INVOICE_PREIMAGE),
         })
@@ -169,11 +185,13 @@ impl ILnRpcClient for FakeLightningTest {
 
     async fn outbound_payment_exists(
         &self,
-        _payment_hash: sha256::Hash,
+        payment_hash: sha256::Hash,
     ) -> Result<bool, LightningRpcError> {
-        // Fake payments complete inline, so a restarted state machine never
-        // has an in-flight payment to resume.
-        Ok(false)
+        Ok(self
+            .outbound_payments
+            .lock()
+            .expect("Not poisoned")
+            .contains(&payment_hash))
     }
 
     async fn pay_private(
@@ -190,6 +208,8 @@ impl ILnRpcClient for FakeLightningTest {
                 failure_reason: "Invoice was invalid".to_string(),
             });
         }
+
+        self.record_outbound_payment(invoice.payment_hash);
 
         Ok(PayInvoiceResponse {
             preimage: Preimage(MOCK_INVOICE_PREIMAGE),
@@ -353,5 +373,48 @@ impl ILnRpcClient for FakeLightningTest {
 
     fn sync_wallet(&self) -> Result<(), LightningRpcError> {
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The fake's outbound record backs `outbound_payment_exists`, which the
+    /// gateway state machines use to distinguish a payment dispatched before
+    /// a restart from one that never left the gateway. A record that answered
+    /// wrongly would make the resume-past-expiry tests pass or fail for the
+    /// wrong reason.
+    #[tokio::test]
+    async fn outbound_record_tracks_dispatched_payments() {
+        let ln = FakeLightningTest::new();
+        let invoice = ln
+            .invoice(Amount::from_sats(1000), None)
+            .expect("can create invoice");
+        let payment_hash = *invoice.payment_hash();
+
+        assert!(
+            !ln.outbound_payment_exists(payment_hash)
+                .await
+                .expect("fake lookup cannot fail"),
+            "no payment has been dispatched yet"
+        );
+
+        ln.pay(invoice, 0, Amount::ZERO)
+            .await
+            .expect("fake payment succeeds");
+
+        assert!(
+            ln.outbound_payment_exists(payment_hash)
+                .await
+                .expect("fake lookup cannot fail"),
+            "the dispatched payment must be on record"
+        );
+        assert!(
+            !ln.outbound_payment_exists(sha256::Hash::hash(b"never dispatched"))
+                .await
+                .expect("fake lookup cannot fail"),
+            "an unrelated hash must not be reported as dispatched"
+        );
     }
 }

--- a/fedimint-testing/src/ln.rs
+++ b/fedimint-testing/src/ln.rs
@@ -167,6 +167,15 @@ impl ILnRpcClient for FakeLightningTest {
         true
     }
 
+    async fn outbound_payment_exists(
+        &self,
+        _payment_hash: sha256::Hash,
+    ) -> Result<bool, LightningRpcError> {
+        // Fake payments complete inline, so a restarted state machine never
+        // has an in-flight payment to resume.
+        Ok(false)
+    }
+
     async fn pay_private(
         &self,
         invoice: PrunedInvoice,

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -1161,10 +1161,14 @@ impl Gateway {
         // using the LNv2 protocol. If the `payment_hash` is not registered,
         // this payment is either a legacy Lightning payment or the end destination is
         // not a Fedimint.
+        // Match and fund against the amount actually locked in the incoming
+        // HTLC, not the sender-controlled onion forward amount, so a forged
+        // `amt_to_forward` cannot satisfy the registered contract's amount
+        // check while only a token amount is really locked.
         let (contract, client) = self
             .get_registered_incoming_contract_and_client_v2(
                 PaymentImage::Hash(htlc_request.payment_hash),
-                htlc_request.amount_msat,
+                htlc_request.incoming_amount_msat,
             )
             .await?;
 
@@ -1176,7 +1180,7 @@ impl Gateway {
                 htlc_request.incoming_chan_id,
                 htlc_request.htlc_id,
                 contract,
-                htlc_request.amount_msat,
+                htlc_request.incoming_amount_msat,
             )
             .await
         {

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -3272,6 +3272,38 @@ impl Gateway {
 
         Ok((registered_incoming_contract.contract, client))
     }
+
+    /// Answers whether the connected Lightning node has any record of an
+    /// outbound payment for `payment_hash`, retrying transient lookup
+    /// failures until the node itself can answer.
+    ///
+    /// Serves [`IGatewayClientV1::outbound_payment_exists`] and
+    /// [`IGatewayClientV2::outbound_payment_exists`]: a wrong `false` lets a
+    /// resumed state machine cancel a contract whose payment is still in
+    /// flight, so no answer is synthesised from a failure.
+    async fn await_outbound_payment_exists(&self, payment_hash: sha256::Hash) -> bool {
+        loop {
+            let lightning_context = self.await_lightning_context().await;
+
+            match lightning_context
+                .lnrpc
+                .outbound_payment_exists(payment_hash)
+                .await
+            {
+                Ok(exists) => return exists,
+                Err(err) => {
+                    warn!(
+                        target: LOG_GATEWAY,
+                        err = %err.fmt_compact(),
+                        %payment_hash,
+                        "Failed to check for a dispatched payment, retrying",
+                    );
+                }
+            }
+
+            sleep(LIGHTNING_CONTEXT_RETRY_INTERVAL).await;
+        }
+    }
 }
 
 #[async_trait]
@@ -3346,6 +3378,10 @@ impl IGatewayClientV2 for Gateway {
             .map(|response| response.preimage.0)
     }
 
+    async fn outbound_payment_exists(&self, payment_hash: sha256::Hash) -> bool {
+        self.await_outbound_payment_exists(payment_hash).await
+    }
+
     async fn min_contract_amount(
         &self,
         federation_id: &FederationId,
@@ -3380,7 +3416,8 @@ impl IGatewayClientV2 for Gateway {
         &self,
         client: &ClientHandleArc,
         invoice: &Bolt11Invoice,
-    ) -> anyhow::Result<FinalReceiveState> {
+        allow_fresh_dispatch: bool,
+    ) -> anyhow::Result<Option<FinalReceiveState>> {
         let swap_params = SwapParameters {
             payment_hash: *invoice.payment_hash(),
             amount_msat: Amount::from_msats(
@@ -3392,7 +3429,12 @@ impl IGatewayClientV2 for Gateway {
         let lnv1 = client
             .get_first_module::<GatewayClientModule>()
             .expect("No LNv1 module");
-        let operation_id = lnv1.gateway_handle_direct_swap(swap_params).await?;
+        let Some(operation_id) = lnv1
+            .gateway_handle_direct_swap(swap_params, allow_fresh_dispatch)
+            .await?
+        else {
+            return Ok(None);
+        };
         let mut stream = lnv1
             .gateway_subscribe_ln_receive(operation_id)
             .await?
@@ -3422,7 +3464,7 @@ impl IGatewayClientV2 for Gateway {
             }
         }
 
-        Ok(final_state)
+        Ok(Some(final_state))
     }
 }
 
@@ -3534,6 +3576,10 @@ impl IGatewayClientV1 for Gateway {
                     .await
             }
         }
+    }
+
+    async fn outbound_payment_exists(&self, payment_hash: sha256::Hash) -> bool {
+        self.await_outbound_payment_exists(payment_hash).await
     }
 
     async fn complete_htlc(

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -3273,6 +3273,44 @@ impl Gateway {
         Ok((registered_incoming_contract.contract, client))
     }
 
+    /// Completes (settles or cancels) an intercepted HTLC, retrying transient
+    /// failures until Lightning reports a terminal outcome.
+    ///
+    /// Serves [`IGatewayClientV1::complete_htlc`] and
+    /// [`IGatewayClientV2::complete_htlc`]: by now the incoming contract is
+    /// funded, so giving up on a transient failure would strand it. Only
+    /// [`LightningRpcError::HtlcCompletionRejected`], a permanent state, is
+    /// returned to the caller.
+    async fn await_complete_htlc(
+        &self,
+        htlc: InterceptPaymentResponse,
+    ) -> std::result::Result<(), LightningRpcError> {
+        loop {
+            let lightning_context = self.await_lightning_context().await;
+
+            match lightning_context.lnrpc.complete_htlc(htlc.clone()).await {
+                Ok(()) => return Ok(()),
+                Err(err @ LightningRpcError::HtlcCompletionRejected { .. }) => {
+                    warn!(
+                        target: LOG_GATEWAY,
+                        err = %err.fmt_compact(),
+                        "Lightning cannot reach the requested terminal HTLC outcome",
+                    );
+                    return Err(err);
+                }
+                Err(err) => {
+                    warn!(
+                        target: LOG_GATEWAY,
+                        err = %err.fmt_compact(),
+                        "Failure trying to complete HTLC, retrying",
+                    );
+                }
+            }
+
+            sleep(LIGHTNING_CONTEXT_RETRY_INTERVAL).await;
+        }
+    }
+
     /// Answers whether the connected Lightning node has any record of an
     /// outbound payment for `payment_hash`, retrying transient lookup
     /// failures until the node itself can answer.
@@ -3312,30 +3350,7 @@ impl IGatewayClientV2 for Gateway {
         &self,
         htlc_response: InterceptPaymentResponse,
     ) -> std::result::Result<(), LightningRpcError> {
-        loop {
-            let lightning_context = self.await_lightning_context().await;
-
-            match lightning_context
-                .lnrpc
-                .complete_htlc(htlc_response.clone())
-                .await
-            {
-                Ok(..) => return Ok(()),
-                Err(err @ LightningRpcError::HtlcCompletionRejected { .. }) => {
-                    warn!(
-                        target: LOG_GATEWAY,
-                        err = %err.fmt_compact(),
-                        "Lightning cannot reach the requested terminal HTLC outcome",
-                    );
-                    return Err(err);
-                }
-                Err(err) => {
-                    warn!(target: LOG_GATEWAY, err = %err.fmt_compact(), "Failure trying to complete payment");
-                }
-            }
-
-            sleep(LIGHTNING_CONTEXT_RETRY_INTERVAL).await;
-        }
+        self.await_complete_htlc(htlc_response).await
     }
 
     async fn is_direct_swap(
@@ -3586,32 +3601,7 @@ impl IGatewayClientV1 for Gateway {
         &self,
         htlc: InterceptPaymentResponse,
     ) -> std::result::Result<(), LightningRpcError> {
-        // Retry transient failures so the already-funded incoming contract is
-        // not stranded; return only on a permanent outcome. See the trait doc.
-        loop {
-            let lightning_context = self.await_lightning_context().await;
-
-            match lightning_context.lnrpc.complete_htlc(htlc.clone()).await {
-                Ok(()) => return Ok(()),
-                Err(err @ LightningRpcError::HtlcCompletionRejected { .. }) => {
-                    warn!(
-                        target: LOG_GATEWAY,
-                        err = %err.fmt_compact(),
-                        "Lightning cannot reach the requested terminal HTLC outcome",
-                    );
-                    return Err(err);
-                }
-                Err(err) => {
-                    warn!(
-                        target: LOG_GATEWAY,
-                        err = %err.fmt_compact(),
-                        "Failure trying to complete HTLC, retrying",
-                    );
-                }
-            }
-
-            sleep(LIGHTNING_CONTEXT_RETRY_INTERVAL).await;
-        }
+        self.await_complete_htlc(htlc).await
     }
 
     async fn is_lnv2_direct_swap(

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -3536,10 +3536,32 @@ impl IGatewayClientV1 for Gateway {
         &self,
         htlc: InterceptPaymentResponse,
     ) -> std::result::Result<(), LightningRpcError> {
-        // Wait until the lightning node is online to complete the HTLC.
-        let lightning_context = self.await_lightning_context().await;
+        // Retry transient failures so the already-funded incoming contract is
+        // not stranded; return only on a permanent outcome. See the trait doc.
+        loop {
+            let lightning_context = self.await_lightning_context().await;
 
-        lightning_context.lnrpc.complete_htlc(htlc).await
+            match lightning_context.lnrpc.complete_htlc(htlc.clone()).await {
+                Ok(()) => return Ok(()),
+                Err(err @ LightningRpcError::HtlcCompletionRejected { .. }) => {
+                    warn!(
+                        target: LOG_GATEWAY,
+                        err = %err.fmt_compact(),
+                        "Lightning cannot reach the requested terminal HTLC outcome",
+                    );
+                    return Err(err);
+                }
+                Err(err) => {
+                    warn!(
+                        target: LOG_GATEWAY,
+                        err = %err.fmt_compact(),
+                        "Failure trying to complete HTLC, retrying",
+                    );
+                }
+            }
+
+            sleep(LIGHTNING_CONTEXT_RETRY_INTERVAL).await;
+        }
     }
 
     async fn is_lnv2_direct_swap(

--- a/gateway/fedimint-gateway-server/src/types.rs
+++ b/gateway/fedimint-gateway-server/src/types.rs
@@ -13,9 +13,10 @@ impl Display for PrettyInterceptPaymentRequest<'_> {
         let PrettyInterceptPaymentRequest(payment_request) = self;
         write!(
             f,
-            "InterceptPaymentRequest {{ payment_hash: {}, amount_msat: {:?}, expiry: {:?}, short_channel_id: {:?}, incoming_chan_id: {:?}, htlc_id: {:?} }}",
+            "InterceptPaymentRequest {{ payment_hash: {}, amount_msat: {:?}, incoming_amount_msat: {:?}, expiry: {:?}, short_channel_id: {:?}, incoming_chan_id: {:?}, htlc_id: {:?} }}",
             payment_request.payment_hash.encode_hex::<String>(),
             payment_request.amount_msat,
+            payment_request.incoming_amount_msat,
             payment_request.expiry,
             payment_request.short_channel_id,
             payment_request.incoming_chan_id,

--- a/gateway/fedimint-gateway-server/tests/tests.rs
+++ b/gateway/fedimint-gateway-server/tests/tests.rs
@@ -5,6 +5,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use anyhow::Context;
 use assert_matches::assert_matches;
 use bitcoin::hashes::{Hash, sha256};
 use fedimint_client::ClientHandleArc;
@@ -12,14 +13,17 @@ use fedimint_client::transaction::{
     ClientInput, ClientInputBundle, ClientOutput, ClientOutputBundle, TransactionBuilder,
 };
 use fedimint_client_module::module::OutPointRange;
+use fedimint_connectors::error::ServerError;
 use fedimint_core::config::FederationId;
 use fedimint_core::core::{IntoDynInstance, OperationId};
 use fedimint_core::encoding::Encodable;
 use fedimint_core::module::{AmountUnit, Amounts};
 use fedimint_core::task::sleep_in_test;
 use fedimint_core::time::now;
-use fedimint_core::util::{NextOrPending, backoff_util, retry};
-use fedimint_core::{Amount, OutPoint, TransactionId, msats, sats, secp256k1};
+use fedimint_core::util::{NextOrPending, SafeUrl, backoff_util, retry};
+use fedimint_core::{
+    Amount, OutPoint, TransactionId, apply, async_trait_maybe_send, msats, sats, secp256k1,
+};
 use fedimint_dummy_client::{DummyClientInit, DummyClientModule};
 use fedimint_dummy_server::DummyInit;
 use fedimint_eventlog::Event;
@@ -55,17 +59,20 @@ use fedimint_ln_common::{LightningGateway, LightningInput, LightningOutput, Prun
 use fedimint_ln_server::LightningInit;
 use fedimint_lnv2_common::LightningInvoice;
 use fedimint_lnv2_common::contracts::{IncomingContract, OutgoingContract, PaymentImage};
-use fedimint_lnv2_common::gateway_api::{PaymentFee, SendPaymentPayload};
+use fedimint_lnv2_common::gateway_api::{
+    GatewayConnection, PaymentFee, RoutingInfo, SendPaymentPayload,
+};
 use fedimint_logging::LOG_TEST;
 use fedimint_testing::btc::BitcoinTest;
 use fedimint_testing::db::BYTE_33;
 use fedimint_testing::federation::FederationTest;
 use fedimint_testing::fixtures::Fixtures;
-use fedimint_testing::ln::FakeLightningTest;
+use fedimint_testing::ln::{FakeLightningTest, MOCK_INVOICE_PREIMAGE};
 use fedimint_unknown_server::UnknownInit;
 use futures::Future;
 use itertools::Itertools;
 use lightning_invoice::{Bolt11Invoice, Bolt11InvoiceDescription, Description, RoutingFees};
+use secp256k1::schnorr::Signature;
 use secp256k1::{Keypair, PublicKey};
 use tpe::G1Affine;
 use tracing::info;
@@ -975,6 +982,153 @@ async fn test_gateway_cannot_pay_expired_invoice() -> anyhow::Result<()> {
     .await
 }
 
+/// Funds an outgoing contract for `invoice` through the user client while the
+/// invoice is still valid, returning the `PayInvoicePayload` a test can hand
+/// to `gateway_pay_bolt11_invoice` after letting the invoice expire.
+async fn funded_lnv1_pay_payload(
+    user_client: &ClientHandleArc,
+    invoice: Bolt11Invoice,
+    gateway_id: &PublicKey,
+) -> anyhow::Result<PayInvoicePayload> {
+    let user_lightning_module = user_client.get_first_module::<LightningClientModule>()?;
+    let lightning_gateway = user_lightning_module.select_gateway(gateway_id).await;
+
+    let OutgoingLightningPayment {
+        payment_type,
+        contract_id,
+        fee: _,
+    } = user_pay_invoice(&user_lightning_module, invoice.clone(), gateway_id).await?;
+    let PayType::Lightning(pay_op) = payment_type else {
+        panic!("Expected Lightning payment!");
+    };
+    let mut pay_sub = user_lightning_module
+        .subscribe_ln_pay(pay_op)
+        .await?
+        .into_stream();
+    assert_eq!(pay_sub.ok().await?, LnPayState::Created);
+    assert_matches!(pay_sub.ok().await?, LnPayState::Funded { .. });
+
+    Ok(PayInvoicePayload {
+        federation_id: user_client.federation_id(),
+        contract_id,
+        payment_data: get_payment_data(lightning_gateway, invoice),
+        preimage_auth: Hash::hash(&[0; 32]),
+    })
+}
+
+/// The restart-forfeiture scenario on LNv1's Lightning rail: the gateway
+/// dispatches the payment, restarts, and its `PayInvoice` state machine
+/// re-runs validation only after the invoice has expired. The node still
+/// knows the payment, so the recorded expiry refusal must step aside and the
+/// state machine must resume to the preimage and claim the contract --
+/// cancelling instead would refund the user while the dispatched payment
+/// settles, leaving the gateway out of pocket.
+#[tokio::test(flavor = "multi_thread")]
+async fn lnv1_pay_resumes_expired_invoice_already_dispatched() -> anyhow::Result<()> {
+    single_federation_test(
+        |gateway, other_lightning_client, fed, user_client, _| async move {
+            let gateway_id = gateway.http_gateway_id().await;
+            let gateway_client = gateway.select_client(fed.id()).await?.into_value();
+            user_client
+                .get_first_module::<DummyClientModule>()?
+                .mock_receive(sats(1000), AmountUnit::BITCOIN)
+                .await?;
+
+            let invoice = other_lightning_client.invoice(sats(250), Some(5))?;
+            let payload =
+                funded_lnv1_pay_payload(&user_client, invoice.clone(), &gateway_id).await?;
+
+            // The pre-restart dispatch: the gateway's own node pays the
+            // invoice, so its outbound store knows the payment hash the way
+            // a real node would after a crash mid-payment.
+            gateway
+                .get_lightning_context()
+                .await?
+                .lnrpc
+                .pay(invoice.clone(), 0, Amount::ZERO)
+                .await?;
+
+            sleep_in_test(
+                "waiting for the dispatched invoice to expire",
+                Duration::from_secs(6),
+            )
+            .await;
+            // Guards against the invoice fixture outliving the wait, which
+            // would make this test pass without exercising the gate at all.
+            assert!(invoice.is_expired());
+
+            let gw_pay_op = gateway_client
+                .get_first_module::<GatewayClientModule>()?
+                .gateway_pay_bolt11_invoice(payload)
+                .await?;
+            let mut gw_pay_sub = gateway_client
+                .get_first_module::<GatewayClientModule>()?
+                .gateway_subscribe_ln_pay(gw_pay_op)
+                .await?
+                .into_stream();
+            assert_eq!(gw_pay_sub.ok().await?, GatewayExtPayStates::Created);
+            assert_matches!(gw_pay_sub.ok().await?, GatewayExtPayStates::Preimage { .. });
+            assert_matches!(gw_pay_sub.ok().await?, GatewayExtPayStates::Success { .. });
+
+            Ok(())
+        },
+    )
+    .await
+}
+
+/// The other side of LNv1's expiry gate: an expired invoice whose payment was
+/// never dispatched anywhere must still cancel the outgoing contract with
+/// `InvoiceExpired`, so the user's escrow is returned.
+#[tokio::test(flavor = "multi_thread")]
+async fn lnv1_pay_cancels_expired_invoice_never_dispatched() -> anyhow::Result<()> {
+    single_federation_test(
+        |gateway, other_lightning_client, fed, user_client, _| async move {
+            let gateway_id = gateway.http_gateway_id().await;
+            let gateway_client = gateway.select_client(fed.id()).await?.into_value();
+            user_client
+                .get_first_module::<DummyClientModule>()?
+                .mock_receive(sats(1000), AmountUnit::BITCOIN)
+                .await?;
+
+            let invoice = other_lightning_client.invoice(sats(250), Some(5))?;
+            let payload =
+                funded_lnv1_pay_payload(&user_client, invoice.clone(), &gateway_id).await?;
+
+            sleep_in_test(
+                "waiting for the undispatched invoice to expire",
+                Duration::from_secs(6),
+            )
+            .await;
+            assert!(invoice.is_expired());
+
+            let gw_pay_op = gateway_client
+                .get_first_module::<GatewayClientModule>()?
+                .gateway_pay_bolt11_invoice(payload)
+                .await?;
+            let mut gw_pay_sub = gateway_client
+                .get_first_module::<GatewayClientModule>()?
+                .gateway_subscribe_ln_pay(gw_pay_op)
+                .await?
+                .into_stream();
+            assert_eq!(gw_pay_sub.ok().await?, GatewayExtPayStates::Created);
+            assert_matches!(
+                gw_pay_sub.ok().await?,
+                GatewayExtPayStates::Canceled {
+                    error: OutgoingPaymentError {
+                        error_type: OutgoingPaymentErrorType::InvalidOutgoingContract {
+                            error: OutgoingContractError::InvoiceExpired(_)
+                        },
+                        ..
+                    }
+                }
+            );
+
+            Ok(())
+        },
+    )
+    .await
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn test_gateway_executes_swaps_between_connected_federations() -> anyhow::Result<()> {
     multi_federation_test(|gateway, fed1, fed2, _| async move {
@@ -1399,6 +1553,115 @@ async fn lnv2_malleated_incoming_contract_is_rejected() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Builds an incoming contract the gateway can fund and decrypt to the
+/// preimage `[0; 32]`, for tests driving `relay_direct_swap` directly.
+fn decryptable_incoming_contract(client: &ClientHandleArc) -> anyhow::Result<IncomingContract> {
+    let module = client.get_first_module::<GatewayClientModuleV2>()?;
+    let contract = IncomingContract::new(
+        module.cfg.tpe_agg_pk,
+        [42; 32],
+        [0; 32],
+        PaymentImage::Hash([0_u8; 32].consensus_hash()),
+        Amount::from_sats(1000),
+        u64::MAX,
+        Keypair::new(secp256k1::SECP256K1, &mut rand::thread_rng()).public_key(),
+        module.keypair.public_key(),
+        Keypair::new(secp256k1::SECP256K1, &mut rand::thread_rng()).public_key(),
+    );
+    assert!(contract.verify());
+    Ok(contract)
+}
+
+/// When a wall-clock gate forbids a fresh dispatch and no swap operation
+/// exists, the relay must start nothing and say so -- and the refusal must
+/// leave no state behind, so the same swap can still be dispatched once the
+/// caller allows it.
+#[tokio::test(flavor = "multi_thread")]
+async fn lnv2_relay_forbidden_fresh_swap_starts_nothing() -> anyhow::Result<()> {
+    let fixtures = fixtures();
+    let fed = fixtures.new_fed_degraded().await;
+    let gateway = fixtures.new_gateway().await;
+    fed.connect_gateway(&gateway).await;
+    send_msats_to_gateway(&gateway, fed.id(), 1_000_000_000).await;
+
+    let client = gateway.select_client(fed.id()).await?.into_value();
+    let contract = decryptable_incoming_contract(&client)?;
+    let balance_before = client.get_balance_for_btc().await?;
+
+    assert_eq!(
+        client
+            .get_first_module::<GatewayClientModuleV2>()?
+            .relay_direct_swap(contract.clone(), 900, false)
+            .await?,
+        None,
+        "no operation exists and fresh dispatch is forbidden, so nothing may start"
+    );
+    assert_eq!(
+        client.get_balance_for_btc().await?,
+        balance_before,
+        "a refused swap must not fund anything"
+    );
+
+    assert_eq!(
+        client
+            .get_first_module::<GatewayClientModuleV2>()?
+            .relay_direct_swap(contract, 900, true)
+            .await?,
+        Some(FinalReceiveState::Success([0; 32])),
+        "the refusal must not have consumed or poisoned the swap"
+    );
+
+    Ok(())
+}
+
+/// The restart-forfeiture scenario on the LNv2 swap rail: the swap was
+/// dispatched, the gateway restarted, and by the time the send state machine
+/// re-enters, its wall-clock gate forbids fresh dispatches. The relay must
+/// join the operation already in flight and hand back its outcome -- without
+/// funding a second time.
+#[tokio::test(flavor = "multi_thread")]
+async fn lnv2_relay_resumes_swap_when_fresh_is_forbidden() -> anyhow::Result<()> {
+    let fixtures = fixtures();
+    let fed = fixtures.new_fed_degraded().await;
+    let gateway = fixtures.new_gateway().await;
+    fed.connect_gateway(&gateway).await;
+    send_msats_to_gateway(&gateway, fed.id(), 1_000_000_000).await;
+
+    let client = gateway.select_client(fed.id()).await?.into_value();
+    let contract = decryptable_incoming_contract(&client)?;
+    let balance_before = client.get_balance_for_btc().await?;
+
+    assert_eq!(
+        client
+            .get_first_module::<GatewayClientModuleV2>()?
+            .relay_direct_swap(contract.clone(), 900, true)
+            .await?,
+        Some(FinalReceiveState::Success([0; 32]))
+    );
+    let balance_after_first = client.get_balance_for_btc().await?;
+    assert!(
+        balance_after_first < balance_before,
+        "the first relay funds the incoming contract"
+    );
+
+    assert_eq!(
+        client
+            .get_first_module::<GatewayClientModuleV2>()?
+            .relay_direct_swap(contract, 900, false)
+            .await?,
+        Some(FinalReceiveState::Success([0; 32])),
+        "the re-entrant relay joins the dispatched swap even though fresh dispatch is forbidden"
+    );
+
+    assert_eq!(
+        client.get_balance_for_btc().await?,
+        balance_after_first,
+        "the incoming contract must only be funded once"
+    );
+
+    Ok(())
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn gateway_read_payment_log() -> anyhow::Result<()> {
     let fixtures = fixtures();
@@ -1641,6 +1904,231 @@ async fn lnv2_routes_reject_a_federation_without_an_lnv2_module() -> anyhow::Res
     assert!(
         gateway.send_payment_v2(payload).await.is_err(),
         "a federation without an LNv2 module cannot be asked to send an LNv2 payment"
+    );
+
+    Ok(())
+}
+
+/// Captures the `SendPaymentPayload` its client built and then parks, leaving
+/// the outgoing contract funded so a test can drive the gateway side itself.
+#[derive(Debug, Default)]
+struct CapturingGatewayConnection {
+    routing_info: std::sync::Mutex<Option<RoutingInfo>>,
+    captured: std::sync::Mutex<Option<SendPaymentPayload>>,
+}
+
+impl CapturingGatewayConnection {
+    /// The client keys its contract to the gateway's `module_public_key`, which
+    /// does not exist until after the fixtures this connection is built into.
+    fn publish(&self, module_public_key: PublicKey) {
+        *self.routing_info.lock().expect("Not poisoned") = Some(RoutingInfo {
+            lightning_public_key: module_public_key,
+            lightning_alias: Some("capturing-gateway".to_string()),
+            module_public_key,
+            send_fee_default: PaymentFee::TRANSACTION_FEE_DEFAULT,
+            send_fee_minimum: PaymentFee::TRANSACTION_FEE_DEFAULT,
+            expiration_delta_default: 500,
+            expiration_delta_minimum: 144,
+            receive_fee: PaymentFee::TRANSACTION_FEE_DEFAULT,
+        });
+    }
+
+    async fn captured(&self) -> SendPaymentPayload {
+        retry(
+            "waiting for the client to send its payment to the gateway",
+            backoff_util::aggressive_backoff(),
+            || async {
+                self.captured
+                    .lock()
+                    .expect("Not poisoned")
+                    .clone()
+                    .context("The client has not sent its payment yet")
+            },
+        )
+        .await
+        .expect("The client sends its payment once the contract is accepted")
+    }
+}
+
+#[apply(async_trait_maybe_send!)]
+impl GatewayConnection for CapturingGatewayConnection {
+    async fn routing_info(
+        &self,
+        _gateway_api: SafeUrl,
+        _federation_id: &FederationId,
+    ) -> Result<Option<RoutingInfo>, ServerError> {
+        Ok(self.routing_info.lock().expect("Not poisoned").clone())
+    }
+
+    async fn bolt11_invoice(
+        &self,
+        _gateway_api: SafeUrl,
+        _federation_id: FederationId,
+        _contract: IncomingContract,
+        _amount: Amount,
+        _description: fedimint_lnv2_common::Bolt11InvoiceDescription,
+        _expiry_secs: u32,
+    ) -> Result<Bolt11Invoice, ServerError> {
+        unimplemented!("This connection only sends")
+    }
+
+    async fn send_payment(
+        &self,
+        _gateway_api: SafeUrl,
+        federation_id: FederationId,
+        outpoint: OutPoint,
+        contract: OutgoingContract,
+        invoice: LightningInvoice,
+        auth: Signature,
+    ) -> Result<Result<[u8; 32], Signature>, ServerError> {
+        *self.captured.lock().expect("Not poisoned") = Some(SendPaymentPayload {
+            federation_id,
+            outpoint,
+            contract,
+            invoice,
+            auth,
+        });
+
+        // Never answer, so the client's state machine stays parked and does not
+        // refund the contract out from under the test.
+        std::future::pending().await
+    }
+}
+
+fn capturing_lnv2_fixtures(gateway_conn: Arc<CapturingGatewayConnection>) -> Fixtures {
+    Fixtures::new_primary(DummyClientInit, DummyInit)
+        .with_server_only_module(UnknownInit)
+        .with_module(
+            LightningClientInit {
+                gateway_conn: Some(Arc::new(MockGatewayConnection)),
+            },
+            LightningInit,
+        )
+        .with_module(
+            fedimint_lnv2_client::LightningClientInit {
+                gateway_conn: Some(gateway_conn),
+                ..Default::default()
+            },
+            fedimint_lnv2_server::LightningInit,
+        )
+}
+
+/// Funds an outgoing contract for `invoice` through a real client send and
+/// returns the `SendPaymentPayload` the client would have posted to the
+/// gateway, so a test can drive `send_payment_v2` itself.
+async fn captured_lnv2_send_payload(
+    gateway: &Gateway,
+    gateway_conn: &CapturingGatewayConnection,
+    fed: &FederationTest,
+    invoice: Bolt11Invoice,
+) -> anyhow::Result<SendPaymentPayload> {
+    let gateway_client = gateway.select_client(fed.id()).await?.into_value();
+    gateway_conn.publish(
+        gateway_client
+            .get_first_module::<GatewayClientModuleV2>()?
+            .keypair
+            .public_key(),
+    );
+
+    let user_client = fed.new_client().await;
+    user_client
+        .get_first_module::<DummyClientModule>()?
+        .mock_receive(sats(10_000), AmountUnit::BITCOIN)
+        .await?;
+
+    let sender = user_client.clone();
+    fedimint_core::runtime::spawn("lnv2-user-send", async move {
+        sender
+            .get_first_module::<fedimint_lnv2_client::LightningClientModule>()
+            .expect("The federation has an LNv2 module")
+            .send(
+                invoice,
+                Some(SafeUrl::parse("http://capturing-gateway.test").expect("Valid url")),
+                serde_json::Value::Null,
+            )
+            .await
+    });
+
+    Ok(gateway_conn.captured().await)
+}
+
+/// The scenario behind the restart-forfeiture fix, on the Lightning rail: the
+/// gateway dispatches a payment, restarts, and re-enters its send state
+/// machine only after the invoice has expired. The node still knows the
+/// payment, so the expiry gate must step aside and the state machine must
+/// resume to the preimage and claim the contract -- cancelling instead would
+/// refund the sender while the dispatched payment settles, leaving the
+/// gateway out of pocket.
+#[tokio::test(flavor = "multi_thread")]
+async fn lnv2_send_resumes_expired_invoice_already_dispatched() -> anyhow::Result<()> {
+    let gateway_conn = Arc::new(CapturingGatewayConnection::default());
+    let fixtures = capturing_lnv2_fixtures(gateway_conn.clone());
+    let fed = fixtures.new_fed_degraded().await;
+    let gateway = fixtures.new_gateway().await;
+    fed.connect_gateway(&gateway).await;
+
+    let invoice = FakeLightningTest::new().invoice(sats(1000), Some(5))?;
+    let payload =
+        captured_lnv2_send_payload(&gateway, &gateway_conn, &fed, invoice.clone()).await?;
+
+    // The pre-restart dispatch: the gateway's own node pays the invoice, so
+    // its outbound store knows the payment hash the way a real node would
+    // after a crash mid-payment.
+    gateway
+        .get_lightning_context()
+        .await?
+        .lnrpc
+        .pay(invoice.clone(), 0, Amount::ZERO)
+        .await?;
+
+    sleep_in_test(
+        "waiting for the dispatched invoice to expire",
+        Duration::from_secs(6),
+    )
+    .await;
+    // Guards against the invoice fixture outliving the wait, which would
+    // make this test pass without exercising the expiry gate at all.
+    assert!(invoice.is_expired());
+
+    let preimage = gateway
+        .send_payment_v2(payload)
+        .await?
+        .expect("the send resumes the dispatched payment instead of forfeiting the contract");
+    assert_eq!(preimage, MOCK_INVOICE_PREIMAGE);
+
+    Ok(())
+}
+
+/// The other side of the expiry gate: an expired invoice whose payment was
+/// never dispatched anywhere must still cancel, handing the sender a forfeit
+/// signature that verifies against the contract so they can reclaim their
+/// escrow.
+#[tokio::test(flavor = "multi_thread")]
+async fn lnv2_send_cancels_expired_invoice_never_dispatched() -> anyhow::Result<()> {
+    let gateway_conn = Arc::new(CapturingGatewayConnection::default());
+    let fixtures = capturing_lnv2_fixtures(gateway_conn.clone());
+    let fed = fixtures.new_fed_degraded().await;
+    let gateway = fixtures.new_gateway().await;
+    fed.connect_gateway(&gateway).await;
+
+    let invoice = FakeLightningTest::new().invoice(sats(1000), Some(5))?;
+    let payload =
+        captured_lnv2_send_payload(&gateway, &gateway_conn, &fed, invoice.clone()).await?;
+
+    sleep_in_test(
+        "waiting for the undispatched invoice to expire",
+        Duration::from_secs(6),
+    )
+    .await;
+    assert!(invoice.is_expired());
+
+    let signature = gateway
+        .send_payment_v2(payload.clone())
+        .await?
+        .expect_err("an expired invoice that was never dispatched is refused");
+    assert!(
+        payload.contract.verify_forfeit_signature(&signature),
+        "the sender must receive a forfeit signature that reclaims the escrow"
     );
 
     Ok(())
@@ -1985,6 +2473,42 @@ async fn test_gateway_client_direct_swap_reentry_joins_the_funded_swap() -> anyh
             gateway_client.get_balance_for_btc().await?,
             initial_gateway_balance.saturating_sub(invoice_amount + invoice_amount),
             "the second swap's incoming contract must also only be funded once"
+        );
+
+        // A swap that was never started must not start when fresh dispatch is
+        // forbidden -- this is the expired-invoice cancel path -- and the
+        // refusal must leave the offer intact for a later permitted dispatch.
+        let (_invoice_op, refused_invoice, _) = ln_module
+            .create_bolt11_invoice(
+                invoice_amount,
+                Bolt11InvoiceDescription::Direct(Description::new("refused".to_string())?),
+                None,
+                "test forbidden fresh direct swap",
+                ln_module.select_gateway(&gateway_id).await,
+            )
+            .await?;
+        let refused_swap_params = SwapParameters {
+            payment_hash: *refused_invoice.payment_hash(),
+            amount_msat: invoice_amount,
+        };
+        assert_eq!(
+            gateway_module
+                .gateway_handle_direct_swap(refused_swap_params.clone(), false)
+                .await?,
+            None,
+            "no operation exists and fresh dispatch is forbidden, so nothing may start"
+        );
+        assert_eq!(
+            gateway_client.get_balance_for_btc().await?,
+            initial_gateway_balance.saturating_sub(invoice_amount + invoice_amount),
+            "a refused swap must not fund anything"
+        );
+        assert!(
+            gateway_module
+                .gateway_handle_direct_swap(refused_swap_params, true)
+                .await?
+                .is_some(),
+            "the refusal must not have consumed the offer"
         );
 
         Ok(())

--- a/gateway/fedimint-gateway-server/tests/tests.rs
+++ b/gateway/fedimint-gateway-server/tests/tests.rs
@@ -1176,9 +1176,9 @@ async fn lnv2_incoming_contract_with_invalid_preimage_is_refunded() -> anyhow::R
     assert_eq!(
         client
             .get_first_module::<GatewayClientModuleV2>()?
-            .relay_direct_swap(contract, 900)
+            .relay_direct_swap(contract, 900, true)
             .await?,
-        FinalReceiveState::Refunded
+        Some(FinalReceiveState::Refunded)
     );
 
     Ok(())
@@ -1335,9 +1335,9 @@ async fn lnv2_expired_incoming_contract_is_rejected() -> anyhow::Result<()> {
     assert_eq!(
         client
             .get_first_module::<GatewayClientModuleV2>()?
-            .relay_direct_swap(contract, 900)
+            .relay_direct_swap(contract, 900, true)
             .await?,
-        FinalReceiveState::Rejected
+        Some(FinalReceiveState::Rejected)
     );
 
     Ok(())
@@ -1379,9 +1379,9 @@ async fn lnv2_malleated_incoming_contract_is_rejected() -> anyhow::Result<()> {
     assert_eq!(
         client
             .get_first_module::<GatewayClientModuleV2>()?
-            .relay_direct_swap(contract.clone(), 900)
+            .relay_direct_swap(contract.clone(), 900, true)
             .await?,
-        FinalReceiveState::Success([0; 32])
+        Some(FinalReceiveState::Success([0; 32]))
     );
 
     contract.commitment.amount = Amount::from_sats(100);
@@ -1391,9 +1391,9 @@ async fn lnv2_malleated_incoming_contract_is_rejected() -> anyhow::Result<()> {
     assert_eq!(
         client
             .get_first_module::<GatewayClientModuleV2>()?
-            .relay_direct_swap(contract, 900)
+            .relay_direct_swap(contract, 900, true)
             .await?,
-        FinalReceiveState::Rejected
+        Some(FinalReceiveState::Rejected)
     );
 
     Ok(())
@@ -1922,8 +1922,9 @@ async fn test_gateway_client_direct_swap_reentry_joins_the_funded_swap() -> anyh
         };
         let gateway_module = gateway_client.get_first_module::<GatewayClientModule>()?;
         let first = gateway_module
-            .gateway_handle_direct_swap(swap_params.clone())
-            .await?;
+            .gateway_handle_direct_swap(swap_params.clone(), true)
+            .await?
+            .expect("a permitted fresh dispatch starts the swap");
         let mut receive_sub = gateway_module
             .gateway_subscribe_ln_receive(first)
             .await?
@@ -1936,15 +1937,19 @@ async fn test_gateway_client_direct_swap_reentry_joins_the_funded_swap() -> anyh
 
         // The restart: the same swap is asked for again, with the offer that
         // funded it already consumed.
+        // A re-entrant call resumes even when a fresh dispatch is forbidden:
+        // this is the restart-after-invoice-expiry case, which must join the
+        // swap already in flight rather than cancel it.
         let second = fedimint_core::task::timeout(
             Duration::from_secs(30),
-            gateway_module.gateway_handle_direct_swap(swap_params),
+            gateway_module.gateway_handle_direct_swap(swap_params, false),
         )
         .await
         .expect("a re-entrant direct swap must not wait on the offer it already consumed")?;
 
         assert_eq!(
-            first, second,
+            Some(first),
+            second,
             "the re-entrant swap joins the operation already holding the preimage"
         );
         assert_eq!(
@@ -1969,8 +1974,8 @@ async fn test_gateway_client_direct_swap_reentry_joins_the_funded_swap() -> anyh
             amount_msat: invoice_amount,
         };
         let (left, right) = tokio::join!(
-            gateway_module.gateway_handle_direct_swap(concurrent_swap_params.clone()),
-            gateway_module.gateway_handle_direct_swap(concurrent_swap_params),
+            gateway_module.gateway_handle_direct_swap(concurrent_swap_params.clone(), true),
+            gateway_module.gateway_handle_direct_swap(concurrent_swap_params, true),
         );
         assert_eq!(
             left?, right?,

--- a/gateway/fedimint-lightning/src/ldk.rs
+++ b/gateway/fedimint-lightning/src/ldk.rs
@@ -341,6 +341,34 @@ fn check_inbound_registration(
     }
 }
 
+/// Classifies an `ldk-node` claim or fail error for the gateway's completion
+/// retry loop.
+///
+/// `claim_for_hash` and `fail_for_hash` fail deterministically for an unknown
+/// payment hash, a preimage that does not hash to it, or an amount below the
+/// registered one. Retrying cannot change any of those, so they are reported
+/// as [`LightningRpcError::HtlcCompletionRejected`] and the completion state
+/// machine records the outcome instead of retrying forever. Everything else,
+/// today only a failed store write, is treated as transient: the incoming
+/// contract is already funded by the time this runs, so an error this list
+/// does not know must keep retrying rather than be recorded as final.
+fn htlc_completion_error(err: &ldk_node::NodeError, payment_hash: &str) -> LightningRpcError {
+    match err {
+        ldk_node::NodeError::InvalidPaymentHash
+        | ldk_node::NodeError::InvalidPaymentPreimage
+        | ldk_node::NodeError::InvalidAmount => LightningRpcError::HtlcCompletionRejected {
+            failure_reason: format!(
+                "LDK rejected completion of payment with hash {payment_hash}: {err}"
+            ),
+        },
+        _ => LightningRpcError::FailedToCompleteHtlc {
+            failure_reason: format!(
+                "Failed to complete LDK payment with hash {payment_hash}: {err}"
+            ),
+        },
+    }
+}
+
 impl Drop for GatewayLdkClient {
     fn drop(&mut self) {
         self.task_group.shutdown();
@@ -523,16 +551,13 @@ impl ILnRpcClient for GatewayLdkClient {
             self.node
                 .bolt11_payment()
                 .claim_for_hash(ph, claimable_amount_msat, PaymentPreimage(preimage.0))
-                .map_err(|_| LightningRpcError::FailedToCompleteHtlc {
-                    failure_reason: format!("Failed to claim LDK payment with hash {ph_hex_str}"),
-                })?;
+                .map_err(|err| htlc_completion_error(&err, &ph_hex_str))?;
         } else {
             warn!(target: LOG_LIGHTNING, payment_hash = %ph_hex_str, "Unwinding payment because the action was not `Settle`");
-            self.node.bolt11_payment().fail_for_hash(ph).map_err(|_| {
-                LightningRpcError::FailedToCompleteHtlc {
-                    failure_reason: format!("Failed to unwind LDK payment with hash {ph_hex_str}"),
-                }
-            })?;
+            self.node
+                .bolt11_payment()
+                .fail_for_hash(ph)
+                .map_err(|err| htlc_completion_error(&err, &ph_hex_str))?;
         }
 
         return Ok(());

--- a/gateway/fedimint-lightning/src/ldk.rs
+++ b/gateway/fedimint-lightning/src/ldk.rs
@@ -18,7 +18,9 @@ use fedimint_ln_common::contracts::Preimage;
 use fedimint_logging::LOG_LIGHTNING;
 use ldk_node::lightning::ln::msgs::SocketAddress;
 use ldk_node::lightning::routing::gossip::{NodeAlias, NodeId};
-use ldk_node::payment::{PaymentDirection, PaymentKind, PaymentStatus, SendingParameters};
+use ldk_node::payment::{
+    PaymentDetails, PaymentDirection, PaymentKind, PaymentStatus, SendingParameters,
+};
 use lightning::ln::channelmanager::PaymentId;
 use lightning::offers::offer::{Offer, OfferId};
 use lightning::types::payment::{PaymentHash, PaymentPreimage};
@@ -266,6 +268,21 @@ impl GatewayLdkClient {
             warn!(err = %err.fmt_compact(), "LDK could not mark event handled");
         }
     }
+
+    /// Returns the node's payment record for `payment_id`, but only when it is
+    /// one of our own outbound attempts.
+    ///
+    /// LDK keys BOLT11 payments by `PaymentId(payment_hash)` in both
+    /// directions, so a registered invoice or a claimed inbound payment for the
+    /// same hash shares a slot with our outbound send. Without this direction
+    /// check such an inbound record could be mistaken for the result of our
+    /// `pay()`: reported as a spurious success (a preimage we never sent for),
+    /// a spurious failure, or -- while still pending -- block `pay()` forever.
+    fn outbound_payment(&self, payment_id: PaymentId) -> Option<PaymentDetails> {
+        self.node
+            .payment(&payment_id)
+            .filter(|details| details.direction == PaymentDirection::Outbound)
+    }
 }
 
 impl Drop for GatewayLdkClient {
@@ -340,13 +357,17 @@ impl ILnRpcClient for GatewayLdkClient {
             .async_lock(payment_id)
             .await;
 
-        // If a payment is not known to the node we can initiate it, and if it is known
-        // we can skip calling `ldk-node::Bolt11Payment::send()` and wait for the
-        // payment to complete. The lock guard above guarantees that this block is only
-        // executed once at a time for a given payment hash, ensuring that there is no
-        // race condition between checking if a payment is known and initiating a new
+        // If no outbound attempt of ours is known to the node we can initiate
+        // it, and if one is known we can skip calling
+        // `ldk-node::Bolt11Payment::send()` and wait for the payment to
+        // complete. Checking specifically for an outbound record matters because
+        // an inbound payment shares `PaymentId(payment_hash)` with our send: a
+        // registered invoice for the same hash must not make us skip `send()`.
+        // The lock guard above guarantees that this block is only executed once
+        // at a time for a given payment hash, ensuring that there is no race
+        // condition between checking if a payment is known and initiating a new
         // payment if it isn't.
-        if self.node.payment(&payment_id).is_none() {
+        if self.outbound_payment(payment_id).is_none() {
             assert_eq!(
                 self.node
                     .bolt11_payment()
@@ -373,7 +394,7 @@ impl ILnRpcClient for GatewayLdkClient {
         // events, but interacting with the node event queue here isn't
         // straightforward.
         loop {
-            if let Some(payment_details) = self.node.payment(&payment_id) {
+            if let Some(payment_details) = self.outbound_payment(payment_id) {
                 match payment_details.status {
                     PaymentStatus::Pending => {}
                     PaymentStatus::Succeeded => {

--- a/gateway/fedimint-lightning/src/ldk.rs
+++ b/gateway/fedimint-lightning/src/ldk.rs
@@ -422,6 +422,15 @@ impl ILnRpcClient for GatewayLdkClient {
         }
     }
 
+    async fn outbound_payment_exists(
+        &self,
+        payment_hash: sha256::Hash,
+    ) -> Result<bool, LightningRpcError> {
+        Ok(self
+            .outbound_payment(PaymentId(payment_hash.to_byte_array()))
+            .is_some())
+    }
+
     async fn route_htlcs<'a>(
         mut self: Box<Self>,
         _task_group: &TaskGroup,

--- a/gateway/fedimint-lightning/src/ldk.rs
+++ b/gateway/fedimint-lightning/src/ldk.rs
@@ -206,7 +206,10 @@ impl GatewayLdkClient {
                     .send(InterceptPaymentRequest {
                         payment_hash: Hash::from_slice(&payment_hash.0)
                             .expect("Failed to create Hash"),
+                        // LDK reports the real claimable amount, so the two
+                        // amounts coincide here.
                         amount_msat: claimable_amount_msat,
+                        incoming_amount_msat: claimable_amount_msat,
                         expiry: claim_deadline.unwrap_or_default(),
                         short_channel_id: None,
                         // LDK claims payments through its own payment store,

--- a/gateway/fedimint-lightning/src/ldk.rs
+++ b/gateway/fedimint-lightning/src/ldk.rs
@@ -288,6 +288,59 @@ impl GatewayLdkClient {
     }
 }
 
+/// Why an invoice must not be registered for a payment hash on the node.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum InboundRegistrationRefusal {
+    /// `pay()` holds the per-hash lock, so an outbound payment for the hash
+    /// is being dispatched or awaited right now.
+    OutboundInFlight,
+    /// The node holds an outbound record for the hash, pending or terminal.
+    OutboundRecorded,
+}
+
+impl std::fmt::Display for InboundRegistrationRefusal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::OutboundInFlight => {
+                write!(f, "an outbound payment for this hash is in flight")
+            }
+            Self::OutboundRecorded => {
+                write!(f, "the node holds an outbound payment for this hash")
+            }
+        }
+    }
+}
+
+/// Decides whether an invoice may be registered for a payment hash the node
+/// may already know as one of our outbound payments.
+///
+/// `ldk-node` keys BOLT11 payments by `PaymentId(payment_hash)` in both
+/// directions, and registering an invoice overwrites whatever record shares
+/// the key. Registering one for a hash we pay would erase the outbound record
+/// `pay()` reads its result from, so a settled payment would be reported as
+/// failed and the outgoing contract forfeited while the payee keeps the funds.
+///
+/// `outbound_lock_acquired` is whether the caller took the per-hash lock
+/// `pay()` holds for the whole life of a payment, and `existing_direction` is
+/// the direction of the node's record for the hash, if any. A terminal
+/// outbound record is refused as well: a restarted state machine re-runs
+/// `pay()` and needs that record to recover the payment's result instead of
+/// re-dispatching. An existing inbound record is left to the caller, whose
+/// own reservation already rejects duplicate registrations.
+fn check_inbound_registration(
+    outbound_lock_acquired: bool,
+    existing_direction: Option<PaymentDirection>,
+) -> Result<(), InboundRegistrationRefusal> {
+    if !outbound_lock_acquired {
+        return Err(InboundRegistrationRefusal::OutboundInFlight);
+    }
+
+    match existing_direction {
+        Some(PaymentDirection::Outbound) => Err(InboundRegistrationRefusal::OutboundRecorded),
+        Some(PaymentDirection::Inbound) | None => Ok(()),
+    }
+}
+
 impl Drop for GatewayLdkClient {
     fn drop(&mut self) {
         self.task_group.shutdown();
@@ -511,12 +564,44 @@ impl ILnRpcClient for GatewayLdkClient {
         };
 
         let invoice = match payment_hash_or {
-            Some(payment_hash) => self.node.bolt11_payment().receive_for_hash(
-                create_invoice_request.amount_msat,
-                &description,
-                create_invoice_request.expiry_secs,
-                payment_hash,
-            ),
+            Some(payment_hash) => {
+                // `pay()` holds this lock for the whole life of an outbound
+                // payment, so failing to take it means a payment for this hash
+                // is in flight right now. Keeping it until `receive_for_hash()`
+                // has run means `pay()` cannot write its outbound record between
+                // our check and the registration's insert, which would
+                // overwrite it.
+                let payment_id = PaymentId(payment_hash.0);
+                let outbound_lock_guard = self
+                    .outbound_lightning_payment_lock_pool
+                    .try_lock(payment_id);
+                let existing_direction = self
+                    .node
+                    .payment(&payment_id)
+                    .map(|details| details.direction);
+                if let Err(refusal) =
+                    check_inbound_registration(outbound_lock_guard.is_some(), existing_direction)
+                {
+                    warn!(
+                        target: LOG_LIGHTNING,
+                        payment_hash = %hex::encode(payment_hash.0),
+                        %refusal,
+                        "Refusing to register an invoice for a payment hash we pay outbound"
+                    );
+                    return Err(LightningRpcError::FailedToGetInvoice {
+                        failure_reason: format!(
+                            "Payment hash cannot be registered for an invoice: {refusal}"
+                        ),
+                    });
+                }
+
+                self.node.bolt11_payment().receive_for_hash(
+                    create_invoice_request.amount_msat,
+                    &description,
+                    create_invoice_request.expiry_secs,
+                    payment_hash,
+                )
+            }
             None => self.node.bolt11_payment().receive(
                 create_invoice_request.amount_msat,
                 &description,

--- a/gateway/fedimint-lightning/src/ldk/tests.rs
+++ b/gateway/fedimint-lightning/src/ldk/tests.rs
@@ -1,6 +1,9 @@
 use fedimint_core::util::SafeUrl;
+use ldk_node::payment::PaymentDirection;
+use lightning::ln::channelmanager::PaymentId;
+use lockable::LockPool;
 
-use super::get_esplora_url;
+use super::{InboundRegistrationRefusal, check_inbound_registration, get_esplora_url};
 
 #[test]
 fn verify_ldk_esplora_url() {
@@ -18,4 +21,52 @@ fn verify_ldk_esplora_url() {
     let esplora_url = get_esplora_url(url).expect("Could not get esplora URL");
     // URLs with ports are NOT allowed to have trailing slashes
     assert!(!esplora_url.ends_with("/"));
+}
+
+#[test]
+fn inbound_registration_refuses_hashes_we_pay_outbound() {
+    // A held `pay()` lock means a payment is in flight, whatever the store
+    // says about the hash.
+    for existing_direction in [
+        None,
+        Some(PaymentDirection::Inbound),
+        Some(PaymentDirection::Outbound),
+    ] {
+        assert_eq!(
+            check_inbound_registration(false, existing_direction),
+            Err(InboundRegistrationRefusal::OutboundInFlight)
+        );
+    }
+
+    // Any outbound record, pending or terminal, is refused so a restarted
+    // `pay()` can still read the payment's result from it.
+    assert_eq!(
+        check_inbound_registration(true, Some(PaymentDirection::Outbound)),
+        Err(InboundRegistrationRefusal::OutboundRecorded)
+    );
+
+    // A fresh hash is fine, as is a duplicate inbound registration, which the
+    // gateway's own reservation screens before reaching the node.
+    assert_eq!(check_inbound_registration(true, None), Ok(()));
+    assert_eq!(
+        check_inbound_registration(true, Some(PaymentDirection::Inbound)),
+        Ok(())
+    );
+}
+
+#[tokio::test]
+async fn registration_try_lock_is_refused_while_pay_holds_the_hash_lock() {
+    // `pay()` takes the per-hash lock with `async_lock` and holds it until the
+    // payment is terminal; `create_invoice` must see that as busy.
+    let pool = LockPool::new();
+    let payment_id = PaymentId([2; 32]);
+    let other_payment_id = PaymentId([3; 32]);
+
+    let pay_guard = pool.async_lock(payment_id).await;
+    assert!(pool.try_lock(payment_id).is_none());
+    // Other hashes are unaffected.
+    assert!(pool.try_lock(other_payment_id).is_some());
+
+    drop(pay_guard);
+    assert!(pool.try_lock(payment_id).is_some());
 }

--- a/gateway/fedimint-lightning/src/ldk/tests.rs
+++ b/gateway/fedimint-lightning/src/ldk/tests.rs
@@ -1,9 +1,38 @@
 use fedimint_core::util::SafeUrl;
+use ldk_node::NodeError;
 use ldk_node::payment::PaymentDirection;
 use lightning::ln::channelmanager::PaymentId;
 use lockable::LockPool;
 
-use super::{InboundRegistrationRefusal, check_inbound_registration, get_esplora_url};
+use super::{
+    InboundRegistrationRefusal, check_inbound_registration, get_esplora_url, htlc_completion_error,
+};
+use crate::LightningRpcError;
+
+/// The gateway retries `FailedToCompleteHtlc` forever and records only
+/// `HtlcCompletionRejected`, so an `ldk-node` error that cannot change on
+/// retry must map to the latter or the completion state machine never ends.
+#[test]
+fn completion_errors_are_permanent_unless_persistence_failed() {
+    for err in [
+        NodeError::InvalidPaymentHash,
+        NodeError::InvalidPaymentPreimage,
+        NodeError::InvalidAmount,
+    ] {
+        assert!(
+            matches!(
+                htlc_completion_error(&err, "ph"),
+                LightningRpcError::HtlcCompletionRejected { .. }
+            ),
+            "{err} must be permanent"
+        );
+    }
+
+    assert!(matches!(
+        htlc_completion_error(&NodeError::PersistenceFailed, "ph"),
+        LightningRpcError::FailedToCompleteHtlc { .. }
+    ));
+}
 
 #[test]
 fn verify_ldk_esplora_url() {

--- a/gateway/fedimint-lightning/src/lib.rs
+++ b/gateway/fedimint-lightning/src/lib.rs
@@ -208,6 +208,12 @@ pub trait ILnRpcClient: Debug + Send + Sync {
     /// Completes an HTLC that was intercepted by the gateway. Must be called
     /// for all successfully intercepted HTLCs sent to the stream returned
     /// by `route_htlcs`.
+    ///
+    /// The gateway retries [`LightningRpcError::FailedToCompleteHtlc`] until
+    /// the call succeeds and records only
+    /// [`LightningRpcError::HtlcCompletionRejected`] as a terminal outcome, so
+    /// implementations must return the latter for a failure no retry can
+    /// change and the former for anything transient.
     async fn complete_htlc(&self, htlc: InterceptPaymentResponse) -> Result<(), LightningRpcError>;
 
     /// Requests the lightning node to create an invoice. The presence of a

--- a/gateway/fedimint-lightning/src/lib.rs
+++ b/gateway/fedimint-lightning/src/lib.rs
@@ -363,7 +363,14 @@ pub const NO_INCOMING_CIRCUIT: (u64, u64) = (0, 0);
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct InterceptPaymentRequest {
     pub payment_hash: sha256::Hash,
+    /// The amount the HTLC claims to deliver. On the LND forward-intercept path
+    /// this is the sender-written onion `amt_to_forward`, so it must never be
+    /// trusted for funding decisions. On the HOLD-invoice and LDK paths it is
+    /// the real received amount.
     pub amount_msat: u64,
+    /// The amount actually locked in the incoming HTLC -- the real value the
+    /// gateway receives on settlement. Funding and fee checks must use this.
+    pub incoming_amount_msat: u64,
     pub expiry: u32,
     pub incoming_chan_id: u64,
     pub short_channel_id: Option<u64>,

--- a/gateway/fedimint-lightning/src/lib.rs
+++ b/gateway/fedimint-lightning/src/lib.rs
@@ -132,6 +132,11 @@ pub trait ILnRpcClient: Debug + Send + Sync {
     ///   as if it were the first call.
     /// * If the payment has already been attempted and failed, return an error.
     /// * If the payment has already succeeded, return a success response.
+    ///
+    /// Consult that record before enforcing `max_delay` or `max_fee`: a state
+    /// machine resuming a payment it dispatched before a restart may pass a
+    /// placeholder `max_delay` of `0`, which must only ever fail a dispatch
+    /// that would otherwise start fresh.
     async fn pay(
         &self,
         invoice: Bolt11Invoice,

--- a/gateway/fedimint-lightning/src/lib.rs
+++ b/gateway/fedimint-lightning/src/lib.rs
@@ -175,6 +175,21 @@ pub trait ILnRpcClient: Debug + Send + Sync {
         false
     }
 
+    /// Returns whether the node has any record of an outbound payment for
+    /// `payment_hash`, whatever its state: in-flight, succeeded, or failed.
+    ///
+    /// State machines call this when they resume after a restart to
+    /// distinguish a payment dispatched before the crash from one that never
+    /// left the gateway: pre-dispatch gates such as invoice expiry must not
+    /// cancel a payment the node may still settle. Implementations must
+    /// answer from the node's own payment store without waiting for the
+    /// payment to reach a terminal state, and must not count inbound records
+    /// for the same hash.
+    async fn outbound_payment_exists(
+        &self,
+        payment_hash: sha256::Hash,
+    ) -> Result<bool, LightningRpcError>;
+
     /// Consumes the current client and returns a stream of intercepted HTLCs
     /// and a new client. `complete_htlc` must be called for all successfully
     /// intercepted HTLCs sent to the returned stream.
@@ -563,6 +578,15 @@ impl ILnRpcClient for LnRpcTracked {
 
     fn supports_private_payments(&self) -> bool {
         self.inner.supports_private_payments()
+    }
+
+    async fn outbound_payment_exists(
+        &self,
+        payment_hash: sha256::Hash,
+    ) -> Result<bool, LightningRpcError> {
+        let result = self.inner.outbound_payment_exists(payment_hash).await;
+        self.record_call("outbound_payment_exists", &result);
+        result
     }
 
     async fn route_htlcs<'a>(

--- a/gateway/fedimint-lightning/src/lnd.rs
+++ b/gateway/fedimint-lightning/src/lnd.rs
@@ -648,21 +648,29 @@ impl GatewayLndClient {
             match payments {
                 Ok(payments) => {
                     // Block until LND returns the completed payment
-                    if let Some(payment) =
-                        payments.into_inner().message().await.map_err(|status| {
-                            LightningRpcError::FailedPayment {
-                                failure_reason: status.message().to_string(),
+                    match payments.into_inner().message().await {
+                        Ok(Some(payment)) => {
+                            if payment.status() == PaymentStatus::Succeeded {
+                                return Ok(Some(payment.payment_preimage));
                             }
-                        })?
-                    {
-                        if payment.status() == PaymentStatus::Succeeded {
-                            return Ok(Some(payment.payment_preimage));
-                        }
 
-                        let failure_reason = payment.failure_reason();
-                        return Err(LightningRpcError::FailedPayment {
-                            failure_reason: format!("{failure_reason:?}"),
-                        });
+                            let failure_reason = payment.failure_reason();
+                            return Err(LightningRpcError::FailedPayment {
+                                failure_reason: format!("{failure_reason:?}"),
+                            });
+                        }
+                        // A premature end of stream (`Ok(None)`) or a transport
+                        // fault (`Err`) is not a payment outcome. Retry rather than
+                        // reporting a failure the node never produced.
+                        outcome => {
+                            warn!(
+                                target: LOG_LIGHTNING,
+                                payment_hash = %PrettyPaymentHash(&payment_hash),
+                                outcome = ?outcome,
+                                "Payment tracking stream ended or faulted. Trying again in 5 seconds"
+                            );
+                            sleep(Duration::from_secs(5)).await;
+                        }
                     }
                 }
                 Err(err) => {
@@ -1089,11 +1097,7 @@ impl ILnRpcClient for GatewayLndClient {
                 );
                 let mut messages = payments.into_inner();
                 loop {
-                    match messages.message().await.map_err(|error| {
-                        LightningRpcError::FailedPayment {
-                            failure_reason: format!("Failed to get payment status {error:?}"),
-                        }
-                    }) {
+                    match messages.message().await {
                         Ok(Some(payment)) if payment.status() == PaymentStatus::Succeeded => {
                             info!(
                                 target: LOG_LIGHTNING,
@@ -1114,6 +1118,8 @@ impl ILnRpcClient for GatewayLndClient {
                             continue;
                         }
                         Ok(Some(payment)) => {
+                            // LND delivered a terminal, non-succeeded status: a
+                            // definitive failure that is safe to report.
                             warn!(
                                 target: LOG_LIGHTNING,
                                 payment_hash = %PrettyPaymentHash(&payment_hash),
@@ -1125,27 +1131,42 @@ impl ILnRpcClient for GatewayLndClient {
                                 failure_reason: format!("{failure_reason:?}"),
                             });
                         }
-                        Ok(None) => {
+                        // `Ok(None)` is a premature end of the update stream and `Err`
+                        // is a tonic/HTTP2 transport fault. Neither is a payment
+                        // outcome: the HTLC may still settle, so reporting failure here
+                        // would forfeit the outgoing contract for a payment that is
+                        // still in flight, violating the idempotency contract on
+                        // `ILnRpcClient::pay`. Resume tracking with `track_payment_v2`
+                        // to await the real terminal result instead.
+                        stream_end_or_fault => {
                             warn!(
                                 target: LOG_LIGHTNING,
                                 payment_hash = %PrettyPaymentHash(&payment_hash),
-                                "LND payment failed with no payment status",
+                                outcome = ?stream_end_or_fault,
+                                "LND payment status stream ended or faulted before a terminal status; resuming tracking",
                             );
-                            return Err(LightningRpcError::FailedPayment {
-                                failure_reason: format!(
-                                    "Failed to get payment status for payment hash {:?}",
-                                    invoice.payment_hash
-                                ),
-                            });
-                        }
-                        Err(err) => {
-                            warn!(
-                                target: LOG_LIGHTNING,
-                                payment_hash = %PrettyPaymentHash(&payment_hash),
-                                err = %err.fmt_compact(),
-                                "LND payment failed",
-                            );
-                            return Err(err);
+                            match self
+                                .lookup_payment(payment_hash.clone(), &mut client)
+                                .await?
+                            {
+                                Some(preimage) => {
+                                    break hex::FromHex::from_hex(preimage.as_str()).map_err(
+                                        |error| LightningRpcError::FailedPayment {
+                                            failure_reason: format!(
+                                                "Failed to convert preimage {error:?}"
+                                            ),
+                                        },
+                                    )?;
+                                }
+                                None => {
+                                    return Err(LightningRpcError::FailedPayment {
+                                        failure_reason: format!(
+                                            "LND has no record of dispatched payment for hash {:?}",
+                                            invoice.payment_hash
+                                        ),
+                                    });
+                                }
+                            }
                         }
                     }
                 }

--- a/gateway/fedimint-lightning/src/lnd.rs
+++ b/gateway/fedimint-lightning/src/lnd.rs
@@ -1027,6 +1027,15 @@ impl ILnRpcClient for GatewayLndClient {
                             ),
                         }
                     })?;
+                // LND reads a `cltv_limit` of zero as "no limit set" and
+                // enforces its `--max-cltv-expiry` default instead, silently
+                // lifting the caller's timelock cap.
+                if max_delay == 0 {
+                    return Err(LightningRpcError::FailedPayment {
+                        failure_reason: "a max delay of zero would disable LND's CLTV limit"
+                            .to_string(),
+                    });
+                }
                 let cltv_limit =
                     max_delay
                         .try_into()

--- a/gateway/fedimint-lightning/src/lnd.rs
+++ b/gateway/fedimint-lightning/src/lnd.rs
@@ -274,7 +274,10 @@ impl GatewayLndClient {
                     let intercept = InterceptPaymentRequest {
                         payment_hash: Hash::from_slice(&hold.r_hash.clone())
                             .expect("Failed to convert to Hash"),
+                        // A HOLD invoice reports the real paid amount, so the
+                        // two amounts coincide here.
                         amount_msat: hold.amt_paid_msat as u64,
+                        incoming_amount_msat: hold.amt_paid_msat as u64,
                         // The rest of the fields are not used in LNv2 and can be removed once LNv1
                         // support is over
                         expiry: hold.expiry as u32,
@@ -537,7 +540,12 @@ impl GatewayLndClient {
                     // Forward all HTLCs to gatewayd, gatewayd will filter them based on scid
                     let intercept = InterceptPaymentRequest {
                         payment_hash: Hash::from_slice(&htlc.payment_hash).expect("Failed to convert payment Hash"),
+                        // `outgoing_amount_msat` is the sender-written onion
+                        // `amt_to_forward`; `incoming_amount_msat` is the amount
+                        // actually locked in the incoming HTLC. Carry both so
+                        // downstream funding is decided against the real value.
                         amount_msat: htlc.outgoing_amount_msat,
+                        incoming_amount_msat: htlc.incoming_amount_msat,
                         expiry: htlc.incoming_expiry,
                         short_channel_id: Some(htlc.outgoing_requested_chan_id),
                         incoming_chan_id: chan_id,

--- a/gateway/fedimint-lightning/src/lnd.rs
+++ b/gateway/fedimint-lightning/src/lnd.rs
@@ -1117,27 +1117,33 @@ impl ILnRpcClient for GatewayLndClient {
                                     failure_reason: format!("Failed to convert preimage {error:?}"),
                                 })?;
                         }
-                        Ok(Some(payment)) if payment.status() == PaymentStatus::InFlight => {
-                            debug!(
-                                target: LOG_LIGHTNING,
-                                payment_hash = %PrettyPaymentHash(&payment_hash),
-                                "LND payment is inflight",
-                            );
-                            continue;
-                        }
-                        Ok(Some(payment)) => {
-                            // LND delivered a terminal, non-succeeded status: a
+                        Ok(Some(payment)) if payment.status() == PaymentStatus::Failed => {
+                            // The one terminal status besides `Succeeded`: a
                             // definitive failure that is safe to report.
                             warn!(
                                 target: LOG_LIGHTNING,
                                 payment_hash = %PrettyPaymentHash(&payment_hash),
-                                status = %payment.status,
+                                status = ?payment.status(),
                                 "LND payment failed",
                             );
                             let failure_reason = payment.failure_reason();
                             return Err(LightningRpcError::FailedPayment {
                                 failure_reason: format!("{failure_reason:?}"),
                             });
+                        }
+                        // `InFlight`, `Initiated` (delivered before the first HTLC
+                        // when `routerrpc.usestatusinitiated` is set) and any status
+                        // this build does not know, which prost decodes as `Unknown`,
+                        // are not outcomes. Keep waiting; a stream that ends without
+                        // a terminal status resumes through `lookup_payment` below.
+                        Ok(Some(payment)) => {
+                            debug!(
+                                target: LOG_LIGHTNING,
+                                payment_hash = %PrettyPaymentHash(&payment_hash),
+                                status = ?payment.status(),
+                                "LND payment is in flight",
+                            );
+                            continue;
                         }
                         // `Ok(None)` is a premature end of the update stream and `Err`
                         // is a tonic/HTTP2 transport fault. Neither is a payment

--- a/gateway/fedimint-lightning/src/lnd.rs
+++ b/gateway/fedimint-lightning/src/lnd.rs
@@ -1191,6 +1191,53 @@ impl ILnRpcClient for GatewayLndClient {
         true
     }
 
+    async fn outbound_payment_exists(
+        &self,
+        payment_hash: sha256::Hash,
+    ) -> Result<bool, LightningRpcError> {
+        let payment_hash_bytes = payment_hash.to_byte_array().to_vec();
+        let mut client = self.connect().await?;
+
+        // Subscribe with in-flight updates enabled so any known payment,
+        // pending or terminal, yields an immediate first message instead of
+        // blocking until the payment resolves; an unknown hash fails with
+        // `NotFound`.
+        let stream = match client
+            .router()
+            .track_payment_v2(TrackPaymentRequest {
+                payment_hash: payment_hash_bytes.clone(),
+                no_inflight_updates: false,
+            })
+            .await
+        {
+            Ok(stream) => stream,
+            Err(status) if status.code() == Code::NotFound => return Ok(false),
+            Err(status) => {
+                return Err(LightningRpcError::FailedPayment {
+                    failure_reason: format!(
+                        "Failed to look up payment {}: {status:?}",
+                        PrettyPaymentHash(&payment_hash_bytes),
+                    ),
+                });
+            }
+        };
+
+        match stream.into_inner().message().await {
+            Ok(Some(_)) => Ok(true),
+            Err(status) if status.code() == Code::NotFound => Ok(false),
+            // A premature end of stream or a transport fault is not an
+            // answer. Report an error so the caller retries, rather than
+            // letting it mistake the payment for never having been
+            // dispatched.
+            outcome => Err(LightningRpcError::FailedPayment {
+                failure_reason: format!(
+                    "Payment lookup stream gave no answer for {}: {outcome:?}",
+                    PrettyPaymentHash(&payment_hash_bytes),
+                ),
+            }),
+        }
+    }
+
     async fn route_htlcs<'a>(
         self: Box<Self>,
         task_group: &TaskGroup,

--- a/modules/fedimint-gw-client/src/complete.rs
+++ b/modules/fedimint-gw-client/src/complete.rs
@@ -254,6 +254,11 @@ impl CompleteHtlcState {
             htlc_id: common.htlc_id,
         };
 
+        // `IGatewayClientV1::complete_htlc` absorbs and retries transient node
+        // and connectivity failures, so any error it returns is a permanent
+        // outcome. Only then is failing terminally correct: the gateway has
+        // already funded the incoming contract, so it must not give up while
+        // settling the upstream HTLC could still succeed.
         context
             .lightning_manager
             .complete_htlc(htlc)

--- a/modules/fedimint-gw-client/src/lib.rs
+++ b/modules/fedimint-gw-client/src/lib.rs
@@ -1231,7 +1231,17 @@ pub trait IGatewayClientV1: Debug + Send + Sync {
         max_fee: Amount,
     ) -> Result<PayInvoiceResponse, LightningRpcError>;
 
-    /// Use the gateway's lightning node to send a complete HTLC response.
+    /// Uses the gateway's lightning node to complete (settle or cancel) a
+    /// previously intercepted HTLC.
+    ///
+    /// By the time the gateway settles the upstream HTLC it has already funded
+    /// the incoming contract, so a transient failure here must not strand it
+    /// out of pocket. Implementations must absorb and retry every transient
+    /// node or connectivity failure, returning `Err` only when Lightning has
+    /// reached a permanent state that makes the requested outcome impossible.
+    /// The future may block while retrying and must remain cancellation-safe.
+    /// The completion state machine persists any returned error as a terminal
+    /// failure.
     async fn complete_htlc(
         &self,
         htlc_response: InterceptPaymentResponse,

--- a/modules/fedimint-gw-client/src/lib.rs
+++ b/modules/fedimint-gw-client/src/lib.rs
@@ -334,10 +334,18 @@ impl GatewayClientModule {
         IncomingSmError,
     > {
         let operation_id = OperationId(htlc.payment_hash.to_byte_array());
+        // The amount passed here only guards solvency: the contract is always
+        // funded at the offer amount, and `create_incoming_contract_output`
+        // rejects the HTLC if this value falls short of it. It must therefore
+        // be the amount actually locked in the incoming HTLC, never the
+        // sender-controlled onion forward amount -- otherwise a sender could
+        // lock a token amount while declaring a large `amt_to_forward`, pass
+        // the check, and have the gateway fund the full offer amount from its
+        // own ecash against a near-worthless HTLC.
         let (incoming_output, amount, contract_id) = create_incoming_contract_output(
             &self.module_api,
             htlc.payment_hash,
-            htlc.outgoing_amount_msat,
+            htlc.incoming_amount_msat,
             &self.redeem_key,
         )
         .await?;
@@ -630,7 +638,7 @@ impl GatewayClientModule {
                 IncomingPaymentStarted {
                     contract_id,
                     payment_hash: htlc.payment_hash,
-                    invoice_amount: htlc.outgoing_amount_msat,
+                    invoice_amount: htlc.incoming_amount_msat,
                     contract_amount: amount,
                     operation_id,
                 },
@@ -1150,7 +1158,11 @@ impl TryFrom<InterceptPaymentRequest> for Htlc {
     fn try_from(s: InterceptPaymentRequest) -> Result<Self, Self::Error> {
         Ok(Self {
             payment_hash: s.payment_hash,
-            incoming_amount_msat: Amount::from_msats(s.amount_msat),
+            // Keep the two amounts distinct: `incoming_amount_msat` is the real
+            // value locked in the HTLC, while `amount_msat` is the sender-written
+            // onion forward amount. Collapsing them lets a sender forge the
+            // amount the gateway funds against.
+            incoming_amount_msat: Amount::from_msats(s.incoming_amount_msat),
             outgoing_amount_msat: Amount::from_msats(s.amount_msat),
             incoming_expiry: s.expiry,
             short_channel_id: s.short_channel_id,

--- a/modules/fedimint-gw-client/src/lib.rs
+++ b/modules/fedimint-gw-client/src/lib.rs
@@ -661,10 +661,16 @@ impl GatewayClientModule {
     /// instead would cancel the outgoing contract that this swap is the other
     /// half of, refunding the sender while the recipient still gets paid out of
     /// the gateway's own funds.
+    ///
+    /// `allow_fresh_dispatch` is consulted only when no such operation exists:
+    /// callers pass `false` when a wall-clock gate such as invoice expiry
+    /// forbids starting a new swap, and receive `Ok(None)` to signal that
+    /// nothing was started.
     pub async fn gateway_handle_direct_swap(
         &self,
         swap_params: SwapParameters,
-    ) -> anyhow::Result<OperationId> {
+        allow_fresh_dispatch: bool,
+    ) -> anyhow::Result<Option<OperationId>> {
         debug!("Handling direct swap {swap_params:?}");
 
         let payment_hash = swap_params.payment_hash;
@@ -681,7 +687,11 @@ impl GatewayClientModule {
                 "Direct swap already in progress, returning the operation already funding it"
             );
 
-            return Ok(operation_id);
+            return Ok(Some(operation_id));
+        }
+
+        if !allow_fresh_dispatch {
+            return Ok(None);
         }
 
         let (op_id_from_funding, client_output, client_output_sm) = self
@@ -716,7 +726,7 @@ impl GatewayClientModule {
                                 "Concurrent direct swap won the race, returning the operation already funding it"
                             );
 
-                            return Ok(operation_id);
+                            return Ok(Some(operation_id));
                         }
 
                         let output = ClientOutput {
@@ -746,7 +756,7 @@ impl GatewayClientModule {
                             "Submitted funding transaction for direct swap"
                         );
 
-                        Ok(operation_id)
+                        Ok(Some(operation_id))
                     })
                 },
                 Some(100),
@@ -1242,6 +1252,18 @@ pub trait IGatewayClientV1: Debug + Send + Sync {
         max_delay: u64,
         max_fee: Amount,
     ) -> Result<PayInvoiceResponse, LightningRpcError>;
+
+    /// Returns whether the gateway's Lightning node has any record of an
+    /// outbound payment for `payment_hash`, whatever its state.
+    ///
+    /// The pay state machine consults this when it resumes after a restart:
+    /// a payment the node already knows was dispatched before the crash and
+    /// must be resolved through [`IGatewayClientV1::pay`]'s idempotent resume
+    /// path rather than cancelled by pre-dispatch checks. A wrong `false`
+    /// cancels a contract whose payment may still settle, so implementations
+    /// must absorb transient node failures and only answer once the node's
+    /// payment store could actually be consulted.
+    async fn outbound_payment_exists(&self, payment_hash: sha256::Hash) -> bool;
 
     /// Uses the gateway's lightning node to complete (settle or cancel) a
     /// previously intercepted HTLC.

--- a/modules/fedimint-gw-client/src/pay.rs
+++ b/modules/fedimint-gw-client/src/pay.rs
@@ -163,7 +163,7 @@ pub enum OutgoingContractError {
     MissingContractData,
     #[error("The invoice is expired. Expiry happened at timestamp: {0}")]
     InvoiceExpired(u64),
-    #[error("The invoice amount exceeds the total bitcoin supply")]
+    #[error("The invoice amount plus the gateway fee overflows")]
     InvoiceAmountTooLarge,
 }
 
@@ -725,14 +725,10 @@ impl GatewayPayInvoice {
             .amount()
             .ok_or(OutgoingContractError::InvoiceMissingAmount)?;
 
-        // A pruned invoice carries a raw, caller-controlled amount. Reject
-        // anything above the bitcoin supply cap, and add the fee with checked
-        // arithmetic, so a huge amount cannot overflow `u64` and wrap the
-        // underfunding check below into passing against a near-empty contract.
-        if payment_amount > Amount::MAX_BITCOIN_SUPPLY {
-            return Err(OutgoingContractError::InvoiceAmountTooLarge);
-        }
-
+        // A pruned invoice carries a raw, caller-controlled amount. Add the fee
+        // with checked arithmetic so a huge amount cannot overflow `u64` and
+        // wrap the underfunding check below into passing against a near-empty
+        // contract.
         let gateway_fee = routing_fees.to_amount(&payment_amount);
         let necessary_contract_amount = payment_amount
             .checked_add(gateway_fee)
@@ -1337,13 +1333,13 @@ mod tests {
             Err(OutgoingContractError::InvoiceAmountTooLarge)
         );
 
-        // The supply cap itself is a legitimate amount and is still accepted
-        // when the contract funds it plus the fee, so the guard rejects only
-        // genuinely invalid sizes rather than everything.
-        let cap = Amount::MAX_BITCOIN_SUPPLY;
-        let funded = cap
-            .checked_add(Amount::from_msats(u64::from(fees.base_msat)))
-            .expect("cap plus a tiny fee stays within u64");
-        assert_eq!(validate_amount(funded, cap), Ok(()));
+        // The largest amount whose sum with the fee still fits is accepted when
+        // the contract funds it, so the guard rejects exactly the overflow and
+        // nothing else.
+        let largest_representable = Amount::from_msats(u64::MAX - u64::from(fees.base_msat));
+        assert_eq!(
+            validate_amount(Amount::from_msats(u64::MAX), largest_representable),
+            Ok(())
+        );
     }
 }

--- a/modules/fedimint-gw-client/src/pay.rs
+++ b/modules/fedimint-gw-client/src/pay.rs
@@ -658,12 +658,15 @@ impl GatewayPayInvoice {
             ));
         }
 
+        // `max_delay` becomes the lightning node's CLTV limit, and LND treats
+        // a limit of zero as "unset", enforcing its `--max-cltv-expiry`
+        // default instead. That would let the HTLC outlive the contract
+        // timelock, so zero must fail closed just like the underflow case.
         let max_delay = u64::from(account.contract.timelock)
             .checked_sub(consensus_block_count.saturating_sub(1))
-            .and_then(|delta| delta.checked_sub(TIMELOCK_DELTA));
-        if max_delay.is_none() {
-            return Err(OutgoingContractError::TimeoutTooClose);
-        }
+            .and_then(|delta| delta.checked_sub(TIMELOCK_DELTA))
+            .filter(|max_delay| *max_delay > 0)
+            .ok_or(OutgoingContractError::TimeoutTooClose)?;
 
         if payment_data.is_expired() {
             return Err(OutgoingContractError::InvoiceExpired(
@@ -672,7 +675,7 @@ impl GatewayPayInvoice {
         }
 
         Ok(PaymentParameters {
-            max_delay: max_delay.unwrap(),
+            max_delay,
             max_send_amount: account.amount,
             payment_data: payment_data.clone(),
         })
@@ -998,7 +1001,7 @@ mod tests {
     use fedimint_ln_common::contracts::outgoing::{OutgoingContract, OutgoingContractAccount};
     use lightning_invoice::RoutingFees;
 
-    use super::{GatewayPayInvoice, OutgoingContractError};
+    use super::{GatewayPayInvoice, OutgoingContractError, TIMELOCK_DELTA};
 
     const CONSENSUS_BLOCK_COUNT: u64 = 1;
     const INVOICE_AMOUNT: Amount = Amount::from_msats(1000);
@@ -1013,6 +1016,14 @@ mod tests {
     /// An account that is valid in every respect other than the payment hash,
     /// which the caller chooses so a mismatch can be tested in isolation.
     fn contract_account(hash: sha256::Hash) -> OutgoingContractAccount {
+        // Comfortably beyond `CONSENSUS_BLOCK_COUNT + TIMELOCK_DELTA`
+        contract_account_with_timelock(hash, 100)
+    }
+
+    fn contract_account_with_timelock(
+        hash: sha256::Hash,
+        timelock: u32,
+    ) -> OutgoingContractAccount {
         let gateway_key = secp256k1::PublicKey::from_keypair(&gateway_keypair());
 
         OutgoingContractAccount {
@@ -1020,8 +1031,7 @@ mod tests {
             contract: OutgoingContract {
                 hash,
                 gateway_key,
-                // Comfortably beyond `CONSENSUS_BLOCK_COUNT + TIMELOCK_DELTA`
-                timelock: 100,
+                timelock,
                 user_key: gateway_key,
                 cancelled: false,
             },
@@ -1045,8 +1055,15 @@ mod tests {
         contract_hash: sha256::Hash,
         invoice_hash: sha256::Hash,
     ) -> Result<(), OutgoingContractError> {
+        validate_account(&contract_account(contract_hash), invoice_hash)
+    }
+
+    fn validate_account(
+        account: &OutgoingContractAccount,
+        invoice_hash: sha256::Hash,
+    ) -> Result<(), OutgoingContractError> {
         GatewayPayInvoice::validate_outgoing_account(
-            &contract_account(contract_hash),
+            account,
             gateway_keypair(),
             CONSENSUS_BLOCK_COUNT,
             &payment_data(invoice_hash),
@@ -1065,6 +1082,35 @@ mod tests {
         let hash = sha256::Hash::hash(b"preimage");
 
         assert_eq!(validate(hash, hash), Ok(()));
+    }
+
+    /// A timelock close enough to the consensus height that `max_delay`
+    /// computes to zero must be rejected: LND treats a CLTV limit of zero as
+    /// "unset" and substitutes its `--max-cltv-expiry` default, which would
+    /// let the HTLC outlive the contract timelock and the user refund the
+    /// contract while the payment is still in flight.
+    #[test]
+    fn rejects_timelock_yielding_a_max_delay_of_zero() {
+        let hash = sha256::Hash::hash(b"preimage");
+        let zero_delay_timelock =
+            u32::try_from(CONSENSUS_BLOCK_COUNT - 1 + TIMELOCK_DELTA).expect("small constant");
+
+        let validate_with_timelock =
+            |timelock| validate_account(&contract_account_with_timelock(hash, timelock), hash);
+
+        // The smallest acceptable timelock, asserted so this test pins the
+        // boundary rather than passing against a check that rejects
+        // everything.
+        assert_eq!(validate_with_timelock(zero_delay_timelock + 1), Ok(()));
+
+        assert_eq!(
+            validate_with_timelock(zero_delay_timelock),
+            Err(OutgoingContractError::TimeoutTooClose)
+        );
+        assert_eq!(
+            validate_with_timelock(zero_delay_timelock - 1),
+            Err(OutgoingContractError::TimeoutTooClose)
+        );
     }
 
     #[test]

--- a/modules/fedimint-gw-client/src/pay.rs
+++ b/modules/fedimint-gw-client/src/pay.rs
@@ -163,6 +163,8 @@ pub enum OutgoingContractError {
     MissingContractData,
     #[error("The invoice is expired. Expiry happened at timestamp: {0}")]
     InvoiceExpired(u64),
+    #[error("The invoice amount exceeds the total bitcoin supply")]
+    InvoiceAmountTooLarge,
 }
 
 #[derive(
@@ -649,8 +651,18 @@ impl GatewayPayInvoice {
             .amount()
             .ok_or(OutgoingContractError::InvoiceMissingAmount)?;
 
+        // A pruned invoice carries a raw, caller-controlled amount. Reject
+        // anything above the bitcoin supply cap, and add the fee with checked
+        // arithmetic, so a huge amount cannot overflow `u64` and wrap the
+        // underfunding check below into passing against a near-empty contract.
+        if payment_amount > Amount::MAX_BITCOIN_SUPPLY {
+            return Err(OutgoingContractError::InvoiceAmountTooLarge);
+        }
+
         let gateway_fee = routing_fees.to_amount(&payment_amount);
-        let necessary_contract_amount = payment_amount + gateway_fee;
+        let necessary_contract_amount = payment_amount
+            .checked_add(gateway_fee)
+            .ok_or(OutgoingContractError::InvoiceAmountTooLarge)?;
         if account.amount < necessary_contract_amount {
             return Err(OutgoingContractError::Underfunded(
                 necessary_contract_amount,
@@ -1024,10 +1036,18 @@ mod tests {
         hash: sha256::Hash,
         timelock: u32,
     ) -> OutgoingContractAccount {
+        contract_account_with(hash, INVOICE_AMOUNT, timelock)
+    }
+
+    fn contract_account_with(
+        hash: sha256::Hash,
+        amount: Amount,
+        timelock: u32,
+    ) -> OutgoingContractAccount {
         let gateway_key = secp256k1::PublicKey::from_keypair(&gateway_keypair());
 
         OutgoingContractAccount {
-            amount: INVOICE_AMOUNT,
+            amount,
             contract: OutgoingContract {
                 hash,
                 gateway_key,
@@ -1039,8 +1059,12 @@ mod tests {
     }
 
     fn payment_data(payment_hash: sha256::Hash) -> PaymentData {
+        pruned_payment_data(payment_hash, INVOICE_AMOUNT)
+    }
+
+    fn pruned_payment_data(payment_hash: sha256::Hash, amount: Amount) -> PaymentData {
         PaymentData::PrunedInvoice(PrunedInvoice {
-            amount: INVOICE_AMOUNT,
+            amount,
             destination: secp256k1::PublicKey::from_keypair(&gateway_keypair()),
             destination_features: vec![],
             payment_hash,
@@ -1128,5 +1152,48 @@ mod tests {
                 contract_id: contract_account(contract_hash).contract.contract_id(),
             })
         );
+    }
+
+    /// A pruned invoice's amount is a raw, caller-supplied `u64`. An amount so
+    /// large that `payment_amount + fee` overflows must be rejected: otherwise
+    /// the sum wraps to a small value, the underfunding check passes against a
+    /// near-empty contract, and the gateway pays out real funds it can never
+    /// reclaim.
+    #[test]
+    fn rejects_invoice_amount_that_would_overflow_the_underfunding_check() {
+        let hash = sha256::Hash::hash(b"preimage");
+
+        // A one-millisatoshi base fee makes `u64::MAX + fee` wrap to zero, so
+        // before the fix the underfunding check passed against any contract.
+        let fees = RoutingFees {
+            base_msat: 1,
+            proportional_millionths: 0,
+        };
+
+        let validate_amount = |contract_amount: Amount, invoice_amount: Amount| {
+            GatewayPayInvoice::validate_outgoing_account(
+                &contract_account_with(hash, contract_amount, 100),
+                gateway_keypair(),
+                CONSENSUS_BLOCK_COUNT,
+                &pruned_payment_data(hash, invoice_amount),
+                fees,
+            )
+            .map(|_| ())
+        };
+
+        // The attack: a wrapping invoice amount against a near-empty contract.
+        assert_eq!(
+            validate_amount(Amount::from_msats(1), Amount::from_msats(u64::MAX)),
+            Err(OutgoingContractError::InvoiceAmountTooLarge)
+        );
+
+        // The supply cap itself is a legitimate amount and is still accepted
+        // when the contract funds it plus the fee, so the guard rejects only
+        // genuinely invalid sizes rather than everything.
+        let cap = Amount::MAX_BITCOIN_SUPPLY;
+        let funded = cap
+            .checked_add(Amount::from_msats(u64::from(fees.base_msat)))
+            .expect("cap plus a tiny fee stays within u64");
+        assert_eq!(validate_amount(funded, cap), Ok(()));
     }
 }

--- a/modules/fedimint-gw-client/src/pay.rs
+++ b/modules/fedimint-gw-client/src/pay.rs
@@ -10,6 +10,7 @@ use fedimint_core::config::FederationId;
 use fedimint_core::core::OperationId;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::Amounts;
+use fedimint_core::util::FmtCompact as _;
 use fedimint_core::{Amount, OutPoint, TransactionId, secp256k1};
 use fedimint_lightning::{LightningRpcError, PayInvoiceResponse};
 use fedimint_ln_client::api::LnFederationApi;
@@ -408,7 +409,7 @@ impl GatewayPayInvoice {
                 contract.clone(),
                 swap_parameters,
                 common.clone(),
-                payment_parameters.fresh_dispatch_refusal.clone(),
+                payment_parameters.fresh_dispatch.clone().err(),
             )
             .await
         {
@@ -428,7 +429,7 @@ impl GatewayPayInvoice {
                             payment_parameters.payment_data.clone(),
                             contract.clone(),
                             common.clone(),
-                            payment_parameters.fresh_dispatch_refusal.clone(),
+                            payment_parameters.fresh_dispatch.clone().err(),
                         )
                     })
                     .await
@@ -535,16 +536,19 @@ impl GatewayPayInvoice {
         debug!("Buying preimage over lightning for contract {contract:?}");
 
         // A payment the node already knows resolves through `pay`'s
-        // idempotent resume path -- which never re-dispatches and ignores
-        // `max_delay` -- so a drifted timelock or expiry gate only refuses a
-        // dispatch that never happened.
-        if let Some(error) = buy_preimage.fresh_dispatch_refusal.clone()
+        // idempotent resume path, which never re-dispatches, so a drifted
+        // timelock or expiry gate only refuses a dispatch that never happened.
+        if let Err(error) = &buy_preimage.fresh_dispatch
             && !context
                 .lightning_manager
                 .outbound_payment_exists(buy_preimage.payment_data.payment_hash())
                 .await
         {
-            warn!("Refusing fresh lightning dispatch for contract {contract:?}: {error:?}");
+            warn!(
+                ?contract,
+                err = %error.fmt_compact(),
+                "Refusing fresh lightning dispatch"
+            );
             return GatewayPayStateMachine {
                 common,
                 state: GatewayPayStates::CancelContract(Box::new(GatewayPayCancelContract {
@@ -552,13 +556,19 @@ impl GatewayPayInvoice {
                     error: OutgoingPaymentError {
                         contract_id: contract.contract.contract_id(),
                         contract: Some(contract),
-                        error_type: OutgoingPaymentErrorType::InvalidOutgoingContract { error },
+                        error_type: OutgoingPaymentErrorType::InvalidOutgoingContract {
+                            error: error.clone(),
+                        },
                     },
                 })),
             };
         }
 
-        let max_delay = buy_preimage.max_delay;
+        // On the resume path `pay` consults the node's own payment record
+        // before the budget, so `0` is a fail-closed sentinel: should that
+        // record have vanished in between, LND rejects a zero CLTV limit and
+        // LDK finds no route, rather than dispatching under a stale budget.
+        let max_delay = buy_preimage.fresh_dispatch.clone().unwrap_or(0);
         let max_fee = buy_preimage.max_send_amount.saturating_sub(
             buy_preimage
                 .payment_data
@@ -758,37 +768,31 @@ impl GatewayPayInvoice {
         // claim it. They are therefore recorded as a refusal that each rail
         // consults only before dispatching fresh; anything already started
         // resumes unconditionally.
-        let fresh_dispatch_refusal = if max_delay.is_none() {
-            Some(OutgoingContractError::TimeoutTooClose)
-        } else if payment_data.is_expired() {
-            Some(OutgoingContractError::InvoiceExpired(
+        let fresh_dispatch = match max_delay {
+            None => Err(OutgoingContractError::TimeoutTooClose),
+            Some(_) if payment_data.is_expired() => Err(OutgoingContractError::InvoiceExpired(
                 payment_data.expiry_timestamp(),
-            ))
-        } else {
-            None
+            )),
+            Some(max_delay) => Ok(max_delay),
         };
 
         Ok(PaymentParameters {
-            // Zero is never dispatched: an exhausted budget records a refusal
-            // above, and the resume path never reads `max_delay`.
-            max_delay: max_delay.unwrap_or(0),
+            fresh_dispatch,
             max_send_amount: account.amount,
             payment_data: payment_data.clone(),
-            fresh_dispatch_refusal,
         })
     }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable, Serialize, Deserialize)]
 struct PaymentParameters {
-    max_delay: u64,
+    /// `Ok` carries the CLTV budget a fresh dispatch must respect. `Err` means
+    /// a drifted pre-dispatch gate (timelock budget or invoice expiry) forbids
+    /// starting one. Each rail consults this only before initiating; a
+    /// dispatch that already exists resumes unconditionally.
+    fresh_dispatch: Result<u64, OutgoingContractError>,
     max_send_amount: Amount,
     payment_data: PaymentData,
-    /// `Some` when a drifted pre-dispatch gate (timelock budget or invoice
-    /// expiry) forbids starting a fresh dispatch. Each rail consults this
-    /// only before initiating; a dispatch that already exists resumes
-    /// unconditionally.
-    fresh_dispatch_refusal: Option<OutgoingContractError>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable, Serialize, Deserialize)]
@@ -1195,10 +1199,7 @@ mod tests {
                 proportional_millionths: 0,
             },
         )
-        .and_then(|parameters| match parameters.fresh_dispatch_refusal {
-            Some(refusal) => Err(refusal),
-            None => Ok(()),
-        })
+        .and_then(|parameters| parameters.fresh_dispatch.map(|_| ()))
     }
 
     /// Payment data whose invoice expired at the unix epoch.

--- a/modules/fedimint-gw-client/src/pay.rs
+++ b/modules/fedimint-gw-client/src/pay.rs
@@ -1182,11 +1182,18 @@ mod tests {
         account: &OutgoingContractAccount,
         invoice_hash: sha256::Hash,
     ) -> Result<(), OutgoingContractError> {
+        validate_payment_data(account, &payment_data(invoice_hash))
+    }
+
+    fn validate_payment_data(
+        account: &OutgoingContractAccount,
+        payment_data: &PaymentData,
+    ) -> Result<(), OutgoingContractError> {
         GatewayPayInvoice::validate_outgoing_account(
             account,
             gateway_keypair(),
             CONSENSUS_BLOCK_COUNT,
-            &payment_data(invoice_hash),
+            payment_data,
             RoutingFees {
                 base_msat: 0,
                 proportional_millionths: 0,
@@ -1196,6 +1203,17 @@ mod tests {
             Some(refusal) => Err(refusal),
             None => Ok(()),
         })
+    }
+
+    /// Payment data whose invoice expired at the unix epoch.
+    fn expired_payment_data(payment_hash: sha256::Hash) -> PaymentData {
+        match payment_data(payment_hash) {
+            PaymentData::PrunedInvoice(mut invoice) => {
+                invoice.expiry_timestamp = 0;
+                PaymentData::PrunedInvoice(invoice)
+            }
+            PaymentData::Invoice(..) => unreachable!("the fixture builds a pruned invoice"),
+        }
     }
 
     /// Guards against the fixture being invalid for some unrelated reason,
@@ -1234,6 +1252,37 @@ mod tests {
         );
         assert_eq!(
             validate_with_timelock(zero_delay_timelock - 1),
+            Err(OutgoingContractError::TimeoutTooClose)
+        );
+    }
+
+    /// An expired invoice must refuse a fresh dispatch. Like the timelock
+    /// gate, the refusal is recorded rather than failing validation, so a
+    /// payment dispatched before a restart can still resume past it.
+    #[test]
+    fn records_refusal_for_an_expired_invoice() {
+        let hash = sha256::Hash::hash(b"preimage");
+
+        assert_eq!(
+            validate_payment_data(&contract_account(hash), &expired_payment_data(hash)),
+            Err(OutgoingContractError::InvoiceExpired(0))
+        );
+    }
+
+    /// When both drifting gates fail, the timelock refusal is reported: with
+    /// no timelock budget left the payment cannot be dispatched at all, so
+    /// expiry never gets a say. Pinned so error reporting stays stable.
+    #[test]
+    fn timelock_refusal_takes_precedence_over_expiry() {
+        let hash = sha256::Hash::hash(b"preimage");
+        let zero_delay_timelock =
+            u32::try_from(CONSENSUS_BLOCK_COUNT - 1 + TIMELOCK_DELTA).expect("small constant");
+
+        assert_eq!(
+            validate_payment_data(
+                &contract_account_with_timelock(hash, zero_delay_timelock),
+                &expired_payment_data(hash),
+            ),
             Err(OutgoingContractError::TimeoutTooClose)
         );
     }

--- a/modules/fedimint-gw-client/src/pay.rs
+++ b/modules/fedimint-gw-client/src/pay.rs
@@ -278,6 +278,7 @@ impl GatewayPayInvoice {
         contract: OutgoingContractAccount,
         swap_parameters: SwapParameters,
         common: GatewayPayCommon,
+        fresh_dispatch_refusal: Option<OutgoingContractError>,
     ) -> Option<GatewayPayStateMachine> {
         let amount = swap_parameters.amount_msat;
         if let Ok(Some((lnv2_incoming_contract, client))) = context
@@ -288,10 +289,14 @@ impl GatewayPayInvoice {
             let state = match client
                 .get_first_module::<fedimint_gwv2_client::GatewayClientModuleV2>()
                 .expect("Must have client module")
-                .relay_direct_swap(lnv2_incoming_contract, amount.msats)
+                .relay_direct_swap(
+                    lnv2_incoming_contract,
+                    amount.msats,
+                    fresh_dispatch_refusal.is_none(),
+                )
                 .await
             {
-                Ok(final_receive_state) => match final_receive_state {
+                Ok(Some(final_receive_state)) => match final_receive_state {
                     fedimint_gwv2_client::FinalReceiveState::Success(preimage) => {
                         GatewayPayStateMachine {
                             common,
@@ -321,6 +326,25 @@ impl GatewayPayInvoice {
                         )),
                     },
                 },
+                Ok(None) => {
+                    let error = fresh_dispatch_refusal
+                        .expect("the relay only refuses a fresh dispatch when one was denied");
+                    GatewayPayStateMachine {
+                        common,
+                        state: GatewayPayStates::CancelContract(Box::new(
+                            GatewayPayCancelContract {
+                                contract: contract.clone(),
+                                error: OutgoingPaymentError {
+                                    contract_id: contract.contract.contract_id(),
+                                    contract: Some(contract.clone()),
+                                    error_type: OutgoingPaymentErrorType::InvalidOutgoingContract {
+                                        error,
+                                    },
+                                },
+                            },
+                        )),
+                    }
+                }
                 Err(err) => GatewayPayStateMachine {
                     common,
                     state: GatewayPayStates::CancelContract(Box::new(GatewayPayCancelContract {
@@ -379,9 +403,14 @@ impl GatewayPayInvoice {
         let swap_parameters: anyhow::Result<SwapParameters> =
             payment_parameters.payment_data.clone().try_into();
         if let Ok(swap_parameters) = swap_parameters
-            && let Some(new_state) =
-                Self::buy_lnv2_preimage(&context, contract.clone(), swap_parameters, common.clone())
-                    .await
+            && let Some(new_state) = Self::buy_lnv2_preimage(
+                &context,
+                contract.clone(),
+                swap_parameters,
+                common.clone(),
+                payment_parameters.fresh_dispatch_refusal.clone(),
+            )
+            .await
         {
             return new_state;
         }
@@ -399,6 +428,7 @@ impl GatewayPayInvoice {
                             payment_parameters.payment_data.clone(),
                             contract.clone(),
                             common.clone(),
+                            payment_parameters.fresh_dispatch_refusal.clone(),
                         )
                     })
                     .await
@@ -504,6 +534,30 @@ impl GatewayPayInvoice {
     ) -> GatewayPayStateMachine {
         debug!("Buying preimage over lightning for contract {contract:?}");
 
+        // A payment the node already knows resolves through `pay`'s
+        // idempotent resume path -- which never re-dispatches and ignores
+        // `max_delay` -- so a drifted timelock or expiry gate only refuses a
+        // dispatch that never happened.
+        if let Some(error) = buy_preimage.fresh_dispatch_refusal.clone()
+            && !context
+                .lightning_manager
+                .outbound_payment_exists(buy_preimage.payment_data.payment_hash())
+                .await
+        {
+            warn!("Refusing fresh lightning dispatch for contract {contract:?}: {error:?}");
+            return GatewayPayStateMachine {
+                common,
+                state: GatewayPayStates::CancelContract(Box::new(GatewayPayCancelContract {
+                    contract: contract.clone(),
+                    error: OutgoingPaymentError {
+                        contract_id: contract.contract.contract_id(),
+                        contract: Some(contract),
+                        error_type: OutgoingPaymentErrorType::InvalidOutgoingContract { error },
+                    },
+                })),
+            };
+        }
+
         let max_delay = buy_preimage.max_delay;
         let max_fee = buy_preimage.max_send_amount.saturating_sub(
             buy_preimage
@@ -558,16 +612,17 @@ impl GatewayPayInvoice {
         payment_data: PaymentData,
         contract: OutgoingContractAccount,
         common: GatewayPayCommon,
+        fresh_dispatch_refusal: Option<OutgoingContractError>,
     ) -> GatewayPayStateMachine {
         debug!("Buying preimage via direct swap for contract {contract:?}");
         match payment_data.try_into() {
             Ok(swap_params) => match client
                 .get_first_module::<GatewayClientModule>()
                 .expect("Must have client module")
-                .gateway_handle_direct_swap(swap_params)
+                .gateway_handle_direct_swap(swap_params, fresh_dispatch_refusal.is_none())
                 .await
             {
-                Ok(operation_id) => {
+                Ok(Some(operation_id)) => {
                     debug!("Direct swap initiated for contract {contract:?}");
                     GatewayPayStateMachine {
                         common,
@@ -576,6 +631,25 @@ impl GatewayPayInvoice {
                                 contract,
                                 federation_id: client.federation_id(),
                                 operation_id,
+                            },
+                        )),
+                    }
+                }
+                Ok(None) => {
+                    let error = fresh_dispatch_refusal
+                        .expect("the relay only refuses a fresh dispatch when one was denied");
+                    GatewayPayStateMachine {
+                        common,
+                        state: GatewayPayStates::CancelContract(Box::new(
+                            GatewayPayCancelContract {
+                                contract: contract.clone(),
+                                error: OutgoingPaymentError {
+                                    contract_id: contract.contract.contract_id(),
+                                    contract: Some(contract.clone()),
+                                    error_type: OutgoingPaymentErrorType::InvalidOutgoingContract {
+                                        error,
+                                    },
+                                },
                             },
                         )),
                     }
@@ -677,19 +751,34 @@ impl GatewayPayInvoice {
         let max_delay = u64::from(account.contract.timelock)
             .checked_sub(consensus_block_count.saturating_sub(1))
             .and_then(|delta| delta.checked_sub(TIMELOCK_DELTA))
-            .filter(|max_delay| *max_delay > 0)
-            .ok_or(OutgoingContractError::TimeoutTooClose)?;
+            .filter(|max_delay| *max_delay > 0);
 
-        if payment_data.is_expired() {
-            return Err(OutgoingContractError::InvoiceExpired(
+        // The timelock budget and invoice expiry drift with the chain tip and
+        // the wall clock, and this validation re-runs from scratch whenever
+        // the state machine restarts. Failing validation outright would
+        // cancel a payment that may have been dispatched before a crash and
+        // still be in flight -- one that settles or fails regardless of
+        // either gate -- returning the escrow while the payment can still
+        // claim it. They are therefore recorded as a refusal that each rail
+        // consults only before dispatching fresh; anything already started
+        // resumes unconditionally.
+        let fresh_dispatch_refusal = if max_delay.is_none() {
+            Some(OutgoingContractError::TimeoutTooClose)
+        } else if payment_data.is_expired() {
+            Some(OutgoingContractError::InvoiceExpired(
                 payment_data.expiry_timestamp(),
-            ));
-        }
+            ))
+        } else {
+            None
+        };
 
         Ok(PaymentParameters {
-            max_delay,
+            // Zero is never dispatched: an exhausted budget records a refusal
+            // above, and the resume path never reads `max_delay`.
+            max_delay: max_delay.unwrap_or(0),
             max_send_amount: account.amount,
             payment_data: payment_data.clone(),
+            fresh_dispatch_refusal,
         })
     }
 }
@@ -699,6 +788,11 @@ struct PaymentParameters {
     max_delay: u64,
     max_send_amount: Amount,
     payment_data: PaymentData,
+    /// `Some` when a drifted pre-dispatch gate (timelock budget or invoice
+    /// expiry) forbids starting a fresh dispatch. Each rail consults this
+    /// only before initiating; a dispatch that already exists resumes
+    /// unconditionally.
+    fresh_dispatch_refusal: Option<OutgoingContractError>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable, Serialize, Deserialize)]
@@ -1082,6 +1176,8 @@ mod tests {
         validate_account(&contract_account(contract_hash), invoice_hash)
     }
 
+    /// Surfaces a recorded fresh-dispatch refusal as an error so tests can
+    /// assert on the drifting gates alongside the hard validation errors.
     fn validate_account(
         account: &OutgoingContractAccount,
         invoice_hash: sha256::Hash,
@@ -1096,7 +1192,10 @@ mod tests {
                 proportional_millionths: 0,
             },
         )
-        .map(|_| ())
+        .and_then(|parameters| match parameters.fresh_dispatch_refusal {
+            Some(refusal) => Err(refusal),
+            None => Ok(()),
+        })
     }
 
     /// Guards against the fixture being invalid for some unrelated reason,
@@ -1109,10 +1208,12 @@ mod tests {
     }
 
     /// A timelock close enough to the consensus height that `max_delay`
-    /// computes to zero must be rejected: LND treats a CLTV limit of zero as
-    /// "unset" and substitutes its `--max-cltv-expiry` default, which would
-    /// let the HTLC outlive the contract timelock and the user refund the
-    /// contract while the payment is still in flight.
+    /// computes to zero must refuse a fresh dispatch: LND treats a CLTV limit
+    /// of zero as "unset" and substitutes its `--max-cltv-expiry` default,
+    /// which would let the HTLC outlive the contract timelock and the user
+    /// refund the contract while the payment is still in flight. The refusal
+    /// is recorded rather than failing validation so a payment dispatched
+    /// before a restart can still resume.
     #[test]
     fn rejects_timelock_yielding_a_max_delay_of_zero() {
         let hash = sha256::Hash::hash(b"preimage");

--- a/modules/fedimint-gw-client/src/tests.rs
+++ b/modules/fedimint-gw-client/src/tests.rs
@@ -1,5 +1,6 @@
 use bitcoin::hashes::{Hash, sha256};
 use fedimint_core::Amount;
+use fedimint_lightning::InterceptPaymentRequest;
 
 use super::{Htlc, LNV1_HTLC_EXPIRY_SAFETY_MARGIN, UnsafeHtlcExpiry};
 
@@ -76,5 +77,39 @@ fn accepts_htlc_near_maximum_height_without_overflow() {
     assert_eq!(
         htlc(incoming_expiry).ensure_safe_expiry(current_block_height),
         Ok(())
+    );
+}
+
+#[test]
+fn htlc_conversion_keeps_incoming_and_outgoing_amounts_distinct() {
+    // `amount_msat` is the sender-written onion forward amount, while
+    // `incoming_amount_msat` is the value actually locked in the HTLC.
+    // Collapsing them into one lets a forged forward amount satisfy the
+    // solvency check that guards contract funding, so the conversion must
+    // keep the two separate.
+    let forged_forward_amount = 1_000_000;
+    let real_locked_amount = 1_000;
+
+    let intercept = InterceptPaymentRequest {
+        payment_hash: sha256::Hash::all_zeros(),
+        amount_msat: forged_forward_amount,
+        incoming_amount_msat: real_locked_amount,
+        expiry: 500,
+        incoming_chan_id: 2,
+        short_channel_id: Some(1),
+        htlc_id: 3,
+    };
+
+    let htlc = Htlc::try_from(intercept).expect("conversion of a valid request succeeds");
+
+    assert_eq!(
+        htlc.incoming_amount_msat,
+        Amount::from_msats(real_locked_amount),
+        "the received amount must come from the real locked value"
+    );
+    assert_eq!(
+        htlc.outgoing_amount_msat,
+        Amount::from_msats(forged_forward_amount),
+        "the onion forward amount must stay in its own field, never conflated with the received amount"
     );
 }

--- a/modules/fedimint-gwv2-client/src/lib.rs
+++ b/modules/fedimint-gwv2-client/src/lib.rs
@@ -665,17 +665,32 @@ impl GatewayClientModuleV2 {
         Ok(())
     }
 
+    /// Funds the incoming contract of a direct swap and waits for its final
+    /// state.
+    ///
+    /// A swap that was already started resumes unconditionally: its operation
+    /// is keyed on the contract, so a re-entrant call — a restarted state
+    /// machine, or a concurrent payer — joins the operation in progress
+    /// instead of funding twice. `allow_fresh_dispatch` is consulted only
+    /// when no such operation exists: callers pass `false` when a wall-clock
+    /// gate such as invoice expiry forbids starting a new swap, and receive
+    /// `Ok(None)` to signal that nothing was started.
     pub async fn relay_direct_swap(
         &self,
         contract: IncomingContract,
         amount_msat: u64,
-    ) -> anyhow::Result<FinalReceiveState> {
+        allow_fresh_dispatch: bool,
+    ) -> anyhow::Result<Option<FinalReceiveState>> {
         let operation_start = now();
 
         let operation_id = OperationId::from_encodable(&contract);
 
         if self.client_ctx.operation_exists(operation_id).await {
-            return Ok(self.await_receive(operation_id).await);
+            return Ok(Some(self.await_receive(operation_id).await));
+        }
+
+        if !allow_fresh_dispatch {
+            return Ok(None);
         }
 
         let refund_keypair = self.keypair;
@@ -730,7 +745,7 @@ impl GatewayClientModuleV2 {
             .await;
         dbtx.commit_tx().await;
 
-        Ok(self.await_receive(operation_id).await)
+        Ok(Some(self.await_receive(operation_id).await))
     }
 
     pub async fn await_receive(&self, operation_id: OperationId) -> FinalReceiveState {
@@ -852,6 +867,18 @@ pub trait IGatewayClientV2: Debug + Send + Sync {
         max_fee: Amount,
     ) -> Result<[u8; 32], LightningRpcError>;
 
+    /// Returns whether the gateway's Lightning node has any record of an
+    /// outbound payment for `payment_hash`, whatever its state.
+    ///
+    /// The send state machine consults this when it resumes after a restart:
+    /// a payment the node already knows was dispatched before the crash and
+    /// must be resolved through [`IGatewayClientV2::pay`]'s idempotent resume
+    /// path rather than cancelled by pre-dispatch checks. A wrong `false`
+    /// forfeits a contract whose payment may still settle, so implementations
+    /// must absorb transient node failures and only answer once the node's
+    /// payment store could actually be consulted.
+    async fn outbound_payment_exists(&self, payment_hash: sha256::Hash) -> bool;
+
     /// Computes the minimum contract amount necessary for making an outgoing
     /// payment.
     ///
@@ -870,12 +897,19 @@ pub trait IGatewayClientV2: Debug + Send + Sync {
     async fn is_lnv1_invoice(&self, invoice: &Bolt11Invoice) -> Option<Spanned<ClientHandleArc>>;
 
     /// Perform a swap from an LNv2 `OutgoingContract` to an LNv1
-    /// `IncomingContract`
+    /// `IncomingContract`.
+    ///
+    /// A swap that was already started resumes unconditionally;
+    /// `allow_fresh_dispatch` is consulted only when no operation for this
+    /// swap exists yet. Callers pass `false` when a wall-clock gate such as
+    /// invoice expiry forbids starting a new swap, and receive `Ok(None)` to
+    /// signal that nothing was started.
     async fn relay_lnv1_swap(
         &self,
         client: &ClientHandleArc,
         invoice: &Bolt11Invoice,
-    ) -> anyhow::Result<FinalReceiveState>;
+        allow_fresh_dispatch: bool,
+    ) -> anyhow::Result<Option<FinalReceiveState>>;
 }
 
 #[cfg(test)]

--- a/modules/fedimint-gwv2-client/src/send_sm.rs
+++ b/modules/fedimint-gwv2-client/src/send_sm.rs
@@ -158,13 +158,11 @@ impl SendStateMachine {
     ) -> Result<PaymentResponse, Cancelled> {
         let LightningInvoice::Bolt11(invoice) = invoice;
 
-        // The following two checks may fail in edge cases since they have inherent
-        // timing assumptions. Therefore, they may only be checked after we have created
-        // the state machine such that we can cancel the contract.
-        if invoice.is_expired() {
-            return Err(Cancelled::InvoiceExpired);
-        }
-
+        // `max_delay` is computed once when the state machine is created and
+        // persisted, so this check cannot drift across a restart. It guards
+        // every rail, not just Lightning: after paying out, a swap races the
+        // outgoing contract's expiration to claim it, the same race an HTLC
+        // runs against the contract timelock.
         if max_delay == 0 {
             return Err(Cancelled::TimeoutTooClose);
         }
@@ -173,6 +171,16 @@ impl SendStateMachine {
             return Err(Cancelled::Underfunded);
         };
 
+        // Invoice expiry, by contrast, reads the wall clock, and this state
+        // machine re-runs from scratch on every restart: the invoice can
+        // expire while a payment dispatched before a crash is still in
+        // flight, and that payment settles or fails regardless of invoice
+        // expiry. Cancelling on expiry alone would forfeit a contract the
+        // in-flight payment can still claim. Each rail below therefore
+        // resumes anything it already started unconditionally and consults
+        // this verdict only before dispatching fresh.
+        let allow_fresh_dispatch = !invoice.is_expired();
+
         // To make gateway operation easier, we check if the invoice was created using
         // the LNv1 protocol and if the gateway supports the target federation.
         // If it does, we can fund an LNv1 incoming contract to satisfy the LNv2
@@ -180,10 +188,10 @@ impl SendStateMachine {
         if let Some(client) = context.gateway.is_lnv1_invoice(&invoice).await {
             let final_state = context
                 .gateway
-                .relay_lnv1_swap(client.value(), &invoice)
+                .relay_lnv1_swap(client.value(), &invoice, allow_fresh_dispatch)
                 .await;
             return match final_state {
-                Ok(final_receive_state) => match final_receive_state {
+                Ok(Some(final_receive_state)) => match final_receive_state {
                     FinalReceiveState::Rejected => Err(Cancelled::Rejected),
                     FinalReceiveState::Success(preimage) => Ok(PaymentResponse {
                         preimage,
@@ -192,6 +200,7 @@ impl SendStateMachine {
                     FinalReceiveState::Refunded => Err(Cancelled::Refunded),
                     FinalReceiveState::Failure => Err(Cancelled::Failure),
                 },
+                Ok(None) => Err(Cancelled::InvoiceExpired),
                 Err(e) => Err(Cancelled::FinalizationError(e.to_string())),
             };
         }
@@ -211,10 +220,11 @@ impl SendStateMachine {
                         invoice
                             .amount_milli_satoshis()
                             .expect("amountless invoices are not supported"),
+                        allow_fresh_dispatch,
                     )
                     .await
                 {
-                    Ok(final_receive_state) => match final_receive_state {
+                    Ok(Some(final_receive_state)) => match final_receive_state {
                         FinalReceiveState::Rejected => Err(Cancelled::Rejected),
                         FinalReceiveState::Success(preimage) => Ok(PaymentResponse {
                             preimage,
@@ -223,10 +233,23 @@ impl SendStateMachine {
                         FinalReceiveState::Refunded => Err(Cancelled::Refunded),
                         FinalReceiveState::Failure => Err(Cancelled::Failure),
                     },
+                    Ok(None) => Err(Cancelled::InvoiceExpired),
                     Err(e) => Err(Cancelled::FinalizationError(e.to_string())),
                 }
             }
             None => {
+                // A payment the node already knows resolves through `pay`'s
+                // idempotent resume path, so expiry only refuses a dispatch
+                // that never happened.
+                if !allow_fresh_dispatch
+                    && !context
+                        .gateway
+                        .outbound_payment_exists(*invoice.payment_hash())
+                        .await
+                {
+                    return Err(Cancelled::InvoiceExpired);
+                }
+
                 let preimage = context
                     .gateway
                     .pay(invoice, max_delay, max_fee)


### PR DESCRIPTION
### Summary

Backport of the gateway Lightning payment-path hardening set to
`releases/v0.11`, plus a version bump to `0.11.3` so the patch
release can be tagged straight from the merge. No protocol or database
format changes.

### Details

The fourteen commits from the master PR (#9130) fall into three groups:

- Tighter validation of values the gateway receives from a Lightning peer
  or a paying client before it commits its own funds.
- Correct handling of restarts and transient backend failures while a
  payment or HTLC completion is in flight, so the gateway neither gives
  up on a payment it already dispatched nor retries one it cannot
  complete.
- Consistent classification of backend errors as transient or permanent
  across LND and LDK, plus small cleanups that fell out of that.

Nine commits apply unchanged. Five needed adapting to v0.11 APIs, done
inside the respective commit so every commit still builds on its own:

- `fix: require outbound payment` — v0.11's LDK backend still polls
  `node.payment()` in a loop instead of waiting on payment events, so the
  new `outbound_payment()` direction filter is applied to the poll loop
  and the "already dispatched?" check rather than to `ldk_payment_result`.
- `fix: push expiry checks into swap/ln dispatches` — `LnRpcTracked` on
  v0.11 has no `tracked_call!` macro, so the new `outbound_payment_exists`
  wrapper records its call the way the neighbouring methods do. The
  `IGatewayClientV2` trait on v0.11 has no `claim_payment_image`, so only
  the `relay_lnv1_swap` signature change is carried over.
- `test: add expiration validation tests` — the new LNv2 send tests rely
  on the `CapturingGatewayConnection` test double and its fixtures, which
  only exist on master; both were ported alongside the tests.
- `fix: invoice registration` and `fix(ldk): report deterministic
  completion errors as rejected` — the LDK unit-test module on v0.11 only
  held the esplora URL test, so the new tests were added to it without
  the surrounding master-only tests.

The final commit bumps every workspace crate from `0.11.3-alpha` to
`0.11.3`; `Cargo.lock` was regenerated with `cargo clippy` so only
workspace version strings changed.

### Reviewing

`git range-diff upstream/master..2026-09-hardening upstream/releases/v0.11..<this-branch>`
shows exactly which hunks differ from the master PR (#9130); everything outside
the five commits listed above is identical.

### Testing

Unit tests were added for every new validation boundary and error
classification, and gateway integration tests cover the restart and
expiry scenarios end to end on both rails. Clippy with warnings denied,
the gateway and Lightning crate test suites, and `just test-ci-all` were
run locally on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
