### PR TITLE
chore: bump version to v0.11.4-alpha

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2248,7 +2248,7 @@ dependencies = [
 
 [[package]]
 name = "devimint"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -2708,7 +2708,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fedimint-aead"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "argon2",
@@ -2740,7 +2740,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-api-client"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2766,7 +2766,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-bip39"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "bip39",
  "fedimint-client",
@@ -2777,7 +2777,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-bitcoind"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2792,14 +2792,14 @@ dependencies = [
 
 [[package]]
 name = "fedimint-build"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "fedimint-cli"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2842,7 +2842,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2874,7 +2874,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client-module"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -2905,7 +2905,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client-rpc"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2933,7 +2933,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client-uniffi"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "fedimint-build",
@@ -2951,7 +2951,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client-wasm"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2969,7 +2969,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-connectors"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "arti-client",
@@ -3004,7 +3004,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-core"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3070,7 +3070,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-cursed-redb"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3090,7 +3090,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-db-locked"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3102,7 +3102,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dbtool"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3138,7 +3138,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-derive"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
@@ -3148,7 +3148,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-derive-secret"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",
@@ -3160,11 +3160,11 @@ dependencies = [
 
 [[package]]
 name = "fedimint-docs"
-version = "0.11.3"
+version = "0.11.4-alpha"
 
 [[package]]
 name = "fedimint-dummy-client"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3186,7 +3186,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dummy-common"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -3196,7 +3196,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dummy-server"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3212,7 +3212,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-empty-client"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3229,7 +3229,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-empty-common"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -3239,7 +3239,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-empty-server"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3255,7 +3255,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-eventlog"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3273,7 +3273,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-fountain"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3285,7 +3285,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-fuzz"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "fedimint-core",
  "fedimint-ln-common",
@@ -3298,7 +3298,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-client"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "bcrypt",
@@ -3323,7 +3323,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-common"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -3340,7 +3340,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-server"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3421,7 +3421,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-server-db"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -3449,7 +3449,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-ui"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "async-trait",
  "axum 0.8.8",
@@ -3481,7 +3481,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gw-client"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3512,7 +3512,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gwv2-client"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3539,7 +3539,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-hkdf"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "bitcoin_hashes",
 ]
@@ -3587,7 +3587,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lightning"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3614,7 +3614,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-client"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3648,7 +3648,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-common"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3671,7 +3671,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-server"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3697,7 +3697,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-tests"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3726,7 +3726,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnurl"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "bech32",
  "lightning-invoice",
@@ -3738,7 +3738,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-client"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3770,7 +3770,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-common"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3790,7 +3790,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-server"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3814,7 +3814,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-tests"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3851,7 +3851,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-load-test-tool"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "clap",
@@ -3879,7 +3879,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-logging"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "console-subscriber",
@@ -3892,7 +3892,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-client"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3913,7 +3913,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-common"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -3927,7 +3927,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-server"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3946,7 +3946,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-tests"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "clap",
@@ -3960,7 +3960,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-metrics"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -3972,7 +3972,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-client"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -4013,7 +4013,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-common"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",
@@ -4026,7 +4026,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-server"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4053,7 +4053,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-tests"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4087,7 +4087,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mintv2-client"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -4126,7 +4126,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mintv2-common"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",
@@ -4139,7 +4139,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mintv2-server"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4164,7 +4164,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mintv2-tests"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4197,7 +4197,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-portalloc"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "dirs",
@@ -4211,7 +4211,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-recoverytool"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -4234,7 +4234,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-recurringd"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -4265,7 +4265,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-recurringd-tests"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "devimint",
@@ -4279,7 +4279,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-recurringdv2"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -4300,7 +4300,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-rocksdb"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4317,7 +4317,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -4374,7 +4374,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server-bitcoin-rpc"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4390,7 +4390,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server-core"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4408,7 +4408,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server-tests"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "bitcoin",
  "fedimint-api-client",
@@ -4428,7 +4428,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server-ui"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4455,7 +4455,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-tbs"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "bls12_381",
  "criterion",
@@ -4470,7 +4470,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-testing"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4510,7 +4510,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-testing-core"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -4571,7 +4571,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-tpe"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "bitcoin_hashes",
  "bls12_381",
@@ -4585,7 +4585,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ui-common"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "axum 0.8.8",
  "axum-extra",
@@ -4597,7 +4597,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-unknown-common"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -4607,7 +4607,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-unknown-server"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4621,14 +4621,14 @@ dependencies = [
 
 [[package]]
 name = "fedimint-util-error"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "fedimint-wallet-client"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -4658,7 +4658,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-common"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -4674,7 +4674,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-server"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4701,7 +4701,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-tests"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4734,7 +4734,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-walletv2-client"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4762,7 +4762,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-walletv2-common"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -4775,7 +4775,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-walletv2-server"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4797,7 +4797,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-walletv2-tests"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4827,7 +4827,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wasm-tests"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "fedimint-client",
@@ -4848,7 +4848,7 @@ dependencies = [
 
 [[package]]
 name = "fedimintd"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -4885,7 +4885,7 @@ dependencies = [
 
 [[package]]
 name = "fedimintd-envs"
-version = "0.11.3"
+version = "0.11.4-alpha"
 
 [[package]]
 name = "ff"
@@ -5201,7 +5201,7 @@ dependencies = [
 
 [[package]]
 name = "gateway-tests"
-version = "0.11.3"
+version = "0.11.4-alpha"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,7 +107,7 @@ keywords = ["bitcoin", "lightning", "chaumian", "e-cash", "federated"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/fedimint/fedimint"
-version = "0.11.3"
+version = "0.11.4-alpha"
 
 [workspace.metadata]
 authors = ["The Fedimint Developers"]
@@ -168,7 +168,7 @@ criterion = "0.5.1"
 # We need to pin this arti's `curve25519-dalek` dependency, due to `https://rustsec.org/advisories/RUSTSEC-2024-0344` vulnerability
 # It's been updated by https://gitlab.torproject.org/tpo/core/arti/-/merge_requests/2211, should be removed in next release.
 curve25519-dalek = ">=4.1.3"
-devimint = { path = "./devimint", version = "=0.11.3" }
+devimint = { path = "./devimint", version = "=0.11.4-alpha" }
 dirs = "6.0.0"
 erased-serde = "0.4"
 esplora-client = { version = "0.12.3", default-features = false, features = [
@@ -178,70 +178,70 @@ esplora-client = { version = "0.12.3", default-features = false, features = [
 ] }
 tor-rtcompat = { version = "0.33.0" }
 
-fedimint-aead = { path = "./crypto/aead", version = "=0.11.3" }
-fedimint-api-client = { path = "./fedimint-api-client", version = "=0.11.3" }
-fedimint-bip39 = { path = "./fedimint-bip39", version = "=0.11.3" }
-fedimint-bitcoind = { path = "./fedimint-bitcoind", version = "=0.11.3" }
-fedimint-build = { path = "./fedimint-build", version = "=0.11.3" }
-fedimint-client = { path = "./fedimint-client", version = "=0.11.3" }
-fedimint-client-module = { path = "./fedimint-client-module", version = "=0.11.3" }
-fedimint-client-rpc = { path = "./fedimint-client-rpc", version = "=0.11.3" }
-fedimint-connectors = { path = "./fedimint-connectors", version = "=0.11.3" }
-fedimint-core = { path = "./fedimint-core", version = "=0.11.3" }
-fedimint-cursed-redb = { path = "./fedimint-cursed-redb", version = "=0.11.3" }
-fedimint-db-locked = { path = "./fedimint-db-locked", version = "=0.11.3" }
-fedimint-derive = { path = "./fedimint-derive", version = "=0.11.3" }
-fedimint-derive-secret = { path = "./crypto/derive-secret", version = "=0.11.3" }
-fedimint-dummy-client = { path = "./modules/fedimint-dummy-client", version = "=0.11.3" }
-fedimint-dummy-common = { path = "./modules/fedimint-dummy-common", version = "=0.11.3" }
-fedimint-dummy-server = { path = "./modules/fedimint-dummy-server", version = "=0.11.3" }
-fedimint-empty-common = { path = "./modules/fedimint-empty-common", version = "=0.11.3" }
-fedimint-eventlog = { path = "./fedimint-eventlog", version = "=0.11.3" }
-fedimint-gateway-common = { package = "fedimint-gateway-common", path = "./gateway/fedimint-gateway-common", version = "=0.11.3" }
-fedimint-gateway-server = { package = "fedimint-gateway-server", path = "./gateway/fedimint-gateway-server", version = "=0.11.3" }
-fedimint-gateway-server-db = { package = "fedimint-gateway-server-db", path = "./gateway/fedimint-gateway-server-db", version = "=0.11.3" }
-fedimint-gateway-ui = { package = "fedimint-gateway-ui", path = "./gateway/fedimint-gateway-ui", version = "=0.11.3" }
-fedimint-gw-client = { path = "./modules/fedimint-gw-client", version = "=0.11.3" }
-fedimint-gwv2-client = { path = "./modules/fedimint-gwv2-client", version = "=0.11.3" }
-fedimint-lightning = { package = "fedimint-lightning", path = "./gateway/fedimint-lightning", version = "=0.11.3" }
-fedimint-ln-client = { path = "./modules/fedimint-ln-client", version = "=0.11.3" }
-fedimint-ln-common = { path = "./modules/fedimint-ln-common", version = "=0.11.3" }
-fedimint-ln-server = { path = "./modules/fedimint-ln-server", version = "=0.11.3" }
-fedimint-lnurl = { path = "./fedimint-lnurl", version = "=0.11.3" }
-fedimint-lnv2-client = { path = "./modules/fedimint-lnv2-client", version = "=0.11.3" }
-fedimint-lnv2-common = { path = "./modules/fedimint-lnv2-common", version = "=0.11.3" }
-fedimint-lnv2-server = { path = "./modules/fedimint-lnv2-server", version = "=0.11.3" }
-fedimint-logging = { path = "./fedimint-logging", version = "=0.11.3" }
-fedimint-meta-client = { path = "./modules/fedimint-meta-client", version = "=0.11.3" }
-fedimint-meta-common = { path = "./modules/fedimint-meta-common", version = "=0.11.3" }
-fedimint-meta-server = { path = "./modules/fedimint-meta-server", version = "=0.11.3" }
-fedimint-metrics = { path = "./fedimint-metrics", version = "=0.11.3" }
-fedimint-mint-client = { path = "./modules/fedimint-mint-client", version = "=0.11.3" }
-fedimint-mint-common = { path = "./modules/fedimint-mint-common", version = "=0.11.3" }
-fedimint-mint-server = { path = "./modules/fedimint-mint-server", version = "=0.11.3" }
-fedimint-mintv2-client = { path = "./modules/fedimint-mintv2-client", version = "=0.11.3" }
-fedimint-mintv2-common = { path = "./modules/fedimint-mintv2-common", version = "=0.11.3" }
-fedimint-mintv2-server = { path = "./modules/fedimint-mintv2-server", version = "=0.11.3" }
-fedimint-portalloc = { path = "utils/portalloc", version = "=0.11.3" }
-fedimint-rocksdb = { path = "./fedimint-rocksdb", version = "=0.11.3" }
-fedimint-server = { path = "./fedimint-server", version = "=0.11.3" }
-fedimint-server-bitcoin-rpc = { path = "./fedimint-server-bitcoin-rpc", version = "=0.11.3" }
-fedimint-server-core = { path = "./fedimint-server-core", version = "=0.11.3" }
-fedimint-server-ui = { path = "./fedimint-server-ui", version = "=0.11.3" }
-fedimint-testing = { path = "./fedimint-testing", version = "=0.11.3" }
-fedimint-testing-core = { path = "./fedimint-testing-core", version = "=0.11.3" }
-fedimint-ui-common = { path = "./fedimint-ui-common", version = "=0.11.3" }
-fedimint-unknown-common = { path = "./modules/fedimint-unknown-common", version = "=0.11.3" }
-fedimint-unknown-server = { path = "./modules/fedimint-unknown-server", version = "=0.11.3" }
-fedimint-util-error = { path = "./fedimint-util-error", version = "=0.11.3" }
-fedimint-wallet-client = { path = "./modules/fedimint-wallet-client", version = "=0.11.3" }
-fedimint-wallet-common = { path = "./modules/fedimint-wallet-common", version = "=0.11.3" }
-fedimint-wallet-server = { path = "./modules/fedimint-wallet-server", version = "=0.11.3" }
-fedimint-walletv2-client = { path = "./modules/fedimint-walletv2-client", version = "=0.11.3" }
-fedimint-walletv2-common = { path = "./modules/fedimint-walletv2-common", version = "=0.11.3" }
-fedimint-walletv2-server = { path = "./modules/fedimint-walletv2-server", version = "=0.11.3" }
-fedimintd = { path = "./fedimintd", version = "=0.11.3" }
-fedimintd-envs = { path = "./fedimintd-envs", version = "=0.11.3" }
+fedimint-aead = { path = "./crypto/aead", version = "=0.11.4-alpha" }
+fedimint-api-client = { path = "./fedimint-api-client", version = "=0.11.4-alpha" }
+fedimint-bip39 = { path = "./fedimint-bip39", version = "=0.11.4-alpha" }
+fedimint-bitcoind = { path = "./fedimint-bitcoind", version = "=0.11.4-alpha" }
+fedimint-build = { path = "./fedimint-build", version = "=0.11.4-alpha" }
+fedimint-client = { path = "./fedimint-client", version = "=0.11.4-alpha" }
+fedimint-client-module = { path = "./fedimint-client-module", version = "=0.11.4-alpha" }
+fedimint-client-rpc = { path = "./fedimint-client-rpc", version = "=0.11.4-alpha" }
+fedimint-connectors = { path = "./fedimint-connectors", version = "=0.11.4-alpha" }
+fedimint-core = { path = "./fedimint-core", version = "=0.11.4-alpha" }
+fedimint-cursed-redb = { path = "./fedimint-cursed-redb", version = "=0.11.4-alpha" }
+fedimint-db-locked = { path = "./fedimint-db-locked", version = "=0.11.4-alpha" }
+fedimint-derive = { path = "./fedimint-derive", version = "=0.11.4-alpha" }
+fedimint-derive-secret = { path = "./crypto/derive-secret", version = "=0.11.4-alpha" }
+fedimint-dummy-client = { path = "./modules/fedimint-dummy-client", version = "=0.11.4-alpha" }
+fedimint-dummy-common = { path = "./modules/fedimint-dummy-common", version = "=0.11.4-alpha" }
+fedimint-dummy-server = { path = "./modules/fedimint-dummy-server", version = "=0.11.4-alpha" }
+fedimint-empty-common = { path = "./modules/fedimint-empty-common", version = "=0.11.4-alpha" }
+fedimint-eventlog = { path = "./fedimint-eventlog", version = "=0.11.4-alpha" }
+fedimint-gateway-common = { package = "fedimint-gateway-common", path = "./gateway/fedimint-gateway-common", version = "=0.11.4-alpha" }
+fedimint-gateway-server = { package = "fedimint-gateway-server", path = "./gateway/fedimint-gateway-server", version = "=0.11.4-alpha" }
+fedimint-gateway-server-db = { package = "fedimint-gateway-server-db", path = "./gateway/fedimint-gateway-server-db", version = "=0.11.4-alpha" }
+fedimint-gateway-ui = { package = "fedimint-gateway-ui", path = "./gateway/fedimint-gateway-ui", version = "=0.11.4-alpha" }
+fedimint-gw-client = { path = "./modules/fedimint-gw-client", version = "=0.11.4-alpha" }
+fedimint-gwv2-client = { path = "./modules/fedimint-gwv2-client", version = "=0.11.4-alpha" }
+fedimint-lightning = { package = "fedimint-lightning", path = "./gateway/fedimint-lightning", version = "=0.11.4-alpha" }
+fedimint-ln-client = { path = "./modules/fedimint-ln-client", version = "=0.11.4-alpha" }
+fedimint-ln-common = { path = "./modules/fedimint-ln-common", version = "=0.11.4-alpha" }
+fedimint-ln-server = { path = "./modules/fedimint-ln-server", version = "=0.11.4-alpha" }
+fedimint-lnurl = { path = "./fedimint-lnurl", version = "=0.11.4-alpha" }
+fedimint-lnv2-client = { path = "./modules/fedimint-lnv2-client", version = "=0.11.4-alpha" }
+fedimint-lnv2-common = { path = "./modules/fedimint-lnv2-common", version = "=0.11.4-alpha" }
+fedimint-lnv2-server = { path = "./modules/fedimint-lnv2-server", version = "=0.11.4-alpha" }
+fedimint-logging = { path = "./fedimint-logging", version = "=0.11.4-alpha" }
+fedimint-meta-client = { path = "./modules/fedimint-meta-client", version = "=0.11.4-alpha" }
+fedimint-meta-common = { path = "./modules/fedimint-meta-common", version = "=0.11.4-alpha" }
+fedimint-meta-server = { path = "./modules/fedimint-meta-server", version = "=0.11.4-alpha" }
+fedimint-metrics = { path = "./fedimint-metrics", version = "=0.11.4-alpha" }
+fedimint-mint-client = { path = "./modules/fedimint-mint-client", version = "=0.11.4-alpha" }
+fedimint-mint-common = { path = "./modules/fedimint-mint-common", version = "=0.11.4-alpha" }
+fedimint-mint-server = { path = "./modules/fedimint-mint-server", version = "=0.11.4-alpha" }
+fedimint-mintv2-client = { path = "./modules/fedimint-mintv2-client", version = "=0.11.4-alpha" }
+fedimint-mintv2-common = { path = "./modules/fedimint-mintv2-common", version = "=0.11.4-alpha" }
+fedimint-mintv2-server = { path = "./modules/fedimint-mintv2-server", version = "=0.11.4-alpha" }
+fedimint-portalloc = { path = "utils/portalloc", version = "=0.11.4-alpha" }
+fedimint-rocksdb = { path = "./fedimint-rocksdb", version = "=0.11.4-alpha" }
+fedimint-server = { path = "./fedimint-server", version = "=0.11.4-alpha" }
+fedimint-server-bitcoin-rpc = { path = "./fedimint-server-bitcoin-rpc", version = "=0.11.4-alpha" }
+fedimint-server-core = { path = "./fedimint-server-core", version = "=0.11.4-alpha" }
+fedimint-server-ui = { path = "./fedimint-server-ui", version = "=0.11.4-alpha" }
+fedimint-testing = { path = "./fedimint-testing", version = "=0.11.4-alpha" }
+fedimint-testing-core = { path = "./fedimint-testing-core", version = "=0.11.4-alpha" }
+fedimint-ui-common = { path = "./fedimint-ui-common", version = "=0.11.4-alpha" }
+fedimint-unknown-common = { path = "./modules/fedimint-unknown-common", version = "=0.11.4-alpha" }
+fedimint-unknown-server = { path = "./modules/fedimint-unknown-server", version = "=0.11.4-alpha" }
+fedimint-util-error = { path = "./fedimint-util-error", version = "=0.11.4-alpha" }
+fedimint-wallet-client = { path = "./modules/fedimint-wallet-client", version = "=0.11.4-alpha" }
+fedimint-wallet-common = { path = "./modules/fedimint-wallet-common", version = "=0.11.4-alpha" }
+fedimint-wallet-server = { path = "./modules/fedimint-wallet-server", version = "=0.11.4-alpha" }
+fedimint-walletv2-client = { path = "./modules/fedimint-walletv2-client", version = "=0.11.4-alpha" }
+fedimint-walletv2-common = { path = "./modules/fedimint-walletv2-common", version = "=0.11.4-alpha" }
+fedimint-walletv2-server = { path = "./modules/fedimint-walletv2-server", version = "=0.11.4-alpha" }
+fedimintd = { path = "./fedimintd", version = "=0.11.4-alpha" }
+fedimintd-envs = { path = "./fedimintd-envs", version = "=0.11.4-alpha" }
 ff = "0.13.1"
 fs-lock = "=0.1.10"
 fs2 = "0.4.3"
@@ -253,7 +253,7 @@ gloo-timers = "0.3.0"
 group = "0.13.0"
 hex = "0.4.3"
 hex-conservative = "1.0.0"
-hkdf = { package = "fedimint-hkdf", path = "./crypto/hkdf", version = "=0.11.3" }
+hkdf = { package = "fedimint-hkdf", path = "./crypto/hkdf", version = "=0.11.4-alpha" }
 honggfuzz = { version = "=0.5.55", default-features = false } # needs to be pinned to the same version `cargo-fuzz` binary uses
 hyper = "1.6"
 imbl = "5.0.0"
@@ -330,7 +330,7 @@ substring = "1.4.5"
 subtle = "2.6.1"
 syn = "2.0"
 tar = "0.4.45"
-tbs = { package = "fedimint-tbs", path = "./crypto/tbs", version = "=0.11.3" }
+tbs = { package = "fedimint-tbs", path = "./crypto/tbs", version = "=0.11.4-alpha" }
 tempfile = "3.20.0"
 test-log = { version = "0.2", features = ["trace"], default-features = false }
 thiserror = "2.0.18"
@@ -349,7 +349,7 @@ tonic_lnd = { version = "0.4.0", package = "fedimint-tonic-lnd", features = [
 ] }
 tower = { version = "0.4.13", default-features = false }
 tower-http = { version = "0.6.8", features = ["cors"] }
-tpe = { package = "fedimint-tpe", path = "./crypto/tpe", version = "=0.11.3" }
+tpe = { package = "fedimint-tpe", path = "./crypto/tpe", version = "=0.11.4-alpha" }
 tracing = "0.1.44"
 tracing-opentelemetry = "0.29.0"
 tracing-subscriber = "0.3.22"


### PR DESCRIPTION
Post-release bump of \`releases/v0.11\` after cutting v0.11.3 (branch \`releases/v0.11.3\` at 8276a229336).

\`Cargo.lock\` regenerated with \`cargo clippy\`; only workspace version strings changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)